### PR TITLE
Add FEC ID for Colleen Hanabusa Senate run

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -14246,6 +14246,7 @@
     votesmart: 17745
     fec:
     - H2HI02110
+    - S4HI00144
     cspan: 61258
     wikipedia: Colleen Hanabusa
     house_history: 15596


### PR DESCRIPTION
This adds an FEC ID for Colleen Hanabusa for her 2014 Senate Run.

http://www.fec.gov/fecviewer/CandidateCommitteeDetail.do?candidateCommitteeId=S4HI00144&tabIndex=1
