### PR TITLE
Add executive entries for vice presidents for whom we have existing data

### DIFF
--- a/executive.yaml
+++ b/executive.yaml
@@ -1238,6 +1238,7 @@
     middle: Arnold
     last: Gore
     suffix: Jr.
+    nickname: Al
   bio:
     birthday: '1948-03-31'
     gender: M


### PR DESCRIPTION
These are only the vice presidents who were also presidents or members of Congress.

I used 'viceprez' for the term type; not sure if we want to use something else instead.

I don't quite know what to do with the vice presidents who were not presidents or members of Congress, because chances are we don't have existing IDs for them. Not sure how that works.

I also made some less significant changes to metadata for some of the entries that should probably backported to the legislators-historical file, but I didn't do that.
