### PR TITLE
Added Kirsten Gillibrand's facebook and twitter

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -5072,6 +5072,9 @@
   social:
     youtube: KirstenEGillibrand
     youtube_id: UCVEloQogVsmnkd5vxJInmYg
+    twitter: SenGillibrand
+    facebook: KirstenGillibrand
+    facebook_id: '6820348410'
 - id:
     bioguide: R000584
     govtrack: 412322


### PR DESCRIPTION
I've noticed that a decent amount of these are either missing or incorrect. How can we ensure that legislator's social media ids are up-to-date and accurate?
