### PR TITLE
Add Ed Markey's FEC ID for 2014 Senate run

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -19762,6 +19762,7 @@
     icpsr: 14435
     fec:
     - H6MA07101
+    - S4MA00028
     cspan: 260
     wikipedia: Ed Markey
     house_history: 17493


### PR DESCRIPTION
Addresses issue #180. See
http://docquery.fec.gov/cgi-bin/fecimg/?S4MA00028
