### PR TITLE
Add FEC ID for Bruce Braley Senate run

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -5567,6 +5567,7 @@
     votesmart: 57382
     fec:
     - H6IA01098
+    - S4IA00087
     cspan: 1020421
     wikipedia: Bruce Braley
     house_history: 10417


### PR DESCRIPTION
This adds an FEC ID for Bruce Braley for his 2014 Senate Run.

http://www.fec.gov/fecviewer/CandidateCommitteeDetail.do?candidateCommitteeId=S4IA00087&tabIndex=1
