### PR TITLE
Update social media accounts for Sen. Cory Gardner

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -2360,11 +2360,10 @@
     thomas: '01998'
     govtrack: 412406
   social:
-    twitter: RepCoryGardner
-    facebook: CongressmanGardner
-    youtube: CongressmanGardner
+    twitter: SenCoryGardner
+    facebook: SenCoryGardner
     facebook_id: '160924893954206'
-    youtube_id: UC1-BXolBAZvDUSNZJCSsrTA
+    youtube_id: UC7Vi5vAFb7piu_BNwrYDBxQ
 - id:
     bioguide: G000560
     thomas: '01979'


### PR DESCRIPTION
Updates for social media accounts of Sen. Cory Gardner via http://www.gardner.senate.gov/

Note, I don't see a valid 'youtube' just a 'youtube_id' linked from his official page. Youtube channel/user/names are weird.