### PR TITLE
corrected CRP ids

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -37469,7 +37469,7 @@
     wikipedia: Robin Kelly
     fec:
     - H2IL02172
-    opensecrets: N00033549
+    opensecrets: N00035215
     ballotpedia: Robin Kelly
     cspan: 70399
     washington_post: 0e9272ea-b743-11e2-b94c-b684dda07add
@@ -37498,7 +37498,7 @@
     bioguide: S000051
     thomas: '01012'
     govtrack: 400607
-    opensecrets: N00033549
+    opensecrets: N00002424
     wikipedia: Mark Sanford
     votesmart: 21991
     ballotpedia: Mark Sanford
@@ -37550,7 +37550,6 @@
     bioguide: S001195
     thomas: '02191'
     govtrack: 412596
-    opensecrets: N00033549
     wikipedia: Jason T. Smith
     votesmart: 59318
     maplight: 35979


### PR DESCRIPTION
Robin Kelley and Mark Sanford had incorrect (duplicate) CRP ids,
created by errer in influence_ids.py (since corrected). Jason Smith had
duplicate similar id, but currently has not been assigned CRP id.
