### PR TITLE
Resolve Facebook usernames to graph IDs

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -6,6 +6,7 @@
     twitter: RepToddYoung
     facebook: RepToddYoung
     youtube: RepToddYoung
+    facebook_id: '186203844738421'
 - id:
     bioguide: Y000063
     thomas: '02021'
@@ -14,6 +15,7 @@
     twitter: RepKevinYoder
     facebook: CongressmanKevinYoder
     youtube: RepYoder
+    facebook_id: '154026694650252'
 - id:
     bioguide: Y000062
     thomas: '01853'
@@ -22,6 +24,7 @@
     twitter: RepJohnYarmuth
     facebook: '214258646163'
     youtube: RepJohnYarmuth
+    facebook_id: '214258646163'
 - id:
     bioguide: Y000033
     thomas: '01256'
@@ -30,6 +33,7 @@
     twitter: repdonyoung
     facebook: RepDonYoung
     youtube: RepDonYoung
+    facebook_id: '7476269851'
 - id:
     bioguide: W000809
     thomas: '01991'
@@ -38,6 +42,7 @@
     twitter: Rep_SteveWomack
     facebook: RepSteveWomack
     youtube: CongressmanWomack
+    facebook_id: '135898413136490'
 - id:
     bioguide: W000808
     thomas: '02004'
@@ -46,6 +51,7 @@
     twitter: RepWilson
     facebook: RepWilson
     youtube: repfredericawilson
+    facebook_id: '162327487151626'
 - id:
     bioguide: W000806
     thomas: '02002'
@@ -54,6 +60,7 @@
     twitter: RepWebster
     facebook: RepWebster
     youtube: repdanwebster
+    facebook_id: '188572961157305'
 - id:
     bioguide: W000805
     thomas: '01897'
@@ -62,6 +69,7 @@
     twitter: MarkWarner
     facebook: MarkRWarner
     youtube: SenatorMarkWarner
+    facebook_id: '7935122852'
 - id:
     bioguide: W000804
     thomas: '01886'
@@ -70,6 +78,7 @@
     twitter: RobWittman
     facebook: RepRobWittman
     youtube: RobWittman
+    facebook_id: '38932542633'
 - id:
     bioguide: W000802
     thomas: '01823'
@@ -77,6 +86,7 @@
   social:
     twitter: SenWhitehouse
     facebook: SenatorWhitehouse
+    facebook_id: '194172833926853'
 - id:
     bioguide: W000800
     thomas: '01879'
@@ -84,6 +94,7 @@
   social:
     facebook: PeterWelch
     youtube: reppeterwelch
+    facebook_id: '72680720883'
 - id:
     bioguide: W000798
     thomas: '01855'
@@ -92,6 +103,7 @@
     twitter: RepWalberg
     facebook: RepWalberg
     youtube: RepWalberg
+    facebook_id: '187654104587692'
 - id:
     bioguide: W000797
     thomas: '01777'
@@ -100,6 +112,7 @@
     twitter: RepDWStweets
     facebook: RepDWS
     youtube: RepWassermanSchultz
+    facebook_id: '88904724121'
 - id:
     bioguide: W000796
     thomas: '01779'
@@ -107,6 +120,7 @@
   social:
     twitter: repwestmoreland
     facebook: '71389451419'
+    facebook_id: '71389451419'
 - id:
     bioguide: W000795
     thomas: '01688'
@@ -115,6 +129,7 @@
     twitter: USRepJoeWilson
     facebook: JoeWilson
     youtube: RepJoeWilson
+    facebook_id: '70150469414'
 - id:
     bioguide: W000791
     thomas: '01596'
@@ -123,6 +138,7 @@
     twitter: repgregwalden
     facebook: repgregwalden
     youtube: RepGregWalden
+    facebook_id: '313301365382225'
 - id:
     bioguide: W000779
     thomas: '01247'
@@ -138,6 +154,7 @@
     twitter: RepWOLFPress
     facebook: RepFrankWolf
     youtube: repfrankwolf
+    facebook_id: '335759964938'
 - id:
     bioguide: W000437
     thomas: '01226'
@@ -146,6 +163,7 @@
     twitter: senatorwicker
     facebook: SenatorWicker
     youtube: SenatorWicker
+    facebook_id: ~
 - id:
     bioguide: W000413
     thomas: '01222'
@@ -154,6 +172,7 @@
     twitter: repedwhitfield
     facebook: RepEdWhitfield
     youtube: WhitfieldKY01
+    facebook_id: '91115765425'
 - id:
     bioguide: W000207
     thomas: '01207'
@@ -162,6 +181,7 @@
     twitter: MelWattNC12
     facebook: CongressmanMelWatt
     youtube: Wattnc12
+    facebook_id: '191136754250537'
 - id:
     bioguide: W000187
     thomas: '01205'
@@ -170,6 +190,7 @@
     twitter: MaxineWaters
     facebook: MaxineWaters
     youtube: MaxineWaters
+    facebook_id: '117483585008'
 - id:
     bioguide: V000128
     thomas: '01729'
@@ -178,6 +199,7 @@
     twitter: chrisvanhollen
     facebook: chrisvanhollen
     youtube: RepChrisVanHollen
+    facebook_id: '109304033877'
 - id:
     bioguide: V000108
     thomas: '01188'
@@ -186,6 +208,7 @@
     twitter: repvisclosky
     facebook: repvisclosky
     youtube: PeteVisclosky1
+    facebook_id: '118723661514709'
 - id:
     bioguide: V000081
     thomas: '01184'
@@ -200,6 +223,7 @@
     twitter: SenatorTomUdall
     facebook: senatortomudall
     youtube: senatortomudall
+    facebook_id: '106433512869'
 - id:
     bioguide: U000038
     thomas: '01595'
@@ -208,6 +232,7 @@
     twitter: MarkUdall
     facebook: markudall
     youtube: senatormarkudall
+    facebook_id: '17204170252'
 - id:
     bioguide: U000031
     thomas: '01177'
@@ -216,6 +241,7 @@
     twitter: RepFredUpton
     facebook: RepFredUpton
     youtube: RepFredUpton
+    facebook_id: '212027388827797'
 - id:
     bioguide: T000470
     thomas: '01997'
@@ -224,6 +250,7 @@
     twitter: RepTipton
     facebook: CongressmanScottTipton
     youtube: RepScottTipton
+    facebook_id: '191428784201721'
 - id:
     bioguide: T000469
     thomas: '01942'
@@ -232,6 +259,7 @@
     twitter: PaulTonko
     facebook: paul.tonko
     youtube: reppaultonko
+    facebook_id: '30671144824'
 - id:
     bioguide: T000468
     thomas: '01940'
@@ -240,6 +268,7 @@
     twitter: repdinatitus
     facebook: CongresswomanTitus
     youtube: CongresswomanTitus
+    facebook_id: '120660834778561'
 - id:
     bioguide: T000467
     thomas: '01952'
@@ -248,6 +277,7 @@
     twitter: CongressmanGT
     facebook: CongressmanGT
     youtube: CongressmanGT
+    facebook_id: '14463006747'
 - id:
     bioguide: T000465
     thomas: '01884'
@@ -256,6 +286,7 @@
     twitter: nikiinthehouse
     facebook: RepTsongas
     youtube: RepTsongas
+    facebook_id: '131079823624873'
 - id:
     bioguide: T000464
     thomas: '01829'
@@ -263,6 +294,7 @@
   social:
     facebook: senatortester
     youtube: senatorjontester
+    facebook_id: '210573031664'
 - id:
     bioguide: T000463
     thomas: '01741'
@@ -271,6 +303,7 @@
     twitter: RepMikeTurner
     facebook: RepMikeTurner
     youtube: CongressmanTurner
+    facebook_id: '9275036647'
 - id:
     bioguide: T000462
     thomas: '01664'
@@ -279,6 +312,7 @@
     twitter: tiberipress
     facebook: RepPatTiberi
     youtube: PatTiberi
+    facebook_id: '90452932937'
 - id:
     bioguide: T000461
     thomas: '02085'
@@ -287,6 +321,7 @@
     twitter: SenToomey
     facebook: senatortoomey
     youtube: sentoomey
+    facebook_id: '189274047751251'
 - id:
     bioguide: T000460
     thomas: '01593'
@@ -295,6 +330,7 @@
     twitter: RepThompson
     facebook: RepMikeThompson
     youtube: CongressmanMThompson
+    facebook_id: '7109195747'
 - id:
     bioguide: T000459
     thomas: '01566'
@@ -303,6 +339,7 @@
     twitter: LEETERRYNE
     facebook: leeterry
     youtube: NebraskaTerry
+    facebook_id: '393886975960'
 - id:
     bioguide: T000266
     thomas: '01535'
@@ -311,6 +348,7 @@
     twitter: RepTierney
     facebook: CongressmanJohnTierney
     youtube: CongressmanTierney
+    facebook_id: '203760666318846'
 - id:
     bioguide: T000250
     thomas: '01534'
@@ -326,6 +364,7 @@
     twitter: MacTXPress
     facebook: repmacthornberry
     youtube: RepMacThornberry
+    facebook_id: '7760165627'
 - id:
     bioguide: T000193
     thomas: '01151'
@@ -334,6 +373,7 @@
     twitter: BennieGThompson
     facebook: '7259193379'
     youtube: RepBennieThompson
+    facebook_id: '7259193379'
 - id:
     bioguide: S001189
     thomas: '02009'
@@ -342,6 +382,7 @@
     twitter: AustinScottGA08
     facebook: RepAustinScott
     youtube: RepAustinScott
+    facebook_id: '131177916946914'
 - id:
     bioguide: S001188
     thomas: '01981'
@@ -350,6 +391,7 @@
     twitter: RepStutzman
     facebook: CongressmanMarlinStutzman
     youtube: repstutzman
+    facebook_id: '109067049164902'
 - id:
     bioguide: S001187
     thomas: '02047'
@@ -358,6 +400,7 @@
     twitter: RepSteveStivers
     facebook: '116058275133542'
     youtube: RepSteveStivers
+    facebook_id: '116058275133542'
 - id:
     bioguide: S001186
     thomas: '02000'
@@ -366,6 +409,7 @@
     twitter: Rep_Southerland
     facebook: RepSteveSoutherland
     youtube: RepSteveSoutherland
+    facebook_id: '156234611092438'
 - id:
     bioguide: S001185
     thomas: '01988'
@@ -374,6 +418,7 @@
     twitter: RepTerriSewell
     facebook: RepSewell
     youtube: RepSewell
+    facebook_id: '117758198297225'
 - id:
     bioguide: S001184
     thomas: '02056'
@@ -382,6 +427,7 @@
     twitter: SenatorTimScott
     facebook: SenatorTimScott
     youtube: SenatorTimScott
+    facebook_id: '163207553711385'
 - id:
     bioguide: S001183
     thomas: '01994'
@@ -390,6 +436,7 @@
     twitter: RepDavid
     facebook: repdavidschweikert
     youtube: RepDavidSchweikert
+    facebook_id: '150338151681908'
 - id:
     bioguide: S001181
     thomas: '01901'
@@ -398,6 +445,7 @@
     twitter: SenatorShaheen
     facebook: SenatorShaheen
     youtube: senatorshaheen
+    facebook_id: '127503767282103'
 - id:
     bioguide: S001180
     thomas: '01950'
@@ -406,6 +454,7 @@
     twitter: repschrader
     facebook: repschrader
     youtube: repkurtschrader
+    facebook_id: '94978896695'
 - id:
     bioguide: S001179
     thomas: '01920'
@@ -414,6 +463,7 @@
     twitter: repaaronschock
     facebook: RepAaronSchock
     youtube: repaaronschock
+    facebook_id: '70882853544'
 - id:
     bioguide: S001177
     thomas: '01962'
@@ -421,6 +471,7 @@
   social:
     facebook: '153423912663'
     youtube: CongressmanSablan
+    facebook_id: '153423912663'
 - id:
     bioguide: S001176
     thomas: '01892'
@@ -429,6 +480,7 @@
     facebook: RepSteveScalise
     youtube: RepSteveScalise
     twitter: SteveScalise
+    facebook_id: '50936151681'
 - id:
     bioguide: S001175
     thomas: '01890'
@@ -437,6 +489,7 @@
     twitter: repspeier
     facebook: JackieSpeier
     youtube: JackieSpeierCA14
+    facebook_id: '99332606976'
 - id:
     bioguide: S001172
     thomas: '01860'
@@ -452,6 +505,7 @@
     twitter: RepSheaPorter
     facebook: RepSheaPorter
     youtube: RepCarolSheaPorter
+    facebook_id: '422460677824474'
 - id:
     bioguide: S001165
     thomas: '01818'
@@ -459,6 +513,7 @@
   social:
     twitter: Rep_Albio_Sires
     facebook: '81058818750'
+    facebook_id: '81058818750'
 - id:
     bioguide: S001162
     thomas: '01798'
@@ -466,6 +521,7 @@
   social:
     facebook: RepAllysonSchwartz
     youtube: repallysonschwartz
+    facebook_id: '244000962363116'
 - id:
     bioguide: S001157
     thomas: '01722'
@@ -474,6 +530,7 @@
     twitter: repdavidscott
     facebook: '113303673339'
     youtube: RepDavidScott
+    facebook_id: '113303673339'
 - id:
     bioguide: S001156
     thomas: '01757'
@@ -482,6 +539,7 @@
     twitter: replindasanchez
     facebook: CongresswomanLindaSanchez
     youtube: LindaTSanchez
+    facebook_id: '110685735673141'
 - id:
     bioguide: S001154
     thomas: '01681'
@@ -490,6 +548,7 @@
     twitter: RepBillShuster
     facebook: Rep.Shuster
     youtube: repshuster
+    facebook_id: '54386677806'
 - id:
     bioguide: S001150
     thomas: '01635'
@@ -498,6 +557,7 @@
     twitter: RepAdamSchiff
     facebook: RepAdamSchiff
     youtube: RepAdamSchiff
+    facebook_id: '9086721830'
 - id:
     bioguide: S001148
     thomas: '01590'
@@ -506,6 +566,7 @@
     twitter: CongMikeSimpson
     facebook: '96007744606'
     youtube: CongMikeSimpson
+    facebook_id: '96007744606'
 - id:
     bioguide: S001145
     thomas: '01588'
@@ -514,6 +575,7 @@
     twitter: janschakowsky
     facebook: janschakowsky
     youtube: repschakowsky
+    facebook_id: '160143957118'
 - id:
     bioguide: S001141
     thomas: '01548'
@@ -522,6 +584,7 @@
     twitter: SenatorSessions
     facebook: jeffsessions
     youtube: SenatorSessions
+    facebook_id: '23444159584'
 - id:
     bioguide: S000770
     thomas: '01531'
@@ -537,6 +600,7 @@
     twitter: LamarSmithTX21
     facebook: LamarSmithTX21
     youtube: lamarsmithtexas21
+    facebook_id: '107736785195'
 - id:
     bioguide: S000510
     thomas: '01528'
@@ -545,6 +609,7 @@
     twitter: Rep_Adam_Smith
     facebook: RepAdamSmith
     youtube: CongressmanAdamSmith
+    facebook_id: '288586617834523'
 - id:
     bioguide: S000480
     thomas: '01069'
@@ -553,6 +618,7 @@
     twitter: louiseslaughter
     facebook: RepLouiseSlaughter
     youtube: louiseslaughter
+    facebook_id: '82424647700'
 - id:
     bioguide: S000364
     thomas: '01527'
@@ -561,6 +627,7 @@
     twitter: RepShimkus
     facebook: repshimkus
     youtube: repshimkus
+    facebook_id: '123916254317516'
 - id:
     bioguide: S000344
     thomas: '01526'
@@ -568,6 +635,7 @@
   social:
     twitter: BradSherman
     facebook: '63158229861'
+    facebook_id: '63158229861'
 - id:
     bioguide: S000320
     thomas: '01049'
@@ -576,6 +644,7 @@
     twitter: SenShelbyPress
     facebook: RichardShelby
     youtube: SenatorRichardShelby
+    facebook_id: '50850514797'
 - id:
     bioguide: S000250
     thomas: '01525'
@@ -584,6 +653,7 @@
     twitter: petesessions
     facebook: petesessions
     youtube: PeteSessions
+    facebook_id: '367963843082'
 - id:
     bioguide: S000248
     thomas: '01042'
@@ -591,6 +661,7 @@
   social:
     twitter: repjoseserrano
     facebook: RepJoseSerrano
+    facebook_id: '273446508512'
 - id:
     bioguide: S000244
     thomas: '01041'
@@ -599,6 +670,7 @@
     twitter: JimPressOffice
     facebook: RepSensenbrenner
     youtube: RepSensenbrenner
+    facebook_id: ~
 - id:
     bioguide: S000185
     thomas: '01037'
@@ -607,6 +679,7 @@
     twitter: repbobbyscott
     facebook: CongressmanBobbyScott
     youtube: repbobbyscott
+    facebook_id: '123839200978190'
 - id:
     bioguide: S000148
     thomas: '01036'
@@ -615,6 +688,7 @@
     twitter: chuckschumer
     facebook: chuckschumer
     youtube: SenatorSchumer
+    facebook_id: '15771239406'
 - id:
     bioguide: S000033
     thomas: '01010'
@@ -623,6 +697,7 @@
     twitter: sensanders
     facebook: senatorsanders
     youtube: senatorsanders
+    facebook_id: '9124187907'
 - id:
     bioguide: S000030
     thomas: '01522'
@@ -631,6 +706,7 @@
     twitter: lorettasanchez
     facebook: LorettaSanchez
     youtube: LorettaSanchezLive
+    facebook_id: '90966961167'
 - id:
     bioguide: R000595
     thomas: '02084'
@@ -639,6 +715,7 @@
     twitter: SenRubioPress
     facebook: SenatorMarcoRubio
     youtube: SenatorMarcoRubio
+    facebook_id: '178910518800987'
 - id:
     bioguide: R000594
     thomas: '02039'
@@ -647,6 +724,7 @@
     twitter: RepJonRunyan
     facebook: congressmanjonrunyan
     youtube: RepRunyan
+    facebook_id: '177208315676754'
 - id:
     bioguide: R000593
     thomas: '02003'
@@ -655,6 +733,7 @@
     twitter: RepDennisRoss
     facebook: dennis.ross.376
     youtube: RepDennisRoss
+    facebook_id: '469477579757018'
 - id:
     bioguide: R000592
     thomas: '02017'
@@ -663,6 +742,7 @@
     twitter: ToddRokita
     facebook: RepToddRokita
     youtube: reptoddrokita
+    facebook_id: '183180288372896'
 - id:
     bioguide: R000591
     thomas: '01986'
@@ -671,6 +751,7 @@
     twitter: RepMarthaRoby
     facebook: Representative.Martha.Roby
     youtube: repmartharoby
+    facebook_id: '174519582574426'
 - id:
     bioguide: R000589
     thomas: '02068'
@@ -679,6 +760,7 @@
     twitter: repscottrigell
     facebook: RepScottRigell
     youtube: RepScottRigell
+    facebook_id: '167851429918010'
 - id:
     bioguide: R000588
     thomas: '02023'
@@ -686,6 +768,7 @@
   social:
     twitter: reprichmond
     facebook: RepRichmond
+    facebook_id: '197737020257085'
 - id:
     bioguide: R000587
     thomas: '02073'
@@ -694,6 +777,7 @@
     twitter: RepRibble
     facebook: CongressmanReidRibble
     youtube: RepRibble
+    facebook_id: '157169920997203'
 - id:
     bioguide: R000586
     thomas: '02048'
@@ -702,6 +786,7 @@
     twitter: repjimrenacci
     facebook: repjimrenacci
     youtube: repjimrenacci
+    facebook_id: '187639524595278'
 - id:
     bioguide: R000585
     thomas: '01982'
@@ -710,13 +795,14 @@
     twitter: RepTomReed
     facebook: RepTomReed
     youtube: CongressmanTomReed
+    facebook_id: '102449199835273'
 - id:
     bioguide: R000583
     thomas: '01916'
     govtrack: 412311
   social:
     twitter: TomRooney
-    facebook: 
+    facebook: ~
     youtube: CongressmanRooney
 - id:
     bioguide: R000582
@@ -726,6 +812,7 @@
     twitter: DrPhilRoe
     facebook: DrPhilRoe
     youtube: drphilroe
+    facebook_id: '130725126985966'
 - id:
     bioguide: R000580
     thomas: '01848'
@@ -740,6 +827,7 @@
     twitter: davereichert
     facebook: repdavereichert
     youtube: repdavereichert
+    facebook_id: '91504302598'
 - id:
     bioguide: R000577
     thomas: '01756'
@@ -748,6 +836,7 @@
     twitter: RepTimRyan
     facebook: timryan
     youtube: timryanvision
+    facebook_id: '121560497865'
 - id:
     bioguide: R000576
     thomas: '01728'
@@ -756,6 +845,7 @@
     twitter: Call_Me_Dutch
     facebook: '184756771570504'
     youtube: ruppersberger
+    facebook_id: '184756771570504'
 - id:
     bioguide: R000575
     thomas: '01704'
@@ -764,6 +854,7 @@
     twitter: RepMikeRogersAL
     facebook: '171770326187035'
     youtube: MikeRogersAL03
+    facebook_id: '171770326187035'
 - id:
     bioguide: R000572
     thomas: '01651'
@@ -772,6 +863,7 @@
     twitter: RepMikeRogers
     facebook: '168209963203416'
     youtube: RepMikeRogers
+    facebook_id: '168209963203416'
 - id:
     bioguide: R000570
     thomas: '01560'
@@ -780,6 +872,7 @@
     twitter: reppaulryan
     facebook: reppaulryan
     youtube: reppaulryan
+    facebook_id: '7123827676'
 - id:
     bioguide: R000515
     thomas: '01003'
@@ -788,6 +881,7 @@
     twitter: RepBobbyRush
     facebook: congressmanbobbyrush
     youtube: CongressmanRush
+    facebook_id: '230753786936538'
 - id:
     bioguide: R000487
     thomas: '00998'
@@ -796,6 +890,7 @@
     twitter: RepEdRoyce
     facebook: EdRoyce
     youtube: RepEdRoyce
+    facebook_id: '6460640558'
 - id:
     bioguide: R000486
     thomas: '00997'
@@ -804,6 +899,7 @@
     twitter: RepRoybalAllard
     facebook: RepRoybalAllard
     youtube: RepRoybalAllard
+    facebook_id: '139773069370563'
 - id:
     bioguide: R000435
     thomas: '00985'
@@ -812,6 +908,7 @@
     twitter: RosLehtinen
     facebook: iroslehtinen
     youtube: IleanaRosLehtinen
+    facebook_id: '286546974761109'
 - id:
     bioguide: R000395
     thomas: '00977'
@@ -820,6 +917,7 @@
     twitter: RepHalRogers
     facebook: CongressmanHalRogers
     youtube: RepHalRogers
+    facebook_id: '6722039085'
 - id:
     bioguide: R000361
     thomas: '01424'
@@ -828,6 +926,7 @@
     twitter: senrockefeller
     facebook: SenRockefeller
     youtube: SenatorRockefeller
+    facebook_id: '134189283320639'
 - id:
     bioguide: R000307
     thomas: '00968'
@@ -836,6 +935,7 @@
     twitter: senpatroberts
     facebook: SenPatRoberts
     youtube: SenPatRoberts
+    facebook_id: '205694792808927'
 - id:
     bioguide: R000146
     thomas: '00952'
@@ -844,6 +944,7 @@
     twitter: SenatorReid
     facebook: SenatorReid
     youtube: SenatorReid
+    facebook_id: '360249323990357'
 - id:
     bioguide: R000122
     thomas: '00949'
@@ -852,6 +953,7 @@
     twitter: SenJackReed
     facebook: SenJackReed
     youtube: SenatorReed
+    facebook_id: '213866375370646'
 - id:
     bioguide: R000053
     thomas: '00944'
@@ -860,6 +962,7 @@
     twitter: cbrangel
     facebook: CBRangel
     youtube: RepRangel
+    facebook_id: '7390589055'
 - id:
     bioguide: R000011
     thomas: '00940'
@@ -867,6 +970,7 @@
   social:
     facebook: NickRahall
     youtube: NRAHALLWV03
+    facebook_id: '357958026910'
 - id:
     bioguide: Q000023
     thomas: '01967'
@@ -875,6 +979,7 @@
     twitter: RepMikeQuigley
     facebook: repmikequigley
     youtube: RepMikeQuigley
+    facebook_id: '158963645688'
 - id:
     bioguide: P000603
     thomas: '02082'
@@ -883,6 +988,7 @@
     twitter: SenRandPaul
     facebook: SenatorRandPaul
     youtube: SenatorRandPaul
+    facebook_id: '161355253917286'
 - id:
     bioguide: P000602
     thomas: '02022'
@@ -891,6 +997,7 @@
     twitter: repmikepompeo
     facebook: CongressmanPompeo
     youtube: congressmanpompeo
+    facebook_id: '101965369880683'
 - id:
     bioguide: P000601
     thomas: '02035'
@@ -899,6 +1006,7 @@
     twitter: congpalazzo
     facebook: stevenpalazzo
     youtube: CongressmanPalazzo
+    facebook_id: '186908658003781'
 - id:
     bioguide: P000599
     thomas: '01915'
@@ -907,6 +1015,7 @@
     twitter: congbillposey
     facebook: bill.posey15
     youtube: CongressmanPosey
+    facebook_id: '100000080395369'
 - id:
     bioguide: P000598
     thomas: '01910'
@@ -915,6 +1024,7 @@
     twitter: RepPolisPress
     facebook: jaredpolis
     youtube: JaredPolis31275
+    facebook_id: '53481427529'
 - id:
     bioguide: P000597
     thomas: '01927'
@@ -923,6 +1033,7 @@
     twitter: chelliepingree
     facebook: ChelliePingree
     youtube: congresswomanpingree
+    facebook_id: '91529332807'
 - id:
     bioguide: P000596
     thomas: '01953'
@@ -937,6 +1048,7 @@
     twitter: RepGaryPeters
     facebook: RepGaryPeters
     youtube: RepGaryPeters
+    facebook_id: '88851604323'
 - id:
     bioguide: P000594
     thomas: '01930'
@@ -945,6 +1057,7 @@
     twitter: RepErikPaulsen
     facebook: CongressmanErikPaulsen
     youtube: reperikpaulsen
+    facebook_id: '128558293848160'
 - id:
     bioguide: P000593
     thomas: '01835'
@@ -953,6 +1066,7 @@
     twitter: RepPerlmutter
     facebook: RepPerlmutter
     youtube: RepPerlmutter
+    facebook_id: '86174496459'
 - id:
     bioguide: P000592
     thomas: '01802'
@@ -961,6 +1075,7 @@
     twitter: JudgeTedPoe
     facebook: '106631626049851'
     youtube: CongressmanTedPoe
+    facebook_id: '106631626049851'
 - id:
     bioguide: P000591
     thomas: '01778'
@@ -969,6 +1084,7 @@
     twitter: RepTomPrice
     facebook: reptomprice
     youtube: RepTomPrice
+    facebook_id: '172032960420'
 - id:
     bioguide: P000590
     thomas: '01701'
@@ -977,6 +1093,7 @@
     twitter: senmarkpryor
     facebook: MarkPryor
     youtube: senatorpryor
+    facebook_id: '9248638978'
 - id:
     bioguide: P000588
     thomas: '01738'
@@ -985,6 +1102,7 @@
     twitter: RepStevePearce
     facebook: RepStevePearce
     youtube: NMStevePearce
+    facebook_id: '180280568662135'
 - id:
     bioguide: P000523
     thomas: '00930'
@@ -1000,6 +1118,7 @@
     twitter: robportman
     facebook: robportman
     youtube: SenRobPortman
+    facebook_id: '45243961073'
 - id:
     bioguide: P000373
     thomas: '01514'
@@ -1008,6 +1127,7 @@
     twitter: RepJoePitts
     facebook: '94156528752'
     youtube: congressmanjoepitts
+    facebook_id: '94156528752'
 - id:
     bioguide: P000265
     thomas: '00912'
@@ -1015,6 +1135,7 @@
   social:
     facebook: thomaspetri
     youtube: TomPetri
+    facebook_id: ~
 - id:
     bioguide: P000197
     thomas: '00905'
@@ -1023,6 +1144,7 @@
     twitter: NancyPelosi
     facebook: NancyPelosi
     youtube: nancypelosi
+    facebook_id: '86574174383'
 - id:
     bioguide: P000096
     thomas: '01510'
@@ -1031,6 +1153,7 @@
     twitter: BillPascrell
     facebook: pascrell
     youtube: RepPascrell
+    facebook_id: '303312929155'
 - id:
     bioguide: P000034
     thomas: '00887'
@@ -1039,6 +1162,7 @@
     twitter: FrankPallone
     facebook: repfrankpallone
     youtube: repfrankpallone
+    facebook_id: '6517277731'
 - id:
     bioguide: O000169
     thomas: '01974'
@@ -1047,6 +1171,7 @@
     twitter: BillOwensNY
     facebook: repbillowens
     youtube: RepBillOwens
+    facebook_id: '132985523396856'
 - id:
     bioguide: O000168
     thomas: '01955'
@@ -1054,6 +1179,7 @@
   social:
     twitter: OlsonPressShop
     facebook: '20718168936'
+    facebook_id: '20718168936'
 - id:
     bioguide: N000186
     thomas: '02034'
@@ -1062,6 +1188,7 @@
     twitter: repalannunnelee
     facebook: CongressmanNunnelee
     youtube: congressmannunnelee
+    facebook_id: '144919278895639'
 - id:
     bioguide: N000185
     thomas: '02001'
@@ -1070,6 +1197,7 @@
     twitter: RepRichNugent
     facebook: RepRichNugent
     youtube: RepRichNugent
+    facebook_id: '183541871674897'
 - id:
     bioguide: N000184
     thomas: '02060'
@@ -1085,6 +1213,7 @@
     twitter: RandyNeugebauer
     facebook: rep.randy.neugebauer
     youtube: RandyNeugebauer
+    facebook_id: '64137294987'
 - id:
     bioguide: N000181
     thomas: '01710'
@@ -1100,6 +1229,7 @@
     twitter: gracenapolitano
     facebook: RepGraceNapolitano
     youtube: RepGraceNapolitano
+    facebook_id: '163108420409412'
 - id:
     bioguide: N000147
     thomas: '00868'
@@ -1108,6 +1238,7 @@
     twitter: EleanorNorton
     facebook: CongresswomanNorton
     youtube: EleanorHNorton
+    facebook_id: '61731840657'
 - id:
     bioguide: N000032
     thomas: '00859'
@@ -1123,6 +1254,7 @@
     twitter: RepRichardNeal
     facebook: '325642654132598'
     youtube: RepRichardENeal
+    facebook_id: '325642654132598'
 - id:
     bioguide: N000002
     thomas: '00850'
@@ -1131,6 +1263,7 @@
     twitter: RepJerryNadler
     facebook: CongressmanNadler
     youtube: congressmannadler
+    facebook_id: '78291598977'
 - id:
     bioguide: M001183
     thomas: '01983'
@@ -1139,6 +1272,7 @@
     twitter: Sen_JoeManchin
     facebook: JoeManchinIII
     youtube: SenatorJoeManchin
+    facebook_id: '10150135395755161'
 - id:
     bioguide: M001182
     thomas: '02059'
@@ -1147,6 +1281,7 @@
     twitter: repmickmulvaney
     facebook: MulvaneySC5
     youtube: RepMickMulvaney
+    facebook_id: '188649667827713'
 - id:
     bioguide: M001181
     thomas: '02052'
@@ -1155,6 +1290,7 @@
     twitter: repmeehan
     facebook: CongressmanPatrickMeehan
     youtube: repmeehan
+    facebook_id: '136000283132824'
 - id:
     bioguide: M001180
     thomas: '02074'
@@ -1163,6 +1299,7 @@
     twitter: RepMcKinley
     facebook: RepMcKinley
     youtube: RepDavidMcKinley
+    facebook_id: '130377260362609'
 - id:
     bioguide: M001179
     thomas: '02053'
@@ -1171,6 +1308,7 @@
     twitter: RepTomMarino
     facebook: '144408762280226'
     youtube: RepMarino
+    facebook_id: '144408762280226'
 - id:
     bioguide: M001177
     thomas: '01908'
@@ -1179,6 +1317,7 @@
     twitter: RepMcClintock
     facebook: '81125319109'
     youtube: McClintockCA04
+    facebook_id: '81125319109'
 - id:
     bioguide: M001176
     thomas: '01900'
@@ -1187,6 +1326,7 @@
     twitter: SenJeffMerkley
     facebook: jeffmerkley
     youtube: SenatorJeffMerkley
+    facebook_id: '74374931545'
 - id:
     bioguide: M001170
     thomas: '01820'
@@ -1195,6 +1335,7 @@
     twitter: mccaskilloffice
     facebook: senatormccaskill
     youtube: SenatorMcCaskill
+    facebook_id: '131498087618'
 - id:
     bioguide: M001166
     thomas: '01832'
@@ -1203,6 +1344,7 @@
     twitter: RepMcNerney
     facebook: jerrymcnerney
     youtube: RepJerryMcNerney
+    facebook_id: '215241308510238'
 - id:
     bioguide: M001165
     thomas: '01833'
@@ -1211,6 +1353,7 @@
     twitter: GOPWhip
     facebook: CongressmanKevinMcCarthy
     youtube: repkevinmccarthy
+    facebook_id: '51052893175'
 - id:
     bioguide: M001163
     thomas: '01814'
@@ -1219,6 +1362,7 @@
     twitter: DorisMatsui
     facebook: doris.matsui
     youtube: RepDorisMatsui
+    facebook_id: ~
 - id:
     bioguide: M001160
     thomas: '01811'
@@ -1227,6 +1371,7 @@
     twitter: RepGwenMoore
     facebook: GwenSMoore
     youtube: RepGwenMoore
+    facebook_id: '58864029545'
 - id:
     bioguide: M001159
     thomas: '01809'
@@ -1235,6 +1380,7 @@
     twitter: cathymcmorris
     facebook: mcmorrisrodgers
     youtube: mcmorrisrodgers
+    facebook_id: '321618789771'
 - id:
     bioguide: M001158
     thomas: '01806'
@@ -1243,6 +1389,7 @@
     twitter: RepKenMarchant
     facebook: RepKennyMarchant
     youtube: RepKennyMarchant
+    facebook_id: '6349487899'
 - id:
     bioguide: M001157
     thomas: '01804'
@@ -1251,6 +1398,7 @@
     twitter: McCaulPressShop
     facebook: michaeltmccaul
     youtube: MichaelTMcCaul
+    facebook_id: '6355254859'
 - id:
     bioguide: M001156
     thomas: '01792'
@@ -1259,6 +1407,7 @@
     twitter: PatrickMcHenry
     facebook: CongressmanMcHenry
     youtube: CongressmanMcHenry
+    facebook_id: '8045519803'
 - id:
     bioguide: M001153
     thomas: '01694'
@@ -1267,6 +1416,7 @@
     twitter: lisamurkowski
     facebook: SenLisaMurkowski
     youtube: senatormurkowski
+    facebook_id: '25271170290'
 - id:
     bioguide: M001151
     thomas: '01744'
@@ -1275,6 +1425,7 @@
     twitter: RepTimMurphy
     facebook: reptimmurphy
     youtube: TimMurphyPA18
+    facebook_id: '105769762798552'
 - id:
     bioguide: M001150
     thomas: '01731'
@@ -1283,6 +1434,7 @@
     twitter: CandiceMiller
     facebook: CongresswomanCandiceMiller
     youtube: candicemi10
+    facebook_id: '210401648605'
 - id:
     bioguide: M001149
     thomas: '01730'
@@ -1291,13 +1443,15 @@
     twitter: RepMikeMichaud
     facebook: RepMikeMichaud
     youtube: repmikemichaud
+    facebook_id: '131279995382'
 - id:
     bioguide: M001144
     thomas: '01685'
     govtrack: 400279
   social:
-    facebook: '66367876671'
+    facebook: RepJeffMiller
     youtube: RepJeffMiller
+    facebook_id: '66367876671'
 - id:
     bioguide: M001143
     thomas: '01653'
@@ -1305,6 +1459,7 @@
   social:
     twitter: BettyMcCollum04
     facebook: repbettymccollum
+    facebook_id: '153386471383393'
 - id:
     bioguide: M001142
     thomas: '01671'
@@ -1313,6 +1468,7 @@
     twitter: RepJimMatheson
     facebook: RepJimMatheson
     youtube: RepJimMatheson
+    facebook_id: '131888123517015'
 - id:
     bioguide: M001139
     thomas: '01584'
@@ -1321,6 +1477,7 @@
     twitter: repgarymiller
     facebook: RepGaryMiller
     youtube: GaryGMiller
+    facebook_id: '105352226181045'
 - id:
     bioguide: M001137
     thomas: '01506'
@@ -1329,6 +1486,7 @@
     twitter: GregoryMeeks
     facebook: gregory.meeks
     youtube: gwmeeks
+    facebook_id: '1557025818'
 - id:
     bioguide: M001111
     thomas: '01409'
@@ -1344,6 +1502,7 @@
     twitter: JerryMoran
     facebook: jerrymoran
     youtube: senatorjerrymoran
+    facebook_id: '171578807105'
 - id:
     bioguide: M000933
     thomas: '00832'
@@ -1352,6 +1511,7 @@
     twitter: Jim_Moran
     facebook: RepJimMoran
     youtube: RepJamesPMoran
+    facebook_id: '100123453059'
 - id:
     bioguide: M000725
     thomas: '00808'
@@ -1360,6 +1520,7 @@
     twitter: askgeorge
     facebook: repgeorgemiller
     youtube: RepGeorgeMiller
+    facebook_id: '75298637905'
 - id:
     bioguide: M000702
     thomas: '00802'
@@ -1368,6 +1529,7 @@
     twitter: senatorbarb
     facebook: SenatorMikulski
     youtube: senatormikulski
+    facebook_id: '142890125771427'
 - id:
     bioguide: M000689
     thomas: '00800'
@@ -1375,6 +1537,7 @@
   social:
     facebook: JohnMica
     youtube: RepJohnMica
+    facebook_id: ~
 - id:
     bioguide: M000639
     thomas: '00791'
@@ -1383,6 +1546,7 @@
     twitter: SenatorMenendez
     facebook: senatormenendez
     youtube: SenatorMenendezNJ
+    facebook_id: '349744811357'
 - id:
     bioguide: M000508
     thomas: '00778'
@@ -1391,6 +1555,7 @@
     twitter: BuckMcKeon
     facebook: BuckMcKeon
     youtube: BuckMcKeon
+    facebook_id: '8138529578'
 - id:
     bioguide: M000485
     thomas: '01505'
@@ -1399,6 +1564,7 @@
     twitter: repmikemcintyre
     facebook: mikemcintyre
     youtube: RepMikeMcIntyre
+    facebook_id: '340903514856'
 - id:
     bioguide: M000404
     thomas: '00766'
@@ -1407,6 +1573,7 @@
     twitter: RepJimMcDermott
     facebook: CongressmanJimMcDermott
     youtube: RepJimMcDermott
+    facebook_id: '246418928093'
 - id:
     bioguide: M000355
     thomas: '01395'
@@ -1414,6 +1581,7 @@
   social:
     twitter: McConnellPress
     facebook: mitchmcconnell
+    facebook_id: ~
 - id:
     bioguide: M000312
     thomas: '01504'
@@ -1436,6 +1604,7 @@
     twitter: SenJohnMcCain
     facebook: johnmccain
     youtube: SenatorJohnMcCain
+    facebook_id: '6425923706'
 - id:
     bioguide: M000133
     thomas: '00735'
@@ -1444,6 +1613,7 @@
     twitter: markeymemo
     facebook: EdJMarkey
     youtube: RepMarkey
+    facebook_id: '6846731378'
 - id:
     bioguide: M000087
     thomas: '00729'
@@ -1458,6 +1628,7 @@
     twitter: SenMikeLee
     facebook: senatormikelee
     youtube: senatormikelee
+    facebook_id: '178081365556898'
 - id:
     bioguide: L000576
     thomas: '02033'
@@ -1465,6 +1636,7 @@
   social:
     facebook: Rep.Billy.Long
     youtube: MOdistrict7
+    facebook_id: '139631049438354'
 - id:
     bioguide: L000575
     thomas: '02050'
@@ -1473,6 +1645,7 @@
     twitter: replankford
     facebook: RepLankford
     youtube: replankford
+    facebook_id: '130873066975024'
 - id:
     bioguide: L000573
     thomas: '02011'
@@ -1481,6 +1654,7 @@
     twitter: Raul_Labrador
     facebook: raul.r.labrador
     youtube: RepLabrador
+    facebook_id: '180970951936493'
 - id:
     bioguide: L000571
     thomas: '01960'
@@ -1489,6 +1663,7 @@
     twitter: CynthiaLummis
     facebook: '152754318103332'
     youtube: CynthiaLummis
+    facebook_id: '152754318103332'
 - id:
     bioguide: L000570
     thomas: '01939'
@@ -1497,6 +1672,7 @@
     twitter: repbenraylujan
     facebook: RepBenRayLujan
     youtube: Repbenraylujan
+    facebook_id: '112962521120'
 - id:
     bioguide: L000569
     thomas: '01931'
@@ -1504,6 +1680,7 @@
   social:
     facebook: BlaineLuetkemeyer
     youtube: BLuetkemeyer
+    facebook_id: '1358702716'
 - id:
     bioguide: L000567
     thomas: '01936'
@@ -1511,6 +1688,7 @@
   social:
     facebook: CongressmanLance
     youtube: CongressmanLance
+    facebook_id: '100830109970339'
 - id:
     bioguide: L000566
     thomas: '01885'
@@ -1519,6 +1697,7 @@
     twitter: boblatta
     facebook: boblatta
     youtube: CongressmanBobLatta
+    facebook_id: '100000004848334'
 - id:
     bioguide: L000565
     thomas: '01846'
@@ -1527,6 +1706,7 @@
     twitter: daveloebsack
     facebook: DaveLoebsack
     youtube: congressmanloebsack
+    facebook_id: '291731316748'
 - id:
     bioguide: L000564
     thomas: '01834'
@@ -1535,6 +1715,7 @@
     twitter: RepDLamborn
     facebook: CongressmanDougLamborn
     youtube: CongressmanLamborn
+    facebook_id: '45059452286'
 - id:
     bioguide: L000563
     thomas: '01781'
@@ -1543,6 +1724,7 @@
     facebook: repdanlipinski
     youtube: lipinski03
     twitter: replipinski
+    facebook_id: '103286879730089'
 - id:
     bioguide: L000562
     thomas: '01686'
@@ -1551,6 +1733,7 @@
     twitter: RepStephenLynch
     facebook: repstephenlynch
     youtube: RepLynch
+    facebook_id: '133720816696865'
 - id:
     bioguide: L000560
     thomas: '01675'
@@ -1559,6 +1742,7 @@
     twitter: RepRickLarsen
     facebook: RepRickLarsen
     youtube: congressmanlarsen
+    facebook_id: '135654683137079'
 - id:
     bioguide: L000559
     thomas: '01668'
@@ -1567,6 +1751,7 @@
     twitter: jimlangevin
     facebook: CongressmanJimLangevin
     youtube: jimlangevin
+    facebook_id: '6578978441'
 - id:
     bioguide: L000557
     thomas: '01583'
@@ -1575,6 +1760,7 @@
     twitter: repjohnlarson
     facebook: RepJohnLarson
     youtube: RepJohnLarson
+    facebook_id: '6352928631'
 - id:
     bioguide: L000554
     thomas: '00699'
@@ -1583,6 +1769,7 @@
     twitter: RepLoBiondo
     facebook: FrankLoBiondo
     youtube: USRepFrankLoBiondo
+    facebook_id: ~
 - id:
     bioguide: L000551
     thomas: '01501'
@@ -1591,6 +1778,7 @@
     twitter: repbarbaralee
     facebook: RepBarbaraLee
     youtube: RepLee
+    facebook_id: '92190287786'
 - id:
     bioguide: L000550
     thomas: '01546'
@@ -1599,6 +1787,7 @@
     twitter: senlandrieu
     facebook: senatormarylandrieu
     youtube: senatorlandrieu
+    facebook_id: '122518851125820'
 - id:
     bioguide: L000491
     thomas: '00711'
@@ -1606,6 +1795,7 @@
   social:
     facebook: '7872057395'
     youtube: RepFrankLucas
+    facebook_id: '7872057395'
 - id:
     bioguide: L000480
     thomas: '00709'
@@ -1614,6 +1804,7 @@
     twitter: NitaLowey
     facebook: RepLowey
     youtube: nitalowey
+    facebook_id: '158290607551599'
 - id:
     bioguide: L000397
     thomas: '00701'
@@ -1621,6 +1812,7 @@
   social:
     twitter: RepZoeLofgren
     facebook: zoelofgren
+    facebook_id: '221191600719'
 - id:
     bioguide: L000287
     thomas: '00688'
@@ -1629,6 +1821,7 @@
     twitter: RepJohnLewis
     facebook: RepJohnLewis
     youtube: repjohnlewis
+    facebook_id: '82737208404'
 - id:
     bioguide: L000263
     thomas: '00683'
@@ -1637,6 +1830,7 @@
     twitter: repsandylevin
     facebook: RepSandyLevin
     youtube: mi12yes
+    facebook_id: '223726364320243'
 - id:
     bioguide: L000261
     thomas: '01384'
@@ -1645,6 +1839,7 @@
     twitter: sencarllevin
     facebook: carllevin
     youtube: SenCarlLevin
+    facebook_id: '7481814545'
 - id:
     bioguide: L000174
     thomas: '01383'
@@ -1653,6 +1848,7 @@
     twitter: SenatorLeahy
     facebook: SenatorPatrickLeahy
     youtube: SenatorPatrickLeahy
+    facebook_id: '178569152181267'
 - id:
     bioguide: L000123
     thomas: '01381'
@@ -1660,6 +1856,7 @@
   social:
     twitter: franklautenberg
     facebook: franklautenberg
+    facebook_id: '121816241167991'
 - id:
     bioguide: L000111
     thomas: '00666'
@@ -1668,6 +1865,7 @@
     twitter: TomLatham
     facebook: tom.latham.733
     youtube: CongressmanTomLatham
+    facebook_id: '345331988887412'
 - id:
     bioguide: K000378
     thomas: '02014'
@@ -1676,6 +1874,7 @@
     twitter: RepKinzinger
     facebook: RepKinzinger
     youtube: RepAdamKinzinger
+    facebook_id: '187811174579106'
 - id:
     bioguide: K000376
     thomas: '02051'
@@ -1684,6 +1883,7 @@
     twitter: MikeKellyPA
     facebook: '191056827594903'
     youtube: repmikekelly
+    facebook_id: '191056827594903'
 - id:
     bioguide: K000375
     thomas: '02025'
@@ -1692,6 +1892,7 @@
     twitter: USRepKeating
     facebook: Congressman.Keating
     youtube: RepBillKeating
+    facebook_id: '183092598372008'
 - id:
     bioguide: K000363
     thomas: '01733'
@@ -1707,6 +1908,7 @@
     twitter: stevekingia
     facebook: stevekingia
     youtube: stevekingia
+    facebook_id: '134325379926458'
 - id:
     bioguide: K000360
     thomas: '01647'
@@ -1715,6 +1917,7 @@
     twitter: senatorkirk
     facebook: SenatorKirk
     youtube: SenatorKirk
+    facebook_id: '116381528428230'
 - id:
     bioguide: K000220
     thomas: '00636'
@@ -1723,6 +1926,7 @@
     twitter: JackKingston
     facebook: JackKingston
     youtube: jackkingston
+    facebook_id: '6914617307'
 - id:
     bioguide: K000210
     thomas: '00635'
@@ -1738,6 +1942,7 @@
     twitter: repronkind
     facebook: repronkind
     youtube: RepRonKind
+    facebook_id: '89152017954'
 - id:
     bioguide: K000009
     thomas: '00616'
@@ -1746,6 +1951,7 @@
     twitter: RepMarcyKaptur
     facebook: RepresentativeMarcyKaptur
     youtube: USRepMarcyKaptur
+    facebook_id: '173753129419169'
 - id:
     bioguide: J000293
     thomas: '02086'
@@ -1754,6 +1960,7 @@
     twitter: SenRonJohnson
     facebook: senronjohnson
     youtube: SenatorRonJohnson
+    facebook_id: '186181661410703'
 - id:
     bioguide: J000292
     thomas: '02046'
@@ -1762,6 +1969,7 @@
     twitter: repbilljohnson
     facebook: RepBillJohnson
     youtube: RepBillJohnson
+    facebook_id: '170477096312258'
 - id:
     bioguide: J000291
     thomas: '01899'
@@ -1770,6 +1978,7 @@
     twitter: Mike_Johanns
     facebook: MikeJohanns
     youtube: SenatorMikeJohanns
+    facebook_id: '399357233834'
 - id:
     bioguide: J000290
     thomas: '01921'
@@ -1778,6 +1987,7 @@
     twitter: RepLynnJenkins
     facebook: replynnjenkins
     youtube: RepLynnJenkins
+    facebook_id: '6974973662'
 - id:
     bioguide: J000289
     thomas: '01868'
@@ -1786,6 +1996,7 @@
     twitter: Jim_Jordan
     facebook: repjimjordan
     youtube: RepJimJordan
+    facebook_id: '35499336459'
 - id:
     bioguide: J000288
     thomas: '01843'
@@ -1794,6 +2005,7 @@
     twitter: RepHankJohnson
     facebook: '115356957005'
     youtube: RepHankJohnson
+    facebook_id: '115356957005'
 - id:
     bioguide: J000255
     thomas: '00612'
@@ -1802,6 +2014,7 @@
     twitter: RepWalterJones
     facebook: '15083070102'
     youtube: RepWalterJones
+    facebook_id: '15083070102'
 - id:
     bioguide: J000177
     thomas: '00604'
@@ -1810,6 +2023,7 @@
     twitter: SenJohnsonSD
     facebook: Senator-Tim-Johnson
     youtube: senatorjohnson
+    facebook_id: '181659658522485'
 - id:
     bioguide: J000174
     thomas: '00603'
@@ -1818,6 +2032,7 @@
     twitter: SamsPressShop
     facebook: RepSamJohnson
     youtube: RepSamJohnson
+    facebook_id: '52454091867'
 - id:
     bioguide: J000126
     thomas: '00599'
@@ -1826,6 +2041,7 @@
     twitter: RepEBJ
     facebook: CongresswomanEBJtx30
     youtube: RepEddieBJohnson
+    facebook_id: '84096022067'
 - id:
     bioguide: J000032
     thomas: '00588'
@@ -1834,6 +2050,7 @@
     twitter: JacksonLeeTX18
     facebook: '169479190984'
     youtube: TX18SJL
+    facebook_id: '169479190984'
 - id:
     bioguide: I000057
     thomas: '01663'
@@ -1842,6 +2059,7 @@
     twitter: RepSteveIsrael
     facebook: RepSteveIsrael
     youtube: repsteveisrael
+    facebook_id: ~
 - id:
     bioguide: I000056
     thomas: '01640'
@@ -1850,6 +2068,7 @@
     twitter: DarrellIssa
     facebook: darrellissa
     youtube: repdarrellissa
+    facebook_id: '19463427992'
 - id:
     bioguide: I000024
     thomas: '00583'
@@ -1858,6 +2077,7 @@
     twitter: InhofePress
     facebook: jiminhofe
     youtube: jiminhofepressoffice
+    facebook_id: '55018309421'
 - id:
     bioguide: H001063
     thomas: '02089'
@@ -1866,6 +2086,7 @@
     twitter: Rep_JaniceHahn
     facebook: RepJaniceHahn
     youtube: RepJaniceHahn
+    facebook_id: '256471267712118'
 - id:
     bioguide: H001061
     thomas: '02079'
@@ -1874,6 +2095,7 @@
     twitter: SenJohnHoeven
     facebook: SenatorJohnHoeven
     youtube: senatorjohnhoevennd
+    facebook_id: '194483057244478'
 - id:
     bioguide: H001060
     thomas: '02069'
@@ -1882,6 +2104,7 @@
     twitter: RepRobertHurt
     facebook: RepRobertHurt
     youtube: RepRobertHurt
+    facebook_id: '120068161395562'
 - id:
     bioguide: H001059
     thomas: '02015'
@@ -1890,6 +2113,7 @@
     twitter: rephultgren
     facebook: RepHultgren
     youtube: rephultgren
+    facebook_id: '186221644739359'
 - id:
     bioguide: H001058
     thomas: '02028'
@@ -1898,6 +2122,7 @@
     twitter: rephuizenga
     facebook: RepHuizenga
     youtube: RepHuizenga
+    facebook_id: '145764842143763'
 - id:
     bioguide: H001057
     thomas: '02020'
@@ -1906,6 +2131,7 @@
     twitter: conghuelskamp
     facebook: congressmanhuelskamp
     youtube: congressmanhuelskamp
+    facebook_id: ~
 - id:
     bioguide: H001056
     thomas: '02071'
@@ -1914,6 +2140,7 @@
     twitter: herrerabeutler
     facebook: herrerabeutler
     youtube: RepHerreraBeutler
+    facebook_id: '177551525610164'
 - id:
     bioguide: H001055
     thomas: '02040'
@@ -1922,6 +2149,7 @@
     twitter: RepJoeHeck
     facebook: RepJoeHeck
     youtube: repjoeheck
+    facebook_id: '155211751194624'
 - id:
     bioguide: H001053
     thomas: '02032'
@@ -1930,6 +2158,7 @@
     twitter: RepHartzler
     facebook: Congresswoman.Hartzler
     youtube: repvickyhartzler
+    facebook_id: '183580061667324'
 - id:
     bioguide: H001051
     thomas: '02044'
@@ -1938,6 +2167,7 @@
     twitter: RepRichardHanna
     facebook: reprichardhanna
     youtube: reprichardhanna
+    facebook_id: '172284859480630'
 - id:
     bioguide: H001050
     thomas: '02010'
@@ -1946,6 +2176,7 @@
     twitter: RepHanabusa
     facebook: '169979129710178'
     youtube: rephanabusa
+    facebook_id: '169979129710178'
 - id:
     bioguide: H001049
     thomas: '01902'
@@ -1954,6 +2185,7 @@
     twitter: SenatorHagan
     facebook: SenatorHagan
     youtube: SenatorHagan
+    facebook_id: '7871449189'
 - id:
     bioguide: H001048
     thomas: '01909'
@@ -1962,6 +2194,7 @@
     twitter: Rep_Hunter
     facebook: DuncanHunter
     youtube: CongressmanHunter
+    facebook_id: '79072979038'
 - id:
     bioguide: H001047
     thomas: '01913'
@@ -1970,6 +2203,7 @@
     twitter: jahimes
     facebook: CongressmanJimHimes
     youtube: congressmanhimes
+    facebook_id: '85767418619'
 - id:
     bioguide: H001046
     thomas: '01937'
@@ -1978,6 +2212,7 @@
     twitter: martinheinrich
     facebook: MartinHeinrich
     youtube: SenMartinHeinrich
+    facebook_id: '137523189213'
 - id:
     bioguide: H001045
     thomas: '01933'
@@ -1986,6 +2221,7 @@
     twitter: GreggHarper
     facebook: GreggHarper
     youtube: congressmanharper
+    facebook_id: '48248435938'
 - id:
     bioguide: H001042
     thomas: '01844'
@@ -2000,6 +2236,7 @@
     twitter: SenDeanHeller
     facebook: SenDeanHeller
     youtube: SenDeanHeller
+    facebook_id: '325751330177'
 - id:
     bioguide: H001038
     thomas: '01794'
@@ -2008,6 +2245,7 @@
     twitter: RepBrianHiggins
     facebook: RepBrianHiggins
     youtube: CongressmanHiggins
+    facebook_id: '88144056440'
 - id:
     bioguide: H001036
     thomas: '01749'
@@ -2016,6 +2254,7 @@
     twitter: RepHensarling
     facebook: RepHensarling
     youtube: repjebhensarling
+    facebook_id: '7875604788'
 - id:
     bioguide: H001034
     thomas: '01634'
@@ -2024,6 +2263,7 @@
     twitter: RepMikeHonda
     facebook: RepMikeHonda
     youtube: RepMikeHonda
+    facebook_id: '15675385380'
 - id:
     bioguide: H000874
     thomas: '00566'
@@ -2032,6 +2272,7 @@
     twitter: WhipHoyer
     facebook: WhipHoyer
     youtube: LeaderHoyer
+    facebook_id: '282861997886'
 - id:
     bioguide: H000636
     thomas: '01490'
@@ -2040,6 +2281,7 @@
     twitter: USRepRHinojosa
     facebook: CongressmanRubenHinojosa
     youtube: RepRubenHinojosa
+    facebook_id: '402891225161'
 - id:
     bioguide: H000338
     thomas: '01351'
@@ -2055,6 +2297,7 @@
     twitter: DocHastings
     facebook: RepDocHastings
     youtube: RepDocHastings
+    facebook_id: '7507129675'
 - id:
     bioguide: H000324
     thomas: '00511'
@@ -2062,6 +2305,7 @@
   social:
     facebook: '95696782238'
     youtube: RepAlceeHastings
+    facebook_id: '95696782238'
 - id:
     bioguide: H000206
     thomas: '00501'
@@ -2070,6 +2314,7 @@
     twitter: SenatorHarkin
     facebook: tomharkin
     youtube: SenatorTomHarkin
+    facebook_id: '252422916567'
 - id:
     bioguide: G000568
     thomas: '02070'
@@ -2078,6 +2323,7 @@
     twitter: RepMGriffith
     facebook: RepMorganGriffith
     youtube: RepMorganGriffith
+    facebook_id: '141893975868919'
 - id:
     bioguide: G000567
     thomas: '01990'
@@ -2092,6 +2338,7 @@
     twitter: tgowdysc
     facebook: '143059759084016'
     youtube: TGowdySC
+    facebook_id: '143059759084016'
 - id:
     bioguide: G000565
     thomas: '01992'
@@ -2100,6 +2347,7 @@
     twitter: RepGosar
     facebook: repgosar
     youtube: repgosar
+    facebook_id: '104329699641957'
 - id:
     bioguide: G000564
     thomas: '02043'
@@ -2108,6 +2356,7 @@
     twitter: RepChrisGibson
     facebook: RepChrisGibson
     youtube: repchrisgibson
+    facebook_id: '190238567659779'
 - id:
     bioguide: G000563
     thomas: '02049'
@@ -2116,6 +2365,7 @@
     twitter: repbobgibbs
     facebook: RepBobGibbs
     youtube: RepBobGibbs
+    facebook_id: '191159267565100'
 - id:
     bioguide: G000562
     thomas: '01998'
@@ -2124,6 +2374,7 @@
     twitter: repcorygardner
     facebook: CongressmanGardner
     youtube: CongressmanGardner
+    facebook_id: '160924893954206'
 - id:
     bioguide: G000560
     thomas: '01979'
@@ -2132,6 +2383,7 @@
     twitter: reptomgraves
     facebook: reptomgraves
     youtube: CongressmanGraves
+    facebook_id: '104548906262119'
 - id:
     bioguide: G000559
     thomas: '01973'
@@ -2140,6 +2392,7 @@
     twitter: RepGaramendi
     facebook: repgaramendi
     youtube: garamendiCA10
+    facebook_id: '182567716746'
 - id:
     bioguide: G000553
     thomas: '01803'
@@ -2148,6 +2401,7 @@
     twitter: RepAlGreen
     facebook: repalgreen
     youtube: RepAlGreen
+    facebook_id: '136237609724391'
 - id:
     bioguide: G000552
     thomas: '01801'
@@ -2156,6 +2410,7 @@
     twitter: replouiegohmert
     facebook: '50375006903'
     youtube: GohmertTX01
+    facebook_id: '50375006903'
 - id:
     bioguide: G000551
     thomas: '01708'
@@ -2164,6 +2419,7 @@
     twitter: repraulgrijalva
     facebook: Rep.Grijalva
     youtube: raulgrijalvaaz07
+    facebook_id: '73539896233'
 - id:
     bioguide: G000550
     thomas: '01720'
@@ -2172,6 +2428,7 @@
     twitter: RepPhilGingrey
     facebook: RepPhilGingrey
     youtube: RepPhilGingrey
+    facebook_id: '6934467868'
 - id:
     bioguide: G000549
     thomas: '01743'
@@ -2180,6 +2437,7 @@
     twitter: JimGerlach
     facebook: RepJimGerlach
     youtube: RepJimGerlach
+    facebook_id: '123113211050305'
 - id:
     bioguide: G000548
     thomas: '01737'
@@ -2188,6 +2446,7 @@
     twitter: repgarrett
     facebook: repscottgarrett
     youtube: repscottgarrett
+    facebook_id: '6756553401'
 - id:
     bioguide: G000535
     thomas: '00478'
@@ -2196,6 +2455,7 @@
     twitter: LuisGutierrez
     facebook: RepGutierrez
     youtube: repluisgutierrez
+    facebook_id: '91052833204'
 - id:
     bioguide: G000410
     thomas: '00462'
@@ -2203,6 +2463,7 @@
   social:
     twitter: RepGeneGreen
     facebook: RepGeneGreen
+    facebook_id: '128735131872'
 - id:
     bioguide: G000386
     thomas: '00457'
@@ -2211,6 +2472,7 @@
     twitter: ChuckGrassley
     facebook: grassley
     youtube: senchuckgrassley
+    facebook_id: '106480645796'
 - id:
     bioguide: G000377
     thomas: '01487'
@@ -2219,6 +2481,7 @@
     twitter: RepKayGranger
     facebook: RepKayGranger
     youtube: RepKayGranger
+    facebook_id: '49640749719'
 - id:
     bioguide: G000359
     thomas: '00452'
@@ -2227,6 +2490,7 @@
     twitter: GrahamBlog
     facebook: USSenatorLindseyGraham
     youtube: USSenLindseyGraham
+    facebook_id: '257937783228'
 - id:
     bioguide: G000289
     thomas: '00446'
@@ -2235,6 +2499,7 @@
     twitter: RepGoodlatte
     facebook: BobGoodlatte
     youtube: RepBobGoodlatte
+    facebook_id: '6459789414'
 - id:
     bioguide: F000461
     thomas: '02065'
@@ -2243,6 +2508,7 @@
     twitter: RepBillFlores
     facebook: RepBillFlores
     youtube: RepBillFlores
+    facebook_id: '146176682102245'
 - id:
     bioguide: F000460
     thomas: '02067'
@@ -2251,6 +2517,7 @@
     twitter: farenthold
     facebook: BlakeFarenthold
     youtube: BlakeFarenthold
+    facebook_id: '186894244673001'
 - id:
     bioguide: F000459
     thomas: '02061'
@@ -2259,6 +2526,7 @@
     twitter: RepChuck
     facebook: repchuck
     youtube: repchuck
+    facebook_id: '189998554345168'
 - id:
     bioguide: F000458
     thomas: '02064'
@@ -2267,6 +2535,7 @@
     twitter: RepFincherTN08
     facebook: RepFincherTN08
     youtube: CongressmanFincher
+    facebook_id: '128861763849209'
 - id:
     bioguide: F000456
     thomas: '01924'
@@ -2275,6 +2544,7 @@
     twitter: RepFleming
     facebook: repjohnfleming
     youtube: larep04
+    facebook_id: '372154186772'
 - id:
     bioguide: F000455
     thomas: '01895'
@@ -2283,6 +2553,7 @@
     twitter: RepMarciaFudge
     facebook: RepMarciaLFudge
     youtube: marcialfudge
+    facebook_id: '279006440801'
 - id:
     bioguide: F000451
     thomas: '01797'
@@ -2291,6 +2562,7 @@
     twitter: RepFitzpatrick
     facebook: RepFitzpatrick
     youtube: RepFitzpatrickPA8
+    facebook_id: '132077153521454'
 - id:
     bioguide: F000450
     thomas: '01791'
@@ -2299,6 +2571,7 @@
     twitter: virginiafoxx
     facebook: RepVirginiaFoxx
     youtube: repvirginiafoxx
+    facebook_id: ~
 - id:
     bioguide: F000449
     thomas: '01793'
@@ -2307,6 +2580,7 @@
     twitter: JeffFortenberry
     facebook: jefffortenberry
     youtube: JeffFortenberry
+    facebook_id: '48426842354'
 - id:
     bioguide: F000448
     thomas: '01707'
@@ -2314,6 +2588,7 @@
   social:
     twitter: RepTrentFranks
     facebook: TrentFranks
+    facebook_id: '209486545087'
 - id:
     bioguide: F000445
     thomas: '01683'
@@ -2322,6 +2597,7 @@
     twitter: Randy_Forbes
     facebook: randyforbes
     youtube: RepRandyForbes
+    facebook_id: '356330225020'
 - id:
     bioguide: F000444
     thomas: '01633'
@@ -2330,6 +2606,7 @@
     twitter: jeffflake
     youtube: flakeoffice
     facebook: senatorjeffflake
+    facebook_id: ~
 - id:
     bioguide: F000062
     thomas: '01332'
@@ -2338,6 +2615,7 @@
     twitter: senfeinstein
     facebook: senatorfeinstein
     youtube: SenatorFeinstein
+    facebook_id: '334887279867783'
 - id:
     bioguide: F000043
     thomas: '00371'
@@ -2346,6 +2624,7 @@
     twitter: chakafattah
     facebook: repfattah
     youtube: ChakaFattah
+    facebook_id: '165961823475034'
 - id:
     bioguide: F000030
     thomas: '00368'
@@ -2354,6 +2633,7 @@
     twitter: RepSamFarr
     facebook: RepSamFarr
     youtube: CongressmanSamFarr
+    facebook_id: '7018136294'
 - id:
     bioguide: E000291
     thomas: '02036'
@@ -2362,6 +2642,7 @@
     twitter: RepReneeEllmers
     facebook: reneeellmers
     youtube: repreneeellmers
+    facebook_id: '167641493275000'
 - id:
     bioguide: E000290
     thomas: '01894'
@@ -2370,6 +2651,7 @@
     twitter: repdonnaedwards
     facebook: '107297211756'
     youtube: RepDonnaFEdwards
+    facebook_id: '107297211756'
 - id:
     bioguide: E000288
     thomas: '01857'
@@ -2378,6 +2660,7 @@
     twitter: keithellison
     facebook: Keith.Ellison
     youtube: RepKeithEllison
+    facebook_id: '7997462059'
 - id:
     bioguide: E000285
     thomas: '01542'
@@ -2386,6 +2669,7 @@
     twitter: SenatorEnzi
     facebook: mikeenzi
     youtube: senatorenzi
+    facebook_id: '23068049436'
 - id:
     bioguide: E000215
     thomas: '00355'
@@ -2394,6 +2678,7 @@
     twitter: RepAnnaEshoo
     facebook: RepAnnaEshoo
     youtube: RepAnnaEshoo
+    facebook_id: '174979964227'
 - id:
     bioguide: E000179
     thomas: '00344'
@@ -2402,6 +2687,7 @@
     twitter: RepEliotEngel
     facebook: RepEliotLEngel
     youtube: engel2161
+    facebook_id: '103355984852'
 - id:
     bioguide: D000616
     thomas: '02062'
@@ -2410,6 +2696,7 @@
     twitter: DesJarlaisTN04
     facebook: ScottDesJarlaisTN04
     youtube: ScottDesJarlaisTN04
+    facebook_id: ~
 - id:
     bioguide: D000615
     thomas: '02057'
@@ -2418,6 +2705,7 @@
     twitter: RepJeffDuncan
     facebook: RepJeffDuncan
     youtube: congjeffduncan
+    facebook_id: '187268144624279'
 - id:
     bioguide: D000614
     thomas: '02072'
@@ -2426,6 +2714,7 @@
     twitter: RepSeanDuffy
     facebook: RepSeanDuffy
     youtube: RepSeanDuffy
+    facebook_id: '119657691436457'
 - id:
     bioguide: D000612
     thomas: '01995'
@@ -2434,6 +2723,7 @@
     twitter: RepJeffDenham
     facebook: RepJeffDenham
     youtube: repjeffdenham
+    facebook_id: '133714040028137'
 - id:
     bioguide: D000610
     thomas: '01976'
@@ -2442,6 +2732,7 @@
     twitter: repteddeutch
     facebook: CongressmanTedDeutch
     youtube: congressmanteddeutch
+    facebook_id: '112179098816942'
 - id:
     bioguide: D000607
     thomas: '01850'
@@ -2449,6 +2740,7 @@
   social:
     twitter: SenDonnelly
     facebook: senatordonnelly
+    facebook_id: '168059529893610'
 - id:
     bioguide: D000604
     thomas: '01799'
@@ -2456,6 +2748,7 @@
   social:
     facebook: CongressmanDent
     youtube: CongressmanDent
+    facebook_id: '69862092533'
 - id:
     bioguide: D000600
     thomas: '01717'
@@ -2464,6 +2757,7 @@
     twitter: MarioDB
     facebook: mdiazbalart
     youtube: MarioDiazBalart
+    facebook_id: '119538428117878'
 - id:
     bioguide: D000563
     thomas: '00326'
@@ -2472,6 +2766,7 @@
     twitter: SenatorDurbin
     facebook: SenatorDurbin
     youtube: SenatorDurbin
+    facebook_id: '180436795325335'
 - id:
     bioguide: D000533
     thomas: '00322'
@@ -2479,6 +2774,7 @@
   social:
     facebook: CongressmanDuncan
     youtube: RepJohnDuncan
+    facebook_id: '102385999834718'
 - id:
     bioguide: D000482
     thomas: '00316'
@@ -2487,6 +2783,7 @@
     twitter: USRepMikeDoyle
     facebook: usrepmikedoyle
     youtube: CongressmanDoyle
+    facebook_id: '79663724861'
 - id:
     bioguide: D000399
     thomas: '00303'
@@ -2495,6 +2792,7 @@
     twitter: RepLloydDoggett
     facebook: lloyddoggett
     youtube: doggett
+    facebook_id: '154050553704'
 - id:
     bioguide: D000355
     thomas: '00299'
@@ -2502,6 +2800,7 @@
   social:
     twitter: john_dingell
     facebook: johndingell
+    facebook_id: '87490183861'
 - id:
     bioguide: D000216
     thomas: '00281'
@@ -2510,6 +2809,7 @@
     twitter: rosadelauro
     facebook: CongresswomanRosaDeLauro
     youtube: rosadelauro
+    facebook_id: '181302611907634'
 - id:
     bioguide: D000197
     thomas: '01479'
@@ -2518,6 +2818,7 @@
     twitter: RepDianaDeGette
     facebook: DianaDeGette
     youtube: RepDianaDeGette
+    facebook_id: '110757973488'
 - id:
     bioguide: D000191
     thomas: '00279'
@@ -2526,6 +2827,7 @@
     twitter: RepPeterDeFazio
     facebook: RepPeterDeFazio
     youtube: PeterDeFazio
+    facebook_id: '94324364811'
 - id:
     bioguide: C001088
     thomas: '01984'
@@ -2534,6 +2836,7 @@
     twitter: SenCoonsOffice
     facebook: senatorchriscoons
     youtube: senatorchriscoons
+    facebook_id: '254950754518205'
 - id:
     bioguide: C001087
     thomas: '01989'
@@ -2542,6 +2845,7 @@
     twitter: RepRickCrawford
     facebook: RepRickCrawford
     youtube: RepRickCrawford
+    facebook_id: '143344975723788'
 - id:
     bioguide: C001084
     thomas: '02055'
@@ -2550,6 +2854,7 @@
     twitter: repcicilline
     facebook: CongressmanDavidCicilline
     youtube: RepDavidCicilline
+    facebook_id: '186949061341027'
 - id:
     bioguide: C001080
     thomas: '01970'
@@ -2558,6 +2863,7 @@
     twitter: RepJudyChu
     facebook: RepJudyChu
     youtube: RepJudyChu
+    facebook_id: '41228315130'
 - id:
     bioguide: C001078
     thomas: '01959'
@@ -2566,6 +2872,7 @@
     twitter: GerryConnolly
     facebook: CongressmanGerryConnolly
     youtube: repconnolly
+    facebook_id: '177164035838'
 - id:
     bioguide: C001077
     thomas: '01912'
@@ -2574,6 +2881,7 @@
     twitter: RepMikeCoffman
     facebook: repmikecoffman
     youtube: CongressmanCoffman
+    facebook_id: '366142384492'
 - id:
     bioguide: C001076
     thomas: '01956'
@@ -2589,14 +2897,16 @@
     twitter: RepAndreCarson
     facebook: CongressmanAndreCarson
     youtube: repandrecarson
+    facebook_id: '123884330964019'
 - id:
     bioguide: C001071
     thomas: '01825'
     govtrack: 412248
   social:
     twitter: SenBobCorker
-    facebook: '109251415789533'
+    facebook: bobcorker
     youtube: senatorcorker
+    facebook_id: '109251415789533'
 - id:
     bioguide: C001070
     thomas: '01828'
@@ -2605,6 +2915,7 @@
     twitter: SenBobCasey
     facebook: SenatorBobCasey
     youtube: SenatorBobCasey
+    facebook_id: '107749545944874'
 - id:
     bioguide: C001069
     thomas: '01836'
@@ -2613,6 +2924,7 @@
     twitter: repjoecourtney
     facebook: joecourtney
     youtube: repcourtney
+    facebook_id: '330408799230'
 - id:
     bioguide: C001068
     thomas: '01878'
@@ -2621,6 +2933,7 @@
     twitter: repcohen
     facebook: CongressmanSteveCohen
     youtube: repcohen
+    facebook_id: '111456965545421'
 - id:
     bioguide: C001067
     thomas: '01864'
@@ -2629,6 +2942,7 @@
     twitter: YvetteClarke
     facebook: repyvettedclarke
     youtube: repyvetteclarke
+    facebook_id: '135031389892682'
 - id:
     bioguide: C001064
     thomas: '01816'
@@ -2637,6 +2951,7 @@
     twitter: RepJohnCampbell
     facebook: JohnCampbell
     youtube: RepJohnCampbellCA48
+    facebook_id: '60546090739'
 - id:
     bioguide: C001063
     thomas: '01807'
@@ -2645,6 +2960,7 @@
     twitter: RepCuellar
     facebook: '152569121550'
     youtube: henrycuellar
+    facebook_id: '152569121550'
 - id:
     bioguide: C001062
     thomas: '01805'
@@ -2653,6 +2969,7 @@
     twitter: ConawayTX11
     facebook: mike.conaway
     youtube: mikeconaway11
+    facebook_id: '203482063021985'
 - id:
     bioguide: C001061
     thomas: '01790'
@@ -2660,6 +2977,7 @@
   social:
     twitter: repcleaver
     facebook: emanuelcleaverii
+    facebook_id: '7954512692'
 - id:
     bioguide: C001059
     thomas: '01774'
@@ -2668,6 +2986,7 @@
     twitter: repjimcosta
     facebook: RepJimCosta
     youtube: RepJimCostaCA20
+    facebook_id: ~
 - id:
     bioguide: C001056
     thomas: '01692'
@@ -2676,6 +2995,7 @@
     twitter: JohnCornyn
     facebook: sen.johncornyn
     youtube: senjohncornyn
+    facebook_id: '75755694423'
 - id:
     bioguide: C001053
     thomas: '01742'
@@ -2684,6 +3004,7 @@
     twitter: tomcoleok04
     facebook: TomColeOK04
     youtube: reptomcole
+    facebook_id: '146497782066300'
 - id:
     bioguide: C001051
     thomas: '01752'
@@ -2692,6 +3013,7 @@
     twitter: JudgeCarter
     facebook: judgecarter
     youtube: repjohncarter
+    facebook_id: '1287257083'
 - id:
     bioguide: C001049
     thomas: '01654'
@@ -2699,6 +3021,7 @@
   social:
     facebook: '109135405838588'
     youtube: WilliamLacyClay
+    facebook_id: '109135405838588'
 - id:
     bioguide: C001048
     thomas: '01670'
@@ -2707,6 +3030,7 @@
     twitter: congculberson
     facebook: CongressmanCulberson
     youtube: johnculbersontx07
+    facebook_id: '1751723339'
 - id:
     bioguide: C001047
     thomas: '01676'
@@ -2715,6 +3039,7 @@
     twitter: RepShelley
     facebook: '8057864757'
     youtube: RepShelleyCapito
+    facebook_id: '8057864757'
 - id:
     bioguide: C001046
     thomas: '01674'
@@ -2730,6 +3055,7 @@
     twitter: AnderCrenshaw
     facebook: '200388204657'
     youtube: RepAnderCrenshaw
+    facebook_id: '200388204657'
 - id:
     bioguide: C001038
     thomas: '01604'
@@ -2738,6 +3064,7 @@
     twitter: repjoecrowley
     facebook: repjoecrowley
     youtube: RepJoeCrowley
+    facebook_id: '176197712425090'
 - id:
     bioguide: C001037
     thomas: '01564'
@@ -2745,6 +3072,7 @@
   social:
     facebook: RepMichaelCapuano
     youtube: RepMikeCapuano
+    facebook_id: '151168844937573'
 - id:
     bioguide: C001036
     thomas: '01471'
@@ -2753,6 +3081,7 @@
     twitter: RepLoisCapps
     facebook: loiscapps
     youtube: reploiscapps
+    facebook_id: '168989481141'
 - id:
     bioguide: C001035
     thomas: '01541'
@@ -2761,6 +3090,7 @@
     twitter: senatorcollins
     facebook: susancollins
     youtube: SenatorSusanCollins
+    facebook_id: '7593313361'
 - id:
     bioguide: C000984
     thomas: '00256'
@@ -2769,6 +3099,7 @@
     twitter: ElijahECummings
     facebook: elijahcummings
     youtube: ElijahECummings
+    facebook_id: '291368465380'
 - id:
     bioguide: C000880
     thomas: '00250'
@@ -2777,6 +3108,7 @@
     twitter: mikecrapo
     facebook: mikecrapo
     youtube: senatorcrapo
+    facebook_id: '80335332266'
 - id:
     bioguide: C000754
     thomas: '00231'
@@ -2785,6 +3117,7 @@
     twitter: repjimcooper
     facebook: JimCooper
     youtube: RepJimCooper
+    facebook_id: ~
 - id:
     bioguide: C000714
     thomas: '00229'
@@ -2793,6 +3126,7 @@
     twitter: repjohnconyers
     facebook: CongressmanConyers
     youtube: JCMI14
+    facebook_id: '206947066849'
 - id:
     bioguide: C000560
     thomas: '00212'
@@ -2807,6 +3141,7 @@
   social:
     twitter: HowardCoble
     facebook: HowardCoble6
+    facebook_id: '208742429162356'
 - id:
     bioguide: C000542
     thomas: '00209'
@@ -2815,6 +3150,7 @@
     twitter: sendancoats
     facebook: '180671148633644'
     youtube: SenatorCoats
+    facebook_id: '180671148633644'
 - id:
     bioguide: C000537
     thomas: '00208'
@@ -2823,6 +3159,7 @@
     twitter: clyburn
     facebook: jameseclyburn
     youtube: repjamesclyburn
+    facebook_id: '127744320598870'
 - id:
     bioguide: C000380
     thomas: '01474'
@@ -2831,6 +3168,7 @@
     twitter: DelegateDonna
     facebook: '138013351189'
     youtube: delegatedonna
+    facebook_id: '138013351189'
 - id:
     bioguide: C000286
     thomas: '00188'
@@ -2839,6 +3177,7 @@
     twitter: SaxbyChambliss
     facebook: SaxbyChambliss
     youtube: SenatorChambliss
+    facebook_id: ~
 - id:
     bioguide: C000266
     thomas: '00186'
@@ -2847,6 +3186,7 @@
     twitter: RepSteveChabot
     facebook: RepSteveChabot
     youtube: congressmanchabot
+    facebook_id: '204705339555378'
 - id:
     bioguide: C000174
     thomas: '00179'
@@ -2855,6 +3195,7 @@
     twitter: SenatorCarper
     facebook: tomcarper
     youtube: senatorcarper
+    facebook_id: '124891107521733'
 - id:
     bioguide: C000141
     thomas: '00174'
@@ -2863,6 +3204,7 @@
     twitter: SenatorCardin
     facebook: senatorbencardin
     youtube: senatorcardin
+    facebook_id: '120421834675191'
 - id:
     bioguide: C000127
     thomas: '00172'
@@ -2878,6 +3220,7 @@
     twitter: RepDaveCamp
     facebook: repdavecamp
     youtube: DaveCampYT
+    facebook_id: '6775033524'
 - id:
     bioguide: C000059
     thomas: '00165'
@@ -2886,6 +3229,7 @@
     twitter: KenCalvert
     facebook: '70063393423'
     youtube: RepKenCalvert
+    facebook_id: '70063393423'
 - id:
     bioguide: B001279
     thomas: '02093'
@@ -2893,6 +3237,7 @@
   social:
     twitter: RepRonBarber
     facebook: RepRonBarber
+    facebook_id: '244907165625305'
 - id:
     bioguide: B001277
     thomas: '02076'
@@ -2901,6 +3246,7 @@
     twitter: SenBlumenthal
     facebook: SenBlumenthal
     youtube: SenatorBlumenthal
+    facebook_id: '289987304364966'
 - id:
     bioguide: B001275
     thomas: '02018'
@@ -2909,6 +3255,7 @@
     twitter: RepLarryBucshon
     facebook: RepLarryBucshon
     youtube: RepLarryBucshon
+    facebook_id: '135670516492974'
 - id:
     bioguide: B001274
     thomas: '01987'
@@ -2917,6 +3264,7 @@
     twitter: RepMoBrooks
     facebook: '155220881193244'
     youtube: RepMoBrooks
+    facebook_id: '155220881193244'
 - id:
     bioguide: B001273
     thomas: '02063'
@@ -2925,6 +3273,7 @@
     twitter: RepDianeBlack
     facebook: DianeBlackTN06
     youtube: RepDianeBlack
+    facebook_id: '186436274719648'
 - id:
     bioguide: B001271
     thomas: '02027'
@@ -2932,6 +3281,7 @@
   social:
     twitter: CongressmanDan
     facebook: CongressmanDan
+    facebook_id: '124163654317596'
 - id:
     bioguide: B001270
     thomas: '01996'
@@ -2940,6 +3290,7 @@
     twitter: RepKarenBass
     facebook: RepKarenBass
     youtube: RepKarenBass
+    facebook_id: '190867440939405'
 - id:
     bioguide: B001269
     thomas: '02054'
@@ -2948,6 +3299,7 @@
     twitter: RepLouBarletta
     facebook: CongressmanLouBarletta
     youtube: reploubarletta
+    facebook_id: '192357174108435'
 - id:
     bioguide: B001267
     thomas: '01965'
@@ -2956,6 +3308,7 @@
     twitter: SenBennetCo
     facebook: senatorbennet
     youtube: SenatorBennet
+    facebook_id: '97172997732'
 - id:
     bioguide: B001265
     thomas: '01898'
@@ -2964,6 +3317,7 @@
     twitter: SenatorBegich
     facebook: Begich
     youtube: USSenatorMarkBegich
+    facebook_id: '121360477876652'
 - id:
     bioguide: B001262
     thomas: '01882'
@@ -2972,6 +3326,7 @@
     twitter: RepPaulBrounMD
     facebook: RepPaulBroun
     youtube: RepPaulBroun
+    facebook_id: '123908980957273'
 - id:
     bioguide: B001261
     thomas: '01881'
@@ -2980,6 +3335,7 @@
     twitter: SenJohnBarrasso
     facebook: johnbarrasso
     youtube: barrassowyo
+    facebook_id: '21146775942'
 - id:
     bioguide: B001260
     thomas: '01840'
@@ -2988,6 +3344,7 @@
     twitter: VernBuchanan
     facebook: CongressmanBuchanan
     youtube: vernbuchanan
+    facebook_id: '67106719910'
 - id:
     bioguide: B001259
     thomas: '01845'
@@ -2996,6 +3353,7 @@
     twitter: brucebraley
     facebook: repbrucebraley
     youtube: repbrucebraley
+    facebook_id: '178887452188843'
 - id:
     bioguide: B001257
     thomas: '01838'
@@ -3004,6 +3362,7 @@
     twitter: RepGusBilirakis
     facebook: GusBilirakis
     youtube: RepGusBilirakis
+    facebook_id: '135445766485586'
 - id:
     bioguide: B001256
     thomas: '01858'
@@ -3012,6 +3371,7 @@
     twitter: MicheleBachmann
     facebook: RepMicheleBachmann
     youtube: RepMicheleBachmann
+    facebook_id: '7658849357'
 - id:
     bioguide: B001255
     thomas: '01787'
@@ -3020,6 +3380,7 @@
     twitter: RepBoustany
     facebook: RepBoustany
     youtube: boustanyla07
+    facebook_id: '197407646951718'
 - id:
     bioguide: B001252
     thomas: '01780'
@@ -3028,6 +3389,7 @@
     twitter: repjohnbarrow
     facebook: CongressmanJohnBarrow
     youtube: RepJohnBarrow
+    facebook_id: '285483767395'
 - id:
     bioguide: B001251
     thomas: '01761'
@@ -3036,6 +3398,7 @@
     twitter: gkbutterfield
     facebook: congressmangkbutterfield
     youtube: GKBNC01
+    facebook_id: '274687979233940'
 - id:
     bioguide: B001250
     thomas: '01753'
@@ -3044,6 +3407,7 @@
     twitter: RepRobBishop
     facebook: RepRobBishop
     youtube: CongressmanBishop
+    facebook_id: ~
 - id:
     bioguide: B001248
     thomas: '01751'
@@ -3052,6 +3416,7 @@
     twitter: michaelcburgess
     facebook: michaelcburgess
     youtube: michaelcburgessmd
+    facebook_id: '6916472567'
 - id:
     bioguide: B001244
     thomas: '01703'
@@ -3060,6 +3425,7 @@
     twitter: repjobonner
     facebook: jobonner
     youtube: JoBonner
+    facebook_id: '49704847429'
 - id:
     bioguide: B001243
     thomas: '01748'
@@ -3068,6 +3434,7 @@
     twitter: MarshaBlackburn
     facebook: marshablackburn
     youtube: RepMarshaBlackburn
+    facebook_id: '6470828395'
 - id:
     bioguide: B001242
     thomas: '01740'
@@ -3076,6 +3443,7 @@
     twitter: timbishopny
     facebook: RepTimBishop
     youtube: timbishop01
+    facebook_id: '7940339401'
 - id:
     bioguide: B001236
     thomas: '01687'
@@ -3084,6 +3452,7 @@
     twitter: JohnBoozman
     facebook: JohnBoozman
     youtube: BoozmanPressOffice
+    facebook_id: '7686715735'
 - id:
     bioguide: B001227
     thomas: '01469'
@@ -3092,6 +3461,7 @@
     twitter: RepBrady
     facebook: RepRobertBrady
     youtube: BradyPA01
+    facebook_id: '118845109487'
 - id:
     bioguide: B001135
     thomas: '00153'
@@ -3100,6 +3470,7 @@
     twitter: senatorburr
     facebook: SenatorRichardBurr
     youtube: SenatorRichardBurr
+    facebook_id: '132653626787856'
 - id:
     bioguide: B000944
     thomas: '00136'
@@ -3115,6 +3486,7 @@
     twitter: RepKevinBrady
     facebook: kevinbrady
     youtube: KBrady8
+    facebook_id: '9307301412'
 - id:
     bioguide: B000711
     thomas: '00116'
@@ -3123,6 +3495,7 @@
     twitter: senatorboxer
     facebook: senatorboxer
     youtube: SenatorBoxer
+    facebook_id: '116513005087055'
 - id:
     bioguide: B000589
     thomas: '00102'
@@ -3138,6 +3511,7 @@
     twitter: RoyBlunt
     facebook: SenatorBlunt
     youtube: SenatorBlunt
+    facebook_id: '142473042477322'
 - id:
     bioguide: B000574
     thomas: '00099'
@@ -3153,6 +3527,7 @@
     twitter: SanfordBishop
     facebook: sanfordbishop
     youtube: RepSanfordBishop
+    facebook_id: '366739521606'
 - id:
     bioguide: B000287
     thomas: '00070'
@@ -3161,6 +3536,7 @@
     twitter: repbecerra
     facebook: XavierBecerra
     youtube: XavierBecerra
+    facebook_id: '90311772229'
 - id:
     bioguide: B000213
     thomas: '00062'
@@ -3169,6 +3545,7 @@
     twitter: RepJoeBarton
     facebook: RepJoeBarton
     youtube: repjoebarton
+    facebook_id: '15617630596'
 - id:
     bioguide: B000013
     thomas: '00038'
@@ -3177,6 +3554,7 @@
     twitter: BachusAL06
     facebook: SpencerBachus
     youtube: congressmanbachus
+    facebook_id: '6769692966'
 - id:
     bioguide: A000368
     thomas: '02075'
@@ -3184,6 +3562,7 @@
   social:
     facebook: kellyayottenh
     youtube: SenatorAyotte
+    facebook_id: '123436097729198'
 - id:
     bioguide: A000367
     thomas: '02029'
@@ -3192,6 +3571,7 @@
     twitter: repjustinamash
     facebook: repjustinamash
     youtube: repjustinamash
+    facebook_id: '173604349345646'
 - id:
     bioguide: A000361
     thomas: '01727'
@@ -3200,6 +3580,7 @@
     twitter: USRepAlexander
     facebook: RepRodneyAlexander
     youtube: RepRodneyMAlexander
+    facebook_id: '20002702544'
 - id:
     bioguide: A000360
     thomas: '01695'
@@ -3208,6 +3589,7 @@
     twitter: senalexander
     youtube: lamaralexander
     facebook: senatorlamaralexander
+    facebook_id: '89927603836'
 - id:
     bioguide: A000055
     thomas: '01460'
@@ -3216,6 +3598,7 @@
     twitter: Robert_Aderholt
     facebook: RobertAderholt
     youtube: RobertAderholt
+    facebook_id: '19787529402'
 - id:
     bioguide: B000911
     thomas: '00132'
@@ -3224,6 +3607,7 @@
     twitter: RepCorrineBrown
     facebook: congresswomanbrown
     youtube: CongresswomanBrown
+    facebook_id: '179120958813519'
 - id:
     bioguide: C001083
     thomas: '01999'
@@ -3232,6 +3616,7 @@
     twitter: johncarneyde
     facebook: JohnCarneyDE
     youtube: RepJohnCarney
+    facebook_id: '156024857781159'
 - id:
     bioguide: M001171
     thomas: '01943'
@@ -3240,6 +3625,7 @@
     twitter: RepDanMaffei
     facebook: RepMaffei
     youtube: repdanmaffei
+    facebook_id: '470842942980263'
 - id:
     bioguide: B001245
     thomas: '01723'
@@ -3247,6 +3633,7 @@
   social:
     twitter: CandiceMiller
     facebook: madeleine.bordallo
+    facebook_id: '161729837225622'
 - id:
     bioguide: D000617
     thomas: '02096'
@@ -3255,6 +3642,7 @@
     twitter: RepDelBene
     facebook: RepDelBene
     youtube: channel/UCd00b7TpKDZIr-Ujhaktvjg
+    facebook_id: '483962224987343'
 - id:
     bioguide: B001278
     thomas: '02092'
@@ -3263,6 +3651,7 @@
     twitter: RepBonamici
     facebook: congresswomanbonamici
     youtube: RepSuzanneBonamici
+    facebook_id: '252633384817156'
 - id:
     bioguide: C000567
     thomas: '00213'
@@ -3276,6 +3665,7 @@
     twitter: SenAngusKing
     facebook: SenatorAngusSKingJr
     youtube: SenatorAngusKing
+    facebook_id: '142803045874943'
 - id:
     bioguide: A000369
     thomas: '02090'
@@ -3284,6 +3674,7 @@
     twitter: markamodeinv2
     facebook: MarkAmodeiNV2
     youtube: markamodeinv2
+    facebook_id: '307227745970624'
 - id:
     bioguide: L000580
     thomas: '02146'
@@ -3292,6 +3683,7 @@
     twitter: replujangrisham
     facebook: RepLujanGrisham
     youtube: RepLujanGrisham
+    facebook_id: '191640657646128'
 - id:
     bioguide: D000621
     thomas: '02116'
@@ -3300,6 +3692,7 @@
     twitter: RepDeSantis
     facebook: RepDeSantis
     youtube: RepRonDeSantis
+    facebook_id: '464253846966014'
 - id:
     bioguide: D000620
     thomas: '02133'
@@ -3308,6 +3701,7 @@
     twitter: RepJohnDelaney
     facebook: congressmanjohndelaney
     youtube: repjohndelaney
+    facebook_id: '324527257655694'
 - id:
     bioguide: S001193
     thomas: '02104'
@@ -3316,6 +3710,7 @@
     twitter: repswalwell
     facebook: CongressmanEricSwalwell
     youtube: ericswalwell
+    facebook_id: '450130878375355'
 - id:
     bioguide: M001190
     thomas: '02156'
@@ -3323,6 +3718,7 @@
   social:
     twitter: RepMullin
     facebook: CongressmanMarkwayneMullin
+    facebook_id: '453637624684399'
 - id:
     bioguide: K000379
     thomas: '02172'
@@ -3330,6 +3726,7 @@
   social:
     twitter: RepJoeKennedy
     facebook: '301936109927957'
+    facebook_id: '301936109927957'
 - id:
     bioguide: B001280
     thomas: '02135'
@@ -3338,6 +3735,7 @@
     twitter: repkerryb
     facebook: repkerryb
     youtube: repkerry
+    facebook_id: '316865541750741'
 - id:
     bioguide: B001284
     thomas: '02129'
@@ -3345,6 +3743,7 @@
   social:
     twitter: SusanWBrooks
     facebook: congresswomansusanwbrooks
+    facebook_id: '517697358277175'
 - id:
     bioguide: W000813
     thomas: '02128'
@@ -3353,6 +3752,7 @@
     twitter: RepWalorski
     facebook: RepJackieWalorski
     youtube: channel/UC8fsSDjVJ_VnCF3ccx3Lkng
+    facebook_id: '466876036704525'
 - id:
     bioguide: R000597
     thomas: '02160'
@@ -3360,6 +3760,7 @@
   social:
     twitter: RepTomRice
     facebook: reptomrice
+    facebook_id: '403403083083104'
 - id:
     bioguide: M001188
     thomas: '02148'
@@ -3367,6 +3768,7 @@
   social:
     twitter: RepGraceMeng
     facebook: repgracemeng
+    facebook_id: '195734010571362'
 - id:
     bioguide: M001189
     thomas: '02130'
@@ -3375,6 +3777,7 @@
     twitter: RepLukeMesser
     facebook: RepLukeMesser
     youtube: RepLukeMesser
+    facebook_id: '367444640018564'
 - id:
     bioguide: M001185
     thomas: '02150'
@@ -3383,6 +3786,7 @@
     twitter: RepSeanMaloney
     facebook: RepSeanMaloney
     youtube: channel/UCNiVzzf4Vz-vCMPBcnjGuXQ
+    facebook_id: '551199354892891'
 - id:
     bioguide: H001064
     thomas: '02170'
@@ -3391,6 +3795,7 @@
     twitter: RepDennyHeck
     facebook: CongressmanDennyHeck
     youtube: RepDennyHeck
+    facebook_id: '547907568553615'
 - id:
     bioguide: H001065
     thomas: '02143'
@@ -3399,6 +3804,7 @@
     twitter: RepHolding
     facebook: CongressmanGeorgeHolding
     youtube: repholding
+    facebook_id: '384164668340890'
 - id:
     bioguide: N000127
     thomas: '00867'
@@ -3406,6 +3812,7 @@
   social:
     twitter: usrepricknolan
     facebook: UsRepRickNolan
+    facebook_id: '388085277945339'
 - id:
     bioguide: T000472
     thomas: '02110'
@@ -3414,6 +3821,7 @@
     twitter: RepMarkTakano
     facebook: RepMarkTakano
     youtube: RepMarkTakano
+    facebook_id: '262447300551014'
 - id:
     bioguide: J000294
     thomas: '02149'
@@ -3422,6 +3830,7 @@
     twitter: HakeemJeffries
     facebook: RepHakeemJeffries
     youtube: channel/UCYVmbsjoNbQ4j-PCQIYgpWQ
+    facebook_id: '118349138343701'
 - id:
     bioguide: J000295
     thomas: '02154'
@@ -3429,6 +3838,7 @@
   social:
     twitter: RepDaveJoyce
     facebook: RepDaveJoyce
+    facebook_id: '404318572981934'
 - id:
     bioguide: H001066
     thomas: '02147'
@@ -3437,6 +3847,7 @@
     twitter: RepHorsford
     facebook: RepHorsford
     youtube: RepHorsford
+    facebook_id: '321461017954658'
 - id:
     bioguide: L000579
     thomas: '02111'
@@ -3445,6 +3856,7 @@
     twitter: RepLowenthal
     facebook: RepLowenthal
     youtube: RepLowenthal
+    facebook_id: '392631677490897'
 - id:
     bioguide: C001093
     thomas: '02121'
@@ -3453,6 +3865,7 @@
     twitter: RepDougCollins
     facebook: RepresentativeDougCollins
     youtube: repdougcollins
+    facebook_id: '505646972800006'
 - id:
     bioguide: W000814
     thomas: '02161'
@@ -3461,6 +3874,7 @@
     twitter: TXRandy14
     facebook: TXRandy14
     youtube: TXRandy14
+    facebook_id: '128891177274584'
 - id:
     bioguide: N000187
     thomas: '02108'
@@ -3469,6 +3883,7 @@
     twitter: RepMcLeod
     facebook: NegreteMcLeod
     youtube: NegreteMcLeod
+    facebook_id: '282772691776629'
 - id:
     bioguide: K000381
     thomas: '02169'
@@ -3476,6 +3891,7 @@
   social:
     twitter: RepDerekKilmer
     facebook: derek.kilmer
+    facebook_id: '450819048314124'
 - id:
     bioguide: G000571
     thomas: '02122'
@@ -3483,6 +3899,7 @@
   social:
     twitter: tulsipress
     facebook: RepTulsiGabbard
+    facebook_id: '392284484191405'
 - id:
     bioguide: D000618
     thomas: '02138'
@@ -3491,6 +3908,7 @@
     twitter: stevedaines
     facebook: SteveDainesMT
     youtube: SteveDainesMT
+    facebook_id: '185361254941832'
 - id:
     bioguide: Y000065
     thomas: '02115'
@@ -3499,6 +3917,7 @@
     twitter: RepTedYoho
     facebook: CongressmanTedYoho
     youtube: RepTedYoho
+    facebook_id: '563532937006022'
 - id:
     bioguide: E000293
     thomas: '02114'
@@ -3507,6 +3926,7 @@
     twitter: RepEsty
     facebook: RepEsty
     youtube: RepEsty
+    facebook_id: '292076514228382'
 - id:
     bioguide: E000292
     thomas: '02125'
@@ -3515,6 +3935,7 @@
     twitter: repbillenyart
     facebook: '527281100637880'
     youtube: CongBillEnyart
+    facebook_id: '527281100637880'
 - id:
     bioguide: K000382
     thomas: '02145'
@@ -3523,6 +3944,7 @@
     twitter: RepAnnieKuster
     facebook: CongresswomanAnnieKuster
     youtube: RepKuster
+    facebook_id: '115543081952049'
 - id:
     bioguide: K000380
     thomas: '02134'
@@ -3530,6 +3952,7 @@
   social:
     twitter: RepDanKildee
     facebook: RepDanKildee
+    facebook_id: '484166588292670'
 - id:
     bioguide: C001090
     thomas: '02159'
@@ -3538,6 +3961,7 @@
     twitter: RepCartwright
     facebook: CongressmanMattCartwright
     youtube: channel/UCnAOvexSGLBnYidaFzguhTQ
+    facebook_id: '248507065275406'
 - id:
     bioguide: G000569
     thomas: '02041'
@@ -3552,6 +3976,7 @@
     twitter: RepTomCotton
     facebook: RepTomCotton
     youtube: RepTomCotton
+    facebook_id: '120355701459307'
 - id:
     bioguide: B001286
     thomas: '02127'
@@ -3560,6 +3985,7 @@
     twitter: RepCheri
     facebook: RepCheri
     youtube: RepCheri
+    facebook_id: '581909665168588'
 - id:
     bioguide: B001287
     thomas: '02102'
@@ -3568,6 +3994,7 @@
     twitter: repbera
     facebook: RepAmiBera
     youtube: repamibera
+    facebook_id: '528662157146886'
 - id:
     bioguide: F000454
     thomas: '01888'
@@ -3575,6 +4002,7 @@
   social:
     twitter: RepBillFoster
     facebook: CongressmanBillFoster
+    facebook_id: '102918290599'
 - id:
     bioguide: P000606
     thomas: '02141'
@@ -3582,6 +4010,7 @@
   social:
     twitter: RepPittenger
     facebook: congressmanpittenger
+    facebook_id: '376142742468386'
 - id:
     bioguide: M001187
     thomas: '02142'
@@ -3590,6 +4019,7 @@
     twitter: RepMarkMeadows
     facebook: Repmarkmeadows
     youtube: RepMarkMeadows
+    facebook_id: '409882952423501'
 - id:
     bioguide: F000462
     thomas: '02119'
@@ -3598,6 +4028,7 @@
     twitter: RepLoisFrankel
     facebook: RepLoisFrankel
     youtube: channel/UCEk5viAhxaW_2OK20-yBwzQ
+    facebook_id: '138220153003017'
 - id:
     bioguide: H001067
     thomas: '02140'
@@ -3606,6 +4037,7 @@
     twitter: RepRichHudson
     facebook: RepRichHudson
     youtube: RepRichHudson
+    facebook_id: '212153802255530'
 - id:
     bioguide: V000131
     thomas: '02166'
@@ -3614,6 +4046,7 @@
     twitter: RepVeasey
     facebook: CongressmanMarcVeasey
     youtube: marcveasey
+    facebook_id: '394849110600016'
 - id:
     bioguide: V000132
     thomas: '02167'
@@ -3621,6 +4054,7 @@
   social:
     twitter: RepFilemonVela
     facebook: USCongressmanFilemonVela
+    facebook_id: '510462622331477'
 - id:
     bioguide: P000605
     thomas: '02157'
@@ -3629,6 +4063,7 @@
     twitter: RepScottPerry
     facebook: Rep.ScottPerry
     youtube: RepScottPerry
+    facebook_id: '376801102416184'
 - id:
     bioguide: R000599
     thomas: '02109'
@@ -3643,6 +4078,7 @@
     twitter: RepMattSalmon
     facebook: RepMattSalmon
     youtube: repmattsalmon
+    facebook_id: '149561218527414'
 - id:
     bioguide: C001094
     thomas: '02103'
@@ -3651,6 +4087,7 @@
     twitter: RepPaulCook
     facebook: RepPaulCook
     youtube: RepPaulCook
+    facebook_id: '464458413604093'
 - id:
     bioguide: C001096
     thomas: '02144'
@@ -3658,6 +4095,7 @@
   social:
     twitter: RepKevinCramer
     facebook: CongressmanKevinCramer
+    facebook_id: '498751820147706'
 - id:
     bioguide: C001092
     thomas: '02151'
@@ -3665,6 +4103,7 @@
   social:
     twitter: RepChrisCollins
     facebook: RepChrisCollins
+    facebook_id: '467047586692268'
 - id:
     bioguide: W000812
     thomas: '02137'
@@ -3673,6 +4112,7 @@
     twitter: RepAnnWagner
     facebook: RepAnnWagner
     youtube: channel/UCy2v2DXXvQnbRc8Zx77Dnsg
+    facebook_id: '215485388588143'
 - id:
     bioguide: W000817
     thomas: '02182'
@@ -3681,6 +4121,7 @@
     twitter: senwarren
     facebook: senatorelizabethwarren
     youtube: senelizabethwarren
+    facebook_id: '131559043673264'
 - id:
     bioguide: K000368
     thomas: '01907'
@@ -3689,6 +4130,7 @@
     twitter: RepKirkpatrick
     facebook: RepKirkpatrick
     youtube: repannkirkpatrick
+    facebook_id: '152493768236405'
 - id:
     bioguide: D000619
     thomas: '02126'
@@ -3697,6 +4139,7 @@
     twitter: RodneyDavis
     facebook: RepRodneyDavis
     youtube: RepRodneyDavis
+    facebook_id: '323631667743052'
 - id:
     bioguide: S001190
     thomas: '02124'
@@ -3705,6 +4148,7 @@
     twitter: RepSchneider
     facebook: CongressmanBradSchneider
     youtube: RepBradSchneider
+    facebook_id: '401029529980053'
 - id:
     bioguide: S001192
     thomas: '02168'
@@ -3713,6 +4157,7 @@
     twitter: repchrisstewart
     facebook: RepChrisStewart
     youtube: repchrisstewart
+    facebook_id: '242042855928904'
 - id:
     bioguide: B001282
     thomas: '02131'
@@ -3721,6 +4166,7 @@
     twitter: RepAndyBarr
     facebook: RepAndyBarr
     youtube: RepAndyBarr
+    facebook_id: '457461137635018'
 - id:
     bioguide: G000572
     thomas: '02164'
@@ -3729,6 +4175,7 @@
     twitter: RepPeteGallego
     facebook: CongressmanPeteGallego
     youtube: RepPeteGallego
+    facebook_id: '123858487781636'
 - id:
     bioguide: C001098
     thomas: '02175'
@@ -3737,12 +4184,14 @@
     twitter: SenTedCruz
     facebook: SenatorTedCruz
     youtube: sentedcruz
+    facebook_id: '315496455229328'
 - id:
     bioguide: D000096
     thomas: '01477'
     govtrack: 400093
   social:
     facebook: '280757931935749'
+    facebook_id: '280757931935749'
 - id:
     bioguide: M001191
     thomas: '02117'
@@ -3751,6 +4200,7 @@
     twitter: RepMurphyFL
     facebook: CongressmanPatrickMurphy
     youtube: RepPatrickMurphyFL
+    facebook_id: '317735028342371'
 - id:
     bioguide: W000215
     thomas: '01209'
@@ -3759,12 +4209,14 @@
     twitter: WaxmanClimate
     facebook: Rep.HenryWaxman
     youtube: RepHenryWaxman
+    facebook_id: '129514917081997'
 - id:
     bioguide: G000546
     thomas: '01656'
     govtrack: 400158
   social:
     facebook: '118514606128'
+    facebook_id: '118514606128'
 - id:
     bioguide: B001283
     thomas: '02155'
@@ -3773,6 +4225,7 @@
     twitter: RepJBridenstine
     facebook: CongressmanJimBridenstine
     youtube: RepJimBridenstine
+    facebook_id: '460003650715961'
 - id:
     bioguide: B001230
     thomas: '01558'
@@ -3781,6 +4234,7 @@
     twitter: SenatorBaldwin
     facebook: TammyBaldwin
     youtube: witammybaldwin
+    facebook_id: '7357041101'
 - id:
     bioguide: W000810
     thomas: '02008'
@@ -3788,6 +4242,7 @@
   social:
     facebook: RepRobWoodall
     youtube: RobWoodallGA07
+    facebook_id: '172573036140374'
 - id:
     bioguide: W000816
     thomas: '02165'
@@ -3796,6 +4251,7 @@
     twitter: RepRWilliams
     facebook: RepRogerWilliams
     youtube: channel/UCBtfmMMQarjtLB9U_pWMOhw
+    facebook_id: '322383274535068'
 - id:
     bioguide: H000067
     thomas: '00484'
@@ -3803,12 +4259,14 @@
   social:
     facebook: '6311458773'
     twitter: RalphHallPress
+    facebook_id: '6311458773'
 - id:
     bioguide: D000598
     thomas: '01641'
     govtrack: 400097
   social:
     facebook: RepSusanDavis
+    facebook_id: '103767526332478'
 - id:
     bioguide: D000622
     thomas: '02123'
@@ -3816,6 +4274,7 @@
   social:
     twitter: repduckworth
     facebook: CongresswomanTammyDuckworth
+    facebook_id: '112300955610529'
 - id:
     bioguide: O000170
     thomas: '02162'
@@ -3824,6 +4283,7 @@
     twitter: betoorourketx16
     facebook: betoorourketx16
     youtube: betoorourketx16
+    facebook_id: '460776160654909'
 - id:
     bioguide: F000463
     thomas: '02179'
@@ -3832,6 +4292,7 @@
     twitter: SenatorFischer
     facebook: senatordebfischer
     youtube: senatordebfischer
+    facebook_id: '531623656856934'
 - id:
     bioguide: H001068
     thomas: '02101'
@@ -3840,6 +4301,7 @@
     twitter: RepHuffman
     facebook: RepHuffman
     youtube: rephuffman
+    facebook_id: '200227780116038'
 - id:
     bioguide: H001069
     thomas: '02174'
@@ -3847,6 +4309,7 @@
   social:
     twitter: SenatorHeitkamp
     facebook: SenatorHeidiHeitkamp
+    facebook_id: '501810613175643'
 - id:
     bioguide: S000937
     thomas: '01114'
@@ -3855,6 +4318,7 @@
     twitter: SteveStockmanTX
     facebook: CongressmanStockman
     youtube: SteveStockmanTX
+    facebook_id: '316293171806077'
 - id:
     bioguide: H001052
     thomas: '02026'
@@ -3863,6 +4327,7 @@
     twitter: repandyharrismd
     facebook: AndyHarrisMD
     youtube: RepAndyHarris
+    facebook_id: '508912729153334'
 - id:
     bioguide: P000604
     thomas: '02097'
@@ -3870,6 +4335,7 @@
   social:
     twitter: RepDonaldPayne
     facebook: DonaldPayneJr
+    facebook_id: '360976767343741'
 - id:
     bioguide: P000608
     thomas: '02113'
@@ -3877,6 +4343,7 @@
   social:
     twitter: RepScottPeters
     facebook: CongressmanScottPeters
+    facebook_id: '449337038470352'
 - id:
     bioguide: R000598
     thomas: '02158'
@@ -3885,6 +4352,7 @@
     twitter: KeithRothfus
     facebook: keithrothfus
     youtube: reprothfus
+    facebook_id: '133803223451004'
 - id:
     bioguide: C001091
     thomas: '02163'
@@ -3892,6 +4360,7 @@
   social:
     twitter: JoaquinCastrotx
     facebook: '326420614138023'
+    facebook_id: '326420614138023'
 - id:
     bioguide: W000815
     thomas: '02152'
@@ -3900,6 +4369,7 @@
     twitter: RepBradWenstrup
     facebook: RepBradWenstrup
     youtube: repbradwenstrup
+    facebook_id: '124462944390458'
 - id:
     bioguide: V000129
     thomas: '02105'
@@ -3908,6 +4378,7 @@
     twitter: RepDavidValadao
     facebook: CongressmanDavidValadao
     youtube: congressmanvaladao
+    facebook_id: '105596689621089'
 - id:
     bioguide: S001191
     thomas: '02099'
@@ -3915,6 +4386,7 @@
   social:
     twitter: RepSinema
     facebook: CongresswomanSinema
+    facebook_id: '233846963416149'
 - id:
     bioguide: V000127
     thomas: '01609'
@@ -4002,6 +4474,7 @@
   social:
     facebook: repmarkpocan
     twitter: repmarkpocan
+    facebook_id: '436881033058309'
 - id:
     bioguide: V000130
     thomas: '02112'
@@ -4010,12 +4483,14 @@
     facebook: RepJuanVargas
     twitter: RepJuanVargas
     youtube: RepJuanVargas
+    facebook_id: '176942192453747'
 - id:
     bioguide: C001099
     thomas: '02189'
   social:
     facebook: SenatorWilliamMoCowan
     twitter: SenMoCowan
+    facebook_id: '529202873791889'
 - id:
     bioguide: K000384
     thomas: '02176'
@@ -4024,6 +4499,7 @@
     facebook: SenatorKaine
     twitter: SenKaineOffice
     youtube: SenatorTimKaine
+    facebook_id: '482778861771212'
 - id:
     bioguide: S001194
     thomas: '02173'


### PR DESCRIPTION
There are a number of cases, such as iOS native app URL schemes, where Facebook graph IDs are needed instead of usernames.

This pull request adds a resolvefb command to _social_media.py_ script and updates _legislators-social-media.yaml_ to include both `facebook` and `facebook_id` keys.
