### PR TITLE
FEC

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -35787,6 +35787,8 @@
     votesmart: 21991
     ballotpedia: Mark Sanford
     cspan: 6513
+    fec :
+      - H4SC01073
   name:
     first: Marshall
     last: Sanford
@@ -35830,6 +35832,8 @@
     opensecrets: N00033549
     wikipedia: Jason T. Smith
     votesmart: 59318
+    fec:
+      - H4MO08162
   name:
     first: Jason
     middle: T.


### PR DESCRIPTION
adding mising fec data, there are no ids for Mo Cowan or Jeff Chiesa
because they were not elected, but appointed
