### PR TITLE
Govtrack ids for social-media.yaml, and a handful of twitter accounts.

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -97,7 +97,6 @@
     thomas: '01777'
     govtrack: 400623
   social:
-    twitter: RepDWStweets
     facebook: '88904724121'
     youtube: RepWassermanSchultz
 - id:
@@ -261,7 +260,6 @@
     thomas: '01829'
     govtrack: 412244
   social:
-    twitter: jontester
     facebook: senatortester
     youtube: senatorjontester
 - id:
@@ -3181,7 +3179,6 @@
     thomas: '02075'
     govtrack: 412493
   social:
-    twitter: KellyAyotte
     facebook: '123436097729198'
     youtube: SenatorAyotte
 - id:
@@ -3920,7 +3917,6 @@
     thomas: '01609'
     govtrack: 400418
   social:
-    twitter: DavidVitter
     youtube: SenatorVitter
 - id:
     bioguide: C001075
@@ -3939,7 +3935,6 @@
     thomas: '01969'
     govtrack: 412378
   social:
-    twitter: alfranken
     youtube: SenatorFranken
 - id:
     bioguide: G000558
@@ -3971,7 +3966,6 @@
     thomas: '01826'
     govtrack: 412242
   social:
-    twitter: amyklobuchar
     youtube: senatorklobuchar
 - id:
     bioguide: H001032
@@ -4033,47 +4027,12 @@
     govtrack: 412507
   social:
     twitter: SenBrianSchatz
-- id:
-    bioguide: B000243
-    govtrack: 300005
-  social:
-    twitter: MaxBaucus
-
-- id:
-    bioguide: A000210
-    govtrack: 400008
-  social:
-    twitter: RepAndrews
-
-- id:
-    bioguide: R000409
-    govtrack: 400343
-  social:
-    twitter: DanaRohrabacher
-
-- id:
-    bioguide: M001169
-    govtrack: 412194
-  social:
-    twitter: ChrisMurphyCT
 
 - id:
     bioguide: S001168
     govtrack: 412212
   social:
     twitter: RepJohnSarbanes
-
-- id:
-    bioguide: G000555
-    govtrack: 412223
-  social:
-    twitter: SenGillibrand
-
-- id:
-    bioguide: G000556
-    govtrack: 412276
-  social:
-    twitter: AlanGrayson
 
 - id:
     bioguide: B001285


### PR DESCRIPTION
This pull request is mostly govtrack ids. 

I've also added the twitter accounts below. The non-verified list is accounts that I'm pretty sure are legit, but they're not listed anywhere (congressional website, verified twitter bio) as the official account for the member's office.

The 'excluded' list are members I haven't added to the file. I've got bioguides and govtrack ids for them, but didn't include them because their twitter accounts appear to be non-official.

I've listed urls and phone numbers in case you want to follow up.

Non-verified:
line 296: https://twitter.com/RepThompson
not linked from his website, but links to his official rather than campaign site, and the tweets look official (congressional art competition, legislation, no fundraising event invites)
http://mikethompson.house.gov (202) 225-3311 

line 2766: https://twitter.com/ElijahECummings
Same deal--not linked but links to, and looks official.
http://cummings.house.gov (202) 225-4741

line 4031: https://twitter.com/RepJohnSarbanes
Same deal--not linked but links to, and looks official.
http://www.sarbanes.house.gov 202.225.4016

Verified:
line 3778: https://twitter.com/SenatorBaldwin
Twitter account is verified, and bio says: "Official Twitter account of United States Senator Tammy Baldwin's office, proudly working for the State of Wisconsin. Tweets from Tammy are signed -TB." Not on her website but she's on the standard Drupal install with no customizations.
http://www.baldwin.senate.gov (202) 224-5653

line 4037: https://twitter.com/JuliaBrownley26
linked from her congressional website; tweets look official.
http://juliabrownley.house.gov 202-225-5811

Excluded:
- id:
  bioguide: A000210
  govtrack: 400008
  social:
    twitter: RepAndrews
  http://andrews.house.gov/ (202) 225-6501
- id:
  bioguide: R000409
  govtrack: 400343
  social:
    twitter: DanaRohrabacher
  http://rohrabacher.house.gov (202) 225-2415
- id:
  bioguide: M001169
  govtrack: 412194
  social:
    twitter: ChrisMurphyCT
  http://www.murphy.senate.gov/ (202) 224-4041
- id:
  bioguide: G000555
  govtrack: 412223
  social:
    twitter: SenGillibrand
  www.gillibrand.senate.gov (202) 224-4451 (this is definitely a campaign acct--links to her campaign website).
- id:
  bioguide: G000556
  govtrack: 412276
  social:
    twitter: AlanGrayson
  grayson.house.gov  202-225-9889 (official site links to the housedemocrats twitter)
