### PR TITLE
Update legislators-social-media.yaml

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -514,7 +514,7 @@
     govtrack: 412399
   social:
     twitter: RepDavid
-    youtube: http://youtube.com/RepDavidSchweikert
+    youtube: RepDavidSchweikert
     facebook_graph: '150338151681908'
 - id:
     bioguide: S001182
@@ -941,7 +941,7 @@
     govtrack: 412483
   social:
     twitter: repscottrigell
-    youtube: http://youtube.com/RepScottRigell
+    youtube: RepScottRigell
     facebook_graph: 167851429918010
 - id:
     bioguide: R000588
@@ -1289,7 +1289,7 @@
     govtrack: 400652
   social:
     twitter: JudgeTedPoe
-    youtube: http://youtube.com/CongressmanTedPoe
+    youtube: CongressmanTedPoe
     facebook_graph: '106631626049851'
 - id:
     bioguide: P000591
@@ -2004,7 +2004,7 @@
   social:
     facebook_graph: '178081365556898'
     twitter: SenMikeLee
-    youtube: http://youtube.com/senatormikelee
+    youtube: senatormikelee
 - id:
     bioguide: L000576
     thomas: '02033'
@@ -2681,7 +2681,7 @@
     govtrack: 412437
   social:
     twitter: rephuizenga
-    youtube: http://youtube.com/RepHuizenga
+    youtube: RepHuizenga
     facebook_graph: 145764842143763
 - id:
     bioguide: H001057


### PR DESCRIPTION
removed "http://youtube.com/" where it appeared for a couple of legislators.

(They  were showing up something like this in the data dump: 
http://youtube.com/http://youtube.com/CongressmanTedPoe
)
