### PR TITLE
Update legislators-social-media.yaml

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -679,7 +679,7 @@
     thomas: '01528'
     govtrack: 400379
   social:
-    twitter: Rep_Adam_Smith
+    twitter: RepAdamSmith
     facebook: RepAdamSmith
     youtube: CongressmanAdamSmith
     facebook_id: '288586617834523'
@@ -1140,7 +1140,7 @@
     thomas: '01910'
     govtrack: 412308
   social:
-    twitter: RepPolisPress
+    twitter: repjaredpolis
     facebook: jaredpolis
     youtube: JaredPolis31275
     facebook_id: '53481427529'


### PR DESCRIPTION
Fixed the handles for Rep. Jared Polis and Rep. Adam Smith, which were pulling the wrong handles for them.
