### PR TITLE
Alter Thad's roles to avoid overlapping terms.

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -1536,13 +1536,7 @@
     district: 4
     party: Republican
   - type: sen
-    start: '1978-01-01'
-    end: '1978-10-15'
-    state: MS
-    class: 2
-    party: Republican
-  - type: sen
-    start: '1979-01-15'
+    start: '1978-12-27'
     end: '1984-10-12'
     state: MS
     class: 2


### PR DESCRIPTION
As far as I can tell, the situation is as follows:

```
93
    - January 3, 1973 – December 22, 1973
    - January 21, 1974 – December 20, 1974
94
    - January 14, 1975 – December 19, 1975
    - January 19, 1976 – October 1, 1976
95
    - January 4, 1977 – December 15, 1977
    - January 19, 1978 – October 15, 1978

  RESIGNED FROM HOR ON December 26, 1978


  APPOINTED TO SENATE ON BY GOV
        December 27, 1978 -> January 3, 1979

Senate:
    January 3, 1979 -> 1990
    1990 -> 1996
    1996 -> 2002
    2002 -> 2008
    2008 -> 2015
```

Can someone double check this?
