### PR TITLE
update scrapelib to 0.10.0, remove follow_robots kwarg

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 rtyaml
-scrapelib
+scrapelib>=0.10.0
 ipython
 lxml>=2.2
 cssselect

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -165,7 +165,7 @@ def save_data(data, path):
 ##### Downloading
 
 import scrapelib
-scraper = scrapelib.Scraper(requests_per_minute=60, follow_robots=False, retry_attempts=3)
+scraper = scrapelib.Scraper(requests_per_minute=60, retry_attempts=3)
 scraper.user_agent = "the @unitedstates project (https://github.com/unitedstates/congress-legislators)"
 
 def cache_dir():


### PR DESCRIPTION
[scrapelib](https://github.com/sunlightlabs/scrapelib) updated to `0.10`, and removed the `follow_robots` parameter and default behavior.

Unfortunately, removing the follow_robots keyword and _not_ updating to `0.10` has the effect of enforcing robots.txt checking.

So after merging, **anyone with this deployed needs to re-run `pip install -r requirements.txt`**. This will fix the 
[currently broken build in Travis CI](https://travis-ci.org/unitedstates/congress-legislators/builds/31331752) as well.

I'll leave it to a project owner to merge.
