### PR TITLE
Update contact_form link

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -4840,7 +4840,7 @@
     address: 112 Hart Senate Office Building Washington DC 20510
     phone: 202-224-3553
     fax: 202-224-0454
-    contact_form: http://www.boxer.senate.gov/en/contact/policycomments.cfm
+    contact_form: https://www.boxer.senate.gov/contact/shareyourviews.html
     office: 112 Hart Senate Office Building
     state_rank: junior
 - id:


### PR DESCRIPTION
Does this repo grab data from the contact-congress repo for contact links? That repo is perhaps the most up to date for contact form links.