### PR TITLE
Update Senator Stabenow's Twitter Handle

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -673,7 +673,7 @@
     thomas: '01531'
     govtrack: 300093
   social:
-    twitter: StabenowPress
+    twitter: SenStabenow
     youtube: senatorstabenow
     youtube_id: UCFoDKCvxSwCUfDv-4Eg4K5A
 - id:


### PR DESCRIPTION
There's a link to the SenStabenow handle on http://www.stabenow.senate.gov/ and stabenow.senate.gov is listed on twitter.com/SenStabenow.
