### PR TITLE
Corrected the Twitter handle for Rep. John Sarbanes

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -5039,7 +5039,7 @@
     bioguide: S001168
     govtrack: 412212
   social:
-    twitter: RepJohnSarbanes
+    twitter: RepSarbanes
 - id:
     bioguide: B001285
     govtrack: 412516


### PR DESCRIPTION
His official site links to [@RepSarbanes](https://twitter.com/RepSarbanes) (a confirmed account) here:
http://sarbanes.house.gov/frontpage

...though [@RepJohnSarbanes](https://twitter.com/RepJohnSarbanes) (an account by the name of "Big Prosperity" with the bio saying "Getting a Break from Social since i'm Making $350 for each day earning a living live on the internet from home. My personal goals in the end grew reality.") is linked on his official site here:
http://sarbanes.house.gov/about-john

I propose making this file change to boldly cause /congress-legislators to be less sloppy than legislators in Congress.
