### PR TITLE
Most Committees for 114th Congress

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -10641,12 +10641,12 @@ JSTX:
   bioguide: S000770
   thomas: '01531'
   chamber: senate
-- name: Dave Camp
+- name: Paul Ryan
   party: majority
   rank: 1
   title: Chairman
-  bioguide: C000071
-  thomas: '00166'
+  bioguide: R000570
+  thomas: '01560'
   chamber: house
 - name: Sam Johnson
   party: majority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -10346,15 +10346,9 @@ JCSE:
   bioguide: A000055
   thomas: '01460'
   chamber: house
-- name: Phil Gingrey
-  party: majority
-  rank: 4
-  bioguide: G000550
-  thomas: '01720'
-  chamber: house
 - name: Michael C. Burgess
   party: majority
-  rank: 5
+  rank: 4
   bioguide: B001248
   thomas: '01751'
   chamber: house
@@ -10370,15 +10364,9 @@ JCSE:
   bioguide: S000480
   thomas: '01069'
   chamber: house
-- name: Mike McIntyre
-  party: minority
-  rank: 3
-  bioguide: M000485
-  thomas: '01505'
-  chamber: house
 - name: Steve Cohen
   party: minority
-  rank: 4
+  rank: 3
   bioguide: C001068
   thomas: '01878'
   chamber: house

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -10536,6 +10536,12 @@ JSLC:
   bioguide: M001150
   thomas: '01731'
   chamber: house
+- name: Tom Cole
+  party: majority
+  rank: 3
+  bioguide: C001053
+  thomas: '01742'
+  chamber: house
 - name: Robert A. Brady
   party: minority
   rank: 1

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -1,240 +1,116 @@
 HLIG:
-- name: Mike Rogers
+- name: Devin Nunes
   party: majority
   rank: 1
   title: Chair
-  bioguide: R000572
-  thomas: '01651'
-- name: Mac Thornberry
-  party: majority
-  rank: 2
-  bioguide: T000238
-  thomas: '01155'
+  bioguide: N000181
+  thomas: '01710'
 - name: Jeff Miller
   party: majority
-  rank: 3
+  rank: 2
   bioguide: M001144
   thomas: '01685'
 - name: K. Michael Conaway
   party: majority
-  rank: 4
+  rank: 3
   bioguide: C001062
   thomas: '01805'
 - name: Peter T. King
   party: majority
-  rank: 5
+  rank: 4
   bioguide: K000210
   thomas: '00635'
 - name: Frank A. LoBiondo
   party: majority
-  rank: 6
+  rank: 5
   bioguide: L000554
   thomas: '00699'
-- name: Devin Nunes
-  party: majority
-  rank: 7
-  bioguide: N000181
-  thomas: '01710'
 - name: Lynn A. Westmoreland
   party: majority
-  rank: 8
+  rank: 6
   bioguide: W000796
   thomas: '01779'
-- name: Michele Bachmann
+- name: Thomas J. Rooney
+  party: majority
+  rank: 7
+  bioguide: R000583
+  thomas: '01916'
+- name: Joseph J. Heck
+  party: majority
+  rank: 8
+  bioguide: H001055
+  thomas: '02040'
+- name: Mike Pompeo
   party: majority
   rank: 9
-  bioguide: B001256
-  thomas: '01858'
-- name: Thomas J. Rooney
+  bioguide: P000602
+  thomas: '02022'
+- name: Ileana Ros-Lehtinen
   party: majority
   rank: 10
-  bioguide: R000583
-  thomas: '01916'
-- name: Joseph J. Heck
+  bioguide: R000435
+  thomas: '00985'
+- name: Michael R. Turner
   party: majority
   rank: 11
-  bioguide: H001055
-  thomas: '02040'
-- name: Mike Pompeo
+  bioguide: T000463
+  thomas: '01741'
+- name: Brad R. Wenstrup
   party: majority
   rank: 12
-  bioguide: P000602
-  thomas: '02022'
-- name: C. A. Dutch Ruppersberger
+  bioguide: W000815
+  thomas: '02152'
+- name: Chris Stewart
+  party: majority
+  rank: 13
+  bioguide: S001192
+  thomas: '02168'
+- name: Adam B. Schiff
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: R000576
-  thomas: '01728'
-- name: Mike Thompson
-  party: minority
-  rank: 2
-  bioguide: T000460
-  thomas: '01593'
-- name: Janice D. Schakowsky
-  party: minority
-  rank: 3
-  bioguide: S001145
-  thomas: '01588'
-- name: James R. Langevin
-  party: minority
-  rank: 4
-  bioguide: L000559
-  thomas: '01668'
-- name: Adam B. Schiff
-  party: minority
-  rank: 5
   bioguide: S001150
   thomas: '01635'
 - name: Luis V. Gutiérrez
+  party: minority
+  rank: 2
+  bioguide: G000535
+  thomas: '00478'
+- name: James A. Himes
+  party: minority
+  rank: 3
+  bioguide: H001047
+  thomas: '01913'
+- name: Terri A. Sewell
+  party: minority
+  rank: 4
+  bioguide: S001185
+  thomas: '01988'
+- name: André Carson
+  party: minority
+  rank: 5
+  bioguide: C001072
+  thomas: '01889'
+- name: Jackie Speier
   party: minority
   rank: 6
-  bioguide: G000535
-  thomas: '00478'
-- name: Ed Pastor
+  bioguide: S001175
+  thomas: '01890'
+- name: Mike Quigley
   party: minority
   rank: 7
-  bioguide: P000099
-  thomas: '00893'
-- name: James A. Himes
+  bioguide: Q000023
+  thomas: '01967'
+- name: Eric Swalwell
   party: minority
   rank: 8
-  bioguide: H001047
-  thomas: '01913'
-- name: Terri A. Sewell
+  bioguide: S001193
+  thomas: '02104'
+- name: Patrick Murphy
   party: minority
   rank: 9
-  bioguide: S001185
-  thomas: '01988'
-HLIG05:
-- name: Joseph J. Heck
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: H001055
-  thomas: '02040'
-- name: Mac Thornberry
-  party: majority
-  rank: 2
-  bioguide: T000238
-  thomas: '01155'
-- name: Frank A. LoBiondo
-  party: majority
-  rank: 3
-  bioguide: L000554
-  thomas: '00699'
-- name: Michele Bachmann
-  party: majority
-  rank: 4
-  bioguide: B001256
-  thomas: '01858'
-- name: Mike Pompeo
-  party: majority
-  rank: 5
-  bioguide: P000602
-  thomas: '02022'
-- name: Adam B. Schiff
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001150
-  thomas: '01635'
-- name: James R. Langevin
-  party: minority
-  rank: 2
-  bioguide: L000559
-  thomas: '01668'
-- name: Terri A. Sewell
-  party: minority
-  rank: 3
-  bioguide: S001185
-  thomas: '01988'
-HLIG08:
-- name: K. Michael Conaway
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001062
-  thomas: '01805'
-- name: Peter T. King
-  party: majority
-  rank: 2
-  bioguide: K000210
-  thomas: '00635'
-- name: Frank A. LoBiondo
-  party: majority
-  rank: 3
-  bioguide: L000554
-  thomas: '00699'
-- name: Thomas J. Rooney
-  party: majority
-  rank: 4
-  bioguide: R000583
-  thomas: '01916'
-- name: Devin Nunes
-  party: majority
-  rank: 5
-  bioguide: N000181
-  thomas: '01710'
-- name: Mike Thompson
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: T000460
-  thomas: '01593'
-- name: Luis V. Gutiérrez
-  party: minority
-  rank: 2
-  bioguide: G000535
-  thomas: '00478'
-- name: James A. Himes
-  party: minority
-  rank: 3
-  bioguide: H001047
-  thomas: '01913'
-HLIG09:
-- name: Lynn A. Westmoreland
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: W000796
-  thomas: '01779'
-- name: Jeff Miller
-  party: majority
-  rank: 2
-  bioguide: M001144
-  thomas: '01685'
-- name: Michele Bachmann
-  party: majority
-  rank: 3
-  bioguide: B001256
-  thomas: '01858'
-- name: Thomas J. Rooney
-  party: majority
-  rank: 4
-  bioguide: R000583
-  thomas: '01916'
-- name: Mike Pompeo
-  party: majority
-  rank: 5
-  bioguide: P000602
-  thomas: '02022'
-- name: Janice D. Schakowsky
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001145
-  thomas: '01588'
-- name: Ed Pastor
-  party: minority
-  rank: 2
-  bioguide: P000099
-  thomas: '00893'
-- name: James A. Himes
-  party: minority
-  rank: 3
-  bioguide: H001047
-  thomas: '01913'
+  bioguide: M001191
+  thomas: '02117'
 HLZI:
 - name: Trey Gowdy
   party: majority
@@ -299,37 +175,37 @@ HLZI:
   bioguide: D000622
   thomas: '02123'
 HSAG:
-- name: Frank D. Lucas
+- name: K. Michael Conaway
   party: majority
   rank: 1
   title: Chair
-  bioguide: L000491
-  thomas: '00711'
+  bioguide: C001062
+  thomas: '01805'
 - name: Bob Goodlatte
   party: majority
   rank: 2
   bioguide: G000289
   thomas: '00446'
-- name: Steve King
+- name: Frank D. Lucas
   party: majority
   rank: 3
+  bioguide: L000491
+  thomas: '00711'
+- name: Steve King
+  party: majority
+  rank: 4
   bioguide: K000362
   thomas: '01724'
 - name: Randy Neugebauer
   party: majority
-  rank: 4
+  rank: 5
   bioguide: N000182
   thomas: '01758'
 - name: Mike Rogers
   party: majority
-  rank: 5
+  rank: 6
   bioguide: R000575
   thomas: '01704'
-- name: K. Michael Conaway
-  party: majority
-  rank: 6
-  bioguide: C001062
-  thomas: '01805'
 - name: Glenn Thompson
   party: majority
   rank: 7
@@ -345,270 +221,358 @@ HSAG:
   rank: 9
   bioguide: S001189
   thomas: '02009'
-- name: Scott R. Tipton
-  party: majority
-  rank: 10
-  bioguide: T000470
-  thomas: '01997'
 - name: Eric A. "Rick" Crawford
   party: majority
-  rank: 11
+  rank: 10
   bioguide: C001087
   thomas: '01989'
 - name: Scott DesJarlais
   party: majority
-  rank: 12
+  rank: 11
   bioguide: D000616
   thomas: '02062'
 - name: Christopher P. Gibson
   party: majority
-  rank: 13
+  rank: 12
   bioguide: G000564
   thomas: '02043'
 - name: Vicky Hartzler
   party: majority
-  rank: 14
+  rank: 13
   bioguide: H001053
   thomas: '02032'
-- name: Reid J. Ribble
-  party: majority
-  rank: 15
-  bioguide: R000587
-  thomas: '02073'
-- name: Kristi L. Noem
-  party: majority
-  rank: 16
-  bioguide: N000184
-  thomas: '02060'
 - name: Dan Benishek
   party: majority
-  rank: 17
+  rank: 14
   bioguide: B001271
   thomas: '02027'
 - name: Jeff Denham
   party: majority
-  rank: 18
+  rank: 15
   bioguide: D000612
   thomas: '01995'
-- name: Stephen Lee Fincher
-  party: majority
-  rank: 19
-  bioguide: F000458
-  thomas: '02064'
 - name: Doug LaMalfa
   party: majority
-  rank: 20
+  rank: 16
   bioguide: L000578
   thomas: '02100'
-- name: Richard Hudson
-  party: majority
-  rank: 21
-  bioguide: H001067
-  thomas: '02140'
 - name: Rodney Davis
   party: majority
-  rank: 22
+  rank: 17
   bioguide: D000619
   thomas: '02126'
-- name: Chris Collins
-  party: majority
-  rank: 23
-  bioguide: C001092
-  thomas: '02151'
 - name: Ted S. Yoho
   party: majority
-  rank: 24
+  rank: 18
   bioguide: Y000065
   thomas: '02115'
-- name: Vance M. McAllister
+- name: Jackie Walorski
+  party: majority
+  rank: 19
+  bioguide: W000813
+  thomas: '02128'
+- name: Rick W. Allen
+  party: majority
+  rank: 20
+  bioguide: A000372
+  thomas: '02239'
+- name: Mike Bost
+  party: majority
+  rank: 21
+  bioguide: B001295
+  thomas: '02243'
+- name: David Rouzer
+  party: majority
+  rank: 22
+  bioguide: R000603
+  thomas: '02256'
+- name: Ralph Lee Abraham
+  party: majority
+  rank: 23
+  bioguide: A000374
+  thomas: '02244'
+- name: Tom Emmer
+  party: majority
+  rank: 24
+  bioguide: E000294
+  thomas: '02253'
+- name: John R. Moolenaar
   party: majority
   rank: 25
-  bioguide: M001192
-  thomas: '02195'
+  bioguide: M001194
+  thomas: '02248'
+- name: Dan Newhouse
+  party: majority
+  rank: 26
+  bioguide: N000189
+  thomas: '02275'
 - name: Collin C. Peterson
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000258
   thomas: '00910'
-- name: Mike McIntyre
-  party: minority
-  rank: 2
-  bioguide: M000485
-  thomas: '01505'
 - name: David Scott
   party: minority
-  rank: 3
+  rank: 2
   bioguide: S001157
   thomas: '01722'
 - name: Jim Costa
   party: minority
-  rank: 4
+  rank: 3
   bioguide: C001059
   thomas: '01774'
 - name: Timothy J. Walz
   party: minority
-  rank: 5
+  rank: 4
   bioguide: W000799
   thomas: '01856'
-- name: Kurt Schrader
-  party: minority
-  rank: 6
-  bioguide: S001180
-  thomas: '01950'
 - name: Marcia L. Fudge
   party: minority
-  rank: 7
+  rank: 5
   bioguide: F000455
   thomas: '01895'
 - name: James P. McGovern
   party: minority
-  rank: 8
+  rank: 6
   bioguide: M000312
   thomas: '01504'
 - name: Suzan K. DelBene
   party: minority
-  rank: 9
+  rank: 7
   bioguide: D000617
   thomas: '02096'
-- name: Gloria Negrete McLeod
-  party: minority
-  rank: 10
-  bioguide: N000187
-  thomas: '02108'
 - name: Filemon Vela
   party: minority
-  rank: 11
+  rank: 8
   bioguide: V000132
   thomas: '02167'
 - name: Michelle Lujan Grisham
   party: minority
-  rank: 12
+  rank: 9
   bioguide: L000580
   thomas: '02146'
 - name: Ann M. Kuster
   party: minority
-  rank: 13
+  rank: 10
   bioguide: K000382
   thomas: '02145'
 - name: Richard M. Nolan
   party: minority
-  rank: 14
+  rank: 11
   bioguide: N000127
   thomas: '00867'
-- name: Pete P. Gallego
-  party: minority
-  rank: 15
-  bioguide: G000572
-  thomas: '02164'
-- name: William L. Enyart
-  party: minority
-  rank: 16
-  bioguide: E000292
-  thomas: '02125'
-- name: Juan Vargas
-  party: minority
-  rank: 17
-  bioguide: V000130
-  thomas: '02112'
 - name: Cheri Bustos
   party: minority
-  rank: 18
+  rank: 12
   bioguide: B001286
   thomas: '02127'
 - name: Sean Patrick Maloney
   party: minority
-  rank: 19
+  rank: 13
   bioguide: M001185
   thomas: '02150'
-- name: Joe Courtney
+- name: Ann Kirkpatrick
   party: minority
-  rank: 20
-  bioguide: C001069
-  thomas: '01836'
-- name: John Garamendi
+  rank: 14
+  bioguide: K000368
+  thomas: '01907'
+- name: Pete Aguilar
   party: minority
-  rank: 21
-  bioguide: G000559
-  thomas: '01973'
-HSAG14:
-- name: Austin Scott
+  rank: 15
+  bioguide: A000371
+  thomas: '02229'
+- name: Stacey E. Plaskett
+  party: minority
+  rank: 16
+  bioguide: P000610
+  thomas: '02274'
+- name: Alma S. Adams
+  party: minority
+  rank: 17
+  bioguide: A000370
+  thomas: '02201'
+- name: Gwen Graham
+  party: minority
+  rank: 18
+  bioguide: G000575
+  thomas: '02234'
+- name: Brad Ashford
+  party: minority
+  rank: 19
+  bioguide: A000373
+  thomas: '02257'
+HSAG03:
+- name: Jackie Walorski
   party: majority
   rank: 1
   title: Chair
-  bioguide: S001189
-  thomas: '02009'
-- name: Vicky Hartzler
+  bioguide: W000813
+  thomas: '02128'
+- name: Randy Neugebauer
   party: majority
   rank: 2
-  bioguide: H001053
-  thomas: '02032'
-- name: Jeff Denham
+  bioguide: N000182
+  thomas: '01758'
+- name: Glenn Thompson
   party: majority
   rank: 3
-  bioguide: D000612
-  thomas: '01995'
-- name: Stephen Lee Fincher
+  bioguide: T000467
+  thomas: '01952'
+- name: Bob Gibbs
   party: majority
   rank: 4
-  bioguide: F000458
-  thomas: '02064'
-- name: Doug LaMalfa
+  bioguide: G000563
+  thomas: '02049'
+- name: Eric A. "Rick" Crawford
   party: majority
   rank: 5
-  bioguide: L000578
-  thomas: '02100'
-- name: Rodney Davis
+  bioguide: C001087
+  thomas: '01989'
+- name: Vicky Hartzler
   party: majority
   rank: 6
-  bioguide: D000619
-  thomas: '02126'
-- name: Chris Collins
+  bioguide: H001053
+  thomas: '02032'
+- name: Dan Benishek
   party: majority
   rank: 7
-  bioguide: C001092
-  thomas: '02151'
-- name: Ted S. Yoho
+  bioguide: B001271
+  thomas: '02027'
+- name: Rodney Davis
   party: majority
   rank: 8
+  bioguide: D000619
+  thomas: '02126'
+- name: Ted S. Yoho
+  party: majority
+  rank: 9
   bioguide: Y000065
   thomas: '02115'
-- name: Kurt Schrader
+- name: David Rouzer
+  party: majority
+  rank: 10
+  bioguide: R000603
+  thomas: '02256'
+- name: Ralph Lee Abraham
+  party: majority
+  rank: 11
+  bioguide: A000374
+  thomas: '02244'
+- name: John R. Moolenaar
+  party: majority
+  rank: 12
+  bioguide: M001194
+  thomas: '02248'
+- name: James P. McGovern
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: S001180
-  thomas: '01950'
-- name: Suzan K. DelBene
-  party: minority
-  rank: 2
-  bioguide: D000617
-  thomas: '02096'
-- name: Jim Costa
-  party: minority
-  rank: 3
-  bioguide: C001059
-  thomas: '01774'
+  bioguide: M000312
+  thomas: '01504'
 - name: Marcia L. Fudge
   party: minority
-  rank: 4
+  rank: 2
   bioguide: F000455
   thomas: '01895'
-- name: Ann M. Kuster
+- name: Alma S. Adams
+  party: minority
+  rank: 3
+  bioguide: A000370
+  thomas: '02201'
+- name: Michelle Lujan Grisham
+  party: minority
+  rank: 4
+  bioguide: L000580
+  thomas: '02146'
+- name: Pete Aguilar
   party: minority
   rank: 5
-  bioguide: K000382
-  thomas: '02145'
-- name: Juan Vargas
+  bioguide: A000371
+  thomas: '02229'
+- name: Stacey E. Plaskett
   party: minority
   rank: 6
-  bioguide: V000130
-  thomas: '02112'
-- name: Sean Patrick Maloney
+  bioguide: P000610
+  thomas: '02274'
+- name: Brad Ashford
   party: minority
   rank: 7
-  bioguide: M001185
-  thomas: '02150'
+  bioguide: A000373
+  thomas: '02257'
+- name: Suzan K. DelBene
+  party: minority
+  rank: 8
+  bioguide: D000617
+  thomas: '02096'
+HSAG14:
+- name: Rodney Davis
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000619
+  thomas: '02126'
+- name: Glenn Thompson
+  party: majority
+  rank: 2
+  bioguide: T000467
+  thomas: '01952'
+- name: Austin Scott
+  party: majority
+  rank: 3
+  bioguide: S001189
+  thomas: '02009'
+- name: Christopher P. Gibson
+  party: majority
+  rank: 4
+  bioguide: G000564
+  thomas: '02043'
+- name: Jeff Denham
+  party: majority
+  rank: 5
+  bioguide: D000612
+  thomas: '01995'
+- name: Ted S. Yoho
+  party: majority
+  rank: 6
+  bioguide: Y000065
+  thomas: '02115'
+- name: John R. Moolenaar
+  party: majority
+  rank: 7
+  bioguide: M001194
+  thomas: '02248'
+- name: Dan Newhouse
+  party: majority
+  rank: 8
+  bioguide: N000189
+  thomas: '02275'
+- name: Suzan K. DelBene
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000617
+  thomas: '02096'
+- name: Marcia L. Fudge
+  party: minority
+  rank: 2
+  bioguide: F000455
+  thomas: '01895'
+- name: James P. McGovern
+  party: minority
+  rank: 3
+  bioguide: M000312
+  thomas: '01504'
+- name: Ann M. Kuster
+  party: minority
+  rank: 4
+  bioguide: K000382
+  thomas: '02145'
+- name: Gwen Graham
+  party: minority
+  rank: 5
+  bioguide: G000575
+  thomas: '02234'
 HSAG15:
 - name: Glenn Thompson
   party: majority
@@ -616,285 +580,187 @@ HSAG15:
   title: Chair
   bioguide: T000467
   thomas: '01952'
-- name: Mike Rogers
+- name: Frank D. Lucas
   party: majority
   rank: 2
+  bioguide: L000491
+  thomas: '00711'
+- name: Steve King
+  party: majority
+  rank: 3
+  bioguide: K000362
+  thomas: '01724'
+- name: Scott DesJarlais
+  party: majority
+  rank: 4
+  bioguide: D000616
+  thomas: '02062'
+- name: Christopher P. Gibson
+  party: majority
+  rank: 5
+  bioguide: G000564
+  thomas: '02043'
+- name: Dan Benishek
+  party: majority
+  rank: 6
+  bioguide: B001271
+  thomas: '02027'
+- name: Rick W. Allen
+  party: majority
+  rank: 7
+  bioguide: A000372
+  thomas: '02239'
+- name: Mike Bost
+  party: majority
+  rank: 8
+  bioguide: B001295
+  thomas: '02243'
+- name: Michelle Lujan Grisham
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000580
+  thomas: '02146'
+- name: Ann M. Kuster
+  party: minority
+  rank: 2
+  bioguide: K000382
+  thomas: '02145'
+- name: Richard M. Nolan
+  party: minority
+  rank: 3
+  bioguide: N000127
+  thomas: '00867'
+- name: Suzan K. DelBene
+  party: minority
+  rank: 4
+  bioguide: D000617
+  thomas: '02096'
+- name: Ann Kirkpatrick
+  party: minority
+  rank: 5
+  bioguide: K000368
+  thomas: '01907'
+HSAG16:
+- name: Eric A. "Rick" Crawford
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001087
+  thomas: '01989'
+- name: Frank D. Lucas
+  party: majority
+  rank: 2
+  bioguide: L000491
+  thomas: '00711'
+- name: Randy Neugebauer
+  party: majority
+  rank: 3
+  bioguide: N000182
+  thomas: '01758'
+- name: Mike Rogers
+  party: majority
+  rank: 4
   bioguide: R000575
   thomas: '01704'
 - name: Bob Gibbs
   party: majority
-  rank: 3
+  rank: 5
   bioguide: G000563
   thomas: '02049'
-- name: Scott R. Tipton
-  party: majority
-  rank: 4
-  bioguide: T000470
-  thomas: '01997'
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 5
-  bioguide: C001087
-  thomas: '01989'
-- name: Reid J. Ribble
+- name: Austin Scott
   party: majority
   rank: 6
-  bioguide: R000587
-  thomas: '02073'
-- name: Kristi L. Noem
+  bioguide: S001189
+  thomas: '02009'
+- name: Jeff Denham
   party: majority
   rank: 7
-  bioguide: N000184
-  thomas: '02060'
-- name: Dan Benishek
+  bioguide: D000612
+  thomas: '01995'
+- name: Doug LaMalfa
   party: majority
   rank: 8
-  bioguide: B001271
-  thomas: '02027'
-- name: Vance M. McAllister
+  bioguide: L000578
+  thomas: '02100'
+- name: Jackie Walorski
   party: majority
   rank: 9
-  bioguide: M001192
-  thomas: '02195'
+  bioguide: W000813
+  thomas: '02128'
+- name: Rick W. Allen
+  party: majority
+  rank: 10
+  bioguide: A000372
+  thomas: '02239'
+- name: Mike Bost
+  party: majority
+  rank: 11
+  bioguide: B001295
+  thomas: '02243'
+- name: Ralph Lee Abraham
+  party: majority
+  rank: 12
+  bioguide: A000374
+  thomas: '02244'
 - name: Timothy J. Walz
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000799
   thomas: '01856'
-- name: Gloria Negrete McLeod
-  party: minority
-  rank: 2
-  bioguide: N000187
-  thomas: '02108'
-- name: Ann M. Kuster
-  party: minority
-  rank: 3
-  bioguide: K000382
-  thomas: '02145'
-- name: Richard M. Nolan
-  party: minority
-  rank: 4
-  bioguide: N000127
-  thomas: '00867'
-- name: Mike McIntyre
-  party: minority
-  rank: 5
-  bioguide: M000485
-  thomas: '01505'
-- name: Kurt Schrader
-  party: minority
-  rank: 6
-  bioguide: S001180
-  thomas: '01950'
-- name: Suzan K. DelBene
-  party: minority
-  rank: 7
-  bioguide: D000617
-  thomas: '02096'
-HSAG16:
-- name: K. Michael Conaway
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001062
-  thomas: '01805'
-- name: Randy Neugebauer
-  party: majority
-  rank: 2
-  bioguide: N000182
-  thomas: '01758'
-- name: Mike Rogers
-  party: majority
-  rank: 3
-  bioguide: R000575
-  thomas: '01704'
-- name: Bob Gibbs
-  party: majority
-  rank: 4
-  bioguide: G000563
-  thomas: '02049'
-- name: Austin Scott
-  party: majority
-  rank: 5
-  bioguide: S001189
-  thomas: '02009'
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 6
-  bioguide: C001087
-  thomas: '01989'
-- name: Christopher P. Gibson
-  party: majority
-  rank: 7
-  bioguide: G000564
-  thomas: '02043'
-- name: Vicky Hartzler
-  party: majority
-  rank: 8
-  bioguide: H001053
-  thomas: '02032'
-- name: Kristi L. Noem
-  party: majority
-  rank: 9
-  bioguide: N000184
-  thomas: '02060'
-- name: Dan Benishek
-  party: majority
-  rank: 10
-  bioguide: B001271
-  thomas: '02027'
-- name: Doug LaMalfa
-  party: majority
-  rank: 11
-  bioguide: L000578
-  thomas: '02100'
-- name: Richard Hudson
-  party: majority
-  rank: 12
-  bioguide: H001067
-  thomas: '02140'
-- name: Rodney Davis
-  party: majority
-  rank: 13
-  bioguide: D000619
-  thomas: '02126'
-- name: Chris Collins
-  party: majority
-  rank: 14
-  bioguide: C001092
-  thomas: '02151'
-- name: Vance M. McAllister
-  party: majority
-  rank: 15
-  bioguide: M001192
-  thomas: '02195'
-- name: David Scott
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001157
-  thomas: '01722'
-- name: Filemon Vela
-  party: minority
-  rank: 2
-  bioguide: V000132
-  thomas: '02167'
-- name: Pete P. Gallego
-  party: minority
-  rank: 3
-  bioguide: G000572
-  thomas: '02164'
-- name: William L. Enyart
-  party: minority
-  rank: 4
-  bioguide: E000292
-  thomas: '02125'
-- name: Juan Vargas
-  party: minority
-  rank: 5
-  bioguide: V000130
-  thomas: '02112'
 - name: Cheri Bustos
   party: minority
-  rank: 6
+  rank: 2
   bioguide: B001286
   thomas: '02127'
+- name: Gwen Graham
+  party: minority
+  rank: 3
+  bioguide: G000575
+  thomas: '02234'
+- name: Brad Ashford
+  party: minority
+  rank: 4
+  bioguide: A000373
+  thomas: '02257'
+- name: David Scott
+  party: minority
+  rank: 5
+  bioguide: S001157
+  thomas: '01722'
+- name: Jim Costa
+  party: minority
+  rank: 6
+  bioguide: C001059
+  thomas: '01774'
 - name: Sean Patrick Maloney
   party: minority
   rank: 7
   bioguide: M001185
   thomas: '02150'
-- name: Timothy J. Walz
+- name: Ann Kirkpatrick
   party: minority
   rank: 8
-  bioguide: W000799
-  thomas: '01856'
-- name: Gloria Negrete McLeod
-  party: minority
-  rank: 9
-  bioguide: N000187
-  thomas: '02108'
-- name: Jim Costa
-  party: minority
-  rank: 10
-  bioguide: C001059
-  thomas: '01774'
-- name: John Garamendi
-  party: minority
-  rank: 11
-  bioguide: G000559
-  thomas: '01973'
+  bioguide: K000368
+  thomas: '01907'
 HSAG22:
-- name: Steve King
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: K000362
-  thomas: '01724'
-- name: Bob Goodlatte
-  party: majority
-  rank: 2
-  bioguide: G000289
-  thomas: '00446'
-- name: Bob Gibbs
-  party: majority
-  rank: 3
-  bioguide: G000563
-  thomas: '02049'
 - name: Austin Scott
   party: majority
-  rank: 4
-  bioguide: S001189
-  thomas: '02009'
-- name: Stephen Lee Fincher
-  party: majority
-  rank: 5
-  bioguide: F000458
-  thomas: '02064'
-- name: Vance M. McAllister
-  party: majority
-  rank: 6
-  bioguide: M001192
-  thomas: '02195'
-- name: Marcia L. Fudge
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: F000455
-  thomas: '01895'
-- name: James P. McGovern
-  party: minority
-  rank: 2
-  bioguide: M000312
-  thomas: '01504'
-- name: Michelle Lujan Grisham
-  party: minority
-  rank: 3
-  bioguide: L000580
-  thomas: '02146'
-- name: Gloria Negrete McLeod
-  party: minority
-  rank: 4
-  bioguide: N000187
-  thomas: '02108'
-HSAG29:
-- name: Eric A. "Rick" Crawford
-  party: majority
   rank: 1
   title: Chair
-  bioguide: C001087
-  thomas: '01989'
+  bioguide: S001189
+  thomas: '02009'
 - name: Bob Goodlatte
   party: majority
   rank: 2
   bioguide: G000289
   thomas: '00446'
-- name: Steve King
+- name: Frank D. Lucas
   party: majority
   rank: 3
-  bioguide: K000362
-  thomas: '01724'
+  bioguide: L000491
+  thomas: '00711'
 - name: Randy Neugebauer
   party: majority
   rank: 4
@@ -905,102 +771,115 @@ HSAG29:
   rank: 5
   bioguide: R000575
   thomas: '01704'
-- name: K. Michael Conaway
+- name: Doug LaMalfa
   party: majority
   rank: 6
-  bioguide: C001062
-  thomas: '01805'
-- name: Glenn Thompson
+  bioguide: L000578
+  thomas: '02100'
+- name: Rodney Davis
   party: majority
   rank: 7
-  bioguide: T000467
-  thomas: '01952'
-- name: Scott DesJarlais
+  bioguide: D000619
+  thomas: '02126'
+- name: Tom Emmer
   party: majority
   rank: 8
+  bioguide: E000294
+  thomas: '02253'
+- name: David Scott
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001157
+  thomas: '01722'
+- name: Filemon Vela
+  party: minority
+  rank: 2
+  bioguide: V000132
+  thomas: '02167'
+- name: Sean Patrick Maloney
+  party: minority
+  rank: 3
+  bioguide: M001185
+  thomas: '02150'
+- name: Ann Kirkpatrick
+  party: minority
+  rank: 4
+  bioguide: K000368
+  thomas: '01907'
+- name: Pete Aguilar
+  party: minority
+  rank: 5
+  bioguide: A000371
+  thomas: '02229'
+HSAG29:
+- name: David Rouzer
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000603
+  thomas: '02256'
+- name: Bob Goodlatte
+  party: majority
+  rank: 2
+  bioguide: G000289
+  thomas: '00446'
+- name: Steve King
+  party: majority
+  rank: 3
+  bioguide: K000362
+  thomas: '01724'
+- name: Scott DesJarlais
+  party: majority
+  rank: 4
   bioguide: D000616
   thomas: '02062'
-- name: Christopher P. Gibson
+- name: Vicky Hartzler
   party: majority
-  rank: 9
-  bioguide: G000564
-  thomas: '02043'
-- name: Reid J. Ribble
-  party: majority
-  rank: 10
-  bioguide: R000587
-  thomas: '02073'
-- name: Jeff Denham
-  party: majority
-  rank: 11
-  bioguide: D000612
-  thomas: '01995'
-- name: Richard Hudson
-  party: majority
-  rank: 12
-  bioguide: H001067
-  thomas: '02140'
+  rank: 5
+  bioguide: H001053
+  thomas: '02032'
 - name: Ted S. Yoho
   party: majority
-  rank: 13
+  rank: 6
   bioguide: Y000065
   thomas: '02115'
+- name: Tom Emmer
+  party: majority
+  rank: 7
+  bioguide: E000294
+  thomas: '02253'
+- name: Dan Newhouse
+  party: majority
+  rank: 8
+  bioguide: N000189
+  thomas: '02275'
 - name: Jim Costa
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001059
   thomas: '01774'
-- name: Mike McIntyre
+- name: Stacey E. Plaskett
   party: minority
   rank: 2
-  bioguide: M000485
-  thomas: '01505'
-- name: David Scott
-  party: minority
-  rank: 3
-  bioguide: S001157
-  thomas: '01722'
+  bioguide: P000610
+  thomas: '02274'
 - name: Filemon Vela
   party: minority
-  rank: 4
+  rank: 3
   bioguide: V000132
   thomas: '02167'
-- name: Michelle Lujan Grisham
-  party: minority
-  rank: 5
-  bioguide: L000580
-  thomas: '02146'
-- name: Pete P. Gallego
-  party: minority
-  rank: 6
-  bioguide: G000572
-  thomas: '02164'
-- name: William L. Enyart
-  party: minority
-  rank: 7
-  bioguide: E000292
-  thomas: '02125'
-- name: Cheri Bustos
-  party: minority
-  rank: 8
-  bioguide: B001286
-  thomas: '02127'
-- name: Kurt Schrader
-  party: minority
-  rank: 9
-  bioguide: S001180
-  thomas: '01950'
 - name: Richard M. Nolan
   party: minority
-  rank: 10
+  rank: 4
   bioguide: N000127
   thomas: '00867'
-- name: Joe Courtney
+- name: Cheri Bustos
   party: minority
-  rank: 11
-  bioguide: C001069
-  thomas: '01836'
+  rank: 5
+  bioguide: B001286
+  thomas: '02127'
 HSAP:
 - name: Harold Rogers
   party: majority
@@ -1008,146 +887,131 @@ HSAP:
   title: Chair
   bioguide: R000395
   thomas: '00977'
-- name: Frank R. Wolf
-  party: majority
-  rank: 2
-  bioguide: W000672
-  thomas: '01238'
-- name: Jack Kingston
-  party: majority
-  rank: 3
-  bioguide: K000220
-  thomas: '00636'
 - name: Rodney P. Frelinghuysen
   party: majority
-  rank: 4
+  rank: 2
   bioguide: F000372
   thomas: '00414'
-- name: Tom Latham
-  party: majority
-  rank: 5
-  bioguide: L000111
-  thomas: '00666'
 - name: Robert B. Aderholt
   party: majority
-  rank: 6
+  rank: 3
   bioguide: A000055
   thomas: '01460'
 - name: Kay Granger
   party: majority
-  rank: 7
+  rank: 4
   bioguide: G000377
   thomas: '01487'
 - name: Michael K. Simpson
   party: majority
-  rank: 8
+  rank: 5
   bioguide: S001148
   thomas: '01590'
 - name: John Abney Culberson
   party: majority
-  rank: 9
+  rank: 6
   bioguide: C001048
   thomas: '01670'
 - name: Ander Crenshaw
   party: majority
-  rank: 10
+  rank: 7
   bioguide: C001045
   thomas: '01643'
 - name: John R. Carter
   party: majority
-  rank: 11
+  rank: 8
   bioguide: C001051
   thomas: '01752'
 - name: Ken Calvert
   party: majority
-  rank: 12
+  rank: 9
   bioguide: C000059
   thomas: '00165'
 - name: Tom Cole
   party: majority
-  rank: 13
+  rank: 10
   bioguide: C001053
   thomas: '01742'
 - name: Mario Diaz-Balart
   party: majority
-  rank: 14
+  rank: 11
   bioguide: D000600
   thomas: '01717'
 - name: Charles W. Dent
   party: majority
-  rank: 15
+  rank: 12
   bioguide: D000604
   thomas: '01799'
 - name: Tom Graves
   party: majority
-  rank: 16
+  rank: 13
   bioguide: G000560
   thomas: '01979'
 - name: Kevin Yoder
   party: majority
-  rank: 17
+  rank: 14
   bioguide: Y000063
   thomas: '02021'
 - name: Steve Womack
   party: majority
-  rank: 18
+  rank: 15
   bioguide: W000809
   thomas: '01991'
-- name: Alan Nunnelee
-  party: majority
-  rank: 19
-  bioguide: N000186
-  thomas: '02034'
 - name: Jeff Fortenberry
   party: majority
-  rank: 20
+  rank: 16
   bioguide: F000449
   thomas: '01793'
 - name: Thomas J. Rooney
   party: majority
-  rank: 21
+  rank: 17
   bioguide: R000583
   thomas: '01916'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
-  rank: 22
+  rank: 18
   bioguide: F000459
   thomas: '02061'
 - name: Jaime Herrera Beutler
+  party: majority
+  rank: 19
+  bioguide: H001056
+  thomas: '02071'
+- name: David P. Joyce
+  party: majority
+  rank: 20
+  bioguide: J000295
+  thomas: '02154'
+- name: David G. Valadao
+  party: majority
+  rank: 21
+  bioguide: V000129
+  thomas: '02105'
+- name: Andy Harris
+  party: majority
+  rank: 22
+  bioguide: H001052
+  thomas: '02026'
+- name: Martha Roby
   party: majority
   rank: 23
-  bioguide: H001056
-  thomas: '02071'
-- name: David P. Joyce
-  party: majority
-  rank: 24
-  bioguide: J000295
-  thomas: '02154'
-- name: David G. Valadao
-  party: majority
-  rank: 25
-  bioguide: V000129
-  thomas: '02105'
-- name: Andy Harris
-  party: majority
-  rank: 26
-  bioguide: H001052
-  thomas: '02026'
-- name: Martha Roby
-  party: majority
-  rank: 27
   bioguide: R000591
   thomas: '01986'
 - name: Mark E. Amodei
   party: majority
-  rank: 28
+  rank: 24
   bioguide: A000369
   thomas: '02090'
 - name: Chris Stewart
   party: majority
-  rank: 29
+  rank: 25
   bioguide: S001192
   thomas: '02168'
+- name: E. Scott Rigell
+  party: majority
+  rank: 26
+  bioguide: R000589
+  thomas: '02068'
 - name: Nita M. Lowey
   party: minority
   rank: 1
@@ -1174,66 +1038,66 @@ HSAP:
   rank: 5
   bioguide: D000216
   thomas: '00281'
-- name: James P. Moran
-  party: minority
-  rank: 6
-  bioguide: M000933
-  thomas: '00832'
-- name: Ed Pastor
-  party: minority
-  rank: 7
-  bioguide: P000099
-  thomas: '00893'
 - name: David E. Price
   party: minority
-  rank: 8
+  rank: 6
   bioguide: P000523
   thomas: '00930'
 - name: Lucille Roybal-Allard
   party: minority
-  rank: 9
+  rank: 7
   bioguide: R000486
   thomas: '00997'
 - name: Sam Farr
   party: minority
-  rank: 10
+  rank: 8
   bioguide: F000030
   thomas: '00368'
 - name: Chaka Fattah
   party: minority
-  rank: 11
+  rank: 9
   bioguide: F000043
   thomas: '00371'
 - name: Sanford D. Bishop Jr.
   party: minority
-  rank: 12
+  rank: 10
   bioguide: B000490
   thomas: '00091'
 - name: Barbara Lee
   party: minority
-  rank: 13
+  rank: 11
   bioguide: L000551
   thomas: '01501'
 - name: Adam B. Schiff
   party: minority
-  rank: 14
+  rank: 12
   bioguide: S001150
   thomas: '01635'
 - name: Michael M. Honda
   party: minority
-  rank: 15
+  rank: 13
   bioguide: H001034
   thomas: '01634'
 - name: Betty McCollum
   party: minority
-  rank: 16
+  rank: 14
   bioguide: M001143
   thomas: '01653'
+- name: Steve Israel
+  party: minority
+  rank: 15
+  bioguide: I000057
+  thomas: '01663'
 - name: Tim Ryan
   party: minority
-  rank: 17
+  rank: 16
   bioguide: R000577
   thomas: '01756'
+- name: C. A. Dutch Ruppersberger
+  party: minority
+  rank: 17
+  bioguide: R000576
+  thomas: '01728'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 18
@@ -1254,901 +1118,193 @@ HSAP:
   rank: 21
   bioguide: Q000023
   thomas: '01967'
-- name: William L. Owens
+- name: Derek Kilmer
   party: minority
   rank: 22
-  bioguide: O000169
-  thomas: '01974'
-HSAP01:
-- name: Robert B. Aderholt
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: A000055
-  thomas: '01460'
-- name: Tom Latham
-  party: majority
-  rank: 2
-  bioguide: L000111
-  thomas: '00666'
-- name: Alan Nunnelee
-  party: majority
-  rank: 3
-  bioguide: N000186
-  thomas: '02034'
-- name: Kevin Yoder
-  party: majority
-  rank: 4
-  bioguide: Y000063
-  thomas: '02021'
-  title: Vice Chair
-- name: Jeff Fortenberry
-  party: majority
-  rank: 5
-  bioguide: F000449
-  thomas: '01793'
-- name: Thomas J. Rooney
-  party: majority
-  rank: 6
-  bioguide: R000583
-  thomas: '01916'
-- name: David G. Valadao
-  party: majority
-  rank: 7
-  bioguide: V000129
-  thomas: '02105'
-- name: Sam Farr
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: F000030
-  thomas: '00368'
-- name: Rosa L. DeLauro
-  party: minority
-  rank: 2
-  bioguide: D000216
-  thomas: '00281'
-- name: Sanford D. Bishop Jr.
-  party: minority
-  rank: 3
-  bioguide: B000490
-  thomas: '00091'
-- name: Chellie Pingree
-  party: minority
-  rank: 4
-  bioguide: P000597
-  thomas: '01927'
-HSAP02:
-- name: Rodney P. Frelinghuysen
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: F000372
-  thomas: '00414'
-- name: Jack Kingston
-  party: majority
-  rank: 2
-  bioguide: K000220
-  thomas: '00636'
-- name: Kay Granger
-  party: majority
-  rank: 3
-  bioguide: G000377
-  thomas: '01487'
-  title: Vice Chair
-- name: Ander Crenshaw
-  party: majority
-  rank: 4
-  bioguide: C001045
-  thomas: '01643'
-- name: Ken Calvert
-  party: majority
-  rank: 5
-  bioguide: C000059
-  thomas: '00165'
-- name: Tom Cole
-  party: majority
-  rank: 6
-  bioguide: C001053
-  thomas: '01742'
-- name: Steve Womack
-  party: majority
-  rank: 7
-  bioguide: W000809
-  thomas: '01991'
-- name: Robert B. Aderholt
-  party: majority
-  rank: 8
-  bioguide: A000055
-  thomas: '01460'
-- name: John R. Carter
-  party: majority
-  rank: 9
-  bioguide: C001051
-  thomas: '01752'
-- name: Peter J. Visclosky
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: V000108
-  thomas: '01188'
-- name: James P. Moran
-  party: minority
-  rank: 2
-  bioguide: M000933
-  thomas: '00832'
-- name: Betty McCollum
-  party: minority
-  rank: 3
-  bioguide: M001143
-  thomas: '01653'
-- name: Tim Ryan
-  party: minority
-  rank: 4
-  bioguide: R000577
-  thomas: '01756'
-- name: William L. Owens
-  party: minority
-  rank: 5
-  bioguide: O000169
-  thomas: '01974'
-- name: Marcy Kaptur
-  party: minority
-  rank: 6
-  bioguide: K000009
-  thomas: '00616'
-HSAP04:
-- name: Kay Granger
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: G000377
-  thomas: '01487'
-- name: Frank R. Wolf
-  party: majority
-  rank: 2
-  bioguide: W000672
-  thomas: '01238'
-- name: Mario Diaz-Balart
-  party: majority
-  rank: 3
-  bioguide: D000600
-  thomas: '01717'
-- name: Charles W. Dent
-  party: majority
-  rank: 4
-  bioguide: D000604
-  thomas: '01799'
-  title: Vice Chair
-- name: Ander Crenshaw
-  party: majority
-  rank: 5
-  bioguide: C001045
-  thomas: '01643'
-- name: Kevin Yoder
-  party: majority
-  rank: 6
-  bioguide: Y000063
-  thomas: '02021'
-- name: Thomas J. Rooney
-  party: majority
-  rank: 7
-  bioguide: R000583
-  thomas: '01916'
-- name: Nita M. Lowey
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000480
-  thomas: '00709'
-- name: Adam B. Schiff
-  party: minority
-  rank: 2
-  bioguide: S001150
-  thomas: '01635'
-- name: Barbara Lee
-  party: minority
-  rank: 3
-  bioguide: L000551
-  thomas: '01501'
-- name: Debbie Wasserman Schultz
-  party: minority
-  rank: 4
-  bioguide: W000797
-  thomas: '01777'
-- name: Henry Cuellar
-  party: minority
-  rank: 5
-  bioguide: C001063
-  thomas: '01807'
-HSAP06:
-- name: Ken Calvert
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C000059
-  thomas: '00165'
-- name: Michael K. Simpson
-  party: majority
-  rank: 2
-  bioguide: S001148
-  thomas: '01590'
-  title: Vice Chair
-- name: Tom Cole
-  party: majority
-  rank: 3
-  bioguide: C001053
-  thomas: '01742'
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 4
-  bioguide: H001056
-  thomas: '02071'
-- name: David P. Joyce
-  party: majority
-  rank: 5
-  bioguide: J000295
-  thomas: '02154'
-- name: David G. Valadao
-  party: majority
-  rank: 6
-  bioguide: V000129
-  thomas: '02105'
-- name: Chris Stewart
-  party: majority
-  rank: 7
-  bioguide: S001192
-  thomas: '02168'
-- name: James P. Moran
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M000933
-  thomas: '00832'
-- name: Betty McCollum
-  party: minority
-  rank: 2
-  bioguide: M001143
-  thomas: '01653'
-- name: Chellie Pingree
-  party: minority
-  rank: 3
-  bioguide: P000597
-  thomas: '01927'
-- name: José E. Serrano
-  party: minority
-  rank: 4
-  bioguide: S000248
-  thomas: '01042'
-HSAP07:
-- name: Jack Kingston
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: K000220
-  thomas: '00636'
-- name: Steve Womack
-  party: majority
-  rank: 2
-  bioguide: W000809
-  thomas: '01991'
-  title: Vice Chair
-- name: Charles J. "Chuck" Fleischmann
-  party: majority
-  rank: 3
-  bioguide: F000459
-  thomas: '02061'
-- name: David P. Joyce
-  party: majority
-  rank: 4
-  bioguide: J000295
-  thomas: '02154'
-- name: Andy Harris
-  party: majority
-  rank: 5
-  bioguide: H001052
-  thomas: '02026'
-- name: Martha Roby
-  party: majority
-  rank: 6
-  bioguide: R000591
-  thomas: '01986'
-- name: Chris Stewart
-  party: majority
-  rank: 7
-  bioguide: S001192
-  thomas: '02168'
-- name: Rosa L. DeLauro
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: D000216
-  thomas: '00281'
-- name: Lucille Roybal-Allard
-  party: minority
-  rank: 2
-  bioguide: R000486
-  thomas: '00997'
-- name: Barbara Lee
-  party: minority
-  rank: 3
-  bioguide: L000551
-  thomas: '01501'
-- name: Michael M. Honda
-  party: minority
-  rank: 4
-  bioguide: H001034
-  thomas: '01634'
-HSAP10:
-- name: Michael K. Simpson
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: S001148
-  thomas: '01590'
-- name: Rodney P. Frelinghuysen
-  party: majority
-  rank: 2
-  bioguide: F000372
-  thomas: '00414'
-- name: Alan Nunnelee
-  party: majority
-  rank: 3
-  bioguide: N000186
-  thomas: '02034'
-  title: Vice Chair
-- name: Ken Calvert
-  party: majority
-  rank: 4
-  bioguide: C000059
-  thomas: '00165'
-- name: Charles J. "Chuck" Fleischmann
-  party: majority
-  rank: 5
-  bioguide: F000459
-  thomas: '02061'
-- name: Tom Graves
-  party: majority
-  rank: 6
-  bioguide: G000560
-  thomas: '01979'
-- name: Jeff Fortenberry
-  party: majority
-  rank: 7
-  bioguide: F000449
-  thomas: '01793'
-- name: Marcy Kaptur
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: K000009
-  thomas: '00616'
-- name: Peter J. Visclosky
-  party: minority
-  rank: 2
-  bioguide: V000108
-  thomas: '01188'
-- name: Ed Pastor
-  party: minority
-  rank: 3
-  bioguide: P000099
-  thomas: '00893'
-- name: Chaka Fattah
-  party: minority
-  rank: 4
-  bioguide: F000043
-  thomas: '00371'
-HSAP15:
-- name: John R. Carter
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001051
-  thomas: '01752'
-- name: John Abney Culberson
-  party: majority
-  rank: 2
-  bioguide: C001048
-  thomas: '01670'
-  title: Vice Chair
-- name: Rodney P. Frelinghuysen
-  party: majority
-  rank: 3
-  bioguide: F000372
-  thomas: '00414'
-- name: Tom Latham
-  party: majority
-  rank: 4
-  bioguide: L000111
-  thomas: '00666'
-- name: Charles W. Dent
-  party: majority
-  rank: 5
-  bioguide: D000604
-  thomas: '01799'
-- name: Charles J. "Chuck" Fleischmann
-  party: majority
-  rank: 6
-  bioguide: F000459
-  thomas: '02061'
-- name: Jack Kingston
-  party: majority
-  rank: 7
-  bioguide: K000220
-  thomas: '00636'
-- name: David E. Price
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000523
-  thomas: '00930'
-- name: Lucille Roybal-Allard
-  party: minority
-  rank: 2
-  bioguide: R000486
-  thomas: '00997'
-- name: Henry Cuellar
-  party: minority
-  rank: 3
-  bioguide: C001063
-  thomas: '01807'
-- name: William L. Owens
-  party: minority
-  rank: 4
-  bioguide: O000169
-  thomas: '01974'
-HSAP18:
-- name: John Abney Culberson
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001048
-  thomas: '01670'
-- name: Alan Nunnelee
-  party: majority
-  rank: 2
-  bioguide: N000186
-  thomas: '02034'
-- name: Jeff Fortenberry
-  party: majority
-  rank: 3
-  bioguide: F000449
-  thomas: '01793'
-  title: Vice Chair
-- name: Thomas J. Rooney
-  party: majority
-  rank: 4
-  bioguide: R000583
-  thomas: '01916'
-- name: Tom Graves
-  party: majority
-  rank: 5
-  bioguide: G000560
-  thomas: '01979'
-- name: David G. Valadao
-  party: majority
-  rank: 6
-  bioguide: V000129
-  thomas: '02105'
-- name: Martha Roby
-  party: majority
-  rank: 7
-  bioguide: R000591
-  thomas: '01986'
-- name: Sanford D. Bishop Jr.
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B000490
-  thomas: '00091'
-- name: Sam Farr
-  party: minority
-  rank: 2
-  bioguide: F000030
-  thomas: '00368'
-- name: David E. Price
-  party: minority
-  rank: 3
-  bioguide: P000523
-  thomas: '00930'
-- name: Chaka Fattah
-  party: minority
-  rank: 4
-  bioguide: F000043
-  thomas: '00371'
-HSAP19:
-- name: Frank R. Wolf
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: W000672
-  thomas: '01238'
-- name: John Abney Culberson
-  party: majority
-  rank: 2
-  bioguide: C001048
-  thomas: '01670'
-- name: Robert B. Aderholt
-  party: majority
-  rank: 3
-  bioguide: A000055
-  thomas: '01460'
-  title: Vice Chair
-- name: Andy Harris
-  party: majority
-  rank: 4
-  bioguide: H001052
-  thomas: '02026'
-- name: John R. Carter
-  party: majority
-  rank: 5
-  bioguide: C001051
-  thomas: '01752'
-- name: Mario Diaz-Balart
-  party: majority
-  rank: 6
-  bioguide: D000600
-  thomas: '01717'
-- name: Mark E. Amodei
-  party: majority
-  rank: 7
-  bioguide: A000369
-  thomas: '02090'
-- name: Chaka Fattah
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: F000043
-  thomas: '00371'
-- name: Adam B. Schiff
-  party: minority
-  rank: 2
-  bioguide: S001150
-  thomas: '01635'
-- name: Michael M. Honda
-  party: minority
-  rank: 3
-  bioguide: H001034
-  thomas: '01634'
-- name: José E. Serrano
-  party: minority
-  rank: 4
-  bioguide: S000248
-  thomas: '01042'
-HSAP20:
-- name: Tom Latham
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: L000111
-  thomas: '00666'
-- name: Frank R. Wolf
-  party: majority
-  rank: 2
-  bioguide: W000672
-  thomas: '01238'
-  title: Vice Chair
-- name: Charles W. Dent
-  party: majority
-  rank: 3
-  bioguide: D000604
-  thomas: '01799'
-- name: Kay Granger
-  party: majority
-  rank: 4
-  bioguide: G000377
-  thomas: '01487'
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 5
-  bioguide: H001056
-  thomas: '02071'
-- name: David P. Joyce
-  party: majority
-  rank: 6
-  bioguide: J000295
-  thomas: '02154'
-- name: Michael K. Simpson
-  party: majority
-  rank: 7
-  bioguide: S001148
-  thomas: '01590'
-- name: Ed Pastor
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000099
-  thomas: '00893'
-- name: David E. Price
-  party: minority
-  rank: 2
-  bioguide: P000523
-  thomas: '00930'
-- name: Mike Quigley
-  party: minority
-  rank: 3
-  bioguide: Q000023
-  thomas: '01967'
-- name: Tim Ryan
-  party: minority
-  rank: 4
-  bioguide: R000577
-  thomas: '01756'
-HSAP23:
-- name: Ander Crenshaw
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001045
-  thomas: '01643'
-- name: Mario Diaz-Balart
-  party: majority
-  rank: 2
-  bioguide: D000600
-  thomas: '01717'
-  title: Vice Chair
-- name: Tom Graves
-  party: majority
-  rank: 3
-  bioguide: G000560
-  thomas: '01979'
-- name: Kevin Yoder
-  party: majority
-  rank: 4
-  bioguide: Y000063
-  thomas: '02021'
-- name: Steve Womack
-  party: majority
-  rank: 5
-  bioguide: W000809
-  thomas: '01991'
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 6
-  bioguide: H001056
-  thomas: '02071'
-- name: Mark E. Amodei
-  party: majority
-  rank: 7
-  bioguide: A000369
-  thomas: '02090'
-- name: José E. Serrano
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S000248
-  thomas: '01042'
-- name: Mike Quigley
-  party: minority
-  rank: 2
-  bioguide: Q000023
-  thomas: '01967'
-- name: Marcy Kaptur
-  party: minority
-  rank: 3
-  bioguide: K000009
-  thomas: '00616'
-- name: Ed Pastor
-  party: minority
-  rank: 4
-  bioguide: P000099
-  thomas: '00893'
-HSAP24:
-- name: Tom Cole
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001053
-  thomas: '01742'
-- name: Andy Harris
-  party: majority
-  rank: 2
-  bioguide: H001052
-  thomas: '02026'
-  title: Vice Chair
-- name: Martha Roby
-  party: majority
-  rank: 3
-  bioguide: R000591
-  thomas: '01986'
-- name: Mark E. Amodei
-  party: majority
-  rank: 4
-  bioguide: A000369
-  thomas: '02090'
-- name: Chris Stewart
-  party: majority
-  rank: 5
-  bioguide: S001192
-  thomas: '02168'
-- name: Debbie Wasserman Schultz
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: W000797
-  thomas: '01777'
-- name: James P. Moran
-  party: minority
-  rank: 2
-  bioguide: M000933
-  thomas: '00832'
-- name: Sanford D. Bishop Jr.
-  party: minority
-  rank: 3
-  bioguide: B000490
-  thomas: '00091'
+  bioguide: K000381
+  thomas: '02169'
 HSAS:
-- name: Howard P. "Buck" McKeon
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: M000508
-  thomas: '00778'
 - name: Mac Thornberry
   party: majority
-  rank: 2
+  rank: 1
+  title: Chair
   bioguide: T000238
   thomas: '01155'
 - name: Walter B. Jones
   party: majority
-  rank: 3
+  rank: 2
   bioguide: J000255
   thomas: '00612'
 - name: J. Randy Forbes
   party: majority
-  rank: 4
+  rank: 3
   bioguide: F000445
   thomas: '01683'
 - name: Jeff Miller
   party: majority
-  rank: 5
+  rank: 4
   bioguide: M001144
   thomas: '01685'
 - name: Joe Wilson
   party: majority
-  rank: 6
+  rank: 5
   bioguide: W000795
   thomas: '01688'
 - name: Frank A. LoBiondo
   party: majority
-  rank: 7
+  rank: 6
   bioguide: L000554
   thomas: '00699'
 - name: Rob Bishop
   party: majority
-  rank: 8
+  rank: 7
   bioguide: B001250
   thomas: '01753'
 - name: Michael R. Turner
   party: majority
-  rank: 9
+  rank: 8
   bioguide: T000463
   thomas: '01741'
 - name: John Kline
   party: majority
-  rank: 10
+  rank: 9
   bioguide: K000363
   thomas: '01733'
 - name: Mike Rogers
   party: majority
-  rank: 11
+  rank: 10
   bioguide: R000575
   thomas: '01704'
 - name: Trent Franks
   party: majority
-  rank: 12
+  rank: 11
   bioguide: F000448
   thomas: '01707'
 - name: Bill Shuster
   party: majority
-  rank: 13
+  rank: 12
   bioguide: S001154
   thomas: '01681'
 - name: K. Michael Conaway
   party: majority
-  rank: 14
+  rank: 13
   bioguide: C001062
   thomas: '01805'
 - name: Doug Lamborn
   party: majority
-  rank: 15
+  rank: 14
   bioguide: L000564
   thomas: '01834'
 - name: Robert J. Wittman
   party: majority
-  rank: 16
+  rank: 15
   bioguide: W000804
   thomas: '01886'
 - name: Duncan Hunter
   party: majority
-  rank: 17
+  rank: 16
   bioguide: H001048
   thomas: '01909'
 - name: John Fleming
   party: majority
-  rank: 18
+  rank: 17
   bioguide: F000456
   thomas: '01924'
 - name: Mike Coffman
   party: majority
-  rank: 19
+  rank: 18
   bioguide: C001077
   thomas: '01912'
-- name: E. Scott Rigell
-  party: majority
-  rank: 20
-  bioguide: R000589
-  thomas: '02068'
 - name: Christopher P. Gibson
   party: majority
-  rank: 21
+  rank: 19
   bioguide: G000564
   thomas: '02043'
 - name: Vicky Hartzler
   party: majority
-  rank: 22
+  rank: 20
   bioguide: H001053
   thomas: '02032'
 - name: Joseph J. Heck
   party: majority
-  rank: 23
+  rank: 21
   bioguide: H001055
   thomas: '02040'
-- name: Jon Runyan
-  party: majority
-  rank: 24
-  bioguide: R000594
-  thomas: '02039'
 - name: Austin Scott
   party: majority
-  rank: 25
+  rank: 22
   bioguide: S001189
   thomas: '02009'
 - name: Steven M. Palazzo
   party: majority
-  rank: 26
+  rank: 23
   bioguide: P000601
   thomas: '02035'
 - name: Mo Brooks
   party: majority
-  rank: 27
+  rank: 24
   bioguide: B001274
   thomas: '01987'
 - name: Richard B. Nugent
   party: majority
-  rank: 28
+  rank: 25
   bioguide: N000185
   thomas: '02001'
-- name: Kristi L. Noem
-  party: majority
-  rank: 29
-  bioguide: N000184
-  thomas: '02060'
 - name: Paul Cook
   party: majority
-  rank: 30
+  rank: 26
   bioguide: C001094
   thomas: '02103'
 - name: Jim Bridenstine
   party: majority
-  rank: 31
+  rank: 27
   bioguide: B001283
   thomas: '02155'
 - name: Brad R. Wenstrup
   party: majority
-  rank: 32
+  rank: 28
   bioguide: W000815
   thomas: '02152'
 - name: Jackie Walorski
   party: majority
-  rank: 33
+  rank: 29
   bioguide: W000813
   thomas: '02128'
 - name: Bradley Byrne
   party: majority
-  rank: 34
+  rank: 30
   bioguide: B001289
   thomas: '02197'
+- name: Sam Graves
+  party: majority
+  rank: 31
+  bioguide: G000546
+  thomas: '01656'
+- name: Ryan K. Zinke
+  party: majority
+  rank: 32
+  bioguide: Z000018
+  thomas: '02254'
+- name: Elise M. Stefanik
+  party: majority
+  rank: 33
+  bioguide: S001196
+  thomas: '02263'
+- name: Martha McSally
+  party: majority
+  rank: 34
+  bioguide: M001197
+  thomas: '02225'
+- name: Stephen Knight
+  party: majority
+  rank: 35
+  bioguide: K000387
+  thomas: '02228'
+- name: Thomas MacArthur
+  party: majority
+  rank: 36
+  bioguide: M001193
+  thomas: '02258'
 - name: Adam Smith
   party: minority
   rank: 1
@@ -2160,178 +1316,173 @@ HSAS:
   rank: 2
   bioguide: S000030
   thomas: '01522'
-- name: Mike McIntyre
-  party: minority
-  rank: 3
-  bioguide: M000485
-  thomas: '01505'
 - name: Robert A. Brady
   party: minority
-  rank: 4
+  rank: 3
   bioguide: B001227
   thomas: '01469'
 - name: Susan A. Davis
   party: minority
-  rank: 5
+  rank: 4
   bioguide: D000598
   thomas: '01641'
 - name: James R. Langevin
   party: minority
-  rank: 6
+  rank: 5
   bioguide: L000559
   thomas: '01668'
 - name: Rick Larsen
   party: minority
-  rank: 7
+  rank: 6
   bioguide: L000560
   thomas: '01675'
 - name: Jim Cooper
   party: minority
-  rank: 8
+  rank: 7
   bioguide: C000754
   thomas: '00231'
 - name: Madeleine Z. Bordallo
   party: minority
-  rank: 9
+  rank: 8
   bioguide: B001245
   thomas: '01723'
 - name: Joe Courtney
   party: minority
-  rank: 10
+  rank: 9
   bioguide: C001069
   thomas: '01836'
-- name: David Loebsack
-  party: minority
-  rank: 11
-  bioguide: L000565
-  thomas: '01846'
 - name: Niki Tsongas
   party: minority
-  rank: 12
+  rank: 10
   bioguide: T000465
   thomas: '01884'
 - name: John Garamendi
   party: minority
-  rank: 13
+  rank: 11
   bioguide: G000559
   thomas: '01973'
 - name: Henry C. "Hank" Johnson Jr.
   party: minority
-  rank: 14
+  rank: 12
   bioguide: J000288
   thomas: '01843'
-- name: Colleen W. Hanabusa
-  party: minority
-  rank: 15
-  bioguide: H001050
-  thomas: '02010'
 - name: Jackie Speier
   party: minority
-  rank: 16
+  rank: 13
   bioguide: S001175
   thomas: '01890'
-- name: Ron Barber
-  party: minority
-  rank: 17
-  bioguide: B001279
-  thomas: '02093'
-- name: André Carson
-  party: minority
-  rank: 18
-  bioguide: C001072
-  thomas: '01889'
-- name: Carol Shea-Porter
-  party: minority
-  rank: 19
-  bioguide: S001170
-  thomas: '01861'
-- name: Daniel B. Maffei
-  party: minority
-  rank: 20
-  bioguide: M001171
-  thomas: '01943'
-- name: Derek Kilmer
-  party: minority
-  rank: 21
-  bioguide: K000381
-  thomas: '02169'
 - name: Joaquin Castro
   party: minority
-  rank: 22
+  rank: 14
   bioguide: C001091
   thomas: '02163'
 - name: Tammy Duckworth
   party: minority
-  rank: 23
+  rank: 15
   bioguide: D000622
   thomas: '02123'
 - name: Scott H. Peters
   party: minority
-  rank: 24
+  rank: 16
   bioguide: P000608
   thomas: '02113'
-- name: William L. Enyart
-  party: minority
-  rank: 25
-  bioguide: E000292
-  thomas: '02125'
-- name: Pete P. Gallego
-  party: minority
-  rank: 26
-  bioguide: G000572
-  thomas: '02164'
 - name: Marc A. Veasey
   party: minority
-  rank: 27
+  rank: 17
   bioguide: V000131
   thomas: '02166'
 - name: Tulsi Gabbard
   party: minority
-  rank: 28
+  rank: 18
   bioguide: G000571
   thomas: '02122'
+- name: Timothy J. Walz
+  party: minority
+  rank: 19
+  bioguide: W000799
+  thomas: '01856'
+- name: Beto O'Rourke
+  party: minority
+  rank: 20
+  bioguide: O000170
+  thomas: '02162'
+- name: Donald Norcross
+  party: minority
+  rank: 21
+  bioguide: N000188
+  thomas: '02202'
+- name: Ruben Gallego
+  party: minority
+  rank: 22
+  bioguide: G000574
+  thomas: '02226'
+- name: Mark Takai
+  party: minority
+  rank: 23
+  bioguide: T000473
+  thomas: '02240'
+- name: Gwen Graham
+  party: minority
+  rank: 24
+  bioguide: G000575
+  thomas: '02234'
+- name: Brad Ashford
+  party: minority
+  rank: 25
+  bioguide: A000373
+  thomas: '02257'
+- name: Seth Moulton
+  party: minority
+  rank: 26
+  bioguide: M001196
+  thomas: '02246'
+- name: Pete Aguilar
+  party: minority
+  rank: 27
+  bioguide: A000371
+  thomas: '02229'
 HSAS02:
-- name: Joe Wilson
+- name: Joseph J. Heck
   party: majority
   rank: 1
   title: Chair
-  bioguide: W000795
-  thomas: '01688'
+  bioguide: H001055
+  thomas: '02040'
 - name: Walter B. Jones
   party: majority
   rank: 2
   bioguide: J000255
   thomas: '00612'
-- name: Joseph J. Heck
+- name: John Kline
   party: majority
   rank: 3
-  bioguide: H001055
-  thomas: '02040'
-- name: Austin Scott
+  bioguide: K000363
+  thomas: '01733'
+- name: Mike Coffman
   party: majority
   rank: 4
-  bioguide: S001189
-  thomas: '02009'
-- name: Brad R. Wenstrup
+  bioguide: C001077
+  thomas: '01912'
+- name: Thomas MacArthur
   party: majority
   rank: 5
-  bioguide: W000815
-  thomas: '02152'
-- name: Jackie Walorski
+  bioguide: M001193
+  thomas: '02258'
+- name: Elise M. Stefanik
   party: majority
   rank: 6
-  bioguide: W000813
-  thomas: '02128'
-- name: Christopher P. Gibson
+  bioguide: S001196
+  thomas: '02263'
+- name: Paul Cook
   party: majority
   rank: 7
-  bioguide: G000564
-  thomas: '02043'
-- name: Kristi L. Noem
+  bioguide: C001094
+  thomas: '02103'
+- name: Stephen Knight
   party: majority
   rank: 8
-  bioguide: N000184
-  thomas: '02060'
+  bioguide: K000387
+  thomas: '02228'
 - name: Susan A. Davis
   party: minority
   rank: 1
@@ -2343,26 +1494,26 @@ HSAS02:
   rank: 2
   bioguide: B001227
   thomas: '01469'
-- name: Madeleine Z. Bordallo
-  party: minority
-  rank: 3
-  bioguide: B001245
-  thomas: '01723'
-- name: David Loebsack
-  party: minority
-  rank: 4
-  bioguide: L000565
-  thomas: '01846'
 - name: Niki Tsongas
   party: minority
-  rank: 5
+  rank: 3
   bioguide: T000465
   thomas: '01884'
-- name: Carol Shea-Porter
+- name: Jackie Speier
+  party: minority
+  rank: 4
+  bioguide: S001175
+  thomas: '01890'
+- name: Timothy J. Walz
+  party: minority
+  rank: 5
+  bioguide: W000799
+  thomas: '01856'
+- name: Beto O'Rourke
   party: minority
   rank: 6
-  bioguide: S001170
-  thomas: '01861'
+  bioguide: O000170
+  thomas: '02162'
 HSAS03:
 - name: Robert J. Wittman
   party: majority
@@ -2385,140 +1536,145 @@ HSAS03:
   rank: 4
   bioguide: S001189
   thomas: '02009'
-- name: Kristi L. Noem
+- name: Elise M. Stefanik
   party: majority
   rank: 5
-  bioguide: N000184
-  thomas: '02060'
-- name: J. Randy Forbes
-  party: majority
-  rank: 6
-  bioguide: F000445
-  thomas: '01683'
+  bioguide: S001196
+  thomas: '02263'
 - name: Frank A. LoBiondo
   party: majority
-  rank: 7
+  rank: 6
   bioguide: L000554
   thomas: '00699'
 - name: Mike Rogers
   party: majority
-  rank: 8
+  rank: 7
   bioguide: R000575
   thomas: '01704'
-- name: Doug Lamborn
+- name: Christopher P. Gibson
   party: majority
-  rank: 9
-  bioguide: L000564
-  thomas: '01834'
-- name: E. Scott Rigell
-  party: majority
-  rank: 10
-  bioguide: R000589
-  thomas: '02068'
+  rank: 8
+  bioguide: G000564
+  thomas: '02043'
 - name: Steven M. Palazzo
   party: majority
-  rank: 11
+  rank: 9
   bioguide: P000601
   thomas: '02035'
+- name: Richard B. Nugent
+  party: majority
+  rank: 10
+  bioguide: N000185
+  thomas: '02001'
+- name: Brad R. Wenstrup
+  party: majority
+  rank: 11
+  bioguide: W000815
+  thomas: '02152'
+- name: Sam Graves
+  party: majority
+  rank: 12
+  bioguide: G000546
+  thomas: '01656'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001245
   thomas: '01723'
-- name: Joe Courtney
+- name: Susan A. Davis
   party: minority
   rank: 2
-  bioguide: C001069
-  thomas: '01836'
-- name: David Loebsack
+  bioguide: D000598
+  thomas: '01641'
+- name: Joe Courtney
   party: minority
   rank: 3
-  bioguide: L000565
-  thomas: '01846'
-- name: Colleen W. Hanabusa
+  bioguide: C001069
+  thomas: '01836'
+- name: Joaquin Castro
   party: minority
   rank: 4
-  bioguide: H001050
-  thomas: '02010'
-- name: Jackie Speier
+  bioguide: C001091
+  thomas: '02163'
+- name: Tammy Duckworth
   party: minority
   rank: 5
-  bioguide: S001175
-  thomas: '01890'
-- name: Ron Barber
+  bioguide: D000622
+  thomas: '02123'
+- name: Scott H. Peters
   party: minority
   rank: 6
-  bioguide: B001279
-  thomas: '02093'
-- name: Carol Shea-Porter
+  bioguide: P000608
+  thomas: '02113'
+- name: Tulsi Gabbard
   party: minority
   rank: 7
-  bioguide: S001170
-  thomas: '01861'
-- name: William L. Enyart
+  bioguide: G000571
+  thomas: '02122'
+- name: Beto O'Rourke
   party: minority
   rank: 8
-  bioguide: E000292
-  thomas: '02125'
-- name: Pete P. Gallego
+  bioguide: O000170
+  thomas: '02162'
+- name: Ruben Gallego
   party: minority
   rank: 9
-  bioguide: G000572
-  thomas: '02164'
+  bioguide: G000574
+  thomas: '02226'
 HSAS06:
-- name: Joseph J. Heck
+- name: Vicky Hartzler
   party: majority
   rank: 1
   title: Chair
-  bioguide: H001055
-  thomas: '02040'
-- name: K. Michael Conaway
+  bioguide: H001053
+  thomas: '02032'
+- name: Jeff Miller
   party: majority
   rank: 2
-  bioguide: C001062
-  thomas: '01805'
-- name: Mo Brooks
+  bioguide: M001144
+  thomas: '01685'
+- name: K. Michael Conaway
   party: majority
   rank: 3
-  bioguide: B001274
-  thomas: '01987'
-- name: Walter B. Jones
+  bioguide: C001062
+  thomas: '01805'
+- name: Joseph J. Heck
   party: majority
   rank: 4
-  bioguide: J000255
-  thomas: '00612'
+  bioguide: H001055
+  thomas: '02040'
 - name: Austin Scott
   party: majority
   rank: 5
   bioguide: S001189
   thomas: '02009'
-- name: Jim Bridenstine
+- name: Martha McSally
   party: majority
   rank: 6
-  bioguide: B001283
-  thomas: '02155'
-- name: Niki Tsongas
+  bioguide: M001197
+  thomas: '02225'
+- name: Jackie Speier
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: T000465
-  thomas: '01884'
-- name: Jackie Speier
-  party: minority
-  rank: 2
   bioguide: S001175
   thomas: '01890'
-- name: Tammy Duckworth
+- name: Jim Cooper
+  party: minority
+  rank: 2
+  bioguide: C000754
+  thomas: '00231'
+- name: Henry C. "Hank" Johnson Jr.
   party: minority
   rank: 3
-  bioguide: D000622
-  thomas: '02123'
-- name: Tulsi Gabbard
+  bioguide: J000288
+  thomas: '01843'
+- name: Gwen Graham
   party: minority
   rank: 4
-  bioguide: G000571
-  thomas: '02122'
+  bioguide: G000575
+  thomas: '02234'
 HSAS25:
 - name: Michael R. Turner
   party: majority
@@ -2541,200 +1697,205 @@ HSAS25:
   rank: 4
   bioguide: G000564
   thomas: '02043'
-- name: Jon Runyan
-  party: majority
-  rank: 5
-  bioguide: R000594
-  thomas: '02039'
 - name: Paul Cook
   party: majority
-  rank: 6
+  rank: 5
   bioguide: C001094
   thomas: '02103'
-- name: Jim Bridenstine
-  party: majority
-  rank: 7
-  bioguide: B001283
-  thomas: '02155'
 - name: Brad R. Wenstrup
   party: majority
-  rank: 8
+  rank: 6
   bioguide: W000815
   thomas: '02152'
 - name: Jackie Walorski
   party: majority
-  rank: 9
+  rank: 7
   bioguide: W000813
   thomas: '02128'
-- name: Mac Thornberry
+- name: Sam Graves
+  party: majority
+  rank: 8
+  bioguide: G000546
+  thomas: '01656'
+- name: Martha McSally
+  party: majority
+  rank: 9
+  bioguide: M001197
+  thomas: '02225'
+- name: Stephen Knight
   party: majority
   rank: 10
-  bioguide: T000238
-  thomas: '01155'
-- name: Walter B. Jones
+  bioguide: K000387
+  thomas: '02228'
+- name: Thomas MacArthur
   party: majority
   rank: 11
-  bioguide: J000255
-  thomas: '00612'
-- name: Rob Bishop
+  bioguide: M001193
+  thomas: '02258'
+- name: Walter B. Jones
   party: majority
   rank: 12
-  bioguide: B001250
-  thomas: '01753'
-- name: Bradley Byrne
+  bioguide: J000255
+  thomas: '00612'
+- name: Joe Wilson
   party: majority
   rank: 13
-  bioguide: B001289
-  thomas: '02197'
+  bioguide: W000795
+  thomas: '01688'
 - name: Loretta Sanchez
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000030
   thomas: '01522'
-- name: Mike McIntyre
+- name: Niki Tsongas
   party: minority
   rank: 2
-  bioguide: M000485
-  thomas: '01505'
-- name: Jim Cooper
+  bioguide: T000465
+  thomas: '01884'
+- name: Henry C. "Hank" Johnson Jr.
   party: minority
   rank: 3
-  bioguide: C000754
-  thomas: '00231'
-- name: John Garamendi
-  party: minority
-  rank: 4
-  bioguide: G000559
-  thomas: '01973'
-- name: Ron Barber
-  party: minority
-  rank: 5
-  bioguide: B001279
-  thomas: '02093'
-- name: Daniel B. Maffei
-  party: minority
-  rank: 6
-  bioguide: M001171
-  thomas: '01943'
-- name: Joaquin Castro
-  party: minority
-  rank: 7
-  bioguide: C001091
-  thomas: '02163'
+  bioguide: J000288
+  thomas: '01843'
 - name: Tammy Duckworth
   party: minority
-  rank: 8
+  rank: 4
   bioguide: D000622
   thomas: '02123'
-- name: William L. Enyart
-  party: minority
-  rank: 9
-  bioguide: E000292
-  thomas: '02125'
-- name: Pete P. Gallego
-  party: minority
-  rank: 10
-  bioguide: G000572
-  thomas: '02164'
 - name: Marc A. Veasey
   party: minority
-  rank: 11
+  rank: 5
   bioguide: V000131
   thomas: '02166'
+- name: Timothy J. Walz
+  party: minority
+  rank: 6
+  bioguide: W000799
+  thomas: '01856'
+- name: Donald Norcross
+  party: minority
+  rank: 7
+  bioguide: N000188
+  thomas: '02202'
+- name: Ruben Gallego
+  party: minority
+  rank: 8
+  bioguide: G000574
+  thomas: '02226'
+- name: Mark Takai
+  party: minority
+  rank: 9
+  bioguide: T000473
+  thomas: '02240'
+- name: Gwen Graham
+  party: minority
+  rank: 10
+  bioguide: G000575
+  thomas: '02234'
+- name: Seth Moulton
+  party: minority
+  rank: 11
+  bioguide: M001196
+  thomas: '02246'
 HSAS26:
-- name: Mac Thornberry
+- name: Joe Wilson
   party: majority
   rank: 1
   title: Chair
-  bioguide: T000238
-  thomas: '01155'
-- name: Jeff Miller
-  party: majority
-  rank: 2
-  bioguide: M001144
-  thomas: '01685'
+  bioguide: W000795
+  thomas: '01688'
 - name: John Kline
   party: majority
-  rank: 3
+  rank: 2
   bioguide: K000363
   thomas: '01733'
 - name: Bill Shuster
   party: majority
-  rank: 4
+  rank: 3
   bioguide: S001154
   thomas: '01681'
+- name: Duncan Hunter
+  party: majority
+  rank: 4
+  bioguide: H001048
+  thomas: '01909'
 - name: Richard B. Nugent
   party: majority
   rank: 5
   bioguide: N000185
   thomas: '02001'
-- name: Trent Franks
+- name: Ryan K. Zinke
   party: majority
   rank: 6
-  bioguide: F000448
-  thomas: '01707'
-- name: Duncan Hunter
+  bioguide: Z000018
+  thomas: '02254'
+- name: Trent Franks
   party: majority
   rank: 7
-  bioguide: H001048
-  thomas: '01909'
-- name: Christopher P. Gibson
+  bioguide: F000448
+  thomas: '01707'
+- name: Doug Lamborn
   party: majority
   rank: 8
-  bioguide: G000564
-  thomas: '02043'
-- name: Vicky Hartzler
+  bioguide: L000564
+  thomas: '01834'
+- name: Mo Brooks
   party: majority
   rank: 9
-  bioguide: H001053
-  thomas: '02032'
-- name: Joseph J. Heck
+  bioguide: B001274
+  thomas: '01987'
+- name: Bradley Byrne
   party: majority
   rank: 10
-  bioguide: H001055
-  thomas: '02040'
+  bioguide: B001289
+  thomas: '02197'
+- name: Elise M. Stefanik
+  party: majority
+  rank: 11
+  bioguide: S001196
+  thomas: '02263'
 - name: James R. Langevin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000559
   thomas: '01668'
-- name: Susan A. Davis
+- name: Jim Cooper
   party: minority
   rank: 2
-  bioguide: D000598
-  thomas: '01641'
-- name: Henry C. "Hank" Johnson Jr.
+  bioguide: C000754
+  thomas: '00231'
+- name: John Garamendi
   party: minority
   rank: 3
-  bioguide: J000288
-  thomas: '01843'
-- name: André Carson
-  party: minority
-  rank: 4
-  bioguide: C001072
-  thomas: '01889'
-- name: Daniel B. Maffei
-  party: minority
-  rank: 5
-  bioguide: M001171
-  thomas: '01943'
-- name: Derek Kilmer
-  party: minority
-  rank: 6
-  bioguide: K000381
-  thomas: '02169'
+  bioguide: G000559
+  thomas: '01973'
 - name: Joaquin Castro
   party: minority
-  rank: 7
+  rank: 4
   bioguide: C001091
   thomas: '02163'
-- name: Scott H. Peters
+- name: Marc A. Veasey
+  party: minority
+  rank: 5
+  bioguide: V000131
+  thomas: '02166'
+- name: Donald Norcross
+  party: minority
+  rank: 6
+  bioguide: N000188
+  thomas: '02202'
+- name: Brad Ashford
+  party: minority
+  rank: 7
+  bioguide: A000373
+  thomas: '02257'
+- name: Pete Aguilar
   party: minority
   rank: 8
-  bioguide: P000608
-  thomas: '02113'
+  bioguide: A000371
+  thomas: '02229'
 HSAS28:
 - name: J. Randy Forbes
   party: majority
@@ -2747,97 +1908,102 @@ HSAS28:
   rank: 2
   bioguide: C001062
   thomas: '01805'
-- name: Duncan Hunter
-  party: majority
-  rank: 3
-  bioguide: H001048
-  thomas: '01909'
-- name: E. Scott Rigell
-  party: majority
-  rank: 4
-  bioguide: R000589
-  thomas: '02068'
 - name: Steven M. Palazzo
   party: majority
-  rank: 5
+  rank: 3
   bioguide: P000601
   thomas: '02035'
-- name: Robert J. Wittman
-  party: majority
-  rank: 6
-  bioguide: W000804
-  thomas: '01886'
-- name: Mike Coffman
-  party: majority
-  rank: 7
-  bioguide: C001077
-  thomas: '01912'
-- name: Jon Runyan
-  party: majority
-  rank: 8
-  bioguide: R000594
-  thomas: '02039'
-- name: Kristi L. Noem
-  party: majority
-  rank: 9
-  bioguide: N000184
-  thomas: '02060'
-- name: Paul Cook
-  party: majority
-  rank: 10
-  bioguide: C001094
-  thomas: '02103'
 - name: Bradley Byrne
   party: majority
-  rank: 11
+  rank: 4
   bioguide: B001289
   thomas: '02197'
-- name: Mike McIntyre
+- name: Robert J. Wittman
+  party: majority
+  rank: 5
+  bioguide: W000804
+  thomas: '01886'
+- name: Duncan Hunter
+  party: majority
+  rank: 6
+  bioguide: H001048
+  thomas: '01909'
+- name: Vicky Hartzler
+  party: majority
+  rank: 7
+  bioguide: H001053
+  thomas: '02032'
+- name: Paul Cook
+  party: majority
+  rank: 8
+  bioguide: C001094
+  thomas: '02103'
+- name: Jim Bridenstine
+  party: majority
+  rank: 9
+  bioguide: B001283
+  thomas: '02155'
+- name: Jackie Walorski
+  party: majority
+  rank: 10
+  bioguide: W000813
+  thomas: '02128'
+- name: Ryan K. Zinke
+  party: majority
+  rank: 11
+  bioguide: Z000018
+  thomas: '02254'
+- name: Stephen Knight
+  party: majority
+  rank: 12
+  bioguide: K000387
+  thomas: '02228'
+- name: Joe Courtney
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: M000485
-  thomas: '01505'
-- name: Joe Courtney
-  party: minority
-  rank: 2
   bioguide: C001069
   thomas: '01836'
 - name: James R. Langevin
   party: minority
-  rank: 3
+  rank: 2
   bioguide: L000559
   thomas: '01668'
 - name: Rick Larsen
   party: minority
-  rank: 4
+  rank: 3
   bioguide: L000560
   thomas: '01675'
+- name: Madeleine Z. Bordallo
+  party: minority
+  rank: 4
+  bioguide: B001245
+  thomas: '01723'
 - name: Henry C. "Hank" Johnson Jr.
   party: minority
   rank: 5
   bioguide: J000288
   thomas: '01843'
-- name: Colleen W. Hanabusa
-  party: minority
-  rank: 6
-  bioguide: H001050
-  thomas: '02010'
-- name: Derek Kilmer
-  party: minority
-  rank: 7
-  bioguide: K000381
-  thomas: '02169'
 - name: Scott H. Peters
   party: minority
-  rank: 8
+  rank: 6
   bioguide: P000608
   thomas: '02113'
 - name: Tulsi Gabbard
   party: minority
-  rank: 9
+  rank: 7
   bioguide: G000571
   thomas: '02122'
+- name: Gwen Graham
+  party: minority
+  rank: 8
+  bioguide: G000575
+  thomas: '02234'
+- name: Seth Moulton
+  party: minority
+  rank: 9
+  bioguide: M001196
+  thomas: '02246'
 HSAS29:
 - name: Mike Rogers
   party: majority
@@ -2865,31 +2031,31 @@ HSAS29:
   rank: 5
   bioguide: B001274
   thomas: '01987'
-- name: Joe Wilson
+- name: Jim Bridenstine
   party: majority
   rank: 6
-  bioguide: W000795
-  thomas: '01688'
-- name: Michael R. Turner
+  bioguide: B001283
+  thomas: '02155'
+- name: J. Randy Forbes
   party: majority
   rank: 7
+  bioguide: F000445
+  thomas: '01683'
+- name: Rob Bishop
+  party: majority
+  rank: 8
+  bioguide: B001250
+  thomas: '01753'
+- name: Michael R. Turner
+  party: majority
+  rank: 9
   bioguide: T000463
   thomas: '01741'
 - name: John Fleming
   party: majority
-  rank: 8
+  rank: 10
   bioguide: F000456
   thomas: '01924'
-- name: Richard B. Nugent
-  party: majority
-  rank: 9
-  bioguide: N000185
-  thomas: '02001'
-- name: Jim Bridenstine
-  party: majority
-  rank: 10
-  bioguide: B001283
-  thomas: '02155'
 - name: Jim Cooper
   party: minority
   rank: 1
@@ -2901,36 +2067,31 @@ HSAS29:
   rank: 2
   bioguide: S000030
   thomas: '01522'
-- name: James R. Langevin
-  party: minority
-  rank: 3
-  bioguide: L000559
-  thomas: '01668'
 - name: Rick Larsen
   party: minority
-  rank: 4
+  rank: 3
   bioguide: L000560
   thomas: '01675'
 - name: John Garamendi
   party: minority
-  rank: 5
+  rank: 4
   bioguide: G000559
   thomas: '01973'
-- name: Henry C. "Hank" Johnson Jr.
+- name: Mark Takai
+  party: minority
+  rank: 5
+  bioguide: T000473
+  thomas: '02240'
+- name: Brad Ashford
   party: minority
   rank: 6
-  bioguide: J000288
-  thomas: '01843'
-- name: André Carson
+  bioguide: A000373
+  thomas: '02257'
+- name: Pete Aguilar
   party: minority
   rank: 7
-  bioguide: C001072
-  thomas: '01889'
-- name: Marc A. Veasey
-  party: minority
-  rank: 8
-  bioguide: V000131
-  thomas: '02166'
+  bioguide: A000371
+  thomas: '02229'
 HSBA:
 - name: Jeb Hensarling
   party: majority
@@ -2938,166 +2099,171 @@ HSBA:
   title: Chair
   bioguide: H001036
   thomas: '01749'
-- name: Spencer Bachus
-  party: majority
-  rank: 2
-  bioguide: B000013
-  thomas: '00038'
 - name: Peter T. King
   party: majority
-  rank: 3
+  rank: 2
   bioguide: K000210
   thomas: '00635'
 - name: Edward R. Royce
   party: majority
-  rank: 4
+  rank: 3
   bioguide: R000487
   thomas: '00998'
 - name: Frank D. Lucas
   party: majority
-  rank: 5
+  rank: 4
   bioguide: L000491
   thomas: '00711'
-- name: Gary G. Miller
-  party: majority
-  rank: 6
-  bioguide: M001139
-  thomas: '01584'
-- name: Shelley Moore Capito
-  party: majority
-  rank: 7
-  bioguide: C001047
-  thomas: '01676'
 - name: Scott Garrett
   party: majority
-  rank: 8
+  rank: 5
   bioguide: G000548
   thomas: '01737'
 - name: Randy Neugebauer
   party: majority
-  rank: 9
+  rank: 6
   bioguide: N000182
   thomas: '01758'
 - name: Patrick T. McHenry
   party: majority
-  rank: 10
+  rank: 7
   bioguide: M001156
   thomas: '01792'
-- name: John Campbell
-  party: majority
-  rank: 11
-  bioguide: C001064
-  thomas: '01816'
-- name: Michele Bachmann
-  party: majority
-  rank: 12
-  bioguide: B001256
-  thomas: '01858'
-- name: Kevin McCarthy
-  party: majority
-  rank: 13
-  bioguide: M001165
-  thomas: '01833'
 - name: Stevan Pearce
   party: majority
-  rank: 14
+  rank: 8
   bioguide: P000588
   thomas: '01738'
 - name: Bill Posey
   party: majority
-  rank: 15
+  rank: 9
   bioguide: P000599
   thomas: '01915'
 - name: Michael G. Fitzpatrick
   party: majority
-  rank: 16
+  rank: 10
   bioguide: F000451
   thomas: '01797'
 - name: Lynn A. Westmoreland
   party: majority
-  rank: 17
+  rank: 11
   bioguide: W000796
   thomas: '01779'
 - name: Blaine Luetkemeyer
   party: majority
-  rank: 18
+  rank: 12
   bioguide: L000569
   thomas: '01931'
 - name: Bill Huizenga
   party: majority
-  rank: 19
+  rank: 13
   bioguide: H001058
   thomas: '02028'
 - name: Sean P. Duffy
   party: majority
-  rank: 20
+  rank: 14
   bioguide: D000614
   thomas: '02072'
 - name: Robert Hurt
   party: majority
-  rank: 21
+  rank: 15
   bioguide: H001060
   thomas: '02069'
 - name: Steve Stivers
   party: majority
-  rank: 22
+  rank: 16
   bioguide: S001187
   thomas: '02047'
 - name: Stephen Lee Fincher
   party: majority
-  rank: 23
+  rank: 17
   bioguide: F000458
   thomas: '02064'
 - name: Marlin A. Stutzman
   party: majority
-  rank: 24
+  rank: 18
   bioguide: S001188
   thomas: '01981'
 - name: Mick Mulvaney
   party: majority
-  rank: 25
+  rank: 19
   bioguide: M001182
   thomas: '02059'
 - name: Randy Hultgren
   party: majority
-  rank: 26
+  rank: 20
   bioguide: H001059
   thomas: '02015'
 - name: Dennis A. Ross
   party: majority
-  rank: 27
+  rank: 21
   bioguide: R000593
   thomas: '02003'
 - name: Robert Pittenger
   party: majority
-  rank: 28
+  rank: 22
   bioguide: P000606
   thomas: '02141'
 - name: Ann Wagner
   party: majority
-  rank: 29
+  rank: 23
   bioguide: W000812
   thomas: '02137'
 - name: Andy Barr
   party: majority
-  rank: 30
+  rank: 24
   bioguide: B001282
   thomas: '02131'
-- name: Tom Cotton
-  party: majority
-  rank: 31
-  bioguide: C001095
-  thomas: '02098'
 - name: Keith J. Rothfus
   party: majority
-  rank: 32
+  rank: 25
   bioguide: R000598
   thomas: '02158'
 - name: Luke Messer
   party: majority
-  rank: 33
+  rank: 26
   bioguide: M001189
   thomas: '02130'
+- name: David Schweikert
+  party: majority
+  rank: 27
+  bioguide: S001183
+  thomas: '01994'
+- name: Robert J. Dold
+  party: majority
+  rank: 28
+  bioguide: D000613
+  thomas: '02013'
+- name: Frank C. Guinta
+  party: majority
+  rank: 29
+  bioguide: G000570
+  thomas: '02038'
+- name: Scott R. Tipton
+  party: majority
+  rank: 30
+  bioguide: T000470
+  thomas: '01997'
+- name: Roger Williams
+  party: majority
+  rank: 31
+  bioguide: W000816
+  thomas: '02165'
+- name: Bruce Poliquin
+  party: majority
+  rank: 32
+  bioguide: P000611
+  thomas: '02247'
+- name: Mia B. Love
+  party: majority
+  rank: 33
+  bioguide: L000584
+  thomas: '02271'
+- name: J. French Hill
+  party: majority
+  rank: 34
+  bioguide: H001072
+  thomas: '02223'
 - name: Maxine Waters
   party: minority
   rank: 1
@@ -3139,248 +2305,255 @@ HSBA:
   rank: 8
   bioguide: C001049
   thomas: '01654'
-- name: Carolyn McCarthy
-  party: minority
-  rank: 9
-  bioguide: M000309
-  thomas: '01503'
 - name: Stephen F. Lynch
   party: minority
-  rank: 10
+  rank: 9
   bioguide: L000562
   thomas: '01686'
 - name: David Scott
   party: minority
-  rank: 11
+  rank: 10
   bioguide: S001157
   thomas: '01722'
 - name: Al Green
   party: minority
-  rank: 12
+  rank: 11
   bioguide: G000553
   thomas: '01803'
 - name: Emanuel Cleaver
   party: minority
-  rank: 13
+  rank: 12
   bioguide: C001061
   thomas: '01790'
 - name: Gwen Moore
   party: minority
-  rank: 14
+  rank: 13
   bioguide: M001160
   thomas: '01811'
 - name: Keith Ellison
   party: minority
-  rank: 15
+  rank: 14
   bioguide: E000288
   thomas: '01857'
 - name: Ed Perlmutter
   party: minority
-  rank: 16
+  rank: 15
   bioguide: P000593
   thomas: '01835'
 - name: James A. Himes
   party: minority
-  rank: 17
+  rank: 16
   bioguide: H001047
   thomas: '01913'
-- name: Gary C. Peters
-  party: minority
-  rank: 18
-  bioguide: P000595
-  thomas: '01929'
 - name: John C. Carney Jr.
   party: minority
-  rank: 19
+  rank: 17
   bioguide: C001083
   thomas: '01999'
 - name: Terri A. Sewell
   party: minority
-  rank: 20
+  rank: 18
   bioguide: S001185
   thomas: '01988'
 - name: Bill Foster
   party: minority
-  rank: 21
+  rank: 19
   bioguide: F000454
   thomas: '01888'
 - name: Daniel T. Kildee
   party: minority
-  rank: 22
+  rank: 20
   bioguide: K000380
   thomas: '02134'
 - name: Patrick Murphy
   party: minority
-  rank: 23
+  rank: 21
   bioguide: M001191
   thomas: '02117'
 - name: John K. Delaney
   party: minority
-  rank: 24
+  rank: 22
   bioguide: D000620
   thomas: '02133'
 - name: Kyrsten Sinema
   party: minority
-  rank: 25
+  rank: 23
   bioguide: S001191
   thomas: '02099'
 - name: Joyce Beatty
   party: minority
-  rank: 26
+  rank: 24
   bioguide: B001281
   thomas: '02153'
 - name: Denny Heck
   party: minority
-  rank: 27
+  rank: 25
   bioguide: H001064
   thomas: '02170'
-- name: Steven A. Horsford
+- name: Juan Vargas
   party: minority
-  rank: 28
-  bioguide: H001066
-  thomas: '02147'
+  rank: 26
+  bioguide: V000130
+  thomas: '02112'
 HSBA04:
-- name: Randy Neugebauer
+- name: Blaine Luetkemeyer
   party: majority
   rank: 1
   title: Chair
-  bioguide: N000182
-  thomas: '01758'
-- name: Blaine Luetkemeyer
-  party: majority
-  rank: 2
   bioguide: L000569
   thomas: '01931'
+- name: Lynn A. Westmoreland
+  party: majority
+  rank: 2
+  bioguide: W000796
+  thomas: '01779'
   title: Vice Chair
 - name: Edward R. Royce
   party: majority
   rank: 3
   bioguide: R000487
   thomas: '00998'
-- name: Gary G. Miller
-  party: majority
-  rank: 4
-  bioguide: M001139
-  thomas: '01584'
-- name: Shelley Moore Capito
-  party: majority
-  rank: 5
-  bioguide: C001047
-  thomas: '01676'
 - name: Scott Garrett
   party: majority
-  rank: 6
+  rank: 4
   bioguide: G000548
   thomas: '01737'
-- name: Lynn A. Westmoreland
+- name: Stevan Pearce
   party: majority
-  rank: 7
-  bioguide: W000796
-  thomas: '01779'
-- name: Sean P. Duffy
-  party: majority
-  rank: 8
-  bioguide: D000614
-  thomas: '02072'
+  rank: 5
+  bioguide: P000588
+  thomas: '01738'
 - name: Robert Hurt
   party: majority
-  rank: 9
+  rank: 6
   bioguide: H001060
   thomas: '02069'
 - name: Steve Stivers
   party: majority
-  rank: 10
+  rank: 7
   bioguide: S001187
   thomas: '02047'
 - name: Dennis A. Ross
   party: majority
-  rank: 11
+  rank: 8
   bioguide: R000593
   thomas: '02003'
-- name: Michael E. Capuano
+- name: Andy Barr
+  party: majority
+  rank: 9
+  bioguide: B001282
+  thomas: '02131'
+- name: Keith J. Rothfus
+  party: majority
+  rank: 10
+  bioguide: R000598
+  thomas: '02158'
+- name: Robert J. Dold
+  party: majority
+  rank: 11
+  bioguide: D000613
+  thomas: '02013'
+- name: Roger Williams
+  party: majority
+  rank: 12
+  bioguide: W000816
+  thomas: '02165'
+- name: Jeb Hensarling
+  party: majority
+  rank: 13
+  bioguide: H001036
+  thomas: '01749'
+  title: Ex Officio
+- name: Emanuel Cleaver
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: C001037
-  thomas: '01564'
+  bioguide: C001061
+  thomas: '01790'
 - name: Nydia M. Velázquez
   party: minority
   rank: 2
   bioguide: V000081
   thomas: '01184'
-- name: Emanuel Cleaver
+- name: Michael E. Capuano
   party: minority
   rank: 3
-  bioguide: C001061
-  thomas: '01790'
+  bioguide: C001037
+  thomas: '01564'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
   bioguide: C001049
   thomas: '01654'
-- name: Carolyn McCarthy
+- name: Al Green
   party: minority
   rank: 5
-  bioguide: M000309
-  thomas: '01503'
-- name: Brad Sherman
-  party: minority
-  rank: 6
-  bioguide: S000344
-  thomas: '01526'
+  bioguide: G000553
+  thomas: '01803'
 - name: Gwen Moore
   party: minority
-  rank: 7
+  rank: 6
   bioguide: M001160
   thomas: '01811'
+- name: Keith Ellison
+  party: minority
+  rank: 7
+  bioguide: E000288
+  thomas: '01857'
 - name: Joyce Beatty
   party: minority
   rank: 8
   bioguide: B001281
   thomas: '02153'
-- name: Steven A. Horsford
+- name: Daniel T. Kildee
   party: minority
   rank: 9
-  bioguide: H001066
-  thomas: '02147'
+  bioguide: K000380
+  thomas: '02134'
+- name: Maxine Waters
+  party: minority
+  rank: 10
+  bioguide: W000187
+  thomas: '01205'
+  title: Ex Officio
 HSBA09:
-- name: Patrick T. McHenry
+- name: Sean P. Duffy
   party: majority
   rank: 1
   title: Chair
-  bioguide: M001156
-  thomas: '01792'
+  bioguide: D000614
+  thomas: '02072'
 - name: Michael G. Fitzpatrick
   party: majority
   rank: 2
   bioguide: F000451
   thomas: '01797'
   title: Vice Chair
-- name: Spencer Bachus
-  party: majority
-  rank: 3
-  bioguide: B000013
-  thomas: '00038'
 - name: Peter T. King
   party: majority
-  rank: 4
+  rank: 3
   bioguide: K000210
   thomas: '00635'
-- name: Michele Bachmann
+- name: Patrick T. McHenry
+  party: majority
+  rank: 4
+  bioguide: M001156
+  thomas: '01792'
+- name: Robert Hurt
   party: majority
   rank: 5
-  bioguide: B001256
-  thomas: '01858'
-- name: Sean P. Duffy
-  party: majority
-  rank: 6
-  bioguide: D000614
-  thomas: '02072'
+  bioguide: H001060
+  thomas: '02069'
 - name: Stephen Lee Fincher
   party: majority
-  rank: 7
+  rank: 6
   bioguide: F000458
   thomas: '02064'
+- name: Mick Mulvaney
+  party: majority
+  rank: 7
+  bioguide: M001182
+  thomas: '02059'
 - name: Randy Hultgren
   party: majority
   rank: 8
@@ -3391,37 +2564,48 @@ HSBA09:
   rank: 9
   bioguide: W000812
   thomas: '02137'
-- name: Andy Barr
+- name: Scott R. Tipton
   party: majority
   rank: 10
-  bioguide: B001282
-  thomas: '02131'
-- name: Keith J. Rothfus
+  bioguide: T000470
+  thomas: '01997'
+- name: Bruce Poliquin
   party: majority
   rank: 11
-  bioguide: R000598
-  thomas: '02158'
+  bioguide: P000611
+  thomas: '02247'
+- name: J. French Hill
+  party: majority
+  rank: 12
+  bioguide: H001072
+  thomas: '02223'
+- name: Jeb Hensarling
+  party: majority
+  rank: 13
+  bioguide: H001036
+  thomas: '01749'
+  title: Ex Officio
 - name: Al Green
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: G000553
   thomas: '01803'
-- name: Emanuel Cleaver
+- name: Michael E. Capuano
   party: minority
   rank: 2
+  bioguide: C001037
+  thomas: '01564'
+- name: Emanuel Cleaver
+  party: minority
+  rank: 3
   bioguide: C001061
   thomas: '01790'
 - name: Keith Ellison
   party: minority
-  rank: 3
+  rank: 4
   bioguide: E000288
   thomas: '01857'
-- name: Carolyn B. Maloney
-  party: minority
-  rank: 4
-  bioguide: M000087
-  thomas: '00729'
 - name: John K. Delaney
   party: minority
   rank: 5
@@ -3437,175 +2621,188 @@ HSBA09:
   rank: 7
   bioguide: H001064
   thomas: '02170'
-- name: Daniel T. Kildee
+- name: Kyrsten Sinema
   party: minority
   rank: 8
-  bioguide: K000380
-  thomas: '02134'
-- name: Steven A. Horsford
+  bioguide: S001191
+  thomas: '02099'
+- name: Juan Vargas
   party: minority
   rank: 9
-  bioguide: H001066
-  thomas: '02147'
+  bioguide: V000130
+  thomas: '02112'
+- name: Maxine Waters
+  party: minority
+  rank: 10
+  bioguide: W000187
+  thomas: '01205'
+  title: Ex Officio
 HSBA15:
-- name: Shelley Moore Capito
+- name: Randy Neugebauer
   party: majority
   rank: 1
   title: Chair
-  bioguide: C001047
-  thomas: '01676'
-- name: Sean P. Duffy
-  party: majority
-  rank: 2
-  bioguide: D000614
-  thomas: '02072'
-  title: Vice Chair
-- name: Spencer Bachus
-  party: majority
-  rank: 3
-  bioguide: B000013
-  thomas: '00038'
-- name: Gary G. Miller
-  party: majority
-  rank: 4
-  bioguide: M001139
-  thomas: '01584'
-- name: Patrick T. McHenry
-  party: majority
-  rank: 5
-  bioguide: M001156
-  thomas: '01792'
-- name: John Campbell
-  party: majority
-  rank: 6
-  bioguide: C001064
-  thomas: '01816'
-- name: Kevin McCarthy
-  party: majority
-  rank: 7
-  bioguide: M001165
-  thomas: '01833'
+  bioguide: N000182
+  thomas: '01758'
 - name: Stevan Pearce
   party: majority
-  rank: 8
+  rank: 2
   bioguide: P000588
   thomas: '01738'
+  title: Vice Chair
+- name: Frank D. Lucas
+  party: majority
+  rank: 3
+  bioguide: L000491
+  thomas: '00711'
 - name: Bill Posey
   party: majority
-  rank: 9
+  rank: 4
   bioguide: P000599
   thomas: '01915'
 - name: Michael G. Fitzpatrick
   party: majority
-  rank: 10
+  rank: 5
   bioguide: F000451
   thomas: '01797'
 - name: Lynn A. Westmoreland
   party: majority
-  rank: 11
+  rank: 6
   bioguide: W000796
   thomas: '01779'
 - name: Blaine Luetkemeyer
   party: majority
-  rank: 12
+  rank: 7
   bioguide: L000569
   thomas: '01931'
 - name: Marlin A. Stutzman
   party: majority
-  rank: 13
+  rank: 8
   bioguide: S001188
   thomas: '01981'
+- name: Mick Mulvaney
+  party: majority
+  rank: 9
+  bioguide: M001182
+  thomas: '02059'
 - name: Robert Pittenger
   party: majority
-  rank: 14
+  rank: 10
   bioguide: P000606
   thomas: '02141'
 - name: Andy Barr
   party: majority
-  rank: 15
+  rank: 11
   bioguide: B001282
   thomas: '02131'
-- name: Tom Cotton
-  party: majority
-  rank: 16
-  bioguide: C001095
-  thomas: '02098'
 - name: Keith J. Rothfus
   party: majority
-  rank: 17
+  rank: 12
   bioguide: R000598
   thomas: '02158'
-- name: Gregory W. Meeks
+- name: Robert J. Dold
+  party: majority
+  rank: 13
+  bioguide: D000613
+  thomas: '02013'
+- name: Frank C. Guinta
+  party: majority
+  rank: 14
+  bioguide: G000570
+  thomas: '02038'
+- name: Scott R. Tipton
+  party: majority
+  rank: 15
+  bioguide: T000470
+  thomas: '01997'
+- name: Roger Williams
+  party: majority
+  rank: 16
+  bioguide: W000816
+  thomas: '02165'
+- name: Mia B. Love
+  party: majority
+  rank: 17
+  bioguide: L000584
+  thomas: '02271'
+- name: Jeb Hensarling
+  party: majority
+  rank: 18
+  bioguide: H001036
+  thomas: '01749'
+  title: Ex Officio
+- name: Wm. Lacy Clay
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: M001137
-  thomas: '01506'
-- name: Carolyn B. Maloney
+  bioguide: C001049
+  thomas: '01654'
+- name: Gregory W. Meeks
   party: minority
   rank: 2
-  bioguide: M000087
-  thomas: '00729'
+  bioguide: M001137
+  thomas: '01506'
 - name: Rubén Hinojosa
   party: minority
   rank: 3
   bioguide: H000636
   thomas: '01490'
-- name: Carolyn McCarthy
-  party: minority
-  rank: 4
-  bioguide: M000309
-  thomas: '01503'
 - name: David Scott
   party: minority
-  rank: 5
+  rank: 4
   bioguide: S001157
   thomas: '01722'
-- name: Al Green
+- name: Carolyn B. Maloney
   party: minority
-  rank: 6
-  bioguide: G000553
-  thomas: '01803'
-- name: Keith Ellison
-  party: minority
-  rank: 7
-  bioguide: E000288
-  thomas: '01857'
+  rank: 5
+  bioguide: M000087
+  thomas: '00729'
 - name: Nydia M. Velázquez
   party: minority
-  rank: 8
+  rank: 6
   bioguide: V000081
   thomas: '01184'
+- name: Brad Sherman
+  party: minority
+  rank: 7
+  bioguide: S000344
+  thomas: '01526'
 - name: Stephen F. Lynch
   party: minority
-  rank: 9
+  rank: 8
   bioguide: L000562
   thomas: '01686'
-- name: Ed Perlmutter
-  party: minority
-  rank: 10
-  bioguide: P000593
-  thomas: '01835'
 - name: Michael E. Capuano
   party: minority
-  rank: 11
+  rank: 9
   bioguide: C001037
   thomas: '01564'
 - name: John K. Delaney
   party: minority
-  rank: 12
+  rank: 10
   bioguide: D000620
   thomas: '02133'
 - name: Denny Heck
   party: minority
-  rank: 13
+  rank: 11
   bioguide: H001064
   thomas: '02170'
 - name: Kyrsten Sinema
   party: minority
-  rank: 14
+  rank: 12
   bioguide: S001191
   thomas: '02099'
+- name: Juan Vargas
+  party: minority
+  rank: 13
+  bioguide: V000130
+  thomas: '02112'
+- name: Maxine Waters
+  party: minority
+  rank: 14
+  bioguide: W000187
+  thomas: '01205'
+  title: Ex Officio
 HSBA16:
 - name: Scott Garrett
   party: majority
@@ -3619,86 +2816,87 @@ HSBA16:
   bioguide: H001060
   thomas: '02069'
   title: Vice Chair
-- name: Spencer Bachus
-  party: majority
-  rank: 3
-  bioguide: B000013
-  thomas: '00038'
 - name: Peter T. King
   party: majority
-  rank: 4
+  rank: 3
   bioguide: K000210
   thomas: '00635'
 - name: Edward R. Royce
   party: majority
-  rank: 5
+  rank: 4
   bioguide: R000487
   thomas: '00998'
-- name: Frank D. Lucas
-  party: majority
-  rank: 6
-  bioguide: L000491
-  thomas: '00711'
 - name: Randy Neugebauer
   party: majority
-  rank: 7
+  rank: 5
   bioguide: N000182
   thomas: '01758'
-- name: Michele Bachmann
+- name: Patrick T. McHenry
   party: majority
-  rank: 8
-  bioguide: B001256
-  thomas: '01858'
-- name: Kevin McCarthy
-  party: majority
-  rank: 9
-  bioguide: M001165
-  thomas: '01833'
-- name: Lynn A. Westmoreland
-  party: majority
-  rank: 10
-  bioguide: W000796
-  thomas: '01779'
+  rank: 6
+  bioguide: M001156
+  thomas: '01792'
 - name: Bill Huizenga
   party: majority
-  rank: 11
+  rank: 7
   bioguide: H001058
   thomas: '02028'
+- name: Sean P. Duffy
+  party: majority
+  rank: 8
+  bioguide: D000614
+  thomas: '02072'
 - name: Steve Stivers
   party: majority
-  rank: 12
+  rank: 9
   bioguide: S001187
   thomas: '02047'
 - name: Stephen Lee Fincher
   party: majority
-  rank: 13
+  rank: 10
   bioguide: F000458
   thomas: '02064'
-- name: Mick Mulvaney
-  party: majority
-  rank: 14
-  bioguide: M001182
-  thomas: '02059'
 - name: Randy Hultgren
   party: majority
-  rank: 15
+  rank: 11
   bioguide: H001059
   thomas: '02015'
 - name: Dennis A. Ross
   party: majority
-  rank: 16
+  rank: 12
   bioguide: R000593
   thomas: '02003'
 - name: Ann Wagner
   party: majority
-  rank: 17
+  rank: 13
   bioguide: W000812
   thomas: '02137'
 - name: Luke Messer
   party: majority
-  rank: 18
+  rank: 14
   bioguide: M001189
   thomas: '02130'
+- name: David Schweikert
+  party: majority
+  rank: 15
+  bioguide: S001183
+  thomas: '01994'
+- name: Bruce Poliquin
+  party: majority
+  rank: 16
+  bioguide: P000611
+  thomas: '02247'
+- name: J. French Hill
+  party: majority
+  rank: 17
+  bioguide: H001072
+  thomas: '02223'
+- name: Jeb Hensarling
+  party: majority
+  rank: 18
+  bioguide: H001036
+  thomas: '01749'
+  title: Ex Officio
 - name: Carolyn B. Maloney
   party: minority
   rank: 1
@@ -3720,73 +2918,69 @@ HSBA16:
   rank: 4
   bioguide: L000562
   thomas: '01686'
-- name: Gwen Moore
-  party: minority
-  rank: 5
-  bioguide: M001160
-  thomas: '01811'
 - name: Ed Perlmutter
   party: minority
-  rank: 6
+  rank: 5
   bioguide: P000593
   thomas: '01835'
 - name: David Scott
   party: minority
-  rank: 7
+  rank: 6
   bioguide: S001157
   thomas: '01722'
 - name: James A. Himes
   party: minority
-  rank: 8
+  rank: 7
   bioguide: H001047
   thomas: '01913'
-- name: Gary C. Peters
-  party: minority
-  rank: 9
-  bioguide: P000595
-  thomas: '01929'
 - name: Keith Ellison
   party: minority
-  rank: 10
+  rank: 8
   bioguide: E000288
   thomas: '01857'
 - name: Bill Foster
   party: minority
-  rank: 11
+  rank: 9
   bioguide: F000454
   thomas: '01888'
+- name: Gregory W. Meeks
+  party: minority
+  rank: 10
+  bioguide: M001137
+  thomas: '01506'
 - name: John C. Carney Jr.
   party: minority
-  rank: 12
+  rank: 11
   bioguide: C001083
   thomas: '01999'
 - name: Terri A. Sewell
   party: minority
-  rank: 13
+  rank: 12
   bioguide: S001185
   thomas: '01988'
-- name: Daniel T. Kildee
-  party: minority
-  rank: 14
-  bioguide: K000380
-  thomas: '02134'
 - name: Patrick Murphy
   party: minority
-  rank: 15
+  rank: 13
   bioguide: M001191
   thomas: '02117'
+- name: Maxine Waters
+  party: minority
+  rank: 14
+  bioguide: W000187
+  thomas: '01205'
+  title: Ex Officio
 HSBA20:
-- name: John Campbell
+- name: Bill Huizenga
   party: majority
   rank: 1
   title: Chair
-  bioguide: C001064
-  thomas: '01816'
-- name: Bill Huizenga
-  party: majority
-  rank: 2
   bioguide: H001058
   thomas: '02028'
+- name: Mick Mulvaney
+  party: majority
+  rank: 2
+  bioguide: M001182
+  thomas: '02059'
   title: Vice Chair
 - name: Frank D. Lucas
   party: majority
@@ -3803,62 +2997,73 @@ HSBA20:
   rank: 5
   bioguide: P000599
   thomas: '01915'
-- name: Stephen Lee Fincher
+- name: Lynn A. Westmoreland
   party: majority
   rank: 6
-  bioguide: F000458
-  thomas: '02064'
+  bioguide: W000796
+  thomas: '01779'
 - name: Marlin A. Stutzman
   party: majority
   rank: 7
   bioguide: S001188
   thomas: '01981'
-- name: Mick Mulvaney
-  party: majority
-  rank: 8
-  bioguide: M001182
-  thomas: '02059'
 - name: Robert Pittenger
   party: majority
-  rank: 9
+  rank: 8
   bioguide: P000606
   thomas: '02141'
-- name: Tom Cotton
-  party: majority
-  rank: 10
-  bioguide: C001095
-  thomas: '02098'
 - name: Luke Messer
   party: majority
-  rank: 11
+  rank: 9
   bioguide: M001189
   thomas: '02130'
-- name: Wm. Lacy Clay
+- name: David Schweikert
+  party: majority
+  rank: 10
+  bioguide: S001183
+  thomas: '01994'
+- name: Frank C. Guinta
+  party: majority
+  rank: 11
+  bioguide: G000570
+  thomas: '02038'
+- name: Mia B. Love
+  party: majority
+  rank: 12
+  bioguide: L000584
+  thomas: '02271'
+- name: Jeb Hensarling
+  party: majority
+  rank: 13
+  bioguide: H001036
+  thomas: '01749'
+  title: Ex Officio
+- name: Gwen Moore
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: C001049
-  thomas: '01654'
-- name: Gary C. Peters
-  party: minority
-  rank: 2
-  bioguide: P000595
-  thomas: '01929'
+  bioguide: M001160
+  thomas: '01811'
 - name: Bill Foster
   party: minority
-  rank: 3
+  rank: 2
   bioguide: F000454
   thomas: '01888'
-- name: John C. Carney Jr.
+- name: Ed Perlmutter
   party: minority
-  rank: 4
-  bioguide: C001083
-  thomas: '01999'
+  rank: 3
+  bioguide: P000593
+  thomas: '01835'
 - name: James A. Himes
   party: minority
-  rank: 5
+  rank: 4
   bioguide: H001047
   thomas: '01913'
+- name: John C. Carney Jr.
+  party: minority
+  rank: 5
+  bioguide: C001083
+  thomas: '01999'
 - name: Terri A. Sewell
   party: minority
   rank: 6
@@ -3869,123 +3074,134 @@ HSBA20:
   rank: 7
   bioguide: M001191
   thomas: '02117'
-- name: Kyrsten Sinema
+- name: Daniel T. Kildee
   party: minority
   rank: 8
-  bioguide: S001191
-  thomas: '02099'
+  bioguide: K000380
+  thomas: '02134'
 - name: Denny Heck
   party: minority
   rank: 9
   bioguide: H001064
   thomas: '02170'
+- name: Maxine Waters
+  party: minority
+  rank: 10
+  bioguide: W000187
+  thomas: '01205'
+  title: Ex Officio
 HSBU:
-- name: Paul Ryan
+- name: Tom Price
   party: majority
   rank: 1
   title: Chair
-  bioguide: R000570
-  thomas: '01560'
+  bioguide: P000591
+  thomas: '01778'
 - name: Scott Garrett
   party: majority
   rank: 2
   bioguide: G000548
   thomas: '01737'
-- name: John Campbell
+- name: Mario Diaz-Balart
   party: majority
   rank: 3
-  bioguide: C001064
-  thomas: '01816'
-- name: Ken Calvert
-  party: majority
-  rank: 4
-  bioguide: C000059
-  thomas: '00165'
+  bioguide: D000600
+  thomas: '01717'
 - name: Tom Cole
   party: majority
-  rank: 5
+  rank: 4
   bioguide: C001053
   thomas: '01742'
-- name: Tom Price
-  party: majority
-  rank: 6
-  bioguide: P000591
-  thomas: '01778'
 - name: Tom McClintock
   party: majority
-  rank: 7
+  rank: 5
   bioguide: M001177
   thomas: '01908'
-- name: James Lankford
-  party: majority
-  rank: 8
-  bioguide: L000575
-  thomas: '02050'
 - name: Diane Black
   party: majority
-  rank: 9
+  rank: 6
   bioguide: B001273
   thomas: '02063'
-- name: Reid J. Ribble
-  party: majority
-  rank: 10
-  bioguide: R000587
-  thomas: '02073'
-- name: Bill Flores
-  party: majority
-  rank: 11
-  bioguide: F000461
-  thomas: '02065'
 - name: Todd Rokita
   party: majority
-  rank: 12
+  rank: 7
   bioguide: R000592
   thomas: '02017'
 - name: Rob Woodall
   party: majority
-  rank: 13
+  rank: 8
   bioguide: W000810
   thomas: '02008'
 - name: Marsha Blackburn
   party: majority
-  rank: 14
+  rank: 9
   bioguide: B001243
   thomas: '01748'
-- name: Alan Nunnelee
-  party: majority
-  rank: 15
-  bioguide: N000186
-  thomas: '02034'
-- name: E. Scott Rigell
-  party: majority
-  rank: 16
-  bioguide: R000589
-  thomas: '02068'
 - name: Vicky Hartzler
   party: majority
-  rank: 17
+  rank: 10
   bioguide: H001053
   thomas: '02032'
-- name: Jackie Walorski
-  party: majority
-  rank: 18
-  bioguide: W000813
-  thomas: '02128'
 - name: Tom Rice
   party: majority
-  rank: 19
+  rank: 11
   bioguide: R000597
   thomas: '02160'
-- name: Roger Williams
+- name: Marlin A. Stutzman
+  party: majority
+  rank: 12
+  bioguide: S001188
+  thomas: '01981'
+- name: Mark Sanford
+  party: majority
+  rank: 13
+  bioguide: S000051
+  thomas: '01012'
+- name: Aaron Schock
+  party: majority
+  rank: 14
+  bioguide: S001179
+  thomas: '01920'
+- name: Steve Womack
+  party: majority
+  rank: 15
+  bioguide: W000809
+  thomas: '01991'
+- name: Dave Brat
+  party: majority
+  rank: 16
+  bioguide: B001290
+  thomas: '02203'
+- name: Rod Blum
+  party: majority
+  rank: 17
+  bioguide: B001294
+  thomas: '02241'
+- name: Alexander X. Mooney
+  party: majority
+  rank: 18
+  bioguide: M001195
+  thomas: '02277'
+- name: Glenn Grothman
+  party: majority
+  rank: 19
+  bioguide: G000576
+  thomas: '02276'
+- name: Gary J. Palmer
   party: majority
   rank: 20
-  bioguide: W000816
-  thomas: '02165'
-- name: Sean P. Duffy
+  bioguide: P000609
+  thomas: '02221'
+- name: John R. Moolenaar
   party: majority
   rank: 21
-  bioguide: D000614
-  thomas: '02072'
+  bioguide: M001194
+  thomas: '02248'
+- name: Bruce Westerman
+  party: majority
+  rank: 22
+  bioguide: W000821
+  thomas: '02224'
 - name: Chris Van Hollen
   party: minority
   rank: 1
@@ -4027,51 +3243,36 @@ HSBU:
   rank: 8
   bioguide: L000551
   thomas: '01501'
-- name: Hakeem S. Jeffries
-  party: minority
-  rank: 9
-  bioguide: J000294
-  thomas: '02149'
 - name: Mark Pocan
   party: minority
-  rank: 10
+  rank: 9
   bioguide: P000607
   thomas: '02171'
 - name: Michelle Lujan Grisham
   party: minority
-  rank: 11
+  rank: 10
   bioguide: L000580
   thomas: '02146'
-- name: Jared Huffman
+- name: Debbie Dingell
+  party: minority
+  rank: 11
+  bioguide: D000624
+  thomas: '02251'
+- name: Ted Lieu
   party: minority
   rank: 12
-  bioguide: H001068
-  thomas: '02101'
-- name: Tony Cárdenas
+  bioguide: L000582
+  thomas: '02230'
+- name: Donald Norcross
   party: minority
   rank: 13
-  bioguide: C001097
-  thomas: '02107'
-- name: Earl Blumenauer
+  bioguide: N000188
+  thomas: '02202'
+- name: Seth Moulton
   party: minority
   rank: 14
-  bioguide: B000574
-  thomas: '00099'
-- name: Kurt Schrader
-  party: minority
-  rank: 15
-  bioguide: S001180
-  thomas: '01950'
-- name: Lloyd Doggett
-  party: minority
-  rank: 16
-  bioguide: D000399
-  thomas: '00303'
-- name: Daniel T. Kildee
-  party: minority
-  rank: 17
-  bioguide: K000380
-  thomas: '02134'
+  bioguide: M001196
+  thomas: '02246'
 HSED:
 - name: John Kline
   party: majority
@@ -4079,207 +3280,192 @@ HSED:
   title: Chair
   bioguide: K000363
   thomas: '01733'
-- name: Thomas E. Petri
-  party: majority
-  rank: 2
-  bioguide: P000265
-  thomas: '00912'
-- name: Howard P. "Buck" McKeon
-  party: majority
-  rank: 3
-  bioguide: M000508
-  thomas: '00778'
 - name: Joe Wilson
   party: majority
-  rank: 4
+  rank: 2
   bioguide: W000795
   thomas: '01688'
 - name: Virginia Foxx
   party: majority
-  rank: 5
+  rank: 3
   bioguide: F000450
   thomas: '01791'
-- name: Tom Price
-  party: majority
-  rank: 6
-  bioguide: P000591
-  thomas: '01778'
-- name: Kenny Marchant
-  party: majority
-  rank: 7
-  bioguide: M001158
-  thomas: '01806'
 - name: Duncan Hunter
   party: majority
-  rank: 8
+  rank: 4
   bioguide: H001048
   thomas: '01909'
 - name: David P. Roe
   party: majority
-  rank: 9
+  rank: 5
   bioguide: R000582
   thomas: '01954'
 - name: Glenn Thompson
   party: majority
-  rank: 10
+  rank: 6
   bioguide: T000467
   thomas: '01952'
 - name: Tim Walberg
   party: majority
-  rank: 11
+  rank: 7
   bioguide: W000798
   thomas: '01855'
 - name: Matt Salmon
   party: majority
-  rank: 12
+  rank: 8
   bioguide: S000018
   thomas: '01009'
 - name: Brett Guthrie
   party: majority
-  rank: 13
+  rank: 9
   bioguide: G000558
   thomas: '01922'
-- name: Scott DesJarlais
-  party: majority
-  rank: 14
-  bioguide: D000616
-  thomas: '02062'
 - name: Todd Rokita
   party: majority
-  rank: 15
+  rank: 10
   bioguide: R000592
   thomas: '02017'
-- name: Larry Bucshon
-  party: majority
-  rank: 16
-  bioguide: B001275
-  thomas: '02018'
 - name: Lou Barletta
   party: majority
-  rank: 17
+  rank: 11
   bioguide: B001269
   thomas: '02054'
 - name: Joseph J. Heck
   party: majority
-  rank: 18
+  rank: 12
   bioguide: H001055
   thomas: '02040'
-- name: Mike Kelly
-  party: majority
-  rank: 19
-  bioguide: K000376
-  thomas: '02051'
-- name: Susan W. Brooks
-  party: majority
-  rank: 20
-  bioguide: B001284
-  thomas: '02129'
-- name: Richard Hudson
-  party: majority
-  rank: 21
-  bioguide: H001067
-  thomas: '02140'
 - name: Luke Messer
   party: majority
-  rank: 22
+  rank: 13
   bioguide: M001189
   thomas: '02130'
 - name: Bradley Byrne
   party: majority
-  rank: 23
+  rank: 14
   bioguide: B001289
   thomas: '02197'
-- name: George Miller
+- name: Dave Brat
+  party: majority
+  rank: 15
+  bioguide: B001290
+  thomas: '02203'
+- name: Earl L. "Buddy" Carter
+  party: majority
+  rank: 16
+  bioguide: C001103
+  thomas: '02236'
+- name: Mike Bishop
+  party: majority
+  rank: 17
+  bioguide: B001293
+  thomas: '02249'
+- name: Glenn Grothman
+  party: majority
+  rank: 18
+  bioguide: G000576
+  thomas: '02276'
+- name: Steve Russell
+  party: majority
+  rank: 19
+  bioguide: R000604
+  thomas: '02265'
+- name: Carlos Curbelo
+  party: majority
+  rank: 20
+  bioguide: C001107
+  thomas: '02235'
+- name: Elise M. Stefanik
+  party: majority
+  rank: 21
+  bioguide: S001196
+  thomas: '02263'
+- name: Rick W. Allen
+  party: majority
+  rank: 22
+  bioguide: A000372
+  thomas: '02239'
+- name: Robert C. "Bobby" Scott
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: M000725
-  thomas: '00808'
-- name: Robert C. "Bobby" Scott
-  party: minority
-  rank: 2
   bioguide: S000185
   thomas: '01037'
 - name: Rubén Hinojosa
   party: minority
-  rank: 3
+  rank: 2
   bioguide: H000636
   thomas: '01490'
-- name: Carolyn McCarthy
-  party: minority
-  rank: 4
-  bioguide: M000309
-  thomas: '01503'
-- name: John F. Tierney
-  party: minority
-  rank: 5
-  bioguide: T000266
-  thomas: '01535'
-- name: Rush Holt
-  party: minority
-  rank: 6
-  bioguide: H001032
-  thomas: '01580'
 - name: Susan A. Davis
   party: minority
-  rank: 7
+  rank: 3
   bioguide: D000598
   thomas: '01641'
 - name: Raúl M. Grijalva
   party: minority
-  rank: 8
+  rank: 4
   bioguide: G000551
   thomas: '01708'
-- name: Timothy H. Bishop
-  party: minority
-  rank: 9
-  bioguide: B001242
-  thomas: '01740'
-- name: David Loebsack
-  party: minority
-  rank: 10
-  bioguide: L000565
-  thomas: '01846'
 - name: Joe Courtney
   party: minority
-  rank: 11
+  rank: 5
   bioguide: C001069
   thomas: '01836'
 - name: Marcia L. Fudge
   party: minority
-  rank: 12
+  rank: 6
   bioguide: F000455
   thomas: '01895'
 - name: Jared Polis
   party: minority
-  rank: 13
+  rank: 7
   bioguide: P000598
   thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
-  rank: 14
+  rank: 8
   bioguide: S001177
   thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
-  rank: 15
+  rank: 9
   bioguide: W000808
   thomas: '02004'
 - name: Suzanne Bonamici
   party: minority
-  rank: 16
+  rank: 10
   bioguide: B001278
   thomas: '02092'
 - name: Mark Pocan
   party: minority
-  rank: 17
+  rank: 11
   bioguide: P000607
   thomas: '02171'
 - name: Mark Takano
   party: minority
-  rank: 18
+  rank: 12
   bioguide: T000472
   thomas: '02110'
+- name: Hakeem S. Jeffries
+  party: minority
+  rank: 13
+  bioguide: J000294
+  thomas: '02149'
+- name: Katherine M. Clark
+  party: minority
+  rank: 14
+  bioguide: C001101
+  thomas: '02196'
+- name: Alma S. Adams
+  party: minority
+  rank: 15
+  bioguide: A000370
+  thomas: '02201'
+- name: Mark DeSaulnier
+  party: minority
+  rank: 16
+  bioguide: D000623
+  thomas: '02227'
 HSED02:
 - name: David P. Roe
   party: majority
@@ -4292,16 +3478,16 @@ HSED02:
   rank: 2
   bioguide: W000795
   thomas: '01688'
-- name: Tom Price
+- name: Virginia Foxx
   party: majority
   rank: 3
-  bioguide: P000591
-  thomas: '01778'
-- name: Kenny Marchant
+  bioguide: F000450
+  thomas: '01791'
+- name: Tim Walberg
   party: majority
   rank: 4
-  bioguide: M001158
-  thomas: '01806'
+  bioguide: W000798
+  thomas: '01855'
 - name: Matt Salmon
   party: majority
   rank: 5
@@ -4312,102 +3498,92 @@ HSED02:
   rank: 6
   bioguide: G000558
   thomas: '01922'
-- name: Scott DesJarlais
-  party: majority
-  rank: 7
-  bioguide: D000616
-  thomas: '02062'
-- name: Larry Bucshon
-  party: majority
-  rank: 8
-  bioguide: B001275
-  thomas: '02018'
 - name: Lou Barletta
   party: majority
-  rank: 9
+  rank: 7
   bioguide: B001269
   thomas: '02054'
 - name: Joseph J. Heck
   party: majority
-  rank: 10
+  rank: 8
   bioguide: H001055
   thomas: '02040'
-- name: Mike Kelly
-  party: majority
-  rank: 11
-  bioguide: K000376
-  thomas: '02051'
-- name: Susan W. Brooks
-  party: majority
-  rank: 12
-  bioguide: B001284
-  thomas: '02129'
 - name: Luke Messer
   party: majority
-  rank: 13
+  rank: 9
   bioguide: M001189
   thomas: '02130'
 - name: Bradley Byrne
   party: majority
-  rank: 14
+  rank: 10
   bioguide: B001289
   thomas: '02197'
-- name: John F. Tierney
+- name: Earl L. "Buddy" Carter
+  party: majority
+  rank: 11
+  bioguide: C001103
+  thomas: '02236'
+- name: Glenn Grothman
+  party: majority
+  rank: 12
+  bioguide: G000576
+  thomas: '02276'
+- name: Rick W. Allen
+  party: majority
+  rank: 13
+  bioguide: A000372
+  thomas: '02239'
+- name: Jared Polis
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: T000266
-  thomas: '01535'
-- name: Rush Holt
+  bioguide: P000598
+  thomas: '01910'
+- name: Joe Courtney
   party: minority
   rank: 2
-  bioguide: H001032
-  thomas: '01580'
+  bioguide: C001069
+  thomas: '01836'
 - name: Mark Pocan
   party: minority
   rank: 3
   bioguide: P000607
   thomas: '02171'
-- name: Robert C. "Bobby" Scott
-  party: minority
-  rank: 4
-  bioguide: S000185
-  thomas: '01037'
 - name: Rubén Hinojosa
   party: minority
-  rank: 5
+  rank: 4
   bioguide: H000636
   thomas: '01490'
-- name: David Loebsack
-  party: minority
-  rank: 6
-  bioguide: L000565
-  thomas: '01846'
-- name: Joe Courtney
-  party: minority
-  rank: 7
-  bioguide: C001069
-  thomas: '01836'
-- name: Jared Polis
-  party: minority
-  rank: 8
-  bioguide: P000598
-  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
-  rank: 9
+  rank: 5
   bioguide: S001177
   thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
-  rank: 10
+  rank: 6
   bioguide: W000808
   thomas: '02004'
 - name: Suzanne Bonamici
   party: minority
-  rank: 11
+  rank: 7
   bioguide: B001278
   thomas: '02092'
+- name: Mark Takano
+  party: minority
+  rank: 8
+  bioguide: T000472
+  thomas: '02110'
+- name: Hakeem S. Jeffries
+  party: minority
+  rank: 9
+  bioguide: J000294
+  thomas: '02149'
+- name: Robert C. "Bobby" Scott
+  party: minority
+  rank: 10
+  bioguide: S000185
+  thomas: '01037'
 HSED10:
 - name: Tim Walberg
   party: majority
@@ -4415,72 +3591,72 @@ HSED10:
   title: Chair
   bioguide: W000798
   thomas: '01855'
-- name: John Kline
-  party: majority
-  rank: 2
-  bioguide: K000363
-  thomas: '01733'
-- name: Tom Price
-  party: majority
-  rank: 3
-  bioguide: P000591
-  thomas: '01778'
 - name: Duncan Hunter
   party: majority
-  rank: 4
+  rank: 2
   bioguide: H001048
   thomas: '01909'
-- name: Scott DesJarlais
+- name: Glenn Thompson
   party: majority
-  rank: 5
-  bioguide: D000616
-  thomas: '02062'
+  rank: 3
+  bioguide: T000467
+  thomas: '01952'
 - name: Todd Rokita
   party: majority
-  rank: 6
+  rank: 4
   bioguide: R000592
   thomas: '02017'
-- name: Larry Bucshon
+- name: Dave Brat
+  party: majority
+  rank: 5
+  bioguide: B001290
+  thomas: '02203'
+- name: Mike Bishop
+  party: majority
+  rank: 6
+  bioguide: B001293
+  thomas: '02249'
+- name: Steve Russell
   party: majority
   rank: 7
-  bioguide: B001275
-  thomas: '02018'
-- name: Richard Hudson
+  bioguide: R000604
+  thomas: '02265'
+- name: Elise M. Stefanik
   party: majority
   rank: 8
-  bioguide: H001067
-  thomas: '02140'
-- name: Joe Courtney
+  bioguide: S001196
+  thomas: '02263'
+- name: Frederica S. Wilson
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: C001069
-  thomas: '01836'
-- name: Raúl M. Grijalva
-  party: minority
-  rank: 2
-  bioguide: G000551
-  thomas: '01708'
-- name: Timothy H. Bishop
-  party: minority
-  rank: 3
-  bioguide: B001242
-  thomas: '01740'
-- name: Marcia L. Fudge
-  party: minority
-  rank: 4
-  bioguide: F000455
-  thomas: '01895'
+  bioguide: W000808
+  thomas: '02004'
 - name: Mark Pocan
   party: minority
-  rank: 5
+  rank: 2
   bioguide: P000607
   thomas: '02171'
-- name: Mark Takano
+- name: Katherine M. Clark
+  party: minority
+  rank: 3
+  bioguide: C001101
+  thomas: '02196'
+- name: Alma S. Adams
+  party: minority
+  rank: 4
+  bioguide: A000370
+  thomas: '02201'
+- name: Mark DeSaulnier
+  party: minority
+  rank: 5
+  bioguide: D000623
+  thomas: '02227'
+- name: Marcia L. Fudge
   party: minority
   rank: 6
-  bioguide: T000472
-  thomas: '02110'
+  bioguide: F000455
+  thomas: '01895'
 HSED13:
 - name: Virginia Foxx
   party: majority
@@ -4488,107 +3664,97 @@ HSED13:
   title: Chair
   bioguide: F000450
   thomas: '01791'
-- name: Thomas E. Petri
+- name: David P. Roe
   party: majority
   rank: 2
-  bioguide: P000265
-  thomas: '00912'
-- name: Howard P. "Buck" McKeon
-  party: majority
-  rank: 3
-  bioguide: M000508
-  thomas: '00778'
-- name: Glenn Thompson
-  party: majority
-  rank: 4
-  bioguide: T000467
-  thomas: '01952'
-- name: Tim Walberg
-  party: majority
-  rank: 5
-  bioguide: W000798
-  thomas: '01855'
+  bioguide: R000582
+  thomas: '01954'
 - name: Matt Salmon
   party: majority
-  rank: 6
+  rank: 3
   bioguide: S000018
   thomas: '01009'
 - name: Brett Guthrie
   party: majority
-  rank: 7
+  rank: 4
   bioguide: G000558
   thomas: '01922'
 - name: Lou Barletta
   party: majority
-  rank: 8
+  rank: 5
   bioguide: B001269
   thomas: '02054'
 - name: Joseph J. Heck
   party: majority
-  rank: 9
+  rank: 6
   bioguide: H001055
   thomas: '02040'
-- name: Susan W. Brooks
-  party: majority
-  rank: 10
-  bioguide: B001284
-  thomas: '02129'
-- name: Richard Hudson
-  party: majority
-  rank: 11
-  bioguide: H001067
-  thomas: '02140'
 - name: Luke Messer
   party: majority
-  rank: 12
+  rank: 7
   bioguide: M001189
   thomas: '02130'
+- name: Bradley Byrne
+  party: majority
+  rank: 8
+  bioguide: B001289
+  thomas: '02197'
+- name: Carlos Curbelo
+  party: majority
+  rank: 9
+  bioguide: C001107
+  thomas: '02235'
+- name: Elise M. Stefanik
+  party: majority
+  rank: 10
+  bioguide: S001196
+  thomas: '02263'
+- name: Rick W. Allen
+  party: majority
+  rank: 11
+  bioguide: A000372
+  thomas: '02239'
 - name: Rubén Hinojosa
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H000636
   thomas: '01490'
-- name: Timothy H. Bishop
+- name: Hakeem S. Jeffries
   party: minority
   rank: 2
-  bioguide: B001242
-  thomas: '01740'
-- name: Frederica S. Wilson
+  bioguide: J000294
+  thomas: '02149'
+- name: Alma S. Adams
   party: minority
   rank: 3
-  bioguide: W000808
-  thomas: '02004'
-- name: Suzanne Bonamici
+  bioguide: A000370
+  thomas: '02201'
+- name: Mark DeSaulnier
   party: minority
   rank: 4
-  bioguide: B001278
-  thomas: '02092'
-- name: Mark Takano
-  party: minority
-  rank: 5
-  bioguide: T000472
-  thomas: '02110'
-- name: Carolyn McCarthy
-  party: minority
-  rank: 6
-  bioguide: M000309
-  thomas: '01503'
-- name: John F. Tierney
-  party: minority
-  rank: 7
-  bioguide: T000266
-  thomas: '01535'
-- name: Rush Holt
-  party: minority
-  rank: 8
-  bioguide: H001032
-  thomas: '01580'
+  bioguide: D000623
+  thomas: '02227'
 - name: Susan A. Davis
   party: minority
-  rank: 9
+  rank: 5
   bioguide: D000598
   thomas: '01641'
+- name: Raúl M. Grijalva
+  party: minority
+  rank: 6
+  bioguide: G000551
+  thomas: '01708'
+- name: Joe Courtney
+  party: minority
+  rank: 7
+  bioguide: C001069
+  thomas: '01836'
+- name: Jared Polis
+  party: minority
+  rank: 8
+  bioguide: P000598
+  thomas: '01910'
 HSED14:
 - name: Todd Rokita
   party: majority
@@ -4596,92 +3762,82 @@ HSED14:
   title: Chair
   bioguide: R000592
   thomas: '02017'
-- name: John Kline
-  party: majority
-  rank: 2
-  bioguide: K000363
-  thomas: '01733'
-- name: Thomas E. Petri
-  party: majority
-  rank: 3
-  bioguide: P000265
-  thomas: '00912'
-- name: Virginia Foxx
-  party: majority
-  rank: 4
-  bioguide: F000450
-  thomas: '01791'
-- name: Kenny Marchant
-  party: majority
-  rank: 5
-  bioguide: M001158
-  thomas: '01806'
 - name: Duncan Hunter
   party: majority
-  rank: 6
+  rank: 2
   bioguide: H001048
   thomas: '01909'
-- name: David P. Roe
-  party: majority
-  rank: 7
-  bioguide: R000582
-  thomas: '01954'
 - name: Glenn Thompson
   party: majority
-  rank: 8
+  rank: 3
   bioguide: T000467
   thomas: '01952'
-- name: Susan W. Brooks
+- name: Dave Brat
+  party: majority
+  rank: 4
+  bioguide: B001290
+  thomas: '02203'
+- name: Earl L. "Buddy" Carter
+  party: majority
+  rank: 5
+  bioguide: C001103
+  thomas: '02236'
+- name: Mike Bishop
+  party: majority
+  rank: 6
+  bioguide: B001293
+  thomas: '02249'
+- name: Glenn Grothman
+  party: majority
+  rank: 7
+  bioguide: G000576
+  thomas: '02276'
+- name: Steve Russell
+  party: majority
+  rank: 8
+  bioguide: R000604
+  thomas: '02265'
+- name: Carlos Curbelo
   party: majority
   rank: 9
-  bioguide: B001284
-  thomas: '02129'
-- name: Bradley Byrne
-  party: majority
-  rank: 10
-  bioguide: B001289
-  thomas: '02197'
-- name: David Loebsack
+  bioguide: C001107
+  thomas: '02235'
+- name: Marcia L. Fudge
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: L000565
-  thomas: '01846'
-- name: Robert C. "Bobby" Scott
-  party: minority
-  rank: 2
-  bioguide: S000185
-  thomas: '01037'
-- name: Carolyn McCarthy
-  party: minority
-  rank: 3
-  bioguide: M000309
-  thomas: '01503'
+  bioguide: F000455
+  thomas: '01895'
 - name: Susan A. Davis
   party: minority
-  rank: 4
+  rank: 2
   bioguide: D000598
   thomas: '01641'
 - name: Raúl M. Grijalva
   party: minority
-  rank: 5
+  rank: 3
   bioguide: G000551
   thomas: '01708'
-- name: Marcia L. Fudge
-  party: minority
-  rank: 6
-  bioguide: F000455
-  thomas: '01895'
-- name: Jared Polis
-  party: minority
-  rank: 7
-  bioguide: P000598
-  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
-  rank: 8
+  rank: 4
   bioguide: S001177
   thomas: '01962'
+- name: Suzanne Bonamici
+  party: minority
+  rank: 5
+  bioguide: B001278
+  thomas: '02092'
+- name: Mark Takano
+  party: minority
+  rank: 6
+  bioguide: T000472
+  thomas: '02110'
+- name: Katherine M. Clark
+  party: minority
+  rank: 7
+  bioguide: C001101
+  thomas: '02196'
 HSFA:
 - name: Edward R. Royce
   party: majority
@@ -4729,240 +3885,230 @@ HSFA:
   rank: 9
   bioguide: S000018
   thomas: '01009'
-- name: Tom Marino
+- name: Darrell E. Issa
   party: majority
   rank: 10
+  bioguide: I000056
+  thomas: '01640'
+- name: Tom Marino
+  party: majority
+  rank: 11
   bioguide: M001179
   thomas: '02053'
 - name: Jeff Duncan
   party: majority
-  rank: 11
+  rank: 12
   bioguide: D000615
   thomas: '02057'
-- name: Adam Kinzinger
-  party: majority
-  rank: 12
-  bioguide: K000378
-  thomas: '02014'
 - name: Mo Brooks
   party: majority
   rank: 13
   bioguide: B001274
   thomas: '01987'
-- name: Tom Cotton
-  party: majority
-  rank: 14
-  bioguide: C001095
-  thomas: '02098'
 - name: Paul Cook
   party: majority
-  rank: 15
+  rank: 14
   bioguide: C001094
   thomas: '02103'
-- name: George Holding
-  party: majority
-  rank: 16
-  bioguide: H001065
-  thomas: '02143'
 - name: Randy K. Weber Sr.
   party: majority
-  rank: 17
+  rank: 15
   bioguide: W000814
   thomas: '02161'
 - name: Scott Perry
   party: majority
-  rank: 18
+  rank: 16
   bioguide: P000605
   thomas: '02157'
-- name: Steve Stockman
-  party: majority
-  rank: 19
-  bioguide: S000937
-  thomas: '01114'
 - name: Ron DeSantis
   party: majority
-  rank: 20
+  rank: 17
   bioguide: D000621
   thomas: '02116'
-- name: Doug Collins
-  party: majority
-  rank: 21
-  bioguide: C001093
-  thomas: '02121'
 - name: Mark Meadows
   party: majority
-  rank: 22
+  rank: 18
   bioguide: M001187
   thomas: '02142'
 - name: Ted S. Yoho
   party: majority
-  rank: 23
+  rank: 19
   bioguide: Y000065
   thomas: '02115'
-- name: Sean P. Duffy
-  party: majority
-  rank: 24
-  bioguide: D000614
-  thomas: '02072'
 - name: Curt Clawson
   party: majority
-  rank: 25
+  rank: 20
   bioguide: C001102
   thomas: '02200'
+- name: Scott DesJarlais
+  party: majority
+  rank: 21
+  bioguide: D000616
+  thomas: '02062'
+- name: Reid J. Ribble
+  party: majority
+  rank: 22
+  bioguide: R000587
+  thomas: '02073'
+- name: David A. Trott
+  party: majority
+  rank: 23
+  bioguide: T000475
+  thomas: '02250'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 24
+  bioguide: Z000017
+  thomas: '02261'
+- name: Tom Emmer
+  party: majority
+  rank: 25
+  bioguide: E000294
+  thomas: '02253'
 - name: Eliot L. Engel
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: E000179
   thomas: '00344'
-- name: Eni F. H. Faleomavaega
-  party: minority
-  rank: 2
-  bioguide: F000010
-  thomas: '00367'
 - name: Brad Sherman
   party: minority
-  rank: 3
+  rank: 2
   bioguide: S000344
   thomas: '01526'
 - name: Gregory W. Meeks
   party: minority
-  rank: 4
+  rank: 3
   bioguide: M001137
   thomas: '01506'
 - name: Albio Sires
   party: minority
-  rank: 5
+  rank: 4
   bioguide: S001165
   thomas: '01818'
 - name: Gerald E. Connolly
   party: minority
-  rank: 6
+  rank: 5
   bioguide: C001078
   thomas: '01959'
 - name: Theodore E. Deutch
   party: minority
-  rank: 7
+  rank: 6
   bioguide: D000610
   thomas: '01976'
 - name: Brian Higgins
   party: minority
-  rank: 8
+  rank: 7
   bioguide: H001038
   thomas: '01794'
 - name: Karen Bass
   party: minority
-  rank: 9
+  rank: 8
   bioguide: B001270
   thomas: '01996'
 - name: William R. Keating
   party: minority
-  rank: 10
+  rank: 9
   bioguide: K000375
   thomas: '02025'
 - name: David N. Cicilline
   party: minority
-  rank: 11
+  rank: 10
   bioguide: C001084
   thomas: '02055'
 - name: Alan Grayson
   party: minority
-  rank: 12
+  rank: 11
   bioguide: G000556
   thomas: '01914'
-- name: Juan Vargas
-  party: minority
-  rank: 13
-  bioguide: V000130
-  thomas: '02112'
-- name: Bradley S. Schneider
-  party: minority
-  rank: 14
-  bioguide: S001190
-  thomas: '02124'
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 15
-  bioguide: K000379
-  thomas: '02172'
 - name: Ami Bera
   party: minority
-  rank: 16
+  rank: 12
   bioguide: B001287
   thomas: '02102'
 - name: Alan S. Lowenthal
   party: minority
-  rank: 17
+  rank: 13
   bioguide: L000579
   thomas: '02111'
 - name: Grace Meng
   party: minority
-  rank: 18
+  rank: 14
   bioguide: M001188
   thomas: '02148'
 - name: Lois Frankel
   party: minority
-  rank: 19
+  rank: 15
   bioguide: F000462
   thomas: '02119'
 - name: Tulsi Gabbard
   party: minority
-  rank: 20
+  rank: 16
   bioguide: G000571
   thomas: '02122'
 - name: Joaquin Castro
   party: minority
-  rank: 21
+  rank: 17
   bioguide: C001091
   thomas: '02163'
+- name: Robin L. Kelly
+  party: minority
+  rank: 18
+  bioguide: K000385
+  thomas: '02190'
+- name: Brendan F. Boyle
+  party: minority
+  rank: 19
+  bioguide: B001296
+  thomas: '02267'
 HSFA05:
-- name: Steve Chabot
+- name: Matt Salmon
   party: majority
   rank: 1
   title: Chair
-  bioguide: C000266
-  thomas: '00186'
+  bioguide: S000018
+  thomas: '01009'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
   bioguide: R000409
   thomas: '00979'
-- name: Matt Salmon
-  party: majority
-  rank: 3
-  bioguide: S000018
-  thomas: '01009'
 - name: Mo Brooks
   party: majority
-  rank: 4
+  rank: 3
   bioguide: B001274
   thomas: '01987'
-- name: George Holding
-  party: majority
-  rank: 5
-  bioguide: H001065
-  thomas: '02143'
 - name: Scott Perry
   party: majority
-  rank: 6
+  rank: 4
   bioguide: P000605
   thomas: '02157'
-- name: Doug Collins
+- name: Steve Chabot
+  party: majority
+  rank: 5
+  bioguide: C000266
+  thomas: '00186'
+- name: Tom Marino
+  party: majority
+  rank: 6
+  bioguide: M001179
+  thomas: '02053'
+- name: Jeff Duncan
   party: majority
   rank: 7
-  bioguide: C001093
-  thomas: '02121'
-- name: Curt Clawson
+  bioguide: D000615
+  thomas: '02057'
+- name: Scott DesJarlais
   party: majority
   rank: 8
-  bioguide: C001102
-  thomas: '02200'
-- name: Eni F. H. Faleomavaega
+  bioguide: D000616
+  thomas: '02062'
+- name: Brad Sherman
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: F000010
-  thomas: '00367'
+  bioguide: S000344
+  thomas: '01526'
 - name: Ami Bera
   party: minority
   rank: 2
@@ -4973,28 +4119,28 @@ HSFA05:
   rank: 3
   bioguide: G000571
   thomas: '02122'
-- name: Brad Sherman
+- name: Alan S. Lowenthal
   party: minority
   rank: 4
-  bioguide: S000344
-  thomas: '01526'
+  bioguide: L000579
+  thomas: '02111'
 - name: Gerald E. Connolly
   party: minority
   rank: 5
   bioguide: C001078
   thomas: '01959'
-- name: William R. Keating
+- name: Grace Meng
   party: minority
   rank: 6
-  bioguide: K000375
-  thomas: '02025'
+  bioguide: M001188
+  thomas: '02148'
 HSFA07:
-- name: Matt Salmon
+- name: Jeff Duncan
   party: majority
   rank: 1
   title: Chair
-  bioguide: S000018
-  thomas: '01009'
+  bioguide: D000615
+  thomas: '02057'
 - name: Christopher H. Smith
   party: majority
   rank: 2
@@ -5010,21 +4156,26 @@ HSFA07:
   rank: 4
   bioguide: M001157
   thomas: '01804'
-- name: Jeff Duncan
-  party: majority
-  rank: 5
-  bioguide: D000615
-  thomas: '02057'
 - name: Ron DeSantis
   party: majority
-  rank: 6
+  rank: 5
   bioguide: D000621
   thomas: '02116'
-- name: Sean P. Duffy
+- name: Matt Salmon
+  party: majority
+  rank: 6
+  bioguide: S000018
+  thomas: '01009'
+- name: Ted S. Yoho
   party: majority
   rank: 7
-  bioguide: D000614
-  thomas: '02072'
+  bioguide: Y000065
+  thomas: '02115'
+- name: Tom Emmer
+  party: majority
+  rank: 8
+  bioguide: E000294
+  thomas: '02253'
 - name: Albio Sires
   party: minority
   rank: 1
@@ -5036,21 +4187,26 @@ HSFA07:
   rank: 2
   bioguide: M001137
   thomas: '01506'
-- name: Eni F. H. Faleomavaega
-  party: minority
-  rank: 3
-  bioguide: F000010
-  thomas: '00367'
-- name: Theodore E. Deutch
-  party: minority
-  rank: 4
-  bioguide: D000610
-  thomas: '01976'
 - name: Alan Grayson
   party: minority
-  rank: 5
+  rank: 3
   bioguide: G000556
   thomas: '01914'
+- name: Joaquin Castro
+  party: minority
+  rank: 4
+  bioguide: C001091
+  thomas: '02163'
+- name: Robin L. Kelly
+  party: minority
+  rank: 5
+  bioguide: K000385
+  thomas: '02190'
+- name: Alan S. Lowenthal
+  party: minority
+  rank: 6
+  bioguide: L000579
+  thomas: '02111'
 HSFA13:
 - name: Ileana Ros-Lehtinen
   party: majority
@@ -5068,51 +4224,46 @@ HSFA13:
   rank: 3
   bioguide: W000795
   thomas: '01688'
-- name: Adam Kinzinger
-  party: majority
-  rank: 4
-  bioguide: K000378
-  thomas: '02014'
-- name: Tom Cotton
-  party: majority
-  rank: 5
-  bioguide: C001095
-  thomas: '02098'
 - name: Randy K. Weber Sr.
   party: majority
-  rank: 6
+  rank: 4
   bioguide: W000814
   thomas: '02161'
 - name: Ron DeSantis
   party: majority
-  rank: 7
+  rank: 5
   bioguide: D000621
   thomas: '02116'
-- name: Doug Collins
-  party: majority
-  rank: 8
-  bioguide: C001093
-  thomas: '02121'
 - name: Mark Meadows
   party: majority
-  rank: 9
+  rank: 6
   bioguide: M001187
   thomas: '02142'
 - name: Ted S. Yoho
   party: majority
-  rank: 10
+  rank: 7
   bioguide: Y000065
   thomas: '02115'
-- name: Sean P. Duffy
-  party: majority
-  rank: 11
-  bioguide: D000614
-  thomas: '02072'
 - name: Curt Clawson
   party: majority
-  rank: 12
+  rank: 8
   bioguide: C001102
   thomas: '02200'
+- name: Darrell E. Issa
+  party: majority
+  rank: 9
+  bioguide: I000056
+  thomas: '01640'
+- name: David A. Trott
+  party: majority
+  rank: 10
+  bioguide: T000475
+  thomas: '02250'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 11
+  bioguide: Z000017
+  thomas: '02261'
 - name: Theodore E. Deutch
   party: minority
   rank: 1
@@ -5139,31 +4290,21 @@ HSFA13:
   rank: 5
   bioguide: G000556
   thomas: '01914'
-- name: Juan Vargas
-  party: minority
-  rank: 6
-  bioguide: V000130
-  thomas: '02112'
-- name: Bradley S. Schneider
-  party: minority
-  rank: 7
-  bioguide: S001190
-  thomas: '02124'
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 8
-  bioguide: K000379
-  thomas: '02172'
 - name: Grace Meng
   party: minority
-  rank: 9
+  rank: 6
   bioguide: M001188
   thomas: '02148'
 - name: Lois Frankel
   party: minority
-  rank: 10
+  rank: 7
   bioguide: F000462
   thomas: '02119'
+- name: Brendan F. Boyle
+  party: minority
+  rank: 8
+  bioguide: B001296
+  thomas: '02267'
 HSFA14:
 - name: Dana Rohrabacher
   party: majority
@@ -5181,52 +4322,72 @@ HSFA14:
   rank: 3
   bioguide: M001179
   thomas: '02053'
-- name: Jeff Duncan
-  party: majority
-  rank: 4
-  bioguide: D000615
-  thomas: '02057'
 - name: Paul Cook
   party: majority
-  rank: 5
+  rank: 4
   bioguide: C001094
   thomas: '02103'
-- name: George Holding
+- name: Mo Brooks
+  party: majority
+  rank: 5
+  bioguide: B001274
+  thomas: '01987'
+- name: Randy K. Weber Sr.
   party: majority
   rank: 6
-  bioguide: H001065
-  thomas: '02143'
-- name: Steve Stockman
+  bioguide: W000814
+  thomas: '02161'
+- name: Reid J. Ribble
   party: majority
   rank: 7
-  bioguide: S000937
-  thomas: '01114'
-- name: William R. Keating
+  bioguide: R000587
+  thomas: '02073'
+- name: David A. Trott
+  party: majority
+  rank: 8
+  bioguide: T000475
+  thomas: '02250'
+- name: Gregory W. Meeks
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: K000375
-  thomas: '02025'
-- name: Gregory W. Meeks
-  party: minority
-  rank: 2
   bioguide: M001137
   thomas: '01506'
 - name: Albio Sires
   party: minority
-  rank: 3
+  rank: 2
   bioguide: S001165
   thomas: '01818'
 - name: Brian Higgins
   party: minority
-  rank: 4
+  rank: 3
   bioguide: H001038
   thomas: '01794'
 - name: Alan S. Lowenthal
   party: minority
-  rank: 5
+  rank: 4
   bioguide: L000579
   thomas: '02111'
+- name: Theodore E. Deutch
+  party: minority
+  rank: 5
+  bioguide: D000610
+  thomas: '01976'
+- name: William R. Keating
+  party: minority
+  rank: 6
+  bioguide: K000375
+  thomas: '02025'
+- name: Lois Frankel
+  party: minority
+  rank: 7
+  bioguide: F000462
+  thomas: '02119'
+- name: Tulsi Gabbard
+  party: minority
+  rank: 8
+  bioguide: G000571
+  thomas: '02122'
 HSFA16:
 - name: Christopher H. Smith
   party: majority
@@ -5234,26 +4395,26 @@ HSFA16:
   title: Chair
   bioguide: S000522
   thomas: '01071'
-- name: Tom Marino
-  party: majority
-  rank: 2
-  bioguide: M001179
-  thomas: '02053'
-- name: Randy K. Weber Sr.
-  party: majority
-  rank: 3
-  bioguide: W000814
-  thomas: '02161'
-- name: Steve Stockman
-  party: majority
-  rank: 4
-  bioguide: S000937
-  thomas: '01114'
 - name: Mark Meadows
   party: majority
-  rank: 5
+  rank: 2
   bioguide: M001187
   thomas: '02142'
+- name: Curt Clawson
+  party: majority
+  rank: 3
+  bioguide: C001102
+  thomas: '02200'
+- name: Scott DesJarlais
+  party: majority
+  rank: 4
+  bioguide: D000616
+  thomas: '02062'
+- name: Tom Emmer
+  party: majority
+  rank: 5
+  bioguide: E000294
+  thomas: '02253'
 - name: Karen Bass
   party: minority
   rank: 1
@@ -5282,184 +4443,184 @@ HSFA18:
   rank: 2
   bioguide: W000795
   thomas: '01688'
-- name: Adam Kinzinger
-  party: majority
-  rank: 3
-  bioguide: K000378
-  thomas: '02014'
-- name: Mo Brooks
-  party: majority
-  rank: 4
-  bioguide: B001274
-  thomas: '01987'
-- name: Tom Cotton
-  party: majority
-  rank: 5
-  bioguide: C001095
-  thomas: '02098'
 - name: Paul Cook
   party: majority
-  rank: 6
+  rank: 3
   bioguide: C001094
   thomas: '02103'
 - name: Scott Perry
   party: majority
-  rank: 7
+  rank: 4
   bioguide: P000605
   thomas: '02157'
-- name: Ted S. Yoho
+- name: Darrell E. Issa
   party: majority
-  rank: 8
-  bioguide: Y000065
-  thomas: '02115'
-- name: Brad Sherman
+  rank: 5
+  bioguide: I000056
+  thomas: '01640'
+- name: Reid J. Ribble
+  party: majority
+  rank: 6
+  bioguide: R000587
+  thomas: '02073'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 7
+  bioguide: Z000017
+  thomas: '02261'
+- name: William R. Keating
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: S000344
-  thomas: '01526'
-- name: Alan S. Lowenthal
+  bioguide: K000375
+  thomas: '02025'
+- name: Brad Sherman
   party: minority
   rank: 2
-  bioguide: L000579
-  thomas: '02111'
+  bioguide: S000344
+  thomas: '01526'
 - name: Joaquin Castro
   party: minority
   rank: 3
   bioguide: C001091
   thomas: '02163'
-- name: Juan Vargas
+- name: Brian Higgins
   party: minority
   rank: 4
-  bioguide: V000130
-  thomas: '02112'
-- name: Bradley S. Schneider
+  bioguide: H001038
+  thomas: '01794'
+- name: Robin L. Kelly
   party: minority
   rank: 5
-  bioguide: S001190
-  thomas: '02124'
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 6
-  bioguide: K000379
-  thomas: '02172'
+  bioguide: K000385
+  thomas: '02190'
 HSGO:
-- name: Darrell E. Issa
+- name: John L. Mica
   party: majority
   rank: 1
   title: Chair
-  bioguide: I000056
-  thomas: '01640'
-- name: John L. Mica
-  party: majority
-  rank: 2
   bioguide: M000689
   thomas: '00800'
 - name: Michael R. Turner
   party: majority
-  rank: 3
+  rank: 2
   bioguide: T000463
   thomas: '01741'
 - name: John J. Duncan Jr.
   party: majority
-  rank: 4
+  rank: 3
   bioguide: D000533
   thomas: '00322'
-- name: Patrick T. McHenry
-  party: majority
-  rank: 5
-  bioguide: M001156
-  thomas: '01792'
 - name: Jim Jordan
   party: majority
-  rank: 6
+  rank: 4
   bioguide: J000289
   thomas: '01868'
-- name: Jason Chaffetz
-  party: majority
-  rank: 7
-  bioguide: C001076
-  thomas: '01956'
 - name: Tim Walberg
   party: majority
-  rank: 8
+  rank: 5
   bioguide: W000798
   thomas: '01855'
-- name: James Lankford
-  party: majority
-  rank: 9
-  bioguide: L000575
-  thomas: '02050'
 - name: Justin Amash
   party: majority
-  rank: 10
+  rank: 6
   bioguide: A000367
   thomas: '02029'
 - name: Paul A. Gosar
   party: majority
-  rank: 11
+  rank: 7
   bioguide: G000565
   thomas: '01992'
-- name: Patrick Meehan
-  party: majority
-  rank: 12
-  bioguide: M001181
-  thomas: '02052'
 - name: Scott DesJarlais
   party: majority
-  rank: 13
+  rank: 8
   bioguide: D000616
   thomas: '02062'
 - name: Trey Gowdy
   party: majority
-  rank: 14
+  rank: 9
   bioguide: G000566
   thomas: '02058'
 - name: Blake Farenthold
   party: majority
-  rank: 15
+  rank: 10
   bioguide: F000460
   thomas: '02067'
-- name: Doc Hastings
-  party: majority
-  rank: 16
-  bioguide: H000329
-  thomas: '00512'
 - name: Cynthia M. Lummis
   party: majority
-  rank: 17
+  rank: 11
   bioguide: L000571
   thomas: '01960'
-- name: Rob Woodall
-  party: majority
-  rank: 18
-  bioguide: W000810
-  thomas: '02008'
 - name: Thomas Massie
   party: majority
-  rank: 19
+  rank: 12
   bioguide: M001184
   thomas: '02094'
-- name: Doug Collins
-  party: majority
-  rank: 20
-  bioguide: C001093
-  thomas: '02121'
 - name: Mark Meadows
   party: majority
-  rank: 21
+  rank: 13
   bioguide: M001187
   thomas: '02142'
-- name: Kerry L. Bentivolio
-  party: majority
-  rank: 22
-  bioguide: B001280
-  thomas: '02135'
 - name: Ron DeSantis
   party: majority
-  rank: 23
+  rank: 14
   bioguide: D000621
   thomas: '02116'
+- name: Mick Mulvaney
+  party: majority
+  rank: 15
+  bioguide: M001182
+  thomas: '02059'
+- name: Ken Buck
+  party: majority
+  rank: 16
+  bioguide: B001297
+  thomas: '02233'
+- name: Mark Walker
+  party: majority
+  rank: 17
+  bioguide: W000819
+  thomas: '02255'
+- name: Rod Blum
+  party: majority
+  rank: 18
+  bioguide: B001294
+  thomas: '02241'
+- name: Jody B. Hice
+  party: majority
+  rank: 19
+  bioguide: H001071
+  thomas: '02237'
+- name: Earl L. "Buddy" Carter
+  party: majority
+  rank: 20
+  bioguide: C001103
+  thomas: '02236'
+- name: Steve Russell
+  party: majority
+  rank: 21
+  bioguide: R000604
+  thomas: '02265'
+- name: Jason Chaffetz
+  party: majority
+  rank: 22
+  bioguide: C001076
+  thomas: '01956'
+- name: Glenn Grothman
+  party: majority
+  rank: 23
+  bioguide: G000576
+  thomas: '02276'
+- name: Will Hurd
+  party: majority
+  rank: 24
+  bioguide: H001073
+  thomas: '02269'
+- name: Gary J. Palmer
+  party: majority
+  rank: 25
+  bioguide: P000609
+  thomas: '02221'
 - name: Elijah E. Cummings
   party: minority
   rank: 1
@@ -5476,446 +4637,160 @@ HSGO:
   rank: 3
   bioguide: N000147
   thomas: '00868'
-- name: John F. Tierney
-  party: minority
-  rank: 4
-  bioguide: T000266
-  thomas: '01535'
 - name: Wm. Lacy Clay
   party: minority
-  rank: 5
+  rank: 4
   bioguide: C001049
   thomas: '01654'
 - name: Stephen F. Lynch
   party: minority
-  rank: 6
+  rank: 5
   bioguide: L000562
   thomas: '01686'
 - name: Jim Cooper
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C000754
   thomas: '00231'
 - name: Gerald E. Connolly
   party: minority
-  rank: 8
+  rank: 7
   bioguide: C001078
   thomas: '01959'
-- name: Jackie Speier
-  party: minority
-  rank: 9
-  bioguide: S001175
-  thomas: '01890'
 - name: Matt Cartwright
   party: minority
-  rank: 10
+  rank: 8
   bioguide: C001090
   thomas: '02159'
 - name: Tammy Duckworth
   party: minority
-  rank: 11
+  rank: 9
   bioguide: D000622
   thomas: '02123'
 - name: Robin L. Kelly
   party: minority
-  rank: 12
+  rank: 10
   bioguide: K000385
   thomas: '02190'
-- name: Danny K. Davis
+- name: Brenda L. Lawrence
+  party: minority
+  rank: 11
+  bioguide: L000581
+  thomas: '02252'
+- name: Ted Lieu
+  party: minority
+  rank: 12
+  bioguide: L000582
+  thomas: '02230'
+- name: Bonnie Watson Coleman
   party: minority
   rank: 13
-  bioguide: D000096
-  thomas: '01477'
-- name: Peter Welch
+  bioguide: W000822
+  thomas: '02259'
+- name: Stacey E. Plaskett
   party: minority
   rank: 14
-  bioguide: W000800
-  thomas: '01879'
-- name: Tony Cárdenas
+  bioguide: P000610
+  thomas: '02274'
+- name: Mark DeSaulnier
   party: minority
   rank: 15
-  bioguide: C001097
-  thomas: '02107'
-- name: Steven A. Horsford
+  bioguide: D000623
+  thomas: '02227'
+- name: Brendan F. Boyle
   party: minority
   rank: 16
-  bioguide: H001066
-  thomas: '02147'
-- name: Michelle Lujan Grisham
+  bioguide: B001296
+  thomas: '02267'
+- name: Peter Welch
   party: minority
   rank: 17
+  bioguide: W000800
+  thomas: '01879'
+- name: Michelle Lujan Grisham
+  party: minority
+  rank: 18
   bioguide: L000580
   thomas: '02146'
-HSGO06:
-- name: Jason Chaffetz
+HSGO24:
+- name: Mark Meadows
   party: majority
   rank: 1
   title: Chair
-  bioguide: C001076
-  thomas: '01956'
-- name: Cynthia M. Lummis
+  bioguide: M001187
+  thomas: '02142'
+- name: Jim Jordan
   party: majority
   rank: 2
-  bioguide: L000571
-  thomas: '01960'
-  title: Vice Chair
-- name: John L. Mica
+  bioguide: J000289
+  thomas: '01868'
+- name: Tim Walberg
   party: majority
   rank: 3
-  bioguide: M000689
-  thomas: '00800'
-- name: John J. Duncan Jr.
-  party: majority
-  rank: 4
-  bioguide: D000533
-  thomas: '00322'
-- name: Justin Amash
-  party: majority
-  rank: 5
-  bioguide: A000367
-  thomas: '02029'
-- name: Paul A. Gosar
-  party: majority
-  rank: 6
-  bioguide: G000565
-  thomas: '01992'
+  bioguide: W000798
+  thomas: '01855'
+  title: Vice Chair
 - name: Trey Gowdy
   party: majority
-  rank: 7
+  rank: 4
   bioguide: G000566
   thomas: '02058'
-- name: Rob Woodall
+- name: Thomas Massie
+  party: majority
+  rank: 5
+  bioguide: M001184
+  thomas: '02094'
+- name: Mick Mulvaney
+  party: majority
+  rank: 6
+  bioguide: M001182
+  thomas: '02059'
+- name: Ken Buck
+  party: majority
+  rank: 7
+  bioguide: B001297
+  thomas: '02233'
+- name: Earl L. "Buddy" Carter
   party: majority
   rank: 8
-  bioguide: W000810
-  thomas: '02008'
-- name: Kerry L. Bentivolio
+  bioguide: C001103
+  thomas: '02236'
+- name: Glenn Grothman
   party: majority
   rank: 9
-  bioguide: B001280
-  thomas: '02135'
-- name: John F. Tierney
+  bioguide: G000576
+  thomas: '02276'
+- name: Gerald E. Connolly
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: T000266
-  thomas: '01535'
+  bioguide: C001078
+  thomas: '01959'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
   bioguide: M000087
   thomas: '00729'
-- name: Stephen F. Lynch
-  party: minority
-  rank: 3
-  bioguide: L000562
-  thomas: '01686'
-- name: Jackie Speier
-  party: minority
-  rank: 4
-  bioguide: S001175
-  thomas: '01890'
-- name: Robin L. Kelly
-  party: minority
-  rank: 5
-  bioguide: K000385
-  thomas: '02190'
-- name: Peter Welch
-  party: minority
-  rank: 6
-  bioguide: W000800
-  thomas: '01879'
-- name: Michelle Lujan Grisham
-  party: minority
-  rank: 7
-  bioguide: L000580
-  thomas: '02146'
-HSGO24:
-- name: John L. Mica
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: M000689
-  thomas: '00800'
-- name: Mark Meadows
-  party: majority
-  rank: 2
-  bioguide: M001187
-  thomas: '02142'
-  title: Vice Chair
-- name: Michael R. Turner
-  party: majority
-  rank: 3
-  bioguide: T000463
-  thomas: '01741'
-- name: Justin Amash
-  party: majority
-  rank: 4
-  bioguide: A000367
-  thomas: '02029'
-- name: Thomas Massie
-  party: majority
-  rank: 5
-  bioguide: M001184
-  thomas: '02094'
-- name: Gerald E. Connolly
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001078
-  thomas: '01959'
-- name: Jim Cooper
-  party: minority
-  rank: 2
-  bioguide: C000754
-  thomas: '00231'
-HSGO25:
-- name: Blake Farenthold
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: F000460
-  thomas: '02067'
-- name: Tim Walberg
-  party: majority
-  rank: 2
-  bioguide: W000798
-  thomas: '01855'
-  title: Vice Chair
-- name: Trey Gowdy
-  party: majority
-  rank: 3
-  bioguide: G000566
-  thomas: '02058'
-- name: Doug Collins
-  party: majority
-  rank: 4
-  bioguide: C001093
-  thomas: '02121'
-- name: Ron DeSantis
-  party: majority
-  rank: 5
-  bioguide: D000621
-  thomas: '02116'
-- name: Stephen F. Lynch
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000562
-  thomas: '01686'
 - name: Eleanor Holmes Norton
   party: minority
-  rank: 2
+  rank: 3
   bioguide: N000147
   thomas: '00868'
 - name: Wm. Lacy Clay
   party: minority
-  rank: 3
+  rank: 4
   bioguide: C001049
   thomas: '01654'
-HSGO27:
-- name: James Lankford
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: L000575
-  thomas: '02050'
-- name: Paul A. Gosar
-  party: majority
-  rank: 2
-  bioguide: G000565
-  thomas: '01992'
-  title: Vice Chair
-- name: Patrick T. McHenry
-  party: majority
-  rank: 3
-  bioguide: M001156
-  thomas: '01792'
-- name: Jim Jordan
-  party: majority
-  rank: 4
-  bioguide: J000289
-  thomas: '01868'
-- name: Jason Chaffetz
-  party: majority
-  rank: 5
-  bioguide: C001076
-  thomas: '01956'
-- name: Tim Walberg
-  party: majority
-  rank: 6
-  bioguide: W000798
-  thomas: '01855'
-- name: Patrick Meehan
-  party: majority
-  rank: 7
-  bioguide: M001181
-  thomas: '02052'
-- name: Scott DesJarlais
-  party: majority
-  rank: 8
-  bioguide: D000616
-  thomas: '02062'
-- name: Blake Farenthold
-  party: majority
-  rank: 9
-  bioguide: F000460
-  thomas: '02067'
-- name: Doc Hastings
-  party: majority
-  rank: 10
-  bioguide: H000329
-  thomas: '00512'
-- name: Rob Woodall
-  party: majority
-  rank: 11
-  bioguide: W000810
-  thomas: '02008'
-- name: Thomas Massie
-  party: majority
-  rank: 12
-  bioguide: M001184
-  thomas: '02094'
-- name: Jackie Speier
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001175
-  thomas: '01890'
-- name: Eleanor Holmes Norton
-  party: minority
-  rank: 2
-  bioguide: N000147
-  thomas: '00868'
-- name: Jim Cooper
-  party: minority
-  rank: 3
-  bioguide: C000754
-  thomas: '00231'
-- name: Matt Cartwright
-  party: minority
-  rank: 4
-  bioguide: C001090
-  thomas: '02159'
-- name: Tammy Duckworth
+- name: Stephen F. Lynch
   party: minority
   rank: 5
-  bioguide: D000622
-  thomas: '02123'
-- name: Danny K. Davis
+  bioguide: L000562
+  thomas: '01686'
+- name: Stacey E. Plaskett
   party: minority
   rank: 6
-  bioguide: D000096
-  thomas: '01477'
-- name: Tony Cárdenas
-  party: minority
-  rank: 7
-  bioguide: C001097
-  thomas: '02107'
-- name: Michelle Lujan Grisham
-  party: minority
-  rank: 8
-  bioguide: L000580
-  thomas: '02146'
-- name: Steven A. Horsford
-  party: minority
-  rank: 9
-  bioguide: H001066
-  thomas: '02147'
-HSGO28:
-- name: Jim Jordan
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: J000289
-  thomas: '01868'
-- name: Ron DeSantis
-  party: majority
-  rank: 2
-  bioguide: D000621
-  thomas: '02116'
-  title: Vice Chair
-- name: John J. Duncan Jr.
-  party: majority
-  rank: 3
-  bioguide: D000533
-  thomas: '00322'
-- name: Patrick T. McHenry
-  party: majority
-  rank: 4
-  bioguide: M001156
-  thomas: '01792'
-- name: Paul A. Gosar
-  party: majority
-  rank: 5
-  bioguide: G000565
-  thomas: '01992'
-- name: Patrick Meehan
-  party: majority
-  rank: 6
-  bioguide: M001181
-  thomas: '02052'
-- name: Scott DesJarlais
-  party: majority
-  rank: 7
-  bioguide: D000616
-  thomas: '02062'
-- name: Doc Hastings
-  party: majority
-  rank: 8
-  bioguide: H000329
-  thomas: '00512'
-- name: Cynthia M. Lummis
-  party: majority
-  rank: 9
-  bioguide: L000571
-  thomas: '01960'
-- name: Doug Collins
-  party: majority
-  rank: 10
-  bioguide: C001093
-  thomas: '02121'
-- name: Mark Meadows
-  party: majority
-  rank: 11
-  bioguide: M001187
-  thomas: '02142'
-- name: Kerry L. Bentivolio
-  party: majority
-  rank: 12
-  bioguide: B001280
-  thomas: '02135'
-- name: Matt Cartwright
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001090
-  thomas: '02159'
-- name: Tammy Duckworth
-  party: minority
-  rank: 2
-  bioguide: D000622
-  thomas: '02123'
-- name: Gerald E. Connolly
-  party: minority
-  rank: 3
-  bioguide: C001078
-  thomas: '01959'
-- name: Robin L. Kelly
-  party: minority
-  rank: 4
-  bioguide: K000385
-  thomas: '02190'
-- name: Danny K. Davis
-  party: minority
-  rank: 5
-  bioguide: D000096
-  thomas: '01477'
-- name: Steven A. Horsford
-  party: minority
-  rank: 6
-  bioguide: H001066
-  thomas: '02147'
+  bioguide: P000610
+  thomas: '02274'
 HSHA:
 - name: Candice S. Miller
   party: majority
@@ -5928,26 +4803,26 @@ HSHA:
   rank: 2
   bioguide: H001045
   thomas: '01933'
-- name: Phil Gingrey
-  party: majority
-  rank: 3
-  bioguide: G000550
-  thomas: '01720'
 - name: Aaron Schock
   party: majority
-  rank: 4
+  rank: 3
   bioguide: S001179
   thomas: '01920'
-- name: Todd Rokita
-  party: majority
-  rank: 5
-  bioguide: R000592
-  thomas: '02017'
 - name: Richard B. Nugent
   party: majority
-  rank: 6
+  rank: 4
   bioguide: N000185
   thomas: '02001'
+- name: Rodney Davis
+  party: majority
+  rank: 5
+  bioguide: D000619
+  thomas: '02126'
+- name: Barbara Comstock
+  party: majority
+  rank: 6
+  bioguide: C001105
+  thomas: '02273'
 - name: Robert A. Brady
   party: minority
   rank: 1
@@ -5986,76 +4861,76 @@ HSHM:
   rank: 4
   bioguide: R000575
   thomas: '01704'
-- name: Paul C. Broun
-  party: majority
-  rank: 5
-  bioguide: B001262
-  thomas: '01882'
 - name: Candice S. Miller
   party: majority
-  rank: 6
+  rank: 5
   bioguide: M001150
   thomas: '01731'
-- name: Patrick Meehan
-  party: majority
-  rank: 7
-  bioguide: M001181
-  thomas: '02052'
 - name: Jeff Duncan
   party: majority
-  rank: 8
+  rank: 6
   bioguide: D000615
   thomas: '02057'
 - name: Tom Marino
   party: majority
-  rank: 9
+  rank: 7
   bioguide: M001179
   thomas: '02053'
-- name: Jason Chaffetz
-  party: majority
-  rank: 10
-  bioguide: C001076
-  thomas: '01956'
 - name: Steven M. Palazzo
   party: majority
-  rank: 11
+  rank: 8
   bioguide: P000601
   thomas: '02035'
 - name: Lou Barletta
   party: majority
-  rank: 12
+  rank: 9
   bioguide: B001269
   thomas: '02054'
-- name: Richard Hudson
-  party: majority
-  rank: 13
-  bioguide: H001067
-  thomas: '02140'
-- name: Steve Daines
-  party: majority
-  rank: 14
-  bioguide: D000618
-  thomas: '02138'
-- name: Susan W. Brooks
-  party: majority
-  rank: 15
-  bioguide: B001284
-  thomas: '02129'
 - name: Scott Perry
   party: majority
-  rank: 16
+  rank: 10
   bioguide: P000605
   thomas: '02157'
-- name: Mark Sanford
-  party: majority
-  rank: 17
-  bioguide: S000051
-  thomas: '01012'
 - name: Curt Clawson
   party: majority
-  rank: 18
+  rank: 11
   bioguide: C001102
   thomas: '02200'
+- name: John Katko
+  party: majority
+  rank: 12
+  bioguide: K000386
+  thomas: '02264'
+- name: Will Hurd
+  party: majority
+  rank: 13
+  bioguide: H001073
+  thomas: '02269'
+- name: Earl L. "Buddy" Carter
+  party: majority
+  rank: 14
+  bioguide: C001103
+  thomas: '02236'
+- name: Mark Walker
+  party: majority
+  rank: 15
+  bioguide: W000819
+  thomas: '02255'
+- name: Barry Loudermilk
+  party: majority
+  rank: 16
+  bioguide: L000583
+  thomas: '02238'
+- name: Martha McSally
+  party: majority
+  rank: 17
+  bioguide: M001197
+  thomas: '02225'
+- name: John Ratcliffe
+  party: majority
+  rank: 18
+  bioguide: R000601
+  thomas: '02268'
 - name: Bennie G. Thompson
   party: minority
   rank: 1
@@ -6072,11 +4947,11 @@ HSHM:
   rank: 3
   bioguide: J000032
   thomas: '00588'
-- name: Yvette D. Clarke
+- name: James R. Langevin
   party: minority
   rank: 4
-  bioguide: C001067
-  thomas: '01864'
+  bioguide: L000559
+  thomas: '01668'
 - name: Brian Higgins
   party: minority
   rank: 5
@@ -6092,31 +4967,31 @@ HSHM:
   rank: 7
   bioguide: K000375
   thomas: '02025'
-- name: Ron Barber
-  party: minority
-  rank: 8
-  bioguide: B001279
-  thomas: '02093'
 - name: Donald M. Payne Jr.
   party: minority
-  rank: 9
+  rank: 8
   bioguide: P000604
   thomas: '02097'
-- name: Beto O'Rourke
-  party: minority
-  rank: 10
-  bioguide: O000170
-  thomas: '02162'
 - name: Filemon Vela
   party: minority
-  rank: 11
+  rank: 9
   bioguide: V000132
   thomas: '02167'
-- name: Eric Swalwell
+- name: Bonnie Watson Coleman
+  party: minority
+  rank: 10
+  bioguide: W000822
+  thomas: '02259'
+- name: Kathleen M. Rice
+  party: minority
+  rank: 11
+  bioguide: R000602
+  thomas: '02262'
+- name: Norma J. Torres
   party: minority
   rank: 12
-  bioguide: S001193
-  thomas: '02104'
+  bioguide: T000474
+  thomas: '02231'
 HSHM05:
 - name: Peter T. King
   party: majority
@@ -6124,27 +4999,26 @@ HSHM05:
   title: Chair
   bioguide: K000210
   thomas: '00635'
-- name: Paul C. Broun
+- name: Candice S. Miller
   party: majority
   rank: 2
-  bioguide: B001262
-  thomas: '01882'
-- name: Patrick Meehan
+  bioguide: M001150
+  thomas: '01731'
+- name: Lou Barletta
   party: majority
   rank: 3
-  bioguide: M001181
-  thomas: '02052'
-  title: Vice Chair
-- name: Jason Chaffetz
+  bioguide: B001269
+  thomas: '02054'
+- name: John Katko
   party: majority
   rank: 4
-  bioguide: C001076
-  thomas: '01956'
-- name: Curt Clawson
+  bioguide: K000386
+  thomas: '02264'
+- name: Will Hurd
   party: majority
   rank: 5
-  bioguide: C001102
-  thomas: '02200'
+  bioguide: H001073
+  thomas: '02269'
 - name: Michael T. McCaul
   party: majority
   rank: 6
@@ -6157,123 +5031,6 @@ HSHM05:
   title: Ranking Member
   bioguide: H001038
   thomas: '01794'
-- name: Loretta Sanchez
-  party: minority
-  rank: 2
-  bioguide: S000030
-  thomas: '01522'
-- name: William R. Keating
-  party: minority
-  rank: 3
-  bioguide: K000375
-  thomas: '02025'
-- name: Bennie G. Thompson
-  party: minority
-  rank: 4
-  bioguide: T000193
-  thomas: '01151'
-  title: Ex Officio
-HSHM07:
-- name: Richard Hudson
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: H001067
-  thomas: '02140'
-- name: Mike Rogers
-  party: majority
-  rank: 2
-  bioguide: R000575
-  thomas: '01704'
-  title: Vice Chair
-- name: Candice S. Miller
-  party: majority
-  rank: 3
-  bioguide: M001150
-  thomas: '01731'
-- name: Susan W. Brooks
-  party: majority
-  rank: 4
-  bioguide: B001284
-  thomas: '02129'
-- name: Mark Sanford
-  party: majority
-  rank: 5
-  bioguide: S000051
-  thomas: '01012'
-- name: Michael T. McCaul
-  party: majority
-  rank: 6
-  bioguide: M001157
-  thomas: '01804'
-  title: Ex Officio
-- name: Cedric L. Richmond
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: R000588
-  thomas: '02023'
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 2
-  bioguide: J000032
-  thomas: '00588'
-- name: Eric Swalwell
-  party: minority
-  rank: 3
-  bioguide: S001193
-  thomas: '02104'
-- name: Bennie G. Thompson
-  party: minority
-  rank: 4
-  bioguide: T000193
-  thomas: '01151'
-  title: Ex Officio
-HSHM08:
-- name: Patrick Meehan
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: M001181
-  thomas: '02052'
-- name: Mike Rogers
-  party: majority
-  rank: 2
-  bioguide: R000575
-  thomas: '01704'
-- name: Tom Marino
-  party: majority
-  rank: 3
-  bioguide: M001179
-  thomas: '02053'
-- name: Jason Chaffetz
-  party: majority
-  rank: 4
-  bioguide: C001076
-  thomas: '01956'
-- name: Steve Daines
-  party: majority
-  rank: 5
-  bioguide: D000618
-  thomas: '02138'
-- name: Scott Perry
-  party: majority
-  rank: 6
-  bioguide: P000605
-  thomas: '02157'
-  title: Vice Chair
-- name: Michael T. McCaul
-  party: majority
-  rank: 7
-  bioguide: M001157
-  thomas: '01804'
-  title: Ex Officio
-- name: Yvette D. Clarke
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001067
-  thomas: '01864'
 - name: William R. Keating
   party: minority
   rank: 2
@@ -6286,60 +5043,179 @@ HSHM08:
   thomas: '02167'
 - name: Bennie G. Thompson
   party: minority
-  rank: 5
+  rank: 4
   bioguide: T000193
   thomas: '01151'
   title: Ex Officio
-HSHM09:
-- name: Jeff Duncan
+HSHM07:
+- name: John Katko
   party: majority
   rank: 1
   title: Chair
-  bioguide: D000615
-  thomas: '02057'
-- name: Paul C. Broun
+  bioguide: K000386
+  thomas: '02264'
+- name: Mike Rogers
   party: majority
   rank: 2
-  bioguide: B001262
-  thomas: '01882'
-- name: Lou Barletta
+  bioguide: R000575
+  thomas: '01704'
+- name: Earl L. "Buddy" Carter
   party: majority
   rank: 3
-  bioguide: B001269
-  thomas: '02054'
-- name: Richard Hudson
+  bioguide: C001103
+  thomas: '02236'
+- name: Mark Walker
   party: majority
   rank: 4
-  bioguide: H001067
-  thomas: '02140'
-- name: Steve Daines
+  bioguide: W000819
+  thomas: '02255'
+- name: John Ratcliffe
   party: majority
   rank: 5
-  bioguide: D000618
-  thomas: '02138'
-  title: Vice Chair
+  bioguide: R000601
+  thomas: '02268'
 - name: Michael T. McCaul
   party: majority
   rank: 6
   bioguide: M001157
   thomas: '01804'
   title: Ex Officio
-- name: Ron Barber
+- name: Kathleen M. Rice
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: B001279
-  thomas: '02093'
-- name: Donald M. Payne Jr.
+  bioguide: R000602
+  thomas: '02262'
+- name: William R. Keating
   party: minority
   rank: 2
-  bioguide: P000604
-  thomas: '02097'
-- name: Beto O'Rourke
+  bioguide: K000375
+  thomas: '02025'
+- name: Donald M. Payne Jr.
   party: minority
   rank: 3
-  bioguide: O000170
-  thomas: '02162'
+  bioguide: P000604
+  thomas: '02097'
+- name: Bennie G. Thompson
+  party: minority
+  rank: 4
+  bioguide: T000193
+  thomas: '01151'
+  title: Ex Officio
+HSHM08:
+- name: John Ratcliffe
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000601
+  thomas: '02268'
+- name: Peter T. King
+  party: majority
+  rank: 2
+  bioguide: K000210
+  thomas: '00635'
+- name: Tom Marino
+  party: majority
+  rank: 3
+  bioguide: M001179
+  thomas: '02053'
+- name: Steven M. Palazzo
+  party: majority
+  rank: 4
+  bioguide: P000601
+  thomas: '02035'
+- name: Scott Perry
+  party: majority
+  rank: 5
+  bioguide: P000605
+  thomas: '02157'
+- name: Curt Clawson
+  party: majority
+  rank: 6
+  bioguide: C001102
+  thomas: '02200'
+- name: Michael T. McCaul
+  party: majority
+  rank: 7
+  bioguide: M001157
+  thomas: '01804'
+  title: Ex Officio
+- name: Cedric L. Richmond
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000588
+  thomas: '02023'
+- name: Loretta Sanchez
+  party: minority
+  rank: 2
+  bioguide: S000030
+  thomas: '01522'
+- name: Sheila Jackson Lee
+  party: minority
+  rank: 3
+  bioguide: J000032
+  thomas: '00588'
+- name: James R. Langevin
+  party: minority
+  rank: 4
+  bioguide: L000559
+  thomas: '01668'
+- name: Bennie G. Thompson
+  party: minority
+  rank: 5
+  bioguide: T000193
+  thomas: '01151'
+  title: Ex Officio
+HSHM09:
+- name: Scott Perry
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: P000605
+  thomas: '02157'
+- name: Jeff Duncan
+  party: majority
+  rank: 2
+  bioguide: D000615
+  thomas: '02057'
+- name: Curt Clawson
+  party: majority
+  rank: 3
+  bioguide: C001102
+  thomas: '02200'
+- name: Earl L. "Buddy" Carter
+  party: majority
+  rank: 4
+  bioguide: C001103
+  thomas: '02236'
+- name: Barry Loudermilk
+  party: majority
+  rank: 5
+  bioguide: L000583
+  thomas: '02238'
+- name: Michael T. McCaul
+  party: majority
+  rank: 6
+  bioguide: M001157
+  thomas: '01804'
+  title: Ex Officio
+- name: Bonnie Watson Coleman
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000822
+  thomas: '02259'
+- name: Cedric L. Richmond
+  party: minority
+  rank: 2
+  bioguide: R000588
+  thomas: '02023'
+- name: Norma J. Torres
+  party: minority
+  rank: 3
+  bioguide: T000474
+  thomas: '02231'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
@@ -6353,87 +5229,101 @@ HSHM11:
   title: Chair
   bioguide: M001150
   thomas: '01731'
-- name: Jeff Duncan
+- name: Lamar Smith
   party: majority
   rank: 2
-  bioguide: D000615
-  thomas: '02057'
-- name: Tom Marino
+  bioguide: S000583
+  thomas: '01075'
+- name: Mike Rogers
   party: majority
   rank: 3
-  bioguide: M001179
-  thomas: '02053'
-- name: Steven M. Palazzo
+  bioguide: R000575
+  thomas: '01704'
+- name: Jeff Duncan
   party: majority
   rank: 4
-  bioguide: P000601
-  thomas: '02035'
+  bioguide: D000615
+  thomas: '02057'
 - name: Lou Barletta
   party: majority
   rank: 5
   bioguide: B001269
   thomas: '02054'
-- name: Curt Clawson
+- name: Will Hurd
   party: majority
   rank: 6
-  bioguide: C001102
-  thomas: '02200'
-- name: Michael T. McCaul
+  bioguide: H001073
+  thomas: '02269'
+- name: Martha McSally
   party: majority
   rank: 7
+  bioguide: M001197
+  thomas: '02225'
+- name: Michael T. McCaul
+  party: majority
+  rank: 8
   bioguide: M001157
   thomas: '01804'
   title: Ex Officio
-- name: Sheila Jackson Lee
+- name: Filemon Vela
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: J000032
-  thomas: '00588'
+  bioguide: V000132
+  thomas: '02167'
 - name: Loretta Sanchez
   party: minority
   rank: 2
   bioguide: S000030
   thomas: '01522'
-- name: Beto O'Rourke
+- name: Sheila Jackson Lee
   party: minority
   rank: 3
-  bioguide: O000170
-  thomas: '02162'
-- name: Bennie G. Thompson
+  bioguide: J000032
+  thomas: '00588'
+- name: Brian Higgins
+  party: minority
+  rank: 4
+  bioguide: H001038
+  thomas: '01794'
+- name: Norma J. Torres
   party: minority
   rank: 5
+  bioguide: T000474
+  thomas: '02231'
+- name: Bennie G. Thompson
+  party: minority
+  rank: 6
   bioguide: T000193
   thomas: '01151'
   title: Ex Officio
 HSHM12:
-- name: Susan W. Brooks
+- name: Martha McSally
   party: majority
   rank: 1
   title: Chair
-  bioguide: B001284
-  thomas: '02129'
-- name: Peter T. King
+  bioguide: M001197
+  thomas: '02225'
+- name: Tom Marino
   party: majority
   rank: 2
-  bioguide: K000210
-  thomas: '00635'
+  bioguide: M001179
+  thomas: '02053'
 - name: Steven M. Palazzo
   party: majority
   rank: 3
   bioguide: P000601
   thomas: '02035'
-  title: Vice Chair
-- name: Scott Perry
+- name: Mark Walker
   party: majority
   rank: 4
-  bioguide: P000605
-  thomas: '02157'
-- name: Mark Sanford
+  bioguide: W000819
+  thomas: '02255'
+- name: Barry Loudermilk
   party: majority
   rank: 5
-  bioguide: S000051
-  thomas: '01012'
+  bioguide: L000583
+  thomas: '02238'
 - name: Michael T. McCaul
   party: majority
   rank: 6
@@ -6446,16 +5336,16 @@ HSHM12:
   title: Ranking Member
   bioguide: P000604
   thomas: '02097'
-- name: Yvette D. Clarke
+- name: Bonnie Watson Coleman
   party: minority
   rank: 2
-  bioguide: C001067
-  thomas: '01864'
-- name: Brian Higgins
+  bioguide: W000822
+  thomas: '02259'
+- name: Kathleen M. Rice
   party: minority
   rank: 3
-  bioguide: H001038
-  thomas: '01794'
+  bioguide: R000602
+  thomas: '02262'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
@@ -6469,272 +5359,272 @@ HSIF:
   title: Chair
   bioguide: U000031
   thomas: '01177'
-- name: Ralph M. Hall
-  party: majority
-  rank: 2
-  bioguide: H000067
-  thomas: '00484'
 - name: Joe Barton
   party: majority
-  rank: 3
+  rank: 2
   bioguide: B000213
   thomas: '00062'
 - name: Ed Whitfield
   party: majority
-  rank: 4
+  rank: 3
   bioguide: W000413
   thomas: '01222'
 - name: John Shimkus
   party: majority
-  rank: 5
+  rank: 4
   bioguide: S000364
   thomas: '01527'
 - name: Joseph R. Pitts
   party: majority
-  rank: 6
+  rank: 5
   bioguide: P000373
   thomas: '01514'
 - name: Greg Walden
   party: majority
-  rank: 7
+  rank: 6
   bioguide: W000791
   thomas: '01596'
-- name: Lee Terry
-  party: majority
-  rank: 8
-  bioguide: T000459
-  thomas: '01566'
-- name: Mike Rogers
-  party: majority
-  rank: 9
-  bioguide: R000572
-  thomas: '01651'
 - name: Tim Murphy
   party: majority
-  rank: 10
+  rank: 7
   bioguide: M001151
   thomas: '01744'
 - name: Michael C. Burgess
   party: majority
-  rank: 11
+  rank: 8
   bioguide: B001248
   thomas: '01751'
 - name: Marsha Blackburn
   party: majority
-  rank: 12
+  rank: 9
   bioguide: B001243
   thomas: '01748'
-- name: Phil Gingrey
-  party: majority
-  rank: 13
-  bioguide: G000550
-  thomas: '01720'
 - name: Steve Scalise
   party: majority
-  rank: 14
+  rank: 10
   bioguide: S001176
   thomas: '01892'
 - name: Robert E. Latta
   party: majority
-  rank: 15
+  rank: 11
   bioguide: L000566
   thomas: '01885'
 - name: Cathy McMorris Rodgers
   party: majority
-  rank: 16
+  rank: 12
   bioguide: M001159
   thomas: '01809'
 - name: Gregg Harper
   party: majority
-  rank: 17
+  rank: 13
   bioguide: H001045
   thomas: '01933'
 - name: Leonard Lance
   party: majority
-  rank: 18
+  rank: 14
   bioguide: L000567
   thomas: '01936'
-- name: Bill Cassidy
-  party: majority
-  rank: 19
-  bioguide: C001075
-  thomas: '01925'
 - name: Brett Guthrie
   party: majority
-  rank: 20
+  rank: 15
   bioguide: G000558
   thomas: '01922'
 - name: Pete Olson
   party: majority
-  rank: 21
+  rank: 16
   bioguide: O000168
   thomas: '01955'
 - name: David B. McKinley
   party: majority
-  rank: 22
+  rank: 17
   bioguide: M001180
   thomas: '02074'
-- name: Cory Gardner
-  party: majority
-  rank: 23
-  bioguide: G000562
-  thomas: '01998'
 - name: Mike Pompeo
   party: majority
-  rank: 24
+  rank: 18
   bioguide: P000602
   thomas: '02022'
 - name: Adam Kinzinger
   party: majority
-  rank: 25
+  rank: 19
   bioguide: K000378
   thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
-  rank: 26
+  rank: 20
   bioguide: G000568
   thomas: '02070'
 - name: Gus M. Bilirakis
   party: majority
-  rank: 27
+  rank: 21
   bioguide: B001257
   thomas: '01838'
 - name: Bill Johnson
   party: majority
-  rank: 28
+  rank: 22
   bioguide: J000292
   thomas: '02046'
 - name: Billy Long
   party: majority
-  rank: 29
+  rank: 23
   bioguide: L000576
   thomas: '02033'
 - name: Renee L. Ellmers
   party: majority
-  rank: 30
+  rank: 24
   bioguide: E000291
   thomas: '02036'
-- name: Henry A. Waxman
+- name: Larry Bucshon
+  party: majority
+  rank: 25
+  bioguide: B001275
+  thomas: '02018'
+- name: Bill Flores
+  party: majority
+  rank: 26
+  bioguide: F000461
+  thomas: '02065'
+- name: Susan W. Brooks
+  party: majority
+  rank: 27
+  bioguide: B001284
+  thomas: '02129'
+- name: Markwayne Mullin
+  party: majority
+  rank: 28
+  bioguide: M001190
+  thomas: '02156'
+- name: Richard Hudson
+  party: majority
+  rank: 29
+  bioguide: H001067
+  thomas: '02140'
+- name: Chris Collins
+  party: majority
+  rank: 30
+  bioguide: C001092
+  thomas: '02151'
+- name: Kevin Cramer
+  party: majority
+  rank: 31
+  bioguide: C001096
+  thomas: '02144'
+- name: Frank Pallone Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: W000215
-  thomas: '01209'
-- name: John D. Dingell
-  party: minority
-  rank: 2
-  bioguide: D000355
-  thomas: '00299'
-- name: Frank Pallone Jr.
-  party: minority
-  rank: 3
   bioguide: P000034
   thomas: '00887'
 - name: Bobby L. Rush
   party: minority
-  rank: 4
+  rank: 2
   bioguide: R000515
   thomas: '01003'
 - name: Anna G. Eshoo
   party: minority
-  rank: 5
+  rank: 3
   bioguide: E000215
   thomas: '00355'
 - name: Eliot L. Engel
   party: minority
-  rank: 6
+  rank: 4
   bioguide: E000179
   thomas: '00344'
 - name: Gene Green
   party: minority
-  rank: 7
+  rank: 5
   bioguide: G000410
   thomas: '00462'
 - name: Diana DeGette
   party: minority
-  rank: 8
+  rank: 6
   bioguide: D000197
   thomas: '01479'
 - name: Lois Capps
   party: minority
-  rank: 9
+  rank: 7
   bioguide: C001036
   thomas: '01471'
 - name: Michael F. Doyle
   party: minority
-  rank: 10
+  rank: 8
   bioguide: D000482
   thomas: '00316'
 - name: Janice D. Schakowsky
   party: minority
-  rank: 11
+  rank: 9
   bioguide: S001145
   thomas: '01588'
-- name: Jim Matheson
-  party: minority
-  rank: 12
-  bioguide: M001142
-  thomas: '01671'
 - name: G. K. Butterfield
   party: minority
-  rank: 13
+  rank: 10
   bioguide: B001251
   thomas: '01761'
-- name: John Barrow
-  party: minority
-  rank: 14
-  bioguide: B001252
-  thomas: '01780'
 - name: Doris O. Matsui
   party: minority
-  rank: 15
+  rank: 11
   bioguide: M001163
   thomas: '01814'
-- name: Donna M. Christensen
-  party: minority
-  rank: 16
-  bioguide: C000380
-  thomas: '01474'
 - name: Kathy Castor
   party: minority
-  rank: 17
+  rank: 12
   bioguide: C001066
   thomas: '01839'
 - name: John P. Sarbanes
   party: minority
-  rank: 18
+  rank: 13
   bioguide: S001168
   thomas: '01854'
 - name: Jerry McNerney
   party: minority
-  rank: 19
+  rank: 14
   bioguide: M001166
   thomas: '01832'
-- name: Bruce L. Braley
-  party: minority
-  rank: 20
-  bioguide: B001259
-  thomas: '01845'
 - name: Peter Welch
   party: minority
-  rank: 21
+  rank: 15
   bioguide: W000800
   thomas: '01879'
 - name: Ben Ray Luján
   party: minority
-  rank: 22
+  rank: 16
   bioguide: L000570
   thomas: '01939'
 - name: Paul Tonko
   party: minority
-  rank: 23
+  rank: 17
   bioguide: T000469
   thomas: '01942'
 - name: John A. Yarmuth
   party: minority
-  rank: 24
+  rank: 18
   bioguide: Y000062
   thomas: '01853'
+- name: Yvette D. Clarke
+  party: minority
+  rank: 19
+  bioguide: C001067
+  thomas: '01864'
+- name: David Loebsack
+  party: minority
+  rank: 20
+  bioguide: L000565
+  thomas: '01846'
+- name: Kurt Schrader
+  party: minority
+  rank: 21
+  bioguide: S001180
+  thomas: '01950'
+- name: Joseph P. Kennedy III
+  party: minority
+  rank: 22
+  bioguide: K000379
+  thomas: '02172'
+- name: Tony Cárdenas
+  party: minority
+  rank: 23
+  bioguide: C001097
+  thomas: '02107'
 HSIF02:
 - name: Tim Murphy
   party: majority
@@ -6742,62 +5632,62 @@ HSIF02:
   title: Chair
   bioguide: M001151
   thomas: '01744'
-- name: Michael C. Burgess
+- name: David B. McKinley
   party: majority
   rank: 2
-  bioguide: B001248
-  thomas: '01751'
+  bioguide: M001180
+  thomas: '02074'
   title: Vice Chair
-- name: Marsha Blackburn
+- name: Michael C. Burgess
   party: majority
   rank: 3
-  bioguide: B001243
-  thomas: '01748'
-- name: Phil Gingrey
+  bioguide: B001248
+  thomas: '01751'
+- name: Marsha Blackburn
   party: majority
   rank: 4
-  bioguide: G000550
-  thomas: '01720'
-- name: Steve Scalise
-  party: majority
-  rank: 5
-  bioguide: S001176
-  thomas: '01892'
-- name: Gregg Harper
-  party: majority
-  rank: 6
-  bioguide: H001045
-  thomas: '01933'
-- name: Pete Olson
-  party: majority
-  rank: 7
-  bioguide: O000168
-  thomas: '01955'
-- name: Cory Gardner
-  party: majority
-  rank: 8
-  bioguide: G000562
-  thomas: '01998'
+  bioguide: B001243
+  thomas: '01748'
 - name: H. Morgan Griffith
   party: majority
-  rank: 9
+  rank: 5
   bioguide: G000568
   thomas: '02070'
-- name: Bill Johnson
+- name: Larry Bucshon
+  party: majority
+  rank: 6
+  bioguide: B001275
+  thomas: '02018'
+- name: Bill Flores
+  party: majority
+  rank: 7
+  bioguide: F000461
+  thomas: '02065'
+- name: Susan W. Brooks
+  party: majority
+  rank: 8
+  bioguide: B001284
+  thomas: '02129'
+- name: Markwayne Mullin
+  party: majority
+  rank: 9
+  bioguide: M001190
+  thomas: '02156'
+- name: Richard Hudson
   party: majority
   rank: 10
-  bioguide: J000292
-  thomas: '02046'
-- name: Billy Long
+  bioguide: H001067
+  thomas: '02140'
+- name: Chris Collins
   party: majority
   rank: 11
-  bioguide: L000576
-  thomas: '02033'
-- name: Renee L. Ellmers
+  bioguide: C001092
+  thomas: '02151'
+- name: Kevin Cramer
   party: majority
   rank: 12
-  bioguide: E000291
-  thomas: '02036'
+  bioguide: C001096
+  thomas: '02144'
 - name: Joe Barton
   party: majority
   rank: 13
@@ -6809,62 +5699,69 @@ HSIF02:
   bioguide: U000031
   thomas: '01177'
   title: Ex Officio
+- name: Fred Upton
+  party: majority
+  rank: 15
+  bioguide: U000031
+  thomas: '01177'
+  title: Ex Officio
 - name: Diana DeGette
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000197
   thomas: '01479'
-- name: Bruce L. Braley
-  party: minority
-  rank: 2
-  bioguide: B001259
-  thomas: '01845'
-- name: Ben Ray Luján
-  party: minority
-  rank: 3
-  bioguide: L000570
-  thomas: '01939'
 - name: Janice D. Schakowsky
   party: minority
-  rank: 4
+  rank: 2
   bioguide: S001145
   thomas: '01588'
-- name: G. K. Butterfield
-  party: minority
-  rank: 5
-  bioguide: B001251
-  thomas: '01761'
 - name: Kathy Castor
   party: minority
-  rank: 6
+  rank: 3
   bioguide: C001066
   thomas: '01839'
-- name: Peter Welch
-  party: minority
-  rank: 7
-  bioguide: W000800
-  thomas: '01879'
 - name: Paul Tonko
   party: minority
-  rank: 8
+  rank: 4
   bioguide: T000469
   thomas: '01942'
 - name: John A. Yarmuth
   party: minority
-  rank: 9
+  rank: 5
   bioguide: Y000062
   thomas: '01853'
+- name: Yvette D. Clarke
+  party: minority
+  rank: 6
+  bioguide: C001067
+  thomas: '01864'
+- name: Joseph P. Kennedy III
+  party: minority
+  rank: 7
+  bioguide: K000379
+  thomas: '02172'
 - name: Gene Green
   party: minority
-  rank: 10
+  rank: 8
   bioguide: G000410
   thomas: '00462'
-- name: Henry A. Waxman
+- name: Peter Welch
+  party: minority
+  rank: 9
+  bioguide: W000800
+  thomas: '01879'
+- name: Frank Pallone Jr.
+  party: minority
+  rank: 10
+  bioguide: P000034
+  thomas: '00887'
+  title: Ex Officio
+- name: Frank Pallone Jr.
   party: minority
   rank: 11
-  bioguide: W000215
-  thomas: '01209'
+  bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF03:
 - name: Ed Whitfield
@@ -6873,85 +5770,96 @@ HSIF03:
   title: Chair
   bioguide: W000413
   thomas: '01222'
-- name: Steve Scalise
+- name: Pete Olson
   party: majority
   rank: 2
-  bioguide: S001176
-  thomas: '01892'
+  bioguide: O000168
+  thomas: '01955'
   title: Vice Chair
-- name: Ralph M. Hall
-  party: majority
-  rank: 3
-  bioguide: H000067
-  thomas: '00484'
 - name: John Shimkus
   party: majority
-  rank: 4
+  rank: 3
   bioguide: S000364
   thomas: '01527'
 - name: Joseph R. Pitts
   party: majority
-  rank: 5
+  rank: 4
   bioguide: P000373
   thomas: '01514'
-- name: Lee Terry
-  party: majority
-  rank: 6
-  bioguide: T000459
-  thomas: '01566'
-- name: Michael C. Burgess
-  party: majority
-  rank: 7
-  bioguide: B001248
-  thomas: '01751'
 - name: Robert E. Latta
   party: majority
-  rank: 8
+  rank: 5
   bioguide: L000566
   thomas: '01885'
-- name: Bill Cassidy
+- name: Gregg Harper
   party: majority
-  rank: 9
-  bioguide: C001075
-  thomas: '01925'
-- name: Pete Olson
-  party: majority
-  rank: 10
-  bioguide: O000168
-  thomas: '01955'
+  rank: 6
+  bioguide: H001045
+  thomas: '01933'
 - name: David B. McKinley
   party: majority
-  rank: 11
+  rank: 7
   bioguide: M001180
   thomas: '02074'
-- name: Cory Gardner
-  party: majority
-  rank: 12
-  bioguide: G000562
-  thomas: '01998'
 - name: Mike Pompeo
   party: majority
-  rank: 13
+  rank: 8
   bioguide: P000602
   thomas: '02022'
 - name: Adam Kinzinger
   party: majority
-  rank: 14
+  rank: 9
   bioguide: K000378
   thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
-  rank: 15
+  rank: 10
   bioguide: G000568
   thomas: '02070'
-- name: Joe Barton
+- name: Bill Johnson
+  party: majority
+  rank: 11
+  bioguide: J000292
+  thomas: '02046'
+- name: Billy Long
+  party: majority
+  rank: 12
+  bioguide: L000576
+  thomas: '02033'
+- name: Renee L. Ellmers
+  party: majority
+  rank: 13
+  bioguide: E000291
+  thomas: '02036'
+- name: Bill Flores
+  party: majority
+  rank: 14
+  bioguide: F000461
+  thomas: '02065'
+- name: Markwayne Mullin
+  party: majority
+  rank: 15
+  bioguide: M001190
+  thomas: '02156'
+- name: Richard Hudson
   party: majority
   rank: 16
+  bioguide: H001067
+  thomas: '02140'
+- name: Joe Barton
+  party: majority
+  rank: 17
   bioguide: B000213
   thomas: '00062'
 - name: Fred Upton
   party: majority
-  rank: 17
+  rank: 18
+  bioguide: U000031
+  thomas: '01177'
+  title: Ex Officio
+- name: Fred Upton
+  party: majority
+  rank: 19
   bioguide: U000031
   thomas: '01177'
   title: Ex Officio
@@ -6971,56 +5879,62 @@ HSIF03:
   rank: 3
   bioguide: T000469
   thomas: '01942'
-- name: John A. Yarmuth
-  party: minority
-  rank: 4
-  bioguide: Y000062
-  thomas: '01853'
 - name: Eliot L. Engel
   party: minority
-  rank: 5
+  rank: 4
   bioguide: E000179
   thomas: '00344'
 - name: Gene Green
   party: minority
-  rank: 6
+  rank: 5
   bioguide: G000410
   thomas: '00462'
 - name: Lois Capps
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C001036
   thomas: '01471'
 - name: Michael F. Doyle
   party: minority
-  rank: 8
+  rank: 7
   bioguide: D000482
   thomas: '00316'
-- name: John Barrow
-  party: minority
-  rank: 9
-  bioguide: B001252
-  thomas: '01780'
-- name: Doris O. Matsui
-  party: minority
-  rank: 10
-  bioguide: M001163
-  thomas: '01814'
-- name: Donna M. Christensen
-  party: minority
-  rank: 11
-  bioguide: C000380
-  thomas: '01474'
 - name: Kathy Castor
   party: minority
-  rank: 12
+  rank: 8
   bioguide: C001066
   thomas: '01839'
-- name: Henry A. Waxman
+- name: John P. Sarbanes
+  party: minority
+  rank: 9
+  bioguide: S001168
+  thomas: '01854'
+- name: Peter Welch
+  party: minority
+  rank: 10
+  bioguide: W000800
+  thomas: '01879'
+- name: John A. Yarmuth
+  party: minority
+  rank: 11
+  bioguide: Y000062
+  thomas: '01853'
+- name: David Loebsack
+  party: minority
+  rank: 12
+  bioguide: L000565
+  thomas: '01846'
+- name: Frank Pallone Jr.
   party: minority
   rank: 13
-  bioguide: W000215
-  thomas: '01209'
+  bioguide: P000034
+  thomas: '00887'
+  title: Ex Officio
+- name: Frank Pallone Jr.
+  party: minority
+  rank: 14
+  bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF14:
 - name: Joseph R. Pitts
@@ -7029,11 +5943,11 @@ HSIF14:
   title: Chair
   bioguide: P000373
   thomas: '01514'
-- name: Michael C. Burgess
+- name: Brett Guthrie
   party: majority
   rank: 2
-  bioguide: B001248
-  thomas: '01751'
+  bioguide: G000558
+  thomas: '01922'
   title: Vice Chair
 - name: Ed Whitfield
   party: majority
@@ -7045,138 +5959,155 @@ HSIF14:
   rank: 4
   bioguide: S000364
   thomas: '01527'
-- name: Mike Rogers
-  party: majority
-  rank: 5
-  bioguide: R000572
-  thomas: '01651'
 - name: Tim Murphy
   party: majority
-  rank: 6
+  rank: 5
   bioguide: M001151
   thomas: '01744'
+- name: Michael C. Burgess
+  party: majority
+  rank: 6
+  bioguide: B001248
+  thomas: '01751'
 - name: Marsha Blackburn
   party: majority
   rank: 7
   bioguide: B001243
   thomas: '01748'
-- name: Phil Gingrey
-  party: majority
-  rank: 8
-  bioguide: G000550
-  thomas: '01720'
 - name: Cathy McMorris Rodgers
   party: majority
-  rank: 9
+  rank: 8
   bioguide: M001159
   thomas: '01809'
 - name: Leonard Lance
   party: majority
-  rank: 10
+  rank: 9
   bioguide: L000567
   thomas: '01936'
-- name: Bill Cassidy
-  party: majority
-  rank: 11
-  bioguide: C001075
-  thomas: '01925'
-- name: Brett Guthrie
-  party: majority
-  rank: 12
-  bioguide: G000558
-  thomas: '01922'
 - name: H. Morgan Griffith
   party: majority
-  rank: 13
+  rank: 10
   bioguide: G000568
   thomas: '02070'
 - name: Gus M. Bilirakis
   party: majority
-  rank: 14
+  rank: 11
   bioguide: B001257
   thomas: '01838'
+- name: Billy Long
+  party: majority
+  rank: 12
+  bioguide: L000576
+  thomas: '02033'
 - name: Renee L. Ellmers
   party: majority
-  rank: 15
+  rank: 13
   bioguide: E000291
   thomas: '02036'
-- name: Joe Barton
+- name: Larry Bucshon
+  party: majority
+  rank: 14
+  bioguide: B001275
+  thomas: '02018'
+- name: Susan W. Brooks
+  party: majority
+  rank: 15
+  bioguide: B001284
+  thomas: '02129'
+- name: Chris Collins
   party: majority
   rank: 16
+  bioguide: C001092
+  thomas: '02151'
+- name: Joe Barton
+  party: majority
+  rank: 17
   bioguide: B000213
   thomas: '00062'
 - name: Fred Upton
   party: majority
-  rank: 17
+  rank: 18
   bioguide: U000031
   thomas: '01177'
   title: Ex Officio
-- name: Frank Pallone Jr.
+- name: Fred Upton
+  party: majority
+  rank: 19
+  bioguide: U000031
+  thomas: '01177'
+  title: Ex Officio
+- name: Gene Green
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: P000034
-  thomas: '00887'
-- name: John D. Dingell
-  party: minority
-  rank: 2
-  bioguide: D000355
-  thomas: '00299'
+  bioguide: G000410
+  thomas: '00462'
 - name: Eliot L. Engel
   party: minority
-  rank: 3
+  rank: 2
   bioguide: E000179
   thomas: '00344'
 - name: Lois Capps
   party: minority
-  rank: 4
+  rank: 3
   bioguide: C001036
   thomas: '01471'
 - name: Janice D. Schakowsky
   party: minority
-  rank: 5
+  rank: 4
   bioguide: S001145
   thomas: '01588'
-- name: Jim Matheson
-  party: minority
-  rank: 6
-  bioguide: M001142
-  thomas: '01671'
-- name: Gene Green
-  party: minority
-  rank: 7
-  bioguide: G000410
-  thomas: '00462'
 - name: G. K. Butterfield
   party: minority
-  rank: 8
+  rank: 5
   bioguide: B001251
   thomas: '01761'
-- name: John Barrow
-  party: minority
-  rank: 9
-  bioguide: B001252
-  thomas: '01780'
-- name: Donna M. Christensen
-  party: minority
-  rank: 10
-  bioguide: C000380
-  thomas: '01474'
 - name: Kathy Castor
   party: minority
-  rank: 11
+  rank: 6
   bioguide: C001066
   thomas: '01839'
 - name: John P. Sarbanes
   party: minority
-  rank: 12
+  rank: 7
   bioguide: S001168
   thomas: '01854'
-- name: Henry A. Waxman
+- name: Doris O. Matsui
+  party: minority
+  rank: 8
+  bioguide: M001163
+  thomas: '01814'
+- name: Ben Ray Luján
+  party: minority
+  rank: 9
+  bioguide: L000570
+  thomas: '01939'
+- name: Kurt Schrader
+  party: minority
+  rank: 10
+  bioguide: S001180
+  thomas: '01950'
+- name: Joseph P. Kennedy III
+  party: minority
+  rank: 11
+  bioguide: K000379
+  thomas: '02172'
+- name: Tony Cárdenas
+  party: minority
+  rank: 12
+  bioguide: C001097
+  thomas: '02107'
+- name: Frank Pallone Jr.
   party: minority
   rank: 13
-  bioguide: W000215
-  thomas: '01209'
+  bioguide: P000034
+  thomas: '00887'
+  title: Ex Officio
+- name: Frank Pallone Jr.
+  party: minority
+  rank: 14
+  bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF16:
 - name: Greg Walden
@@ -7196,51 +6127,51 @@ HSIF16:
   rank: 3
   bioguide: S000364
   thomas: '01527'
-- name: Lee Terry
-  party: majority
-  rank: 4
-  bioguide: T000459
-  thomas: '01566'
-- name: Mike Rogers
-  party: majority
-  rank: 5
-  bioguide: R000572
-  thomas: '01651'
 - name: Marsha Blackburn
   party: majority
-  rank: 6
+  rank: 4
   bioguide: B001243
   thomas: '01748'
 - name: Steve Scalise
   party: majority
-  rank: 7
+  rank: 5
   bioguide: S001176
   thomas: '01892'
 - name: Leonard Lance
   party: majority
-  rank: 8
+  rank: 6
   bioguide: L000567
   thomas: '01936'
 - name: Brett Guthrie
   party: majority
-  rank: 9
+  rank: 7
   bioguide: G000558
   thomas: '01922'
-- name: Cory Gardner
+- name: Pete Olson
   party: majority
-  rank: 10
-  bioguide: G000562
-  thomas: '01998'
+  rank: 8
+  bioguide: O000168
+  thomas: '01955'
 - name: Mike Pompeo
   party: majority
-  rank: 11
+  rank: 9
   bioguide: P000602
   thomas: '02022'
 - name: Adam Kinzinger
   party: majority
-  rank: 12
+  rank: 10
   bioguide: K000378
   thomas: '02014'
+- name: Gus M. Bilirakis
+  party: majority
+  rank: 11
+  bioguide: B001257
+  thomas: '01838'
+- name: Bill Johnson
+  party: majority
+  rank: 12
+  bioguide: J000292
+  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 13
@@ -7251,14 +6182,30 @@ HSIF16:
   rank: 14
   bioguide: E000291
   thomas: '02036'
-- name: Joe Barton
+- name: Chris Collins
   party: majority
   rank: 15
+  bioguide: C001092
+  thomas: '02151'
+- name: Kevin Cramer
+  party: majority
+  rank: 16
+  bioguide: C001096
+  thomas: '02144'
+- name: Joe Barton
+  party: majority
+  rank: 17
   bioguide: B000213
   thomas: '00062'
 - name: Fred Upton
   party: majority
-  rank: 16
+  rank: 18
+  bioguide: U000031
+  thomas: '01177'
+  title: Ex Officio
+- name: Fred Upton
+  party: majority
+  rank: 19
   bioguide: U000031
   thomas: '01177'
   title: Ex Officio
@@ -7273,69 +6220,75 @@ HSIF16:
   rank: 2
   bioguide: D000482
   thomas: '00316'
-- name: Doris O. Matsui
-  party: minority
-  rank: 3
-  bioguide: M001163
-  thomas: '01814'
-- name: Bruce L. Braley
-  party: minority
-  rank: 4
-  bioguide: B001259
-  thomas: '01845'
 - name: Peter Welch
   party: minority
-  rank: 5
+  rank: 3
   bioguide: W000800
   thomas: '01879'
-- name: Ben Ray Luján
+- name: John A. Yarmuth
+  party: minority
+  rank: 4
+  bioguide: Y000062
+  thomas: '01853'
+- name: Yvette D. Clarke
+  party: minority
+  rank: 5
+  bioguide: C001067
+  thomas: '01864'
+- name: David Loebsack
   party: minority
   rank: 6
-  bioguide: L000570
-  thomas: '01939'
-- name: John D. Dingell
-  party: minority
-  rank: 7
-  bioguide: D000355
-  thomas: '00299'
-- name: Frank Pallone Jr.
-  party: minority
-  rank: 8
-  bioguide: P000034
-  thomas: '00887'
+  bioguide: L000565
+  thomas: '01846'
 - name: Bobby L. Rush
   party: minority
-  rank: 9
+  rank: 7
   bioguide: R000515
   thomas: '01003'
 - name: Diana DeGette
   party: minority
-  rank: 10
+  rank: 8
   bioguide: D000197
   thomas: '01479'
-- name: Jim Matheson
-  party: minority
-  rank: 11
-  bioguide: M001142
-  thomas: '01671'
 - name: G. K. Butterfield
   party: minority
-  rank: 12
+  rank: 9
   bioguide: B001251
   thomas: '01761'
-- name: Henry A. Waxman
+- name: Doris O. Matsui
+  party: minority
+  rank: 10
+  bioguide: M001163
+  thomas: '01814'
+- name: Jerry McNerney
+  party: minority
+  rank: 11
+  bioguide: M001166
+  thomas: '01832'
+- name: Ben Ray Luján
+  party: minority
+  rank: 12
+  bioguide: L000570
+  thomas: '01939'
+- name: Frank Pallone Jr.
   party: minority
   rank: 13
-  bioguide: W000215
-  thomas: '01209'
+  bioguide: P000034
+  thomas: '00887'
+  title: Ex Officio
+- name: Frank Pallone Jr.
+  party: minority
+  rank: 14
+  bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF17:
-- name: Lee Terry
+- name: Michael C. Burgess
   party: majority
   rank: 1
   title: Chair
-  bioguide: T000459
-  thomas: '01566'
+  bioguide: B001248
+  thomas: '01751'
 - name: Leonard Lance
   party: majority
   rank: 2
@@ -7362,44 +6315,40 @@ HSIF17:
   rank: 6
   bioguide: O000168
   thomas: '01955'
-- name: David B. McKinley
-  party: majority
-  rank: 7
-  bioguide: M001180
-  thomas: '02074'
 - name: Mike Pompeo
   party: majority
-  rank: 8
+  rank: 7
   bioguide: P000602
   thomas: '02022'
 - name: Adam Kinzinger
   party: majority
-  rank: 9
+  rank: 8
   bioguide: K000378
   thomas: '02014'
 - name: Gus M. Bilirakis
   party: majority
-  rank: 10
+  rank: 9
   bioguide: B001257
   thomas: '01838'
-- name: Bill Johnson
+- name: Susan W. Brooks
+  party: majority
+  rank: 10
+  bioguide: B001284
+  thomas: '02129'
+- name: Markwayne Mullin
   party: majority
   rank: 11
-  bioguide: J000292
-  thomas: '02046'
-- name: Billy Long
-  party: majority
-  rank: 12
-  bioguide: L000576
-  thomas: '02033'
-- name: Joe Barton
-  party: majority
-  rank: 13
-  bioguide: B000213
-  thomas: '00062'
+  bioguide: M001190
+  thomas: '02156'
 - name: Fred Upton
   party: majority
-  rank: 14
+  rank: 12
+  bioguide: U000031
+  thomas: '01177'
+  title: Ex Officio
+- name: Fred Upton
+  party: majority
+  rank: 13
   bioguide: U000031
   thomas: '01177'
   title: Ex Officio
@@ -7409,56 +6358,47 @@ HSIF17:
   title: Ranking Member
   bioguide: S001145
   thomas: '01588'
-- name: John P. Sarbanes
+- name: Yvette D. Clarke
   party: minority
   rank: 2
-  bioguide: S001168
-  thomas: '01854'
-- name: Jerry McNerney
+  bioguide: C001067
+  thomas: '01864'
+- name: Joseph P. Kennedy III
   party: minority
   rank: 3
-  bioguide: M001166
-  thomas: '01832'
-- name: Peter Welch
+  bioguide: K000379
+  thomas: '02172'
+- name: Tony Cárdenas
   party: minority
   rank: 4
-  bioguide: W000800
-  thomas: '01879'
-- name: John A. Yarmuth
-  party: minority
-  rank: 5
-  bioguide: Y000062
-  thomas: '01853'
-- name: John D. Dingell
-  party: minority
-  rank: 6
-  bioguide: D000355
-  thomas: '00299'
+  bioguide: C001097
+  thomas: '02107'
 - name: Bobby L. Rush
   party: minority
-  rank: 7
+  rank: 5
   bioguide: R000515
   thomas: '01003'
-- name: Jim Matheson
+- name: G. K. Butterfield
+  party: minority
+  rank: 6
+  bioguide: B001251
+  thomas: '01761'
+- name: Peter Welch
+  party: minority
+  rank: 7
+  bioguide: W000800
+  thomas: '01879'
+- name: Frank Pallone Jr.
   party: minority
   rank: 8
-  bioguide: M001142
-  thomas: '01671'
-- name: John Barrow
+  bioguide: P000034
+  thomas: '00887'
+  title: Ex Officio
+- name: Frank Pallone Jr.
   party: minority
   rank: 9
-  bioguide: B001252
-  thomas: '01780'
-- name: Donna M. Christensen
-  party: minority
-  rank: 10
-  bioguide: C000380
-  thomas: '01474'
-- name: Henry A. Waxman
-  party: minority
-  rank: 11
-  bioguide: W000215
-  thomas: '01209'
+  bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF18:
 - name: John Shimkus
@@ -7467,67 +6407,68 @@ HSIF18:
   title: Chair
   bioguide: S000364
   thomas: '01527'
-- name: Phil Gingrey
+- name: Gregg Harper
   party: majority
   rank: 2
-  bioguide: G000550
-  thomas: '01720'
+  bioguide: H001045
+  thomas: '01933'
   title: Vice Chair
-- name: Ralph M. Hall
-  party: majority
-  rank: 3
-  bioguide: H000067
-  thomas: '00484'
 - name: Ed Whitfield
   party: majority
-  rank: 4
+  rank: 3
   bioguide: W000413
   thomas: '01222'
 - name: Joseph R. Pitts
   party: majority
-  rank: 5
+  rank: 4
   bioguide: P000373
   thomas: '01514'
 - name: Tim Murphy
   party: majority
-  rank: 6
+  rank: 5
   bioguide: M001151
   thomas: '01744'
 - name: Robert E. Latta
   party: majority
-  rank: 7
+  rank: 6
   bioguide: L000566
   thomas: '01885'
-- name: Gregg Harper
-  party: majority
-  rank: 8
-  bioguide: H001045
-  thomas: '01933'
-- name: Bill Cassidy
-  party: majority
-  rank: 9
-  bioguide: C001075
-  thomas: '01925'
 - name: David B. McKinley
   party: majority
-  rank: 10
+  rank: 7
   bioguide: M001180
   thomas: '02074'
-- name: Gus M. Bilirakis
-  party: majority
-  rank: 11
-  bioguide: B001257
-  thomas: '01838'
 - name: Bill Johnson
   party: majority
-  rank: 12
+  rank: 8
   bioguide: J000292
   thomas: '02046'
-- name: Joe Barton
+- name: Larry Bucshon
+  party: majority
+  rank: 9
+  bioguide: B001275
+  thomas: '02018'
+- name: Bill Flores
+  party: majority
+  rank: 10
+  bioguide: F000461
+  thomas: '02065'
+- name: Richard Hudson
+  party: majority
+  rank: 11
+  bioguide: H001067
+  thomas: '02140'
+- name: Kevin Cramer
+  party: majority
+  rank: 12
+  bioguide: C001096
+  thomas: '02144'
+- name: Fred Upton
   party: majority
   rank: 13
-  bioguide: B000213
-  thomas: '00062'
+  bioguide: U000031
+  thomas: '01177'
+  title: Ex Officio
 - name: Fred Upton
   party: majority
   rank: 14
@@ -7540,11 +6481,11 @@ HSIF18:
   title: Ranking Member
   bioguide: T000469
   thomas: '01942'
-- name: Frank Pallone Jr.
+- name: Kurt Schrader
   party: minority
   rank: 2
-  bioguide: P000034
-  thomas: '00887'
+  bioguide: S001180
+  thomas: '01950'
 - name: Gene Green
   party: minority
   rank: 3
@@ -7560,44 +6501,40 @@ HSIF18:
   rank: 5
   bioguide: C001036
   thomas: '01471'
-- name: Jerry McNerney
+- name: Michael F. Doyle
   party: minority
   rank: 6
-  bioguide: M001166
-  thomas: '01832'
-- name: John D. Dingell
+  bioguide: D000482
+  thomas: '00316'
+- name: Jerry McNerney
   party: minority
   rank: 7
-  bioguide: D000355
-  thomas: '00299'
-- name: Janice D. Schakowsky
+  bioguide: M001166
+  thomas: '01832'
+- name: Tony Cárdenas
   party: minority
   rank: 8
-  bioguide: S001145
-  thomas: '01588'
-- name: John Barrow
+  bioguide: C001097
+  thomas: '02107'
+- name: Frank Pallone Jr.
   party: minority
   rank: 9
-  bioguide: B001252
-  thomas: '01780'
-- name: Doris O. Matsui
+  bioguide: P000034
+  thomas: '00887'
+  title: Ex Officio
+- name: Frank Pallone Jr.
   party: minority
   rank: 10
-  bioguide: M001163
-  thomas: '01814'
-- name: Henry A. Waxman
-  party: minority
-  rank: 11
-  bioguide: W000215
-  thomas: '01209'
+  bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSII:
-- name: Doc Hastings
+- name: Rob Bishop
   party: majority
   rank: 1
   title: Chair
-  bioguide: H000329
-  thomas: '00512'
+  bioguide: B001250
+  thomas: '01753'
 - name: Don Young
   party: majority
   rank: 2
@@ -7608,771 +6545,266 @@ HSII:
   rank: 3
   bioguide: G000552
   thomas: '01801'
-- name: Rob Bishop
-  party: majority
-  rank: 4
-  bioguide: B001250
-  thomas: '01753'
 - name: Doug Lamborn
   party: majority
-  rank: 5
+  rank: 4
   bioguide: L000564
   thomas: '01834'
 - name: Robert J. Wittman
   party: majority
-  rank: 6
+  rank: 5
   bioguide: W000804
   thomas: '01886'
-- name: Paul C. Broun
-  party: majority
-  rank: 7
-  bioguide: B001262
-  thomas: '01882'
 - name: John Fleming
   party: majority
-  rank: 8
+  rank: 6
   bioguide: F000456
   thomas: '01924'
 - name: Tom McClintock
   party: majority
-  rank: 9
+  rank: 7
   bioguide: M001177
   thomas: '01908'
 - name: Glenn Thompson
   party: majority
-  rank: 10
+  rank: 8
   bioguide: T000467
   thomas: '01952'
 - name: Cynthia M. Lummis
   party: majority
-  rank: 11
+  rank: 9
   bioguide: L000571
   thomas: '01960'
 - name: Dan Benishek
   party: majority
-  rank: 12
+  rank: 10
   bioguide: B001271
   thomas: '02027'
 - name: Jeff Duncan
   party: majority
-  rank: 13
+  rank: 11
   bioguide: D000615
   thomas: '02057'
-- name: Scott R. Tipton
-  party: majority
-  rank: 14
-  bioguide: T000470
-  thomas: '01997'
 - name: Paul A. Gosar
   party: majority
-  rank: 15
+  rank: 12
   bioguide: G000565
   thomas: '01992'
 - name: Raúl R. Labrador
   party: majority
-  rank: 16
+  rank: 13
   bioguide: L000573
   thomas: '02011'
-- name: Steve Southerland II
-  party: majority
-  rank: 17
-  bioguide: S001186
-  thomas: '02000'
-- name: Bill Flores
-  party: majority
-  rank: 18
-  bioguide: F000461
-  thomas: '02065'
-- name: Jon Runyan
-  party: majority
-  rank: 19
-  bioguide: R000594
-  thomas: '02039'
-- name: Markwayne Mullin
-  party: majority
-  rank: 20
-  bioguide: M001190
-  thomas: '02156'
-- name: Steve Daines
-  party: majority
-  rank: 21
-  bioguide: D000618
-  thomas: '02138'
-- name: Kevin Cramer
-  party: majority
-  rank: 22
-  bioguide: C001096
-  thomas: '02144'
 - name: Doug LaMalfa
   party: majority
-  rank: 23
+  rank: 14
   bioguide: L000578
   thomas: '02100'
-- name: Jason T. Smith
-  party: majority
-  rank: 24
-  bioguide: S001195
-  thomas: '02191'
-- name: Vance M. McAllister
-  party: majority
-  rank: 25
-  bioguide: M001192
-  thomas: '02195'
 - name: Bradley Byrne
   party: majority
-  rank: 26
+  rank: 15
   bioguide: B001289
   thomas: '02197'
-- name: Peter A. DeFazio
+- name: Jeff Denham
+  party: majority
+  rank: 16
+  bioguide: D000612
+  thomas: '01995'
+- name: Paul Cook
+  party: majority
+  rank: 17
+  bioguide: C001094
+  thomas: '02103'
+- name: Bruce Westerman
+  party: majority
+  rank: 18
+  bioguide: W000821
+  thomas: '02224'
+- name: Garret Graves
+  party: majority
+  rank: 19
+  bioguide: G000577
+  thomas: '02245'
+- name: Dan Newhouse
+  party: majority
+  rank: 20
+  bioguide: N000189
+  thomas: '02275'
+- name: Ryan K. Zinke
+  party: majority
+  rank: 21
+  bioguide: Z000018
+  thomas: '02254'
+- name: Jody B. Hice
+  party: majority
+  rank: 22
+  bioguide: H001071
+  thomas: '02237'
+- name: Amata Coleman Radewagen
+  party: majority
+  rank: 23
+  bioguide: R000600
+  thomas: '02222'
+- name: Thomas MacArthur
+  party: majority
+  rank: 24
+  bioguide: M001193
+  thomas: '02258'
+- name: Alexander X. Mooney
+  party: majority
+  rank: 25
+  bioguide: M001195
+  thomas: '02277'
+- name: Cresent Hardy
+  party: majority
+  rank: 26
+  bioguide: H001070
+  thomas: '02260'
+- name: Raúl M. Grijalva
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: D000191
-  thomas: '00279'
-- name: Eni F. H. Faleomavaega
-  party: minority
-  rank: 2
-  bioguide: F000010
-  thomas: '00367'
-- name: Frank Pallone Jr.
-  party: minority
-  rank: 3
-  bioguide: P000034
-  thomas: '00887'
-- name: Grace F. Napolitano
-  party: minority
-  rank: 4
-  bioguide: N000179
-  thomas: '01602'
-- name: Rush Holt
-  party: minority
-  rank: 5
-  bioguide: H001032
-  thomas: '01580'
-- name: Raúl M. Grijalva
-  party: minority
-  rank: 6
   bioguide: G000551
   thomas: '01708'
+- name: Grace F. Napolitano
+  party: minority
+  rank: 2
+  bioguide: N000179
+  thomas: '01602'
 - name: Madeleine Z. Bordallo
   party: minority
-  rank: 7
+  rank: 3
   bioguide: B001245
   thomas: '01723'
 - name: Jim Costa
   party: minority
-  rank: 8
+  rank: 4
   bioguide: C001059
   thomas: '01774'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
-  rank: 9
+  rank: 5
   bioguide: S001177
   thomas: '01962'
 - name: Niki Tsongas
   party: minority
-  rank: 10
+  rank: 6
   bioguide: T000465
   thomas: '01884'
 - name: Pedro R. Pierluisi
   party: minority
-  rank: 11
+  rank: 7
   bioguide: P000596
   thomas: '01953'
-- name: Colleen W. Hanabusa
-  party: minority
-  rank: 12
-  bioguide: H001050
-  thomas: '02010'
-- name: Tony Cárdenas
-  party: minority
-  rank: 13
-  bioguide: C001097
-  thomas: '02107'
 - name: Jared Huffman
   party: minority
-  rank: 14
+  rank: 8
   bioguide: H001068
   thomas: '02101'
 - name: Raul Ruiz
   party: minority
-  rank: 15
+  rank: 9
   bioguide: R000599
   thomas: '02109'
-- name: Carol Shea-Porter
+- name: Alan S. Lowenthal
+  party: minority
+  rank: 10
+  bioguide: L000579
+  thomas: '02111'
+- name: Matt Cartwright
+  party: minority
+  rank: 11
+  bioguide: C001090
+  thomas: '02159'
+- name: Donald S. Beyer Jr.
+  party: minority
+  rank: 12
+  bioguide: B001292
+  thomas: '02272'
+- name: Norma J. Torres
+  party: minority
+  rank: 13
+  bioguide: T000474
+  thomas: '02231'
+- name: Debbie Dingell
+  party: minority
+  rank: 14
+  bioguide: D000624
+  thomas: '02251'
+- name: Mark Takai
+  party: minority
+  rank: 15
+  bioguide: T000473
+  thomas: '02240'
+- name: Ruben Gallego
   party: minority
   rank: 16
-  bioguide: S001170
-  thomas: '01861'
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 17
-  bioguide: L000579
-  thomas: '02111'
-- name: Joe Garcia
-  party: minority
-  rank: 18
-  bioguide: G000573
-  thomas: '02120'
-- name: Matt Cartwright
-  party: minority
-  rank: 19
-  bioguide: C001090
-  thomas: '02159'
-- name: Katherine M. Clark
-  party: minority
-  rank: 20
-  bioguide: C001101
-  thomas: '02196'
+  bioguide: G000574
+  thomas: '02226'
 HSII06:
-- name: Doug Lamborn
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: L000564
-  thomas: '01834'
-- name: Louie Gohmert
-  party: majority
-  rank: 2
-  bioguide: G000552
-  thomas: '01801'
 - name: Rob Bishop
   party: majority
-  rank: 3
+  rank: 17
   bioguide: B001250
   thomas: '01753'
-- name: Robert J. Wittman
-  party: majority
-  rank: 4
-  bioguide: W000804
-  thomas: '01886'
-- name: Paul C. Broun
-  party: majority
-  rank: 5
-  bioguide: B001262
-  thomas: '01882'
-- name: John Fleming
-  party: majority
-  rank: 6
-  bioguide: F000456
-  thomas: '01924'
-- name: Glenn Thompson
-  party: majority
-  rank: 7
-  bioguide: T000467
-  thomas: '01952'
-- name: Cynthia M. Lummis
-  party: majority
-  rank: 8
-  bioguide: L000571
-  thomas: '01960'
-- name: Dan Benishek
-  party: majority
-  rank: 9
-  bioguide: B001271
-  thomas: '02027'
-- name: Jeff Duncan
-  party: majority
-  rank: 10
-  bioguide: D000615
-  thomas: '02057'
-- name: Paul A. Gosar
-  party: majority
-  rank: 11
-  bioguide: G000565
-  thomas: '01992'
-- name: Bill Flores
-  party: majority
-  rank: 12
-  bioguide: F000461
-  thomas: '02065'
-- name: Markwayne Mullin
-  party: majority
-  rank: 13
-  bioguide: M001190
-  thomas: '02156'
-- name: Steve Daines
-  party: majority
-  rank: 14
-  bioguide: D000618
-  thomas: '02138'
-- name: Kevin Cramer
-  party: majority
-  rank: 15
-  bioguide: C001096
-  thomas: '02144'
-- name: Doc Hastings
-  party: majority
-  rank: 17
-  bioguide: H000329
-  thomas: '00512'
   title: Ex Officio
-- name: Rush Holt
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H001032
-  thomas: '01580'
-- name: Matt Cartwright
-  party: minority
-  rank: 2
-  bioguide: C001090
-  thomas: '02159'
-- name: Jim Costa
-  party: minority
-  rank: 3
-  bioguide: C001059
-  thomas: '01774'
-- name: Niki Tsongas
-  party: minority
-  rank: 4
-  bioguide: T000465
-  thomas: '01884'
-- name: Jared Huffman
-  party: minority
-  rank: 5
-  bioguide: H001068
-  thomas: '02101'
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 6
-  bioguide: L000579
-  thomas: '02111'
-- name: Tony Cárdenas
-  party: minority
-  rank: 7
-  bioguide: C001097
-  thomas: '02107'
 - name: Raúl M. Grijalva
   party: minority
-  rank: 8
+  rank: 15
   bioguide: G000551
   thomas: '01708'
-- name: Colleen W. Hanabusa
-  party: minority
-  rank: 9
-  bioguide: H001050
-  thomas: '02010'
-- name: Joe Garcia
-  party: minority
-  rank: 10
-  bioguide: G000573
-  thomas: '02120'
-- name: Katherine M. Clark
-  party: minority
-  rank: 11
-  bioguide: C001101
-  thomas: '02196'
-- name: Peter A. DeFazio
-  party: minority
-  rank: 15
-  bioguide: D000191
-  thomas: '00279'
   title: Ex Officio
 HSII10:
 - name: Rob Bishop
   party: majority
-  rank: 1
-  title: Chair
+  rank: 15
   bioguide: B001250
   thomas: '01753'
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-  thomas: '01256'
-- name: Louie Gohmert
-  party: majority
-  rank: 3
-  bioguide: G000552
-  thomas: '01801'
-- name: Doug Lamborn
-  party: majority
-  rank: 4
-  bioguide: L000564
-  thomas: '01834'
-- name: Paul C. Broun
-  party: majority
-  rank: 5
-  bioguide: B001262
-  thomas: '01882'
-- name: Tom McClintock
-  party: majority
-  rank: 6
-  bioguide: M001177
-  thomas: '01908'
-- name: Cynthia M. Lummis
-  party: majority
-  rank: 7
-  bioguide: L000571
-  thomas: '01960'
-- name: Scott R. Tipton
-  party: majority
-  rank: 8
-  bioguide: T000470
-  thomas: '01997'
-- name: Raúl R. Labrador
-  party: majority
-  rank: 9
-  bioguide: L000573
-  thomas: '02011'
-- name: Steve Daines
-  party: majority
-  rank: 10
-  bioguide: D000618
-  thomas: '02138'
-- name: Kevin Cramer
-  party: majority
-  rank: 11
-  bioguide: C001096
-  thomas: '02144'
-- name: Doug LaMalfa
-  party: majority
-  rank: 12
-  bioguide: L000578
-  thomas: '02100'
-- name: Jason T. Smith
-  party: majority
-  rank: 13
-  bioguide: S001195
-  thomas: '02191'
-- name: Vance M. McAllister
-  party: majority
-  rank: 14
-  bioguide: M001192
-  thomas: '02195'
-- name: Doc Hastings
-  party: majority
-  rank: 15
-  bioguide: H000329
-  thomas: '00512'
   title: Ex Officio
 - name: Raúl M. Grijalva
   party: minority
-  rank: 1
-  title: Ranking Member
+  rank: 13
   bioguide: G000551
   thomas: '01708'
-- name: Niki Tsongas
-  party: minority
-  rank: 2
-  bioguide: T000465
-  thomas: '01884'
-- name: Rush Holt
-  party: minority
-  rank: 3
-  bioguide: H001032
-  thomas: '01580'
-- name: Madeleine Z. Bordallo
-  party: minority
-  rank: 4
-  bioguide: B001245
-  thomas: '01723'
-- name: Gregorio Kilili Camacho Sablan
-  party: minority
-  rank: 5
-  bioguide: S001177
-  thomas: '01962'
-- name: Pedro R. Pierluisi
-  party: minority
-  rank: 6
-  bioguide: P000596
-  thomas: '01953'
-- name: Colleen W. Hanabusa
-  party: minority
-  rank: 7
-  bioguide: H001050
-  thomas: '02010'
-- name: Carol Shea-Porter
-  party: minority
-  rank: 8
-  bioguide: S001170
-  thomas: '01861'
-- name: Joe Garcia
-  party: minority
-  rank: 9
-  bioguide: G000573
-  thomas: '02120'
-- name: Matt Cartwright
-  party: minority
-  rank: 10
-  bioguide: C001090
-  thomas: '02159'
-- name: Jared Huffman
-  party: minority
-  rank: 11
-  bioguide: H001068
-  thomas: '02101'
-- name: Peter A. DeFazio
-  party: minority
-  rank: 13
-  bioguide: D000191
-  thomas: '00279'
   title: Ex Officio
 HSII13:
-- name: Tom McClintock
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: M001177
-  thomas: '01908'
-- name: Cynthia M. Lummis
-  party: majority
-  rank: 2
-  bioguide: L000571
-  thomas: '01960'
-- name: Scott R. Tipton
-  party: majority
-  rank: 3
-  bioguide: T000470
-  thomas: '01997'
-- name: Paul A. Gosar
-  party: majority
-  rank: 4
-  bioguide: G000565
-  thomas: '01992'
-- name: Raúl R. Labrador
-  party: majority
-  rank: 5
-  bioguide: L000573
-  thomas: '02011'
-- name: Doug LaMalfa
-  party: majority
-  rank: 6
-  bioguide: L000578
-  thomas: '02100'
-- name: Jason T. Smith
-  party: majority
-  rank: 7
-  bioguide: S001195
-  thomas: '02191'
-- name: Bradley Byrne
-  party: majority
-  rank: 8
-  bioguide: B001289
-  thomas: '02197'
-- name: Doc Hastings
+- name: Rob Bishop
   party: majority
   rank: 9
-  bioguide: H000329
-  thomas: '00512'
+  bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
-- name: Grace F. Napolitano
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: N000179
-  thomas: '01602'
-- name: Jim Costa
-  party: minority
-  rank: 2
-  bioguide: C001059
-  thomas: '01774'
-- name: Jared Huffman
-  party: minority
-  rank: 3
-  bioguide: H001068
-  thomas: '02101'
-- name: Tony Cárdenas
-  party: minority
-  rank: 4
-  bioguide: C001097
-  thomas: '02107'
-- name: Raul Ruiz
-  party: minority
-  rank: 5
-  bioguide: R000599
-  thomas: '02109'
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 6
-  bioguide: L000579
-  thomas: '02111'
-- name: Peter A. DeFazio
-  party: minority
-  rank: 7
-  bioguide: D000191
-  thomas: '00279'
-  title: Ex Officio
-HSII22:
-- name: John Fleming
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: F000456
-  thomas: '01924'
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-  thomas: '01256'
-- name: Robert J. Wittman
-  party: majority
-  rank: 3
-  bioguide: W000804
-  thomas: '01886'
-- name: Glenn Thompson
-  party: majority
-  rank: 4
-  bioguide: T000467
-  thomas: '01952'
-- name: Jeff Duncan
-  party: majority
-  rank: 5
-  bioguide: D000615
-  thomas: '02057'
-- name: Steve Southerland II
-  party: majority
-  rank: 6
-  bioguide: S001186
-  thomas: '02000'
-- name: Bill Flores
-  party: majority
-  rank: 7
-  bioguide: F000461
-  thomas: '02065'
-- name: Jon Runyan
-  party: majority
-  rank: 8
-  bioguide: R000594
-  thomas: '02039'
-- name: Vance M. McAllister
-  party: majority
-  rank: 9
-  bioguide: M001192
-  thomas: '02195'
-- name: Bradley Byrne
-  party: majority
-  rank: 10
-  bioguide: B001289
-  thomas: '02197'
-- name: Doc Hastings
-  party: majority
-  rank: 11
-  bioguide: H000329
-  thomas: '00512'
-  title: Ex Officio
-- name: Gregorio Kilili Camacho Sablan
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001177
-  thomas: '01962'
-- name: Eni F. H. Faleomavaega
-  party: minority
-  rank: 2
-  bioguide: F000010
-  thomas: '00367'
-- name: Frank Pallone Jr.
-  party: minority
-  rank: 3
-  bioguide: P000034
-  thomas: '00887'
-- name: Madeleine Z. Bordallo
-  party: minority
-  rank: 4
-  bioguide: B001245
-  thomas: '01723'
-- name: Pedro R. Pierluisi
-  party: minority
-  rank: 5
-  bioguide: P000596
-  thomas: '01953'
-- name: Carol Shea-Porter
-  party: minority
-  rank: 6
-  bioguide: S001170
-  thomas: '01861'
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 7
-  bioguide: L000579
-  thomas: '02111'
-- name: Joe Garcia
-  party: minority
-  rank: 8
-  bioguide: G000573
-  thomas: '02120'
-- name: Peter A. DeFazio
-  party: minority
-  rank: 9
-  bioguide: D000191
-  thomas: '00279'
-  title: Ex Officio
-HSII24:
-- name: Don Young
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: Y000033
-  thomas: '01256'
-- name: Dan Benishek
-  party: majority
-  rank: 2
-  bioguide: B001271
-  thomas: '02027'
-- name: Paul A. Gosar
-  party: majority
-  rank: 3
-  bioguide: G000565
-  thomas: '01992'
-- name: Markwayne Mullin
-  party: majority
-  rank: 4
-  bioguide: M001190
-  thomas: '02156'
-- name: Steve Daines
-  party: majority
-  rank: 5
-  bioguide: D000618
-  thomas: '02138'
-- name: Kevin Cramer
-  party: majority
-  rank: 6
-  bioguide: C001096
-  thomas: '02144'
-- name: Doug LaMalfa
-  party: majority
-  rank: 7
-  bioguide: L000578
-  thomas: '02100'
-- name: Doc Hastings
-  party: majority
-  rank: 8
-  bioguide: H000329
-  thomas: '00512'
-  title: Ex Officio
-- name: Colleen W. Hanabusa
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H001050
-  thomas: '02010'
-- name: Tony Cárdenas
-  party: minority
-  rank: 2
-  bioguide: C001097
-  thomas: '02107'
-- name: Raul Ruiz
-  party: minority
-  rank: 3
-  bioguide: R000599
-  thomas: '02109'
-- name: Eni F. H. Faleomavaega
-  party: minority
-  rank: 4
-  bioguide: F000010
-  thomas: '00367'
 - name: Raúl M. Grijalva
   party: minority
-  rank: 5
+  rank: 7
   bioguide: G000551
   thomas: '01708'
-- name: Peter A. DeFazio
+  title: Ex Officio
+HSII22:
+- name: Rob Bishop
+  party: majority
+  rank: 11
+  bioguide: B001250
+  thomas: '01753'
+  title: Ex Officio
+- name: Raúl M. Grijalva
+  party: minority
+  rank: 9
+  bioguide: G000551
+  thomas: '01708'
+  title: Ex Officio
+HSII24:
+- name: Rob Bishop
+  party: majority
+  rank: 8
+  bioguide: B001250
+  thomas: '01753'
+  title: Ex Officio
+- name: Raúl M. Grijalva
   party: minority
   rank: 6
-  bioguide: D000191
-  thomas: '00279'
+  bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSJU:
 - name: Bob Goodlatte
@@ -8386,106 +6818,111 @@ HSJU:
   rank: 2
   bioguide: S000244
   thomas: '01041'
-- name: Howard Coble
-  party: majority
-  rank: 3
-  bioguide: C000556
-  thomas: '00211'
 - name: Lamar Smith
   party: majority
-  rank: 4
+  rank: 3
   bioguide: S000583
   thomas: '01075'
 - name: Steve Chabot
   party: majority
-  rank: 5
+  rank: 4
   bioguide: C000266
   thomas: '00186'
-- name: Spencer Bachus
-  party: majority
-  rank: 6
-  bioguide: B000013
-  thomas: '00038'
 - name: Darrell E. Issa
   party: majority
-  rank: 7
+  rank: 5
   bioguide: I000056
   thomas: '01640'
 - name: J. Randy Forbes
   party: majority
-  rank: 8
+  rank: 6
   bioguide: F000445
   thomas: '01683'
 - name: Steve King
   party: majority
-  rank: 9
+  rank: 7
   bioguide: K000362
   thomas: '01724'
 - name: Trent Franks
   party: majority
-  rank: 10
+  rank: 8
   bioguide: F000448
   thomas: '01707'
 - name: Louie Gohmert
   party: majority
-  rank: 11
+  rank: 9
   bioguide: G000552
   thomas: '01801'
 - name: Jim Jordan
   party: majority
-  rank: 12
+  rank: 10
   bioguide: J000289
   thomas: '01868'
 - name: Ted Poe
   party: majority
-  rank: 13
+  rank: 11
   bioguide: P000592
   thomas: '01802'
 - name: Jason Chaffetz
   party: majority
-  rank: 14
+  rank: 12
   bioguide: C001076
   thomas: '01956'
 - name: Tom Marino
   party: majority
-  rank: 15
+  rank: 13
   bioguide: M001179
   thomas: '02053'
 - name: Trey Gowdy
   party: majority
-  rank: 16
+  rank: 14
   bioguide: G000566
   thomas: '02058'
 - name: Raúl R. Labrador
   party: majority
-  rank: 17
+  rank: 15
   bioguide: L000573
   thomas: '02011'
 - name: Blake Farenthold
   party: majority
-  rank: 18
+  rank: 16
   bioguide: F000460
   thomas: '02067'
-- name: George Holding
-  party: majority
-  rank: 19
-  bioguide: H001065
-  thomas: '02143'
 - name: Doug Collins
   party: majority
-  rank: 20
+  rank: 17
   bioguide: C001093
   thomas: '02121'
 - name: Ron DeSantis
   party: majority
-  rank: 21
+  rank: 18
   bioguide: D000621
   thomas: '02116'
-- name: Jason T. Smith
+- name: Mimi Walters
+  party: majority
+  rank: 19
+  bioguide: W000820
+  thomas: '02232'
+- name: Ken Buck
+  party: majority
+  rank: 20
+  bioguide: B001297
+  thomas: '02233'
+- name: John Ratcliffe
+  party: majority
+  rank: 21
+  bioguide: R000601
+  thomas: '02268'
+- name: David A. Trott
   party: majority
   rank: 22
-  bioguide: S001195
-  thomas: '02191'
+  bioguide: T000475
+  thomas: '02250'
+- name: Mike Bishop
+  party: majority
+  rank: 23
+  bioguide: B001293
+  thomas: '02249'
 - name: John Conyers Jr.
   party: minority
   rank: 1
@@ -8497,81 +6934,76 @@ HSJU:
   rank: 2
   bioguide: N000002
   thomas: '00850'
-- name: Robert C. "Bobby" Scott
-  party: minority
-  rank: 3
-  bioguide: S000185
-  thomas: '01037'
 - name: Zoe Lofgren
   party: minority
-  rank: 4
+  rank: 3
   bioguide: L000397
   thomas: '00701'
 - name: Sheila Jackson Lee
   party: minority
-  rank: 5
+  rank: 4
   bioguide: J000032
   thomas: '00588'
 - name: Steve Cohen
   party: minority
-  rank: 6
+  rank: 5
   bioguide: C001068
   thomas: '01878'
 - name: Henry C. "Hank" Johnson Jr.
   party: minority
-  rank: 7
+  rank: 6
   bioguide: J000288
   thomas: '01843'
 - name: Pedro R. Pierluisi
   party: minority
-  rank: 8
+  rank: 7
   bioguide: P000596
   thomas: '01953'
 - name: Judy Chu
   party: minority
-  rank: 9
+  rank: 8
   bioguide: C001080
   thomas: '01970'
 - name: Theodore E. Deutch
   party: minority
-  rank: 10
+  rank: 9
   bioguide: D000610
   thomas: '01976'
 - name: Luis V. Gutiérrez
   party: minority
-  rank: 11
+  rank: 10
   bioguide: G000535
   thomas: '00478'
 - name: Karen Bass
   party: minority
-  rank: 12
+  rank: 11
   bioguide: B001270
   thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
-  rank: 13
+  rank: 12
   bioguide: R000588
   thomas: '02023'
 - name: Suzan K. DelBene
   party: minority
-  rank: 14
+  rank: 13
   bioguide: D000617
   thomas: '02096'
-- name: Joe Garcia
-  party: minority
-  rank: 15
-  bioguide: G000573
-  thomas: '02120'
 - name: Hakeem S. Jeffries
   party: minority
-  rank: 16
+  rank: 14
   bioguide: J000294
   thomas: '02149'
 - name: David N. Cicilline
   party: minority
-  rank: 17
+  rank: 15
   bioguide: C001084
   thomas: '02055'
+- name: Scott H. Peters
+  party: minority
+  rank: 16
+  bioguide: P000608
+  thomas: '02113'
 HSJU01:
 - name: Trey Gowdy
   party: majority
@@ -8579,11 +7011,11 @@ HSJU01:
   title: Chair
   bioguide: G000566
   thomas: '02058'
-- name: Ted Poe
+- name: Raúl R. Labrador
   party: majority
   rank: 2
-  bioguide: P000592
-  thomas: '01802'
+  bioguide: L000573
+  thomas: '02011'
   title: Vice Chair
 - name: Lamar Smith
   party: majority
@@ -8595,59 +7027,54 @@ HSJU01:
   rank: 4
   bioguide: K000362
   thomas: '01724'
-- name: Jim Jordan
+- name: Ken Buck
   party: majority
   rank: 5
-  bioguide: J000289
-  thomas: '01868'
-- name: Raúl R. Labrador
+  bioguide: B001297
+  thomas: '02233'
+- name: John Ratcliffe
   party: majority
   rank: 6
-  bioguide: L000573
-  thomas: '02011'
-- name: George Holding
+  bioguide: R000601
+  thomas: '02268'
+- name: David A. Trott
   party: majority
   rank: 7
-  bioguide: H001065
-  thomas: '02143'
+  bioguide: T000475
+  thomas: '02250'
 - name: Zoe Lofgren
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000397
   thomas: '00701'
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 2
-  bioguide: J000032
-  thomas: '00588'
 - name: Luis V. Gutiérrez
   party: minority
-  rank: 3
+  rank: 2
   bioguide: G000535
   thomas: '00478'
-- name: Joe Garcia
+- name: Sheila Jackson Lee
   party: minority
-  rank: 4
-  bioguide: G000573
-  thomas: '02120'
+  rank: 3
+  bioguide: J000032
+  thomas: '00588'
 - name: Pedro R. Pierluisi
   party: minority
-  rank: 5
+  rank: 4
   bioguide: P000596
   thomas: '01953'
 HSJU03:
-- name: Howard Coble
+- name: Darrell E. Issa
   party: majority
   rank: 1
   title: Chair
-  bioguide: C000556
-  thomas: '00211'
-- name: Tom Marino
+  bioguide: I000056
+  thomas: '01640'
+- name: Doug Collins
   party: majority
   rank: 2
-  bioguide: M001179
-  thomas: '02053'
+  bioguide: C001093
+  thomas: '02121'
   title: Vice Chair
 - name: F. James Sensenbrenner Jr.
   party: majority
@@ -8664,114 +7091,119 @@ HSJU03:
   rank: 5
   bioguide: C000266
   thomas: '00186'
-- name: Darrell E. Issa
+- name: J. Randy Forbes
   party: majority
   rank: 6
-  bioguide: I000056
-  thomas: '01640'
-- name: Ted Poe
+  bioguide: F000445
+  thomas: '01683'
+- name: Trent Franks
   party: majority
   rank: 7
+  bioguide: F000448
+  thomas: '01707'
+- name: Jim Jordan
+  party: majority
+  rank: 8
+  bioguide: J000289
+  thomas: '01868'
+- name: Ted Poe
+  party: majority
+  rank: 9
   bioguide: P000592
   thomas: '01802'
 - name: Jason Chaffetz
   party: majority
-  rank: 8
+  rank: 10
   bioguide: C001076
   thomas: '01956'
-- name: Blake Farenthold
-  party: majority
-  rank: 9
-  bioguide: F000460
-  thomas: '02067'
-- name: George Holding
-  party: majority
-  rank: 10
-  bioguide: H001065
-  thomas: '02143'
-- name: Doug Collins
+- name: Tom Marino
   party: majority
   rank: 11
-  bioguide: C001093
-  thomas: '02121'
-- name: Ron DeSantis
+  bioguide: M001179
+  thomas: '02053'
+- name: Blake Farenthold
   party: majority
   rank: 12
-  bioguide: D000621
-  thomas: '02116'
-- name: Jason T. Smith
+  bioguide: F000460
+  thomas: '02067'
+- name: Ron DeSantis
   party: majority
   rank: 13
-  bioguide: S001195
-  thomas: '02191'
+  bioguide: D000621
+  thomas: '02116'
+- name: Mimi Walters
+  party: majority
+  rank: 14
+  bioguide: W000820
+  thomas: '02232'
 - name: Jerrold Nadler
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: N000002
   thomas: '00850'
-- name: John Conyers Jr.
-  party: minority
-  rank: 2
-  bioguide: C000714
-  thomas: '00229'
 - name: Judy Chu
   party: minority
-  rank: 3
+  rank: 2
   bioguide: C001080
   thomas: '01970'
 - name: Theodore E. Deutch
   party: minority
-  rank: 4
+  rank: 3
   bioguide: D000610
   thomas: '01976'
 - name: Karen Bass
   party: minority
-  rank: 5
+  rank: 4
   bioguide: B001270
   thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
-  rank: 6
+  rank: 5
   bioguide: R000588
   thomas: '02023'
 - name: Suzan K. DelBene
   party: minority
-  rank: 7
+  rank: 6
   bioguide: D000617
   thomas: '02096'
 - name: Hakeem S. Jeffries
   party: minority
-  rank: 8
+  rank: 7
   bioguide: J000294
   thomas: '02149'
 - name: David N. Cicilline
   party: minority
-  rank: 9
+  rank: 8
   bioguide: C001084
   thomas: '02055'
+- name: Scott H. Peters
+  party: minority
+  rank: 9
+  bioguide: P000608
+  thomas: '02113'
 - name: Zoe Lofgren
   party: minority
   rank: 10
   bioguide: L000397
   thomas: '00701'
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 11
-  bioguide: J000032
-  thomas: '00588'
 - name: Steve Cohen
   party: minority
-  rank: 12
+  rank: 11
   bioguide: C001068
   thomas: '01878'
+- name: Henry C. "Hank" Johnson Jr.
+  party: minority
+  rank: 12
+  bioguide: J000288
+  thomas: '01843'
 HSJU05:
-- name: Spencer Bachus
+- name: Tom Marino
   party: majority
   rank: 1
   title: Chair
-  bioguide: B000013
-  thomas: '00038'
+  bioguide: M001179
+  thomas: '02053'
 - name: Blake Farenthold
   party: majority
   rank: 2
@@ -8783,26 +7215,31 @@ HSJU05:
   rank: 3
   bioguide: I000056
   thomas: '01640'
-- name: Tom Marino
-  party: majority
-  rank: 4
-  bioguide: M001179
-  thomas: '02053'
-- name: George Holding
-  party: majority
-  rank: 5
-  bioguide: H001065
-  thomas: '02143'
 - name: Doug Collins
   party: majority
-  rank: 6
+  rank: 4
   bioguide: C001093
   thomas: '02121'
-- name: Jason T. Smith
+- name: Mimi Walters
+  party: majority
+  rank: 5
+  bioguide: W000820
+  thomas: '02232'
+- name: John Ratcliffe
+  party: majority
+  rank: 6
+  bioguide: R000601
+  thomas: '02268'
+- name: David A. Trott
   party: majority
   rank: 7
-  bioguide: S001195
-  thomas: '02191'
+  bioguide: T000475
+  thomas: '02250'
+- name: Mike Bishop
+  party: majority
+  rank: 8
+  bioguide: B001293
+  thomas: '02249'
 - name: Henry C. "Hank" Johnson Jr.
   party: minority
   rank: 1
@@ -8814,21 +7251,21 @@ HSJU05:
   rank: 2
   bioguide: D000617
   thomas: '02096'
-- name: Joe Garcia
-  party: minority
-  rank: 3
-  bioguide: G000573
-  thomas: '02120'
 - name: Hakeem S. Jeffries
   party: minority
-  rank: 4
+  rank: 3
   bioguide: J000294
   thomas: '02149'
 - name: David N. Cicilline
   party: minority
-  rank: 5
+  rank: 4
   bioguide: C001084
   thomas: '02055'
+- name: Scott H. Peters
+  party: minority
+  rank: 5
+  bioguide: P000608
+  thomas: '02113'
 HSJU08:
 - name: F. James Sensenbrenner Jr.
   party: majority
@@ -8842,47 +7279,52 @@ HSJU08:
   bioguide: G000552
   thomas: '01801'
   title: Vice Chair
-- name: Howard Coble
+- name: Steve Chabot
   party: majority
   rank: 3
-  bioguide: C000556
-  thomas: '00211'
-- name: Spencer Bachus
-  party: majority
-  rank: 4
-  bioguide: B000013
-  thomas: '00038'
+  bioguide: C000266
+  thomas: '00186'
 - name: J. Randy Forbes
   party: majority
-  rank: 5
+  rank: 4
   bioguide: F000445
   thomas: '01683'
-- name: Trent Franks
+- name: Ted Poe
   party: majority
-  rank: 6
-  bioguide: F000448
-  thomas: '01707'
+  rank: 5
+  bioguide: P000592
+  thomas: '01802'
 - name: Jason Chaffetz
   party: majority
-  rank: 7
+  rank: 6
   bioguide: C001076
   thomas: '01956'
 - name: Trey Gowdy
   party: majority
-  rank: 8
+  rank: 7
   bioguide: G000566
   thomas: '02058'
 - name: Raúl R. Labrador
   party: majority
-  rank: 9
+  rank: 8
   bioguide: L000573
   thomas: '02011'
-- name: Robert C. "Bobby" Scott
+- name: Ken Buck
+  party: majority
+  rank: 9
+  bioguide: B001297
+  thomas: '02233'
+- name: Mike Bishop
+  party: majority
+  rank: 10
+  bioguide: B001293
+  thomas: '02249'
+- name: Sheila Jackson Lee
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: S000185
-  thomas: '01037'
+  bioguide: J000032
+  thomas: '00588'
 - name: Pedro R. Pierluisi
   party: minority
   rank: 2
@@ -8915,42 +7357,27 @@ HSJU10:
   title: Chair
   bioguide: F000448
   thomas: '01707'
-- name: Jim Jordan
+- name: Ron DeSantis
   party: majority
   rank: 2
-  bioguide: J000289
-  thomas: '01868'
+  bioguide: D000621
+  thomas: '02116'
   title: Vice Chair
-- name: Steve Chabot
-  party: majority
-  rank: 3
-  bioguide: C000266
-  thomas: '00186'
-- name: J. Randy Forbes
-  party: majority
-  rank: 4
-  bioguide: F000445
-  thomas: '01683'
 - name: Steve King
   party: majority
-  rank: 5
+  rank: 3
   bioguide: K000362
   thomas: '01724'
 - name: Louie Gohmert
   party: majority
-  rank: 6
+  rank: 4
   bioguide: G000552
   thomas: '01801'
-- name: Ron DeSantis
+- name: Jim Jordan
   party: majority
-  rank: 7
-  bioguide: D000621
-  thomas: '02116'
-- name: Jason T. Smith
-  party: majority
-  rank: 8
-  bioguide: S001195
-  thomas: '02191'
+  rank: 5
+  bioguide: J000289
+  thomas: '01868'
 - name: Steve Cohen
   party: minority
   rank: 1
@@ -8962,19 +7389,9 @@ HSJU10:
   rank: 2
   bioguide: N000002
   thomas: '00850'
-- name: Robert C. "Bobby" Scott
-  party: minority
-  rank: 3
-  bioguide: S000185
-  thomas: '01037'
-- name: Henry C. "Hank" Johnson Jr.
-  party: minority
-  rank: 4
-  bioguide: J000288
-  thomas: '01843'
 - name: Theodore E. Deutch
   party: minority
-  rank: 5
+  rank: 3
   bioguide: D000610
   thomas: '01976'
 HSPW:
@@ -8989,297 +7406,292 @@ HSPW:
   rank: 2
   bioguide: Y000033
   thomas: '01256'
-- name: Thomas E. Petri
-  party: majority
-  rank: 3
-  bioguide: P000265
-  thomas: '00912'
-- name: Howard Coble
-  party: majority
-  rank: 4
-  bioguide: C000556
-  thomas: '00211'
 - name: John J. Duncan Jr.
   party: majority
-  rank: 5
+  rank: 3
   bioguide: D000533
   thomas: '00322'
 - name: John L. Mica
   party: majority
-  rank: 6
+  rank: 4
   bioguide: M000689
   thomas: '00800'
 - name: Frank A. LoBiondo
   party: majority
-  rank: 7
+  rank: 5
   bioguide: L000554
   thomas: '00699'
-- name: Gary G. Miller
-  party: majority
-  rank: 8
-  bioguide: M001139
-  thomas: '01584'
 - name: Sam Graves
   party: majority
-  rank: 9
+  rank: 6
   bioguide: G000546
   thomas: '01656'
-- name: Shelley Moore Capito
-  party: majority
-  rank: 10
-  bioguide: C001047
-  thomas: '01676'
 - name: Candice S. Miller
   party: majority
-  rank: 11
+  rank: 7
   bioguide: M001150
   thomas: '01731'
 - name: Duncan Hunter
   party: majority
-  rank: 12
+  rank: 8
   bioguide: H001048
   thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
-  rank: 13
+  rank: 9
   bioguide: C001087
   thomas: '01989'
 - name: Lou Barletta
   party: majority
-  rank: 14
+  rank: 10
   bioguide: B001269
   thomas: '02054'
 - name: Blake Farenthold
   party: majority
-  rank: 15
+  rank: 11
   bioguide: F000460
   thomas: '02067'
-- name: Larry Bucshon
-  party: majority
-  rank: 16
-  bioguide: B001275
-  thomas: '02018'
 - name: Bob Gibbs
   party: majority
-  rank: 17
+  rank: 12
   bioguide: G000563
   thomas: '02049'
-- name: Patrick Meehan
-  party: majority
-  rank: 18
-  bioguide: M001181
-  thomas: '02052'
 - name: Richard L. Hanna
   party: majority
-  rank: 19
+  rank: 13
   bioguide: H001051
   thomas: '02044'
 - name: Daniel Webster
   party: majority
-  rank: 20
+  rank: 14
   bioguide: W000806
   thomas: '02002'
-- name: Steve Southerland II
-  party: majority
-  rank: 21
-  bioguide: S001186
-  thomas: '02000'
 - name: Jeff Denham
   party: majority
-  rank: 22
+  rank: 15
   bioguide: D000612
   thomas: '01995'
 - name: Reid J. Ribble
   party: majority
-  rank: 23
+  rank: 16
   bioguide: R000587
   thomas: '02073'
 - name: Thomas Massie
   party: majority
-  rank: 24
+  rank: 17
   bioguide: M001184
   thomas: '02094'
-- name: Steve Daines
-  party: majority
-  rank: 25
-  bioguide: D000618
-  thomas: '02138'
 - name: Tom Rice
   party: majority
-  rank: 26
+  rank: 18
   bioguide: R000597
   thomas: '02160'
-- name: Markwayne Mullin
-  party: majority
-  rank: 27
-  bioguide: M001190
-  thomas: '02156'
-- name: Roger Williams
-  party: majority
-  rank: 28
-  bioguide: W000816
-  thomas: '02165'
 - name: Mark Meadows
   party: majority
-  rank: 29
+  rank: 19
   bioguide: M001187
   thomas: '02142'
 - name: Scott Perry
   party: majority
-  rank: 30
+  rank: 20
   bioguide: P000605
   thomas: '02157'
 - name: Rodney Davis
   party: majority
-  rank: 31
+  rank: 21
   bioguide: D000619
   thomas: '02126'
 - name: Mark Sanford
   party: majority
-  rank: 32
+  rank: 22
   bioguide: S000051
   thomas: '01012'
-- name: David W. Jolly
+- name: Rob Woodall
+  party: majority
+  rank: 23
+  bioguide: W000810
+  thomas: '02008'
+- name: Todd Rokita
+  party: majority
+  rank: 24
+  bioguide: R000592
+  thomas: '02017'
+- name: John Katko
+  party: majority
+  rank: 25
+  bioguide: K000386
+  thomas: '02264'
+- name: Brian Babin
+  party: majority
+  rank: 26
+  bioguide: B001291
+  thomas: '02270'
+- name: Cresent Hardy
+  party: majority
+  rank: 27
+  bioguide: H001070
+  thomas: '02260'
+- name: Ryan A. Costello
+  party: majority
+  rank: 28
+  bioguide: C001106
+  thomas: '02266'
+- name: Garret Graves
+  party: majority
+  rank: 29
+  bioguide: G000577
+  thomas: '02245'
+- name: Mimi Walters
+  party: majority
+  rank: 30
+  bioguide: W000820
+  thomas: '02232'
+- name: Barbara Comstock
+  party: majority
+  rank: 31
+  bioguide: C001105
+  thomas: '02273'
+- name: Carlos Curbelo
+  party: majority
+  rank: 32
+  bioguide: C001107
+  thomas: '02235'
+- name: David Rouzer
   party: majority
   rank: 33
-  bioguide: J000296
-  thomas: '02199'
-- name: Nick J. Rahall II
+  bioguide: R000603
+  thomas: '02256'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 34
+  bioguide: Z000017
+  thomas: '02261'
+- name: Peter A. DeFazio
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: R000011
-  thomas: '00940'
-- name: Peter A. DeFazio
-  party: minority
-  rank: 2
   bioguide: D000191
   thomas: '00279'
 - name: Eleanor Holmes Norton
   party: minority
-  rank: 3
+  rank: 2
   bioguide: N000147
   thomas: '00868'
 - name: Jerrold Nadler
   party: minority
-  rank: 4
+  rank: 3
   bioguide: N000002
   thomas: '00850'
 - name: Corrine Brown
   party: minority
-  rank: 5
+  rank: 4
   bioguide: B000911
   thomas: '00132'
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 6
+  rank: 5
   bioguide: J000126
   thomas: '00599'
 - name: Elijah E. Cummings
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C000984
   thomas: '00256'
 - name: Rick Larsen
   party: minority
-  rank: 8
+  rank: 7
   bioguide: L000560
   thomas: '01675'
 - name: Michael E. Capuano
   party: minority
-  rank: 9
+  rank: 8
   bioguide: C001037
   thomas: '01564'
-- name: Timothy H. Bishop
-  party: minority
-  rank: 10
-  bioguide: B001242
-  thomas: '01740'
-- name: Michael H. Michaud
-  party: minority
-  rank: 11
-  bioguide: M001149
-  thomas: '01730'
 - name: Grace F. Napolitano
   party: minority
-  rank: 12
+  rank: 9
   bioguide: N000179
   thomas: '01602'
 - name: Daniel Lipinski
   party: minority
-  rank: 13
+  rank: 10
   bioguide: L000563
   thomas: '01781'
-- name: Timothy J. Walz
-  party: minority
-  rank: 14
-  bioguide: W000799
-  thomas: '01856'
 - name: Steve Cohen
   party: minority
-  rank: 15
+  rank: 11
   bioguide: C001068
   thomas: '01878'
 - name: Albio Sires
   party: minority
-  rank: 16
+  rank: 12
   bioguide: S001165
   thomas: '01818'
 - name: Donna F. Edwards
   party: minority
-  rank: 17
+  rank: 13
   bioguide: E000290
   thomas: '01894'
 - name: John Garamendi
   party: minority
-  rank: 18
+  rank: 14
   bioguide: G000559
   thomas: '01973'
 - name: André Carson
   party: minority
-  rank: 19
+  rank: 15
   bioguide: C001072
   thomas: '01889'
 - name: Janice Hahn
   party: minority
-  rank: 20
+  rank: 16
   bioguide: H001063
   thomas: '02089'
 - name: Richard M. Nolan
   party: minority
-  rank: 21
+  rank: 17
   bioguide: N000127
   thomas: '00867'
 - name: Ann Kirkpatrick
   party: minority
-  rank: 22
+  rank: 18
   bioguide: K000368
   thomas: '01907'
 - name: Dina Titus
   party: minority
-  rank: 23
+  rank: 19
   bioguide: T000468
   thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
-  rank: 24
+  rank: 20
   bioguide: M001185
   thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
-  rank: 25
+  rank: 21
   bioguide: E000293
   thomas: '02114'
 - name: Lois Frankel
   party: minority
-  rank: 26
+  rank: 22
   bioguide: F000462
   thomas: '02119'
 - name: Cheri Bustos
   party: minority
-  rank: 27
+  rank: 23
   bioguide: B001286
   thomas: '02127'
+- name: Jared Huffman
+  party: minority
+  rank: 24
+  bioguide: H001068
+  thomas: '02101'
+- name: Julia Brownley
+  party: minority
+  rank: 25
+  bioguide: B001285
+  thomas: '02106'
 HSPW02:
 - name: Bob Gibbs
   party: majority
@@ -9287,99 +7699,104 @@ HSPW02:
   title: Chair
   bioguide: G000563
   thomas: '02049'
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-  thomas: '01256'
-- name: Gary G. Miller
-  party: majority
-  rank: 3
-  bioguide: M001139
-  thomas: '01584'
-- name: Shelley Moore Capito
-  party: majority
-  rank: 4
-  bioguide: C001047
-  thomas: '01676'
 - name: Candice S. Miller
   party: majority
-  rank: 5
+  rank: 2
   bioguide: M001150
   thomas: '01731'
+- name: Duncan Hunter
+  party: majority
+  rank: 3
+  bioguide: H001048
+  thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
-  rank: 6
+  rank: 4
   bioguide: C001087
   thomas: '01989'
-  title: Vice Chair
 - name: Daniel Webster
   party: majority
-  rank: 7
+  rank: 5
   bioguide: W000806
   thomas: '02002'
 - name: Jeff Denham
   party: majority
-  rank: 8
+  rank: 6
   bioguide: D000612
   thomas: '01995'
 - name: Reid J. Ribble
   party: majority
-  rank: 9
+  rank: 7
   bioguide: R000587
   thomas: '02073'
 - name: Thomas Massie
   party: majority
-  rank: 10
+  rank: 8
   bioguide: M001184
   thomas: '02094'
-- name: Steve Daines
-  party: majority
-  rank: 11
-  bioguide: D000618
-  thomas: '02138'
 - name: Tom Rice
   party: majority
-  rank: 12
+  rank: 9
   bioguide: R000597
   thomas: '02160'
-- name: Markwayne Mullin
-  party: majority
-  rank: 13
-  bioguide: M001190
-  thomas: '02156'
-- name: Mark Meadows
-  party: majority
-  rank: 14
-  bioguide: M001187
-  thomas: '02142'
 - name: Rodney Davis
   party: majority
-  rank: 15
+  rank: 10
   bioguide: D000619
   thomas: '02126'
 - name: Mark Sanford
   party: majority
-  rank: 16
+  rank: 11
   bioguide: S000051
   thomas: '01012'
-- name: David W. Jolly
+- name: Todd Rokita
+  party: majority
+  rank: 12
+  bioguide: R000592
+  thomas: '02017'
+- name: John Katko
+  party: majority
+  rank: 13
+  bioguide: K000386
+  thomas: '02264'
+- name: Brian Babin
+  party: majority
+  rank: 14
+  bioguide: B001291
+  thomas: '02270'
+- name: Cresent Hardy
+  party: majority
+  rank: 15
+  bioguide: H001070
+  thomas: '02260'
+- name: Garret Graves
+  party: majority
+  rank: 16
+  bioguide: G000577
+  thomas: '02245'
+- name: David Rouzer
   party: majority
   rank: 17
-  bioguide: J000296
-  thomas: '02199'
+  bioguide: R000603
+  thomas: '02256'
 - name: Bill Shuster
   party: majority
   rank: 18
   bioguide: S001154
   thomas: '01681'
   title: Ex Officio
-- name: Timothy H. Bishop
+- name: Bill Shuster
+  party: majority
+  rank: 19
+  bioguide: S001154
+  thomas: '01681'
+  title: Ex Officio
+- name: Grace F. Napolitano
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: B001242
-  thomas: '01740'
+  bioguide: N000179
+  thomas: '01602'
 - name: Donna F. Edwards
   party: minority
   rank: 2
@@ -9395,56 +7812,57 @@ HSPW02:
   rank: 4
   bioguide: F000462
   thomas: '02119'
-- name: Eleanor Holmes Norton
+- name: Jared Huffman
   party: minority
   rank: 5
-  bioguide: N000147
-  thomas: '00868'
+  bioguide: H001068
+  thomas: '02101'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
   bioguide: J000126
   thomas: '00599'
-- name: Grace F. Napolitano
-  party: minority
-  rank: 7
-  bioguide: N000179
-  thomas: '01602'
-- name: Steve Cohen
-  party: minority
-  rank: 8
-  bioguide: C001068
-  thomas: '01878'
-- name: Janice Hahn
-  party: minority
-  rank: 9
-  bioguide: H001063
-  thomas: '02089'
-- name: Richard M. Nolan
-  party: minority
-  rank: 10
-  bioguide: N000127
-  thomas: '00867'
 - name: Ann Kirkpatrick
   party: minority
-  rank: 11
+  rank: 7
   bioguide: K000368
   thomas: '01907'
 - name: Dina Titus
   party: minority
-  rank: 12
+  rank: 8
   bioguide: T000468
   thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
-  rank: 13
+  rank: 9
   bioguide: M001185
   thomas: '02150'
-- name: Nick J. Rahall II
+- name: Elizabeth H. Esty
+  party: minority
+  rank: 10
+  bioguide: E000293
+  thomas: '02114'
+- name: Eleanor Holmes Norton
+  party: minority
+  rank: 11
+  bioguide: N000147
+  thomas: '00868'
+- name: Richard M. Nolan
+  party: minority
+  rank: 12
+  bioguide: N000127
+  thomas: '00867'
+- name: Peter A. DeFazio
+  party: minority
+  rank: 13
+  bioguide: D000191
+  thomas: '00279'
+  title: Ex Officio
+- name: Peter A. DeFazio
   party: minority
   rank: 14
-  bioguide: R000011
-  thomas: '00940'
+  bioguide: D000191
+  thomas: '00279'
   title: Ex Officio
 HSPW05:
 - name: Frank A. LoBiondo
@@ -9453,90 +7871,105 @@ HSPW05:
   title: Chair
   bioguide: L000554
   thomas: '00699'
-- name: Thomas E. Petri
+- name: Don Young
   party: majority
   rank: 2
-  bioguide: P000265
-  thomas: '00912'
-- name: Howard Coble
-  party: majority
-  rank: 3
-  bioguide: C000556
-  thomas: '00211'
+  bioguide: Y000033
+  thomas: '01256'
 - name: John J. Duncan Jr.
   party: majority
-  rank: 4
+  rank: 3
   bioguide: D000533
   thomas: '00322'
+- name: John L. Mica
+  party: majority
+  rank: 4
+  bioguide: M000689
+  thomas: '00800'
 - name: Sam Graves
   party: majority
   rank: 5
   bioguide: G000546
   thomas: '01656'
-- name: Blake Farenthold
+- name: Candice S. Miller
   party: majority
   rank: 6
-  bioguide: F000460
-  thomas: '02067'
-- name: Larry Bucshon
+  bioguide: M001150
+  thomas: '01731'
+- name: Blake Farenthold
   party: majority
   rank: 7
-  bioguide: B001275
-  thomas: '02018'
-- name: Patrick Meehan
-  party: majority
-  rank: 8
-  bioguide: M001181
-  thomas: '02052'
+  bioguide: F000460
+  thomas: '02067'
 - name: Richard L. Hanna
   party: majority
-  rank: 9
+  rank: 8
   bioguide: H001051
   thomas: '02044'
-- name: Daniel Webster
-  party: majority
-  rank: 10
-  bioguide: W000806
-  thomas: '02002'
-- name: Jeff Denham
-  party: majority
-  rank: 11
-  bioguide: D000612
-  thomas: '01995'
 - name: Reid J. Ribble
   party: majority
-  rank: 12
+  rank: 9
   bioguide: R000587
   thomas: '02073'
-- name: Thomas Massie
-  party: majority
-  rank: 13
-  bioguide: M001184
-  thomas: '02094'
-- name: Steve Daines
-  party: majority
-  rank: 14
-  bioguide: D000618
-  thomas: '02138'
-- name: Roger Williams
-  party: majority
-  rank: 15
-  bioguide: W000816
-  thomas: '02165'
 - name: Mark Meadows
   party: majority
-  rank: 16
+  rank: 10
   bioguide: M001187
   thomas: '02142'
 - name: Rodney Davis
   party: majority
-  rank: 17
+  rank: 11
   bioguide: D000619
   thomas: '02126'
-  title: Vice Chair
-- name: Bill Shuster
+- name: Mark Sanford
+  party: majority
+  rank: 12
+  bioguide: S000051
+  thomas: '01012'
+- name: Rob Woodall
+  party: majority
+  rank: 13
+  bioguide: W000810
+  thomas: '02008'
+- name: Todd Rokita
+  party: majority
+  rank: 14
+  bioguide: R000592
+  thomas: '02017'
+- name: Ryan A. Costello
+  party: majority
+  rank: 15
+  bioguide: C001106
+  thomas: '02266'
+- name: Mimi Walters
+  party: majority
+  rank: 16
+  bioguide: W000820
+  thomas: '02232'
+- name: Barbara Comstock
+  party: majority
+  rank: 17
+  bioguide: C001105
+  thomas: '02273'
+- name: Carlos Curbelo
   party: majority
   rank: 18
+  bioguide: C001107
+  thomas: '02235'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 19
+  bioguide: Z000017
+  thomas: '02261'
+- name: Bill Shuster
+  party: majority
+  rank: 20
+  bioguide: S001154
+  thomas: '01681'
+  title: Ex Officio
+- name: Bill Shuster
+  party: majority
+  rank: 21
   bioguide: S001154
   thomas: '01681'
   title: Ex Officio
@@ -9546,71 +7979,82 @@ HSPW05:
   title: Ranking Member
   bioguide: L000560
   thomas: '01675'
-- name: Peter A. DeFazio
+- name: Eleanor Holmes Norton
   party: minority
   rank: 2
-  bioguide: D000191
-  thomas: '00279'
+  bioguide: N000147
+  thomas: '00868'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 3
   bioguide: J000126
   thomas: '00599'
-- name: Michael E. Capuano
-  party: minority
-  rank: 4
-  bioguide: C001037
-  thomas: '01564'
 - name: Daniel Lipinski
   party: minority
-  rank: 5
+  rank: 4
   bioguide: L000563
   thomas: '01781'
-- name: Steve Cohen
-  party: minority
-  rank: 6
-  bioguide: C001068
-  thomas: '01878'
 - name: André Carson
   party: minority
-  rank: 7
+  rank: 5
   bioguide: C001072
   thomas: '01889'
-- name: Richard M. Nolan
+- name: Ann Kirkpatrick
   party: minority
-  rank: 8
-  bioguide: N000127
-  thomas: '00867'
+  rank: 6
+  bioguide: K000368
+  thomas: '01907'
 - name: Dina Titus
   party: minority
-  rank: 9
+  rank: 7
   bioguide: T000468
   thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
-  rank: 10
+  rank: 8
   bioguide: M001185
   thomas: '02150'
 - name: Cheri Bustos
   party: minority
-  rank: 11
+  rank: 9
   bioguide: B001286
   thomas: '02127'
-- name: Corrine Brown
+- name: Julia Brownley
+  party: minority
+  rank: 10
+  bioguide: B001285
+  thomas: '02106'
+- name: Michael E. Capuano
+  party: minority
+  rank: 11
+  bioguide: C001037
+  thomas: '01564'
+- name: Steve Cohen
   party: minority
   rank: 12
-  bioguide: B000911
-  thomas: '00132'
-- name: Elizabeth H. Esty
+  bioguide: C001068
+  thomas: '01878'
+- name: Richard M. Nolan
   party: minority
   rank: 13
-  bioguide: E000293
-  thomas: '02114'
-- name: Nick J. Rahall II
+  bioguide: N000127
+  thomas: '00867'
+- name: John Garamendi
   party: minority
   rank: 14
-  bioguide: R000011
-  thomas: '00940'
+  bioguide: G000559
+  thomas: '01973'
+- name: Peter A. DeFazio
+  party: minority
+  rank: 15
+  bioguide: D000191
+  thomas: '00279'
+  title: Ex Officio
+- name: Peter A. DeFazio
+  party: minority
+  rank: 16
+  bioguide: D000191
+  thomas: '00279'
   title: Ex Officio
 HSPW07:
 - name: Duncan Hunter
@@ -9624,45 +8068,50 @@ HSPW07:
   rank: 2
   bioguide: Y000033
   thomas: '01256'
-- name: Howard Coble
-  party: majority
-  rank: 3
-  bioguide: C000556
-  thomas: '00211'
 - name: Frank A. LoBiondo
   party: majority
-  rank: 4
+  rank: 3
   bioguide: L000554
   thomas: '00699'
-- name: Patrick Meehan
+- name: Bob Gibbs
   party: majority
-  rank: 5
-  bioguide: M001181
-  thomas: '02052'
-- name: Steve Southerland II
-  party: majority
-  rank: 6
-  bioguide: S001186
-  thomas: '02000'
-  title: Vice Chair
-- name: Tom Rice
-  party: majority
-  rank: 7
-  bioguide: R000597
-  thomas: '02160'
+  rank: 4
+  bioguide: G000563
+  thomas: '02049'
 - name: Mark Sanford
   party: majority
-  rank: 8
+  rank: 5
   bioguide: S000051
   thomas: '01012'
-- name: David W. Jolly
+- name: Garret Graves
+  party: majority
+  rank: 6
+  bioguide: G000577
+  thomas: '02245'
+- name: Carlos Curbelo
+  party: majority
+  rank: 7
+  bioguide: C001107
+  thomas: '02235'
+- name: David Rouzer
+  party: majority
+  rank: 8
+  bioguide: R000603
+  thomas: '02256'
+- name: Lee M. Zeldin
   party: majority
   rank: 9
-  bioguide: J000296
-  thomas: '02199'
+  bioguide: Z000017
+  thomas: '02261'
 - name: Bill Shuster
   party: majority
   rank: 10
+  bioguide: S001154
+  thomas: '01681'
+  title: Ex Officio
+- name: Bill Shuster
+  party: majority
+  rank: 11
   bioguide: S001154
   thomas: '01681'
   title: Ex Officio
@@ -9677,163 +8126,184 @@ HSPW07:
   rank: 2
   bioguide: C000984
   thomas: '00256'
-- name: Rick Larsen
+- name: Corrine Brown
   party: minority
   rank: 3
-  bioguide: L000560
-  thomas: '01675'
-- name: Timothy H. Bishop
+  bioguide: B000911
+  thomas: '00132'
+- name: Janice Hahn
   party: minority
   rank: 4
-  bioguide: B001242
-  thomas: '01740'
+  bioguide: H001063
+  thomas: '02089'
 - name: Lois Frankel
   party: minority
   rank: 5
   bioguide: F000462
   thomas: '02119'
-- name: Corrine Brown
+- name: Julia Brownley
   party: minority
   rank: 6
-  bioguide: B000911
-  thomas: '00132'
-- name: Janice Hahn
+  bioguide: B001285
+  thomas: '02106'
+- name: Peter A. DeFazio
   party: minority
   rank: 7
-  bioguide: H001063
-  thomas: '02089'
-- name: Nick J. Rahall II
+  bioguide: D000191
+  thomas: '00279'
+  title: Ex Officio
+- name: Peter A. DeFazio
   party: minority
   rank: 8
-  bioguide: R000011
-  thomas: '00940'
+  bioguide: D000191
+  thomas: '00279'
   title: Ex Officio
 HSPW12:
-- name: Thomas E. Petri
+- name: Sam Graves
   party: majority
   rank: 1
   title: Chair
-  bioguide: P000265
-  thomas: '00912'
+  bioguide: G000546
+  thomas: '01656'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
   thomas: '01256'
-- name: Howard Coble
-  party: majority
-  rank: 3
-  bioguide: C000556
-  thomas: '00211'
 - name: John J. Duncan Jr.
   party: majority
-  rank: 4
+  rank: 3
   bioguide: D000533
   thomas: '00322'
 - name: John L. Mica
   party: majority
-  rank: 5
+  rank: 4
   bioguide: M000689
   thomas: '00800'
 - name: Frank A. LoBiondo
   party: majority
-  rank: 6
+  rank: 5
   bioguide: L000554
   thomas: '00699'
-- name: Gary G. Miller
-  party: majority
-  rank: 7
-  bioguide: M001139
-  thomas: '01584'
-- name: Sam Graves
-  party: majority
-  rank: 8
-  bioguide: G000546
-  thomas: '01656'
-- name: Shelley Moore Capito
-  party: majority
-  rank: 9
-  bioguide: C001047
-  thomas: '01676'
 - name: Duncan Hunter
   party: majority
-  rank: 10
+  rank: 6
   bioguide: H001048
   thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
-  rank: 11
+  rank: 7
   bioguide: C001087
   thomas: '01989'
 - name: Lou Barletta
   party: majority
-  rank: 12
+  rank: 8
   bioguide: B001269
   thomas: '02054'
 - name: Blake Farenthold
   party: majority
-  rank: 13
+  rank: 9
   bioguide: F000460
   thomas: '02067'
-- name: Larry Bucshon
-  party: majority
-  rank: 14
-  bioguide: B001275
-  thomas: '02018'
 - name: Bob Gibbs
   party: majority
-  rank: 15
+  rank: 10
   bioguide: G000563
   thomas: '02049'
 - name: Richard L. Hanna
   party: majority
-  rank: 16
+  rank: 11
   bioguide: H001051
   thomas: '02044'
-- name: Steve Southerland II
+- name: Daniel Webster
   party: majority
-  rank: 17
-  bioguide: S001186
-  thomas: '02000'
+  rank: 12
+  bioguide: W000806
+  thomas: '02002'
+- name: Jeff Denham
+  party: majority
+  rank: 13
+  bioguide: D000612
+  thomas: '01995'
 - name: Reid J. Ribble
   party: majority
-  rank: 18
+  rank: 14
   bioguide: R000587
   thomas: '02073'
-  title: Vice Chair
-- name: Steve Daines
+- name: Thomas Massie
   party: majority
-  rank: 19
-  bioguide: D000618
-  thomas: '02138'
+  rank: 15
+  bioguide: M001184
+  thomas: '02094'
 - name: Tom Rice
   party: majority
-  rank: 20
+  rank: 16
   bioguide: R000597
   thomas: '02160'
-- name: Markwayne Mullin
+- name: Mark Meadows
   party: majority
-  rank: 21
-  bioguide: M001190
-  thomas: '02156'
-- name: Roger Williams
-  party: majority
-  rank: 22
-  bioguide: W000816
-  thomas: '02165'
+  rank: 17
+  bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
-  rank: 23
+  rank: 18
   bioguide: P000605
   thomas: '02157'
 - name: Rodney Davis
   party: majority
-  rank: 24
+  rank: 19
   bioguide: D000619
   thomas: '02126'
-- name: Bill Shuster
+- name: Rob Woodall
+  party: majority
+  rank: 20
+  bioguide: W000810
+  thomas: '02008'
+- name: John Katko
+  party: majority
+  rank: 21
+  bioguide: K000386
+  thomas: '02264'
+- name: Brian Babin
+  party: majority
+  rank: 22
+  bioguide: B001291
+  thomas: '02270'
+- name: Cresent Hardy
+  party: majority
+  rank: 23
+  bioguide: H001070
+  thomas: '02260'
+- name: Ryan A. Costello
+  party: majority
+  rank: 24
+  bioguide: C001106
+  thomas: '02266'
+- name: Garret Graves
   party: majority
   rank: 25
+  bioguide: G000577
+  thomas: '02245'
+- name: Mimi Walters
+  party: majority
+  rank: 26
+  bioguide: W000820
+  thomas: '02232'
+- name: Barbara Comstock
+  party: majority
+  rank: 27
+  bioguide: C001105
+  thomas: '02273'
+- name: Bill Shuster
+  party: majority
+  rank: 28
+  bioguide: S001154
+  thomas: '01681'
+  title: Ex Officio
+- name: Bill Shuster
+  party: majority
+  rank: 29
   bioguide: S001154
   thomas: '01681'
   title: Ex Officio
@@ -9843,101 +8313,112 @@ HSPW12:
   title: Ranking Member
   bioguide: N000147
   thomas: '00868'
-- name: Peter A. DeFazio
-  party: minority
-  rank: 2
-  bioguide: D000191
-  thomas: '00279'
 - name: Jerrold Nadler
   party: minority
-  rank: 3
+  rank: 2
   bioguide: N000002
   thomas: '00850'
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 4
+  rank: 3
   bioguide: J000126
   thomas: '00599'
-- name: Michael E. Capuano
-  party: minority
-  rank: 5
-  bioguide: C001037
-  thomas: '01564'
-- name: Michael H. Michaud
-  party: minority
-  rank: 6
-  bioguide: M001149
-  thomas: '01730'
-- name: Grace F. Napolitano
-  party: minority
-  rank: 7
-  bioguide: N000179
-  thomas: '01602'
-- name: Timothy J. Walz
-  party: minority
-  rank: 8
-  bioguide: W000799
-  thomas: '01856'
 - name: Steve Cohen
   party: minority
-  rank: 9
+  rank: 4
   bioguide: C001068
   thomas: '01878'
 - name: Albio Sires
   party: minority
-  rank: 10
+  rank: 5
   bioguide: S001165
   thomas: '01818'
 - name: Donna F. Edwards
   party: minority
-  rank: 11
+  rank: 6
   bioguide: E000290
   thomas: '01894'
 - name: Janice Hahn
   party: minority
-  rank: 12
+  rank: 7
   bioguide: H001063
   thomas: '02089'
 - name: Richard M. Nolan
   party: minority
-  rank: 13
+  rank: 8
   bioguide: N000127
   thomas: '00867'
 - name: Ann Kirkpatrick
   party: minority
-  rank: 14
+  rank: 9
   bioguide: K000368
   thomas: '01907'
 - name: Dina Titus
   party: minority
-  rank: 15
+  rank: 10
   bioguide: T000468
   thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
-  rank: 16
+  rank: 11
   bioguide: M001185
   thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
-  rank: 17
+  rank: 12
   bioguide: E000293
   thomas: '02114'
 - name: Lois Frankel
   party: minority
-  rank: 18
+  rank: 13
   bioguide: F000462
   thomas: '02119'
 - name: Cheri Bustos
   party: minority
-  rank: 19
+  rank: 14
   bioguide: B001286
   thomas: '02127'
-- name: Nick J. Rahall II
+- name: Jared Huffman
+  party: minority
+  rank: 15
+  bioguide: H001068
+  thomas: '02101'
+- name: Julia Brownley
+  party: minority
+  rank: 16
+  bioguide: B001285
+  thomas: '02106'
+- name: Michael E. Capuano
+  party: minority
+  rank: 17
+  bioguide: C001037
+  thomas: '01564'
+- name: Grace F. Napolitano
+  party: minority
+  rank: 18
+  bioguide: N000179
+  thomas: '01602'
+- name: Corrine Brown
+  party: minority
+  rank: 19
+  bioguide: B000911
+  thomas: '00132'
+- name: Daniel Lipinski
   party: minority
   rank: 20
-  bioguide: R000011
-  thomas: '00940'
+  bioguide: L000563
+  thomas: '01781'
+- name: Peter A. DeFazio
+  party: minority
+  rank: 21
+  bioguide: D000191
+  thomas: '00279'
+  title: Ex Officio
+- name: Peter A. DeFazio
+  party: minority
+  rank: 22
+  bioguide: D000191
+  thomas: '00279'
   title: Ex Officio
 HSPW13:
 - name: Lou Barletta
@@ -9946,50 +8427,55 @@ HSPW13:
   title: Chair
   bioguide: B001269
   thomas: '02054'
-- name: Thomas E. Petri
-  party: majority
-  rank: 2
-  bioguide: P000265
-  thomas: '00912'
-- name: John L. Mica
-  party: majority
-  rank: 3
-  bioguide: M000689
-  thomas: '00800'
 - name: Eric A. "Rick" Crawford
   party: majority
-  rank: 4
+  rank: 2
   bioguide: C001087
   thomas: '01989'
-- name: Blake Farenthold
+- name: Thomas Massie
   party: majority
-  rank: 5
-  bioguide: F000460
-  thomas: '02067'
-  title: Vice Chair
-- name: Markwayne Mullin
-  party: majority
-  rank: 6
-  bioguide: M001190
-  thomas: '02156'
+  rank: 3
+  bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
-  rank: 7
+  rank: 4
   bioguide: M001187
   thomas: '02142'
 - name: Scott Perry
   party: majority
-  rank: 8
+  rank: 5
   bioguide: P000605
   thomas: '02157'
-- name: Mark Sanford
+- name: Ryan A. Costello
+  party: majority
+  rank: 6
+  bioguide: C001106
+  thomas: '02266'
+- name: Barbara Comstock
+  party: majority
+  rank: 7
+  bioguide: C001105
+  thomas: '02273'
+- name: Carlos Curbelo
+  party: majority
+  rank: 8
+  bioguide: C001107
+  thomas: '02235'
+- name: David Rouzer
   party: majority
   rank: 9
-  bioguide: S000051
-  thomas: '01012'
+  bioguide: R000603
+  thomas: '02256'
 - name: Bill Shuster
   party: majority
   rank: 10
+  bioguide: S001154
+  thomas: '01681'
+  title: Ex Officio
+- name: Bill Shuster
+  party: majority
+  rank: 11
   bioguide: S001154
   thomas: '01681'
   title: Ex Officio
@@ -10004,36 +8490,32 @@ HSPW13:
   rank: 2
   bioguide: N000147
   thomas: '00868'
-- name: Michael H. Michaud
+- name: Albio Sires
   party: minority
   rank: 3
-  bioguide: M001149
-  thomas: '01730'
-- name: Timothy J. Walz
-  party: minority
-  rank: 4
-  bioguide: W000799
-  thomas: '01856'
+  bioguide: S001165
+  thomas: '01818'
 - name: Donna F. Edwards
   party: minority
-  rank: 5
+  rank: 4
   bioguide: E000290
   thomas: '01894'
-- name: Richard M. Nolan
-  party: minority
-  rank: 6
-  bioguide: N000127
-  thomas: '00867'
 - name: Dina Titus
   party: minority
-  rank: 7
+  rank: 5
   bioguide: T000468
   thomas: '01940'
-- name: Nick J. Rahall II
+- name: Peter A. DeFazio
+  party: minority
+  rank: 6
+  bioguide: D000191
+  thomas: '00279'
+  title: Ex Officio
+- name: Peter A. DeFazio
   party: minority
   rank: 8
-  bioguide: R000011
-  thomas: '00940'
+  bioguide: D000191
+  thomas: '00279'
   title: Ex Officio
 HSPW14:
 - name: Jeff Denham
@@ -10052,149 +8534,160 @@ HSPW14:
   rank: 3
   bioguide: M000689
   thomas: '00800'
-- name: Gary G. Miller
-  party: majority
-  rank: 4
-  bioguide: M001139
-  thomas: '01584'
 - name: Sam Graves
   party: majority
-  rank: 5
+  rank: 4
   bioguide: G000546
   thomas: '01656'
-- name: Shelley Moore Capito
-  party: majority
-  rank: 6
-  bioguide: C001047
-  thomas: '01676'
 - name: Candice S. Miller
   party: majority
-  rank: 7
+  rank: 5
   bioguide: M001150
   thomas: '01731'
 - name: Lou Barletta
   party: majority
-  rank: 8
+  rank: 6
   bioguide: B001269
   thomas: '02054'
-- name: Larry Bucshon
+- name: Blake Farenthold
   party: majority
-  rank: 9
-  bioguide: B001275
-  thomas: '02018'
-- name: Bob Gibbs
-  party: majority
-  rank: 10
-  bioguide: G000563
-  thomas: '02049'
-- name: Patrick Meehan
-  party: majority
-  rank: 11
-  bioguide: M001181
-  thomas: '02052'
+  rank: 7
+  bioguide: F000460
+  thomas: '02067'
 - name: Richard L. Hanna
   party: majority
-  rank: 12
+  rank: 8
   bioguide: H001051
   thomas: '02044'
-  title: Vice Chair
 - name: Daniel Webster
   party: majority
-  rank: 13
+  rank: 9
   bioguide: W000806
   thomas: '02002'
-- name: Thomas Massie
+- name: Tom Rice
   party: majority
-  rank: 14
-  bioguide: M001184
-  thomas: '02094'
-- name: Roger Williams
-  party: majority
-  rank: 15
-  bioguide: W000816
-  thomas: '02165'
+  rank: 10
+  bioguide: R000597
+  thomas: '02160'
 - name: Scott Perry
   party: majority
-  rank: 16
+  rank: 11
   bioguide: P000605
   thomas: '02157'
+- name: Todd Rokita
+  party: majority
+  rank: 12
+  bioguide: R000592
+  thomas: '02017'
+- name: John Katko
+  party: majority
+  rank: 13
+  bioguide: K000386
+  thomas: '02264'
+- name: Brian Babin
+  party: majority
+  rank: 14
+  bioguide: B001291
+  thomas: '02270'
+- name: Cresent Hardy
+  party: majority
+  rank: 15
+  bioguide: H001070
+  thomas: '02260'
+- name: Mimi Walters
+  party: majority
+  rank: 16
+  bioguide: W000820
+  thomas: '02232'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 17
+  bioguide: Z000017
+  thomas: '02261'
 - name: Bill Shuster
   party: majority
   rank: 18
   bioguide: S001154
   thomas: '01681'
   title: Ex Officio
-- name: Corrine Brown
+- name: Bill Shuster
+  party: majority
+  rank: 19
+  bioguide: S001154
+  thomas: '01681'
+  title: Ex Officio
+- name: Michael E. Capuano
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: C001037
+  thomas: '01564'
+- name: Corrine Brown
+  party: minority
+  rank: 2
   bioguide: B000911
   thomas: '00132'
 - name: Daniel Lipinski
   party: minority
-  rank: 2
+  rank: 3
   bioguide: L000563
   thomas: '01781'
 - name: Jerrold Nadler
   party: minority
-  rank: 3
+  rank: 4
   bioguide: N000002
   thomas: '00850'
 - name: Elijah E. Cummings
   party: minority
-  rank: 4
+  rank: 5
   bioguide: C000984
   thomas: '00256'
-- name: Michael H. Michaud
-  party: minority
-  rank: 5
-  bioguide: M001149
-  thomas: '01730'
-- name: Grace F. Napolitano
+- name: Rick Larsen
   party: minority
   rank: 6
-  bioguide: N000179
-  thomas: '01602'
-- name: Timothy J. Walz
+  bioguide: L000560
+  thomas: '01675'
+- name: Steve Cohen
   party: minority
   rank: 7
-  bioguide: W000799
-  thomas: '01856'
+  bioguide: C001068
+  thomas: '01878'
 - name: Albio Sires
   party: minority
   rank: 8
   bioguide: S001165
   thomas: '01818'
-- name: Janice Hahn
+- name: Richard M. Nolan
   party: minority
   rank: 9
-  bioguide: H001063
-  thomas: '02089'
-- name: Ann Kirkpatrick
-  party: minority
-  rank: 10
-  bioguide: K000368
-  thomas: '01907'
+  bioguide: N000127
+  thomas: '00867'
 - name: Elizabeth H. Esty
   party: minority
-  rank: 11
+  rank: 10
   bioguide: E000293
   thomas: '02114'
-- name: Peter A. DeFazio
+- name: Grace F. Napolitano
+  party: minority
+  rank: 11
+  bioguide: N000179
+  thomas: '01602'
+- name: Janice Hahn
   party: minority
   rank: 12
-  bioguide: D000191
-  thomas: '00279'
-- name: Michael E. Capuano
+  bioguide: H001063
+  thomas: '02089'
+- name: Peter A. DeFazio
   party: minority
   rank: 13
-  bioguide: C001037
-  thomas: '01564'
-- name: Nick J. Rahall II
+  bioguide: D000191
+  thomas: '00279'
+  title: Ex Officio
+- name: Peter A. DeFazio
   party: minority
   rank: 14
-  bioguide: R000011
-  thomas: '00940'
+  bioguide: D000191
+  thomas: '00279'
   title: Ex Officio
 HSRU:
 - name: Pete Sessions
@@ -10208,41 +8701,31 @@ HSRU:
   rank: 2
   bioguide: F000450
   thomas: '01791'
-- name: Rob Bishop
-  party: majority
-  rank: 3
-  bioguide: B001250
-  thomas: '01753'
 - name: Tom Cole
   party: majority
-  rank: 4
+  rank: 3
   bioguide: C001053
   thomas: '01742'
 - name: Rob Woodall
   party: majority
-  rank: 5
+  rank: 4
   bioguide: W000810
   thomas: '02008'
-- name: Richard B. Nugent
+- name: Michael C. Burgess
+  party: majority
+  rank: 5
+  bioguide: B001248
+  thomas: '01751'
+- name: Steve Stivers
   party: majority
   rank: 6
-  bioguide: N000185
-  thomas: '02001'
-- name: Daniel Webster
+  bioguide: S001187
+  thomas: '02047'
+- name: Doug Collins
   party: majority
   rank: 7
-  bioguide: W000806
-  thomas: '02002'
-- name: Ileana Ros-Lehtinen
-  party: majority
-  rank: 8
-  bioguide: R000435
-  thomas: '00985'
-- name: Michael C. Burgess
-  party: majority
-  rank: 9
-  bioguide: B001248
-  thomas: '01751'
+  bioguide: C001093
+  thomas: '02121'
 - name: Louise McIntosh Slaughter
   party: minority
   rank: 1
@@ -10264,507 +8747,167 @@ HSRU:
   rank: 4
   bioguide: P000598
   thomas: '01910'
-HSRU02:
-- name: Rob Woodall
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: W000810
-  thomas: '02008'
-- name: Virginia Foxx
-  party: majority
-  rank: 2
-  bioguide: F000450
-  thomas: '01791'
-- name: Richard B. Nugent
-  party: majority
-  rank: 3
-  bioguide: N000185
-  thomas: '02001'
-- name: Daniel Webster
-  party: majority
-  rank: 4
-  bioguide: W000806
-  thomas: '02002'
-- name: Michael C. Burgess
-  party: majority
-  rank: 5
-  bioguide: B001248
-  thomas: '01751'
-- name: Alcee L. Hastings
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H000324
-  thomas: '00511'
-- name: Jared Polis
-  party: minority
-  rank: 2
-  bioguide: P000598
-  thomas: '01910'
-HSRU04:
-- name: Richard B. Nugent
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: N000185
-  thomas: '02001'
-- name: Rob Bishop
-  party: majority
-  rank: 2
-  bioguide: B001250
-  thomas: '01753'
-- name: Ileana Ros-Lehtinen
-  party: majority
-  rank: 3
-  bioguide: R000435
-  thomas: '00985'
-- name: Daniel Webster
-  party: majority
-  rank: 4
-  bioguide: W000806
-  thomas: '02002'
-- name: Pete Sessions
-  party: majority
-  rank: 5
-  bioguide: S000250
-  thomas: '01525'
-- name: James P. McGovern
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M000312
-  thomas: '01504'
-- name: Louise McIntosh Slaughter
-  party: minority
-  rank: 2
-  bioguide: S000480
-  thomas: '01069'
 HSSM:
-- name: Sam Graves
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: G000546
-  thomas: '01656'
 - name: Steve Chabot
   party: majority
-  rank: 2
+  rank: 1
+  title: Chair
   bioguide: C000266
   thomas: '00186'
 - name: Steve King
   party: majority
-  rank: 3
+  rank: 2
   bioguide: K000362
   thomas: '01724'
-- name: Mike Coffman
-  party: majority
-  rank: 4
-  bioguide: C001077
-  thomas: '01912'
 - name: Blaine Luetkemeyer
   party: majority
-  rank: 5
+  rank: 3
   bioguide: L000569
   thomas: '01931'
-- name: Mick Mulvaney
-  party: majority
-  rank: 6
-  bioguide: M001182
-  thomas: '02059'
-- name: Scott R. Tipton
-  party: majority
-  rank: 7
-  bioguide: T000470
-  thomas: '01997'
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 8
-  bioguide: H001056
-  thomas: '02071'
 - name: Richard L. Hanna
   party: majority
-  rank: 9
+  rank: 4
   bioguide: H001051
   thomas: '02044'
 - name: Tim Huelskamp
   party: majority
-  rank: 10
+  rank: 5
   bioguide: H001057
   thomas: '02020'
-- name: David Schweikert
-  party: majority
-  rank: 11
-  bioguide: S001183
-  thomas: '01994'
-- name: Kerry L. Bentivolio
-  party: majority
-  rank: 12
-  bioguide: B001280
-  thomas: '02135'
-- name: Chris Collins
-  party: majority
-  rank: 13
-  bioguide: C001092
-  thomas: '02151'
 - name: Tom Rice
   party: majority
-  rank: 14
+  rank: 6
   bioguide: R000597
   thomas: '02160'
+- name: Christopher P. Gibson
+  party: majority
+  rank: 7
+  bioguide: G000564
+  thomas: '02043'
+- name: Dave Brat
+  party: majority
+  rank: 8
+  bioguide: B001290
+  thomas: '02203'
+- name: Amata Coleman Radewagen
+  party: majority
+  rank: 9
+  bioguide: R000600
+  thomas: '02222'
+- name: Stephen Knight
+  party: majority
+  rank: 10
+  bioguide: K000387
+  thomas: '02228'
+- name: Will Hurd
+  party: majority
+  rank: 11
+  bioguide: H001073
+  thomas: '02269'
+- name: Carlos Curbelo
+  party: majority
+  rank: 12
+  bioguide: C001107
+  thomas: '02235'
+- name: Mike Bost
+  party: majority
+  rank: 13
+  bioguide: B001295
+  thomas: '02243'
+- name: Cresent Hardy
+  party: majority
+  rank: 14
+  bioguide: H001070
+  thomas: '02260'
 - name: Nydia M. Velázquez
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: V000081
   thomas: '01184'
-- name: Kurt Schrader
-  party: minority
-  rank: 2
-  bioguide: S001180
-  thomas: '01950'
-- name: Yvette D. Clarke
-  party: minority
-  rank: 3
-  bioguide: C001067
-  thomas: '01864'
 - name: Judy Chu
   party: minority
-  rank: 4
+  rank: 2
   bioguide: C001080
   thomas: '01970'
 - name: Janice Hahn
   party: minority
-  rank: 5
+  rank: 3
   bioguide: H001063
   thomas: '02089'
 - name: Donald M. Payne Jr.
   party: minority
-  rank: 6
+  rank: 4
   bioguide: P000604
   thomas: '02097'
 - name: Grace Meng
+  party: minority
+  rank: 5
+  bioguide: M001188
+  thomas: '02148'
+- name: Brenda L. Lawrence
+  party: minority
+  rank: 6
+  bioguide: L000581
+  thomas: '02252'
+- name: Alma S. Adams
   party: minority
   rank: 7
-  bioguide: M001188
-  thomas: '02148'
-- name: Bradley S. Schneider
-  party: minority
-  rank: 8
-  bioguide: S001190
-  thomas: '02124'
-- name: Ron Barber
-  party: minority
-  rank: 9
-  bioguide: B001279
-  thomas: '02093'
-- name: Ann M. Kuster
-  party: minority
-  rank: 10
-  bioguide: K000382
-  thomas: '02145'
-- name: Patrick Murphy
-  party: minority
-  rank: 11
-  bioguide: M001191
-  thomas: '02117'
-HSSM23:
-- name: Richard L. Hanna
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: H001051
-  thomas: '02044'
-- name: Steve King
-  party: majority
-  rank: 2
-  bioguide: K000362
-  thomas: '01724'
-- name: Mick Mulvaney
-  party: majority
-  rank: 3
-  bioguide: M001182
-  thomas: '02059'
-- name: Scott R. Tipton
-  party: majority
-  rank: 4
-  bioguide: T000470
-  thomas: '01997'
-- name: Tim Huelskamp
-  party: majority
-  rank: 5
-  bioguide: H001057
-  thomas: '02020'
-- name: Kerry L. Bentivolio
-  party: majority
-  rank: 6
-  bioguide: B001280
-  thomas: '02135'
-- name: Grace Meng
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M001188
-  thomas: '02148'
-- name: Yvette D. Clarke
-  party: minority
-  rank: 2
-  bioguide: C001067
-  thomas: '01864'
-- name: Judy Chu
-  party: minority
-  rank: 3
-  bioguide: C001080
-  thomas: '01970'
-HSSM24:
-- name: Steve Chabot
-  party: majority
-  rank: 2
-  bioguide: C000266
-  thomas: '00186'
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 3
-  bioguide: H001056
-  thomas: '02071'
-- name: Kerry L. Bentivolio
-  party: majority
-  rank: 4
-  bioguide: B001280
-  thomas: '02135'
-- name: Chris Collins
-  party: majority
-  rank: 5
-  bioguide: C001092
-  thomas: '02151'
-- name: Tom Rice
-  party: majority
-  rank: 6
-  bioguide: R000597
-  thomas: '02160'
-- name: Yvette D. Clarke
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001067
-  thomas: '01864'
-- name: Judy Chu
-  party: minority
-  rank: 2
-  bioguide: C001080
-  thomas: '01970'
-- name: Ann M. Kuster
-  party: minority
-  rank: 3
-  bioguide: K000382
-  thomas: '02145'
-HSSM25:
-- name: Scott R. Tipton
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: T000470
-  thomas: '01997'
-- name: Steve King
-  party: majority
-  rank: 2
-  bioguide: K000362
-  thomas: '01724'
-- name: Blaine Luetkemeyer
-  party: majority
-  rank: 3
-  bioguide: L000569
-  thomas: '01931'
-- name: Mick Mulvaney
-  party: majority
-  rank: 4
-  bioguide: M001182
-  thomas: '02059'
-- name: Richard L. Hanna
-  party: majority
-  rank: 5
-  bioguide: H001051
-  thomas: '02044'
-- name: Tim Huelskamp
-  party: majority
-  rank: 6
-  bioguide: H001057
-  thomas: '02020'
-- name: Patrick Murphy
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M001191
-  thomas: '02117'
-- name: Kurt Schrader
-  party: minority
-  rank: 2
-  bioguide: S001180
-  thomas: '01950'
-- name: Grace Meng
-  party: minority
-  rank: 3
-  bioguide: M001188
-  thomas: '02148'
-- name: Ron Barber
-  party: minority
-  rank: 4
-  bioguide: B001279
-  thomas: '02093'
-HSSM26:
-- name: Chris Collins
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001092
-  thomas: '02151'
-- name: Steve King
-  party: majority
-  rank: 2
-  bioguide: K000362
-  thomas: '01724'
-- name: Mike Coffman
-  party: majority
-  rank: 3
-  bioguide: C001077
-  thomas: '01912'
-- name: Blaine Luetkemeyer
-  party: majority
-  rank: 4
-  bioguide: L000569
-  thomas: '01931'
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 5
-  bioguide: H001056
-  thomas: '02071'
-- name: Tim Huelskamp
-  party: majority
-  rank: 6
-  bioguide: H001057
-  thomas: '02020'
-- name: Janice Hahn
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H001063
-  thomas: '02089'
-- name: Kurt Schrader
-  party: minority
-  rank: 2
-  bioguide: S001180
-  thomas: '01950'
-- name: Bradley S. Schneider
-  party: minority
-  rank: 3
-  bioguide: S001190
-  thomas: '02124'
-HSSM27:
-- name: Tom Rice
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: R000597
-  thomas: '02160'
-- name: Steve Chabot
-  party: majority
-  rank: 2
-  bioguide: C000266
-  thomas: '00186'
-- name: Steve King
-  party: majority
-  rank: 3
-  bioguide: K000362
-  thomas: '01724'
-- name: Mike Coffman
-  party: majority
-  rank: 4
-  bioguide: C001077
-  thomas: '01912'
-- name: Mick Mulvaney
-  party: majority
-  rank: 5
-  bioguide: M001182
-  thomas: '02059'
-- name: David Schweikert
-  party: majority
-  rank: 6
-  bioguide: S001183
-  thomas: '01994'
-- name: Judy Chu
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001080
-  thomas: '01970'
-- name: Donald M. Payne Jr.
-  party: minority
-  rank: 2
-  bioguide: P000604
-  thomas: '02097'
-- name: Bradley S. Schneider
-  party: minority
-  rank: 3
-  bioguide: S001190
-  thomas: '02124'
-- name: Ron Barber
-  party: minority
-  rank: 4
-  bioguide: B001279
-  thomas: '02093'
+  bioguide: A000370
+  thomas: '02201'
 HSSO:
-- name: K. Michael Conaway
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001062
-  thomas: '01805'
 - name: Charles W. Dent
   party: majority
-  rank: 2
+  rank: 1
+  title: Chair
   bioguide: D000604
   thomas: '01799'
 - name: Patrick Meehan
   party: majority
-  rank: 3
+  rank: 2
   bioguide: M001181
   thomas: '02052'
 - name: Trey Gowdy
   party: majority
-  rank: 4
+  rank: 3
   bioguide: G000566
   thomas: '02058'
 - name: Susan W. Brooks
   party: majority
-  rank: 5
+  rank: 4
   bioguide: B001284
   thomas: '02129'
+- name: Kenny Marchant
+  party: majority
+  rank: 5
+  bioguide: M001158
+  thomas: '01806'
 - name: Linda T. Sánchez
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001156
   thomas: '01757'
-- name: Pedro R. Pierluisi
-  party: minority
-  rank: 2
-  bioguide: P000596
-  thomas: '01953'
 - name: Michael E. Capuano
   party: minority
-  rank: 3
+  rank: 2
   bioguide: C001037
   thomas: '01564'
 - name: Yvette D. Clarke
   party: minority
-  rank: 4
+  rank: 3
   bioguide: C001067
   thomas: '01864'
 - name: Theodore E. Deutch
   party: minority
-  rank: 5
+  rank: 4
   bioguide: D000610
   thomas: '01976'
+- name: John B. Larson
+  party: minority
+  rank: 5
+  bioguide: L000557
+  thomas: '01583'
 HSSY:
 - name: Lamar Smith
   party: majority
@@ -10777,106 +8920,106 @@ HSSY:
   rank: 2
   bioguide: S000244
   thomas: '01041'
-- name: Ralph M. Hall
-  party: majority
-  rank: 3
-  bioguide: H000067
-  thomas: '00484'
 - name: Dana Rohrabacher
   party: majority
-  rank: 4
+  rank: 3
   bioguide: R000409
   thomas: '00979'
 - name: Frank D. Lucas
   party: majority
-  rank: 5
+  rank: 4
   bioguide: L000491
   thomas: '00711'
 - name: Randy Neugebauer
   party: majority
-  rank: 6
+  rank: 5
   bioguide: N000182
   thomas: '01758'
 - name: Michael T. McCaul
   party: majority
-  rank: 7
+  rank: 6
   bioguide: M001157
   thomas: '01804'
-- name: Paul C. Broun
-  party: majority
-  rank: 8
-  bioguide: B001262
-  thomas: '01882'
 - name: Steven M. Palazzo
   party: majority
-  rank: 9
+  rank: 7
   bioguide: P000601
   thomas: '02035'
 - name: Mo Brooks
   party: majority
-  rank: 10
+  rank: 8
   bioguide: B001274
   thomas: '01987'
 - name: Randy Hultgren
   party: majority
-  rank: 11
+  rank: 9
   bioguide: H001059
   thomas: '02015'
-- name: Larry Bucshon
-  party: majority
-  rank: 12
-  bioguide: B001275
-  thomas: '02018'
-- name: Steve Stockman
-  party: majority
-  rank: 13
-  bioguide: S000937
-  thomas: '01114'
 - name: Bill Posey
   party: majority
-  rank: 14
+  rank: 10
   bioguide: P000599
   thomas: '01915'
-- name: Cynthia M. Lummis
-  party: majority
-  rank: 15
-  bioguide: L000571
-  thomas: '01960'
-- name: David Schweikert
-  party: majority
-  rank: 16
-  bioguide: S001183
-  thomas: '01994'
 - name: Thomas Massie
   party: majority
-  rank: 17
+  rank: 11
   bioguide: M001184
   thomas: '02094'
-- name: Kevin Cramer
-  party: majority
-  rank: 18
-  bioguide: C001096
-  thomas: '02144'
 - name: Jim Bridenstine
   party: majority
-  rank: 19
+  rank: 12
   bioguide: B001283
   thomas: '02155'
 - name: Randy K. Weber Sr.
   party: majority
-  rank: 20
+  rank: 13
   bioguide: W000814
   thomas: '02161'
-- name: Chris Collins
-  party: majority
-  rank: 21
-  bioguide: C001092
-  thomas: '02151'
 - name: Bill Johnson
   party: majority
-  rank: 22
+  rank: 14
   bioguide: J000292
   thomas: '02046'
+- name: John R. Moolenaar
+  party: majority
+  rank: 15
+  bioguide: M001194
+  thomas: '02248'
+- name: Stephen Knight
+  party: majority
+  rank: 16
+  bioguide: K000387
+  thomas: '02228'
+- name: Brian Babin
+  party: majority
+  rank: 17
+  bioguide: B001291
+  thomas: '02270'
+- name: Bruce Westerman
+  party: majority
+  rank: 18
+  bioguide: W000821
+  thomas: '02224'
+- name: Barbara Comstock
+  party: majority
+  rank: 19
+  bioguide: C001105
+  thomas: '02273'
+- name: Dan Newhouse
+  party: majority
+  rank: 20
+  bioguide: N000189
+  thomas: '02275'
+- name: Gary J. Palmer
+  party: majority
+  rank: 21
+  bioguide: P000609
+  thomas: '02221'
+- name: Barry Loudermilk
+  party: majority
+  rank: 22
+  bioguide: L000583
+  thomas: '02238'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 1
@@ -10913,164 +9056,102 @@ HSSY:
   rank: 7
   bioguide: S001193
   thomas: '02104'
-- name: Daniel B. Maffei
-  party: minority
-  rank: 8
-  bioguide: M001171
-  thomas: '01943'
 - name: Alan Grayson
   party: minority
-  rank: 9
+  rank: 8
   bioguide: G000556
   thomas: '01914'
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 10
-  bioguide: K000379
-  thomas: '02172'
-- name: Scott H. Peters
-  party: minority
-  rank: 11
-  bioguide: P000608
-  thomas: '02113'
-- name: Derek Kilmer
-  party: minority
-  rank: 12
-  bioguide: K000381
-  thomas: '02169'
 - name: Ami Bera
   party: minority
-  rank: 13
+  rank: 9
   bioguide: B001287
   thomas: '02102'
 - name: Elizabeth H. Esty
   party: minority
-  rank: 14
+  rank: 10
   bioguide: E000293
   thomas: '02114'
 - name: Marc A. Veasey
   party: minority
-  rank: 15
+  rank: 11
   bioguide: V000131
   thomas: '02166'
-- name: Julia Brownley
-  party: minority
-  rank: 16
-  bioguide: B001285
-  thomas: '02106'
-- name: Robin L. Kelly
-  party: minority
-  rank: 17
-  bioguide: K000385
-  thomas: '02190'
 - name: Katherine M. Clark
   party: minority
-  rank: 18
+  rank: 12
   bioguide: C001101
   thomas: '02196'
+- name: Donald S. Beyer Jr.
+  party: minority
+  rank: 13
+  bioguide: B001292
+  thomas: '02272'
+- name: Ed Perlmutter
+  party: minority
+  rank: 14
+  bioguide: P000593
+  thomas: '01835'
+- name: Paul Tonko
+  party: minority
+  rank: 15
+  bioguide: T000469
+  thomas: '01942'
 HSSY15:
-- name: Larry Bucshon
+- name: Barbara Comstock
   party: majority
   rank: 1
   title: Chair
-  bioguide: B001275
-  thomas: '02018'
-- name: Steven M. Palazzo
+  bioguide: C001105
+  thomas: '02273'
+- name: Frank D. Lucas
   party: majority
   rank: 2
-  bioguide: P000601
-  thomas: '02035'
-- name: Mo Brooks
+  bioguide: L000491
+  thomas: '00711'
+- name: Michael T. McCaul
   party: majority
   rank: 3
-  bioguide: B001274
-  thomas: '01987'
-- name: Randy Hultgren
+  bioguide: M001157
+  thomas: '01804'
+- name: Steven M. Palazzo
   party: majority
   rank: 4
-  bioguide: H001059
-  thomas: '02015'
-- name: Steve Stockman
+  bioguide: P000601
+  thomas: '02035'
+- name: Randy Hultgren
   party: majority
   rank: 5
-  bioguide: S000937
-  thomas: '01114'
-- name: Cynthia M. Lummis
+  bioguide: H001059
+  thomas: '02015'
+- name: John R. Moolenaar
   party: majority
   rank: 6
-  bioguide: L000571
-  thomas: '01960'
-- name: Thomas Massie
+  bioguide: M001194
+  thomas: '02248'
+- name: Stephen Knight
   party: majority
   rank: 7
-  bioguide: M001184
-  thomas: '02094'
-  title: Vice Chair
-- name: Jim Bridenstine
+  bioguide: K000387
+  thomas: '02228'
+- name: Bruce Westerman
   party: majority
   rank: 8
-  bioguide: B001283
-  thomas: '02155'
-- name: Chris Collins
+  bioguide: W000821
+  thomas: '02224'
+- name: Gary J. Palmer
   party: majority
   rank: 9
-  bioguide: C001092
-  thomas: '02151'
-- name: Bill Johnson
-  party: majority
-  rank: 10
-  bioguide: J000292
-  thomas: '02046'
+  bioguide: P000609
+  thomas: '02221'
 - name: Lamar Smith
   party: majority
-  rank: 11
+  rank: 10
   bioguide: S000583
   thomas: '01075'
   title: Ex Officio
-- name: Daniel Lipinski
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000563
-  thomas: '01781'
-- name: Frederica S. Wilson
-  party: minority
-  rank: 2
-  bioguide: W000808
-  thomas: '02004'
-- name: Zoe Lofgren
-  party: minority
-  rank: 3
-  bioguide: L000397
-  thomas: '00701'
-- name: Scott H. Peters
-  party: minority
-  rank: 4
-  bioguide: P000608
-  thomas: '02113'
-- name: Ami Bera
-  party: minority
-  rank: 5
-  bioguide: B001287
-  thomas: '02102'
-- name: Derek Kilmer
-  party: minority
-  rank: 6
-  bioguide: K000381
-  thomas: '02169'
-- name: Elizabeth H. Esty
-  party: minority
-  rank: 7
-  bioguide: E000293
-  thomas: '02114'
-- name: Robin L. Kelly
-  party: minority
-  rank: 8
-  bioguide: K000385
-  thomas: '02190'
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 9
+  rank: 7
   bioguide: J000126
   thomas: '00599'
   title: Ex Officio
@@ -11081,299 +9162,184 @@ HSSY16:
   title: Chair
   bioguide: P000601
   thomas: '02035'
-- name: Ralph M. Hall
-  party: majority
-  rank: 2
-  bioguide: H000067
-  thomas: '00484'
 - name: Dana Rohrabacher
   party: majority
-  rank: 3
+  rank: 2
   bioguide: R000409
   thomas: '00979'
 - name: Frank D. Lucas
   party: majority
-  rank: 4
+  rank: 3
   bioguide: L000491
   thomas: '00711'
 - name: Michael T. McCaul
   party: majority
-  rank: 5
+  rank: 4
   bioguide: M001157
   thomas: '01804'
 - name: Mo Brooks
   party: majority
-  rank: 6
+  rank: 5
   bioguide: B001274
   thomas: '01987'
   title: Vice Chair
-- name: Larry Bucshon
-  party: majority
-  rank: 7
-  bioguide: B001275
-  thomas: '02018'
-- name: Steve Stockman
-  party: majority
-  rank: 8
-  bioguide: S000937
-  thomas: '01114'
 - name: Bill Posey
   party: majority
-  rank: 9
+  rank: 6
   bioguide: P000599
   thomas: '01915'
-- name: David Schweikert
+- name: Bill Johnson
   party: majority
-  rank: 10
-  bioguide: S001183
-  thomas: '01994'
-- name: Jim Bridenstine
+  rank: 7
+  bioguide: J000292
+  thomas: '02046'
+- name: Stephen Knight
   party: majority
-  rank: 11
-  bioguide: B001283
-  thomas: '02155'
-- name: Chris Collins
+  rank: 8
+  bioguide: K000387
+  thomas: '02228'
+- name: Brian Babin
   party: majority
-  rank: 12
-  bioguide: C001092
-  thomas: '02151'
+  rank: 9
+  bioguide: B001291
+  thomas: '02270'
 - name: Lamar Smith
   party: majority
-  rank: 13
+  rank: 10
   bioguide: S000583
   thomas: '01075'
   title: Ex Officio
-- name: Donna F. Edwards
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: E000290
-  thomas: '01894'
-- name: Suzanne Bonamici
-  party: minority
-  rank: 2
-  bioguide: B001278
-  thomas: '02092'
-- name: Daniel B. Maffei
-  party: minority
-  rank: 3
-  bioguide: M001171
-  thomas: '01943'
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 4
-  bioguide: K000379
-  thomas: '02172'
-- name: Derek Kilmer
-  party: minority
-  rank: 5
-  bioguide: K000381
-  thomas: '02169'
-- name: Ami Bera
-  party: minority
-  rank: 6
-  bioguide: B001287
-  thomas: '02102'
-- name: Marc A. Veasey
-  party: minority
-  rank: 7
-  bioguide: V000131
-  thomas: '02166'
-- name: Julia Brownley
-  party: minority
-  rank: 8
-  bioguide: B001285
-  thomas: '02106'
-- name: Frederica S. Wilson
-  party: minority
-  rank: 9
-  bioguide: W000808
-  thomas: '02004'
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 10
+  rank: 7
   bioguide: J000126
   thomas: '00599'
   title: Ex Officio
 HSSY18:
-- name: David Schweikert
+- name: Jim Bridenstine
   party: majority
   rank: 1
   title: Chair
-  bioguide: S001183
-  thomas: '01994'
+  bioguide: B001283
+  thomas: '02155'
 - name: F. James Sensenbrenner Jr.
   party: majority
   rank: 2
   bioguide: S000244
   thomas: '01041'
-- name: Dana Rohrabacher
-  party: majority
-  rank: 3
-  bioguide: R000409
-  thomas: '00979'
 - name: Randy Neugebauer
   party: majority
-  rank: 4
+  rank: 3
   bioguide: N000182
   thomas: '01758'
-- name: Paul C. Broun
-  party: majority
-  rank: 5
-  bioguide: B001262
-  thomas: '01882'
-- name: Jim Bridenstine
-  party: majority
-  rank: 6
-  bioguide: B001283
-  thomas: '02155'
-  title: Vice Chair
 - name: Randy K. Weber Sr.
   party: majority
-  rank: 7
+  rank: 4
   bioguide: W000814
   thomas: '02161'
-- name: Lamar Smith
-  party: majority
-  rank: 8
-  bioguide: S000583
-  thomas: '01075'
-  title: Ex Officio
-- name: Suzanne Bonamici
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001278
-  thomas: '02092'
-- name: Julia Brownley
-  party: minority
-  rank: 2
-  bioguide: B001285
-  thomas: '02106'
-- name: Donna F. Edwards
-  party: minority
-  rank: 3
-  bioguide: E000290
-  thomas: '01894'
-- name: Alan Grayson
-  party: minority
-  rank: 4
-  bioguide: G000556
-  thomas: '01914'
-- name: Katherine M. Clark
-  party: minority
-  rank: 5
-  bioguide: C001101
-  thomas: '02196'
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 6
-  bioguide: J000126
-  thomas: '00599'
-  title: Ex Officio
-HSSY20:
-- name: Cynthia M. Lummis
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: L000571
-  thomas: '01960'
-- name: Ralph M. Hall
-  party: majority
-  rank: 2
-  bioguide: H000067
-  thomas: '00484'
-- name: Frank D. Lucas
-  party: majority
-  rank: 3
-  bioguide: L000491
-  thomas: '00711'
-- name: Randy Neugebauer
-  party: majority
-  rank: 4
-  bioguide: N000182
-  thomas: '01758'
-- name: Michael T. McCaul
+- name: John R. Moolenaar
   party: majority
   rank: 5
-  bioguide: M001157
-  thomas: '01804'
-- name: Randy Hultgren
+  bioguide: M001194
+  thomas: '02248'
+- name: Brian Babin
   party: majority
   rank: 6
-  bioguide: H001059
-  thomas: '02015'
-- name: Thomas Massie
+  bioguide: B001291
+  thomas: '02270'
+- name: Bruce Westerman
   party: majority
   rank: 7
-  bioguide: M001184
-  thomas: '02094'
-- name: Kevin Cramer
+  bioguide: W000821
+  thomas: '02224'
+- name: Dan Newhouse
   party: majority
   rank: 8
-  bioguide: C001096
-  thomas: '02144'
-- name: Randy K. Weber Sr.
+  bioguide: N000189
+  thomas: '02275'
+- name: Gary J. Palmer
   party: majority
   rank: 9
-  bioguide: W000814
-  thomas: '02161'
-  title: Vice Chair
+  bioguide: P000609
+  thomas: '02221'
 - name: Lamar Smith
   party: majority
   rank: 10
   bioguide: S000583
   thomas: '01075'
   title: Ex Officio
-- name: Eric Swalwell
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001193
-  thomas: '02104'
-- name: Alan Grayson
-  party: minority
-  rank: 2
-  bioguide: G000556
-  thomas: '01914'
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 3
-  bioguide: K000379
-  thomas: '02172'
-- name: Marc A. Veasey
-  party: minority
-  rank: 4
-  bioguide: V000131
-  thomas: '02166'
-- name: Zoe Lofgren
-  party: minority
-  rank: 5
-  bioguide: L000397
-  thomas: '00701'
-- name: Daniel Lipinski
-  party: minority
-  rank: 6
-  bioguide: L000563
-  thomas: '01781'
-- name: Katherine M. Clark
-  party: minority
-  rank: 7
-  bioguide: C001101
-  thomas: '02196'
 - name: Eddie Bernice Johnson
   party: minority
+  rank: 7
+  bioguide: J000126
+  thomas: '00599'
+  title: Ex Officio
+HSSY20:
+- name: Randy K. Weber Sr.
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: W000814
+  thomas: '02161'
+- name: Dana Rohrabacher
+  party: majority
+  rank: 2
+  bioguide: R000409
+  thomas: '00979'
+- name: Randy Neugebauer
+  party: majority
+  rank: 3
+  bioguide: N000182
+  thomas: '01758'
+- name: Mo Brooks
+  party: majority
+  rank: 4
+  bioguide: B001274
+  thomas: '01987'
+- name: Randy Hultgren
+  party: majority
+  rank: 5
+  bioguide: H001059
+  thomas: '02015'
+- name: Thomas Massie
+  party: majority
+  rank: 6
+  bioguide: M001184
+  thomas: '02094'
+- name: Barbara Comstock
+  party: majority
+  rank: 7
+  bioguide: C001105
+  thomas: '02273'
+- name: Dan Newhouse
+  party: majority
   rank: 8
+  bioguide: N000189
+  thomas: '02275'
+- name: Barry Loudermilk
+  party: majority
+  rank: 9
+  bioguide: L000583
+  thomas: '02238'
+- name: Lamar Smith
+  party: majority
+  rank: 10
+  bioguide: S000583
+  thomas: '01075'
+  title: Ex Officio
+- name: Eddie Bernice Johnson
+  party: minority
+  rank: 7
   bioguide: J000126
   thomas: '00599'
   title: Ex Officio
 HSSY21:
-- name: Paul C. Broun
+- name: Barry Loudermilk
   party: majority
   rank: 1
   title: Chair
-  bioguide: B001262
-  thomas: '01882'
+  bioguide: L000583
+  thomas: '02238'
 - name: F. James Sensenbrenner Jr.
   party: majority
   rank: 2
@@ -11384,42 +9350,30 @@ HSSY21:
   rank: 3
   bioguide: P000599
   thomas: '01915'
-- name: Kevin Cramer
+- name: Thomas Massie
   party: majority
   rank: 4
-  bioguide: C001096
-  thomas: '02144'
-  title: Vice Chair
-- name: Bill Johnson
+  bioguide: M001184
+  thomas: '02094'
+- name: Jim Bridenstine
   party: majority
   rank: 5
+  bioguide: B001283
+  thomas: '02155'
+- name: Bill Johnson
+  party: majority
+  rank: 6
   bioguide: J000292
   thomas: '02046'
 - name: Lamar Smith
   party: majority
-  rank: 6
+  rank: 7
   bioguide: S000583
   thomas: '01075'
   title: Ex Officio
-- name: Daniel B. Maffei
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M001171
-  thomas: '01943'
-- name: Eric Swalwell
-  party: minority
-  rank: 2
-  bioguide: S001193
-  thomas: '02104'
-- name: Scott H. Peters
-  party: minority
-  rank: 3
-  bioguide: P000608
-  thomas: '02113'
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 4
+  rank: 5
   bioguide: J000126
   thomas: '00599'
   title: Ex Officio
@@ -11445,112 +9399,107 @@ HSVR:
   rank: 4
   bioguide: R000582
   thomas: '01954'
-- name: Bill Flores
-  party: majority
-  rank: 5
-  bioguide: F000461
-  thomas: '02065'
-- name: Jeff Denham
-  party: majority
-  rank: 6
-  bioguide: D000612
-  thomas: '01995'
-- name: Jon Runyan
-  party: majority
-  rank: 7
-  bioguide: R000594
-  thomas: '02039'
 - name: Dan Benishek
   party: majority
-  rank: 8
+  rank: 5
   bioguide: B001271
   thomas: '02027'
 - name: Tim Huelskamp
   party: majority
-  rank: 9
+  rank: 6
   bioguide: H001057
   thomas: '02020'
 - name: Mike Coffman
   party: majority
-  rank: 10
+  rank: 7
   bioguide: C001077
   thomas: '01912'
 - name: Brad R. Wenstrup
   party: majority
-  rank: 11
+  rank: 8
   bioguide: W000815
   thomas: '02152'
-- name: Paul Cook
-  party: majority
-  rank: 12
-  bioguide: C001094
-  thomas: '02103'
 - name: Jackie Walorski
   party: majority
-  rank: 13
+  rank: 9
   bioguide: W000813
   thomas: '02128'
-- name: David W. Jolly
+- name: Ralph Lee Abraham
+  party: majority
+  rank: 10
+  bioguide: A000374
+  thomas: '02244'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 11
+  bioguide: Z000017
+  thomas: '02261'
+- name: Ryan A. Costello
+  party: majority
+  rank: 12
+  bioguide: C001106
+  thomas: '02266'
+- name: Amata Coleman Radewagen
+  party: majority
+  rank: 13
+  bioguide: R000600
+  thomas: '02222'
+- name: Mike Bost
   party: majority
   rank: 14
-  bioguide: J000296
-  thomas: '02199'
-- name: Michael H. Michaud
+  bioguide: B001295
+  thomas: '02243'
+- name: Corrine Brown
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: M001149
-  thomas: '01730'
-- name: Corrine Brown
-  party: minority
-  rank: 2
   bioguide: B000911
   thomas: '00132'
 - name: Mark Takano
   party: minority
-  rank: 3
+  rank: 2
   bioguide: T000472
   thomas: '02110'
 - name: Julia Brownley
   party: minority
-  rank: 4
+  rank: 3
   bioguide: B001285
   thomas: '02106'
 - name: Dina Titus
   party: minority
-  rank: 5
+  rank: 4
   bioguide: T000468
   thomas: '01940'
-- name: Ann Kirkpatrick
-  party: minority
-  rank: 6
-  bioguide: K000368
-  thomas: '01907'
 - name: Raul Ruiz
   party: minority
-  rank: 7
+  rank: 5
   bioguide: R000599
   thomas: '02109'
-- name: Gloria Negrete McLeod
-  party: minority
-  rank: 8
-  bioguide: N000187
-  thomas: '02108'
 - name: Ann M. Kuster
   party: minority
-  rank: 9
+  rank: 6
   bioguide: K000382
   thomas: '02145'
 - name: Beto O'Rourke
   party: minority
-  rank: 10
+  rank: 7
   bioguide: O000170
   thomas: '02162'
+- name: Kathleen M. Rice
+  party: minority
+  rank: 8
+  bioguide: R000602
+  thomas: '02262'
 - name: Timothy J. Walz
   party: minority
-  rank: 11
+  rank: 9
   bioguide: W000799
   thomas: '01856'
+- name: Jerry McNerney
+  party: minority
+  rank: 10
+  bioguide: M001166
+  thomas: '01832'
 HSVR03:
 - name: Dan Benishek
   party: majority
@@ -11558,57 +9507,62 @@ HSVR03:
   title: Chair
   bioguide: B001271
   thomas: '02027'
-- name: David P. Roe
+- name: Gus M. Bilirakis
   party: majority
   rank: 2
-  bioguide: R000582
-  thomas: '01954'
-- name: Jeff Denham
+  bioguide: B001257
+  thomas: '01838'
+- name: David P. Roe
   party: majority
   rank: 3
-  bioguide: D000612
-  thomas: '01995'
+  bioguide: R000582
+  thomas: '01954'
 - name: Tim Huelskamp
   party: majority
   rank: 4
   bioguide: H001057
   thomas: '02020'
-- name: Jackie Walorski
+- name: Mike Coffman
   party: majority
   rank: 5
-  bioguide: W000813
-  thomas: '02128'
+  bioguide: C001077
+  thomas: '01912'
 - name: Brad R. Wenstrup
   party: majority
   rank: 6
   bioguide: W000815
   thomas: '02152'
+- name: Ralph Lee Abraham
+  party: majority
+  rank: 7
+  bioguide: A000374
+  thomas: '02244'
 - name: Julia Brownley
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001285
   thomas: '02106'
-- name: Corrine Brown
+- name: Mark Takano
   party: minority
   rank: 2
-  bioguide: B000911
-  thomas: '00132'
+  bioguide: T000472
+  thomas: '02110'
 - name: Raul Ruiz
   party: minority
   rank: 3
   bioguide: R000599
   thomas: '02109'
-- name: Gloria Negrete McLeod
-  party: minority
-  rank: 4
-  bioguide: N000187
-  thomas: '02108'
 - name: Ann M. Kuster
   party: minority
-  rank: 5
+  rank: 4
   bioguide: K000382
   thomas: '02145'
+- name: Beto O'Rourke
+  party: minority
+  rank: 5
+  bioguide: O000170
+  thomas: '02162'
 HSVR08:
 - name: Mike Coffman
   party: majority
@@ -11626,145 +9580,120 @@ HSVR08:
   rank: 3
   bioguide: R000582
   thomas: '01954'
-- name: Tim Huelskamp
-  party: majority
-  rank: 4
-  bioguide: H001057
-  thomas: '02020'
 - name: Dan Benishek
   party: majority
-  rank: 5
+  rank: 4
   bioguide: B001271
   thomas: '02027'
+- name: Tim Huelskamp
+  party: majority
+  rank: 5
+  bioguide: H001057
+  thomas: '02020'
 - name: Jackie Walorski
   party: majority
   rank: 6
   bioguide: W000813
   thomas: '02128'
-- name: Ann Kirkpatrick
+- name: Ann M. Kuster
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: K000368
-  thomas: '01907'
-- name: Mark Takano
-  party: minority
-  rank: 2
-  bioguide: T000472
-  thomas: '02110'
-- name: Ann M. Kuster
-  party: minority
-  rank: 3
   bioguide: K000382
   thomas: '02145'
 - name: Beto O'Rourke
   party: minority
-  rank: 4
+  rank: 2
   bioguide: O000170
   thomas: '02162'
-- name: Timothy J. Walz
-  party: minority
-  rank: 5
-  bioguide: W000799
-  thomas: '01856'
 HSVR09:
-- name: Jon Runyan
+- name: Ralph Lee Abraham
   party: majority
   rank: 1
   title: Chair
-  bioguide: R000594
-  thomas: '02039'
+  bioguide: A000374
+  thomas: '02244'
 - name: Doug Lamborn
   party: majority
   rank: 2
   bioguide: L000564
   thomas: '01834'
-- name: Gus M. Bilirakis
+- name: Lee M. Zeldin
   party: majority
   rank: 3
-  bioguide: B001257
-  thomas: '01838'
-- name: Paul Cook
+  bioguide: Z000017
+  thomas: '02261'
+- name: Ryan A. Costello
   party: majority
   rank: 4
-  bioguide: C001094
-  thomas: '02103'
+  bioguide: C001106
+  thomas: '02266'
+- name: Mike Bost
+  party: majority
+  rank: 5
+  bioguide: B001295
+  thomas: '02243'
 - name: Dina Titus
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: T000468
   thomas: '01940'
-- name: Beto O'Rourke
+- name: Julia Brownley
   party: minority
   rank: 2
-  bioguide: O000170
-  thomas: '02162'
+  bioguide: B001285
+  thomas: '02106'
 - name: Raul Ruiz
   party: minority
   rank: 3
   bioguide: R000599
   thomas: '02109'
-- name: Gloria Negrete McLeod
-  party: minority
-  rank: 4
-  bioguide: N000187
-  thomas: '02108'
 HSVR10:
-- name: Bill Flores
+- name: Brad R. Wenstrup
   party: majority
   rank: 1
   title: Chair
-  bioguide: F000461
-  thomas: '02065'
-- name: Jon Runyan
-  party: majority
-  rank: 2
-  bioguide: R000594
-  thomas: '02039'
-- name: Mike Coffman
-  party: majority
-  rank: 3
-  bioguide: C001077
-  thomas: '01912'
-- name: Paul Cook
-  party: majority
-  rank: 4
-  bioguide: C001094
-  thomas: '02103'
-- name: Brad R. Wenstrup
-  party: majority
-  rank: 5
   bioguide: W000815
   thomas: '02152'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 2
+  bioguide: Z000017
+  thomas: '02261'
+- name: Amata Coleman Radewagen
+  party: majority
+  rank: 3
+  bioguide: R000600
+  thomas: '02222'
+- name: Ryan A. Costello
+  party: majority
+  rank: 4
+  bioguide: C001106
+  thomas: '02266'
+- name: Mike Bost
+  party: majority
+  rank: 5
+  bioguide: B001295
+  thomas: '02243'
 - name: Mark Takano
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: T000472
   thomas: '02110'
-- name: Julia Brownley
-  party: minority
-  rank: 2
-  bioguide: B001285
-  thomas: '02106'
 - name: Dina Titus
   party: minority
-  rank: 3
+  rank: 2
   bioguide: T000468
   thomas: '01940'
-- name: Ann Kirkpatrick
-  party: minority
-  rank: 4
-  bioguide: K000368
-  thomas: '01907'
 HSWM:
-- name: Dave Camp
+- name: Paul Ryan
   party: majority
   rank: 1
   title: Chair
-  bioguide: C000071
-  thomas: '00166'
+  bioguide: R000570
+  thomas: '01560'
 - name: Sam Johnson
   party: majority
   rank: 2
@@ -11775,106 +9704,111 @@ HSWM:
   rank: 3
   bioguide: B000755
   thomas: '01468'
-- name: Paul Ryan
-  party: majority
-  rank: 4
-  bioguide: R000570
-  thomas: '01560'
 - name: Devin Nunes
   party: majority
-  rank: 5
+  rank: 4
   bioguide: N000181
   thomas: '01710'
 - name: Patrick J. Tiberi
   party: majority
-  rank: 6
+  rank: 5
   bioguide: T000462
   thomas: '01664'
 - name: David G. Reichert
   party: majority
-  rank: 7
+  rank: 6
   bioguide: R000578
   thomas: '01810'
 - name: Charles W. Boustany Jr.
   party: majority
-  rank: 8
+  rank: 7
   bioguide: B001255
   thomas: '01787'
 - name: Peter J. Roskam
   party: majority
-  rank: 9
+  rank: 8
   bioguide: R000580
   thomas: '01848'
-- name: Jim Gerlach
-  party: majority
-  rank: 10
-  bioguide: G000549
-  thomas: '01743'
 - name: Tom Price
   party: majority
-  rank: 11
+  rank: 9
   bioguide: P000591
   thomas: '01778'
 - name: Vern Buchanan
   party: majority
-  rank: 12
+  rank: 10
   bioguide: B001260
   thomas: '01840'
 - name: Adrian Smith
   party: majority
-  rank: 13
+  rank: 11
   bioguide: S001172
   thomas: '01860'
 - name: Aaron Schock
   party: majority
-  rank: 14
+  rank: 12
   bioguide: S001179
   thomas: '01920'
 - name: Lynn Jenkins
   party: majority
-  rank: 15
+  rank: 13
   bioguide: J000290
   thomas: '01921'
 - name: Erik Paulsen
   party: majority
-  rank: 16
+  rank: 14
   bioguide: P000594
   thomas: '01930'
 - name: Kenny Marchant
   party: majority
-  rank: 17
+  rank: 15
   bioguide: M001158
   thomas: '01806'
 - name: Diane Black
   party: majority
-  rank: 18
+  rank: 16
   bioguide: B001273
   thomas: '02063'
 - name: Tom Reed
   party: majority
-  rank: 19
+  rank: 17
   bioguide: R000585
   thomas: '01982'
 - name: Todd C. Young
   party: majority
-  rank: 20
+  rank: 18
   bioguide: Y000064
   thomas: '02019'
 - name: Mike Kelly
   party: majority
-  rank: 21
+  rank: 19
   bioguide: K000376
   thomas: '02051'
-- name: Tim Griffin
-  party: majority
-  rank: 22
-  bioguide: G000567
-  thomas: '01990'
 - name: James B. Renacci
   party: majority
-  rank: 23
+  rank: 20
   bioguide: R000586
   thomas: '02048'
+- name: Patrick Meehan
+  party: majority
+  rank: 21
+  bioguide: M001181
+  thomas: '02052'
+- name: Kristi L. Noem
+  party: majority
+  rank: 22
+  bioguide: N000184
+  thomas: '02060'
+- name: George Holding
+  party: majority
+  rank: 23
+  bioguide: H001065
+  thomas: '02143'
+- name: Jason Smith
+  party: majority
+  rank: 24
+  bioguide: S001195
+  thomas: '02191'
 - name: Sander M. Levin
   party: minority
   rank: 1
@@ -11941,19 +9875,14 @@ HSWM:
   rank: 13
   bioguide: C001038
   thomas: '01604'
-- name: Allyson Y. Schwartz
-  party: minority
-  rank: 14
-  bioguide: S001162
-  thomas: '01798'
 - name: Danny K. Davis
   party: minority
-  rank: 15
+  rank: 14
   bioguide: D000096
   thomas: '01477'
 - name: Linda T. Sánchez
   party: minority
-  rank: 16
+  rank: 15
   bioguide: S001156
   thomas: '01757'
 HSWM01:
@@ -11963,36 +9892,36 @@ HSWM01:
   title: Chair
   bioguide: J000174
   thomas: '00603'
-- name: Patrick J. Tiberi
-  party: majority
-  rank: 2
-  bioguide: T000462
-  thomas: '01664'
-- name: Tim Griffin
-  party: majority
-  rank: 3
-  bioguide: G000567
-  thomas: '01990'
 - name: James B. Renacci
   party: majority
-  rank: 4
+  rank: 2
   bioguide: R000586
   thomas: '02048'
+- name: Vern Buchanan
+  party: majority
+  rank: 3
+  bioguide: B001260
+  thomas: '01840'
 - name: Aaron Schock
   party: majority
-  rank: 5
+  rank: 4
   bioguide: S001179
   thomas: '01920'
-- name: Mike Kelly
+- name: Tom Reed
+  party: majority
+  rank: 5
+  bioguide: R000585
+  thomas: '01982'
+- name: Todd C. Young
   party: majority
   rank: 6
-  bioguide: K000376
-  thomas: '02051'
-- name: Kevin Brady
+  bioguide: Y000064
+  thomas: '02019'
+- name: Mike Kelly
   party: majority
   rank: 7
-  bioguide: B000755
-  thomas: '01468'
+  bioguide: K000376
+  thomas: '02051'
 - name: Xavier Becerra
   party: minority
   rank: 1
@@ -12004,16 +9933,16 @@ HSWM01:
   rank: 2
   bioguide: D000399
   thomas: '00303'
-- name: Mike Thompson
+- name: John B. Larson
   party: minority
   rank: 3
-  bioguide: T000460
-  thomas: '01593'
-- name: Allyson Y. Schwartz
+  bioguide: L000557
+  thomas: '01583'
+- name: Earl Blumenauer
   party: minority
   rank: 4
-  bioguide: S001162
-  thomas: '01798'
+  bioguide: B000574
+  thomas: '00099'
 HSWM02:
 - name: Kevin Brady
   party: majority
@@ -12026,41 +9955,46 @@ HSWM02:
   rank: 2
   bioguide: J000174
   thomas: '00603'
-- name: Paul Ryan
-  party: majority
-  rank: 3
-  bioguide: R000570
-  thomas: '01560'
 - name: Devin Nunes
   party: majority
-  rank: 4
+  rank: 3
   bioguide: N000181
   thomas: '01710'
 - name: Peter J. Roskam
   party: majority
-  rank: 5
+  rank: 4
   bioguide: R000580
   thomas: '01848'
-- name: Jim Gerlach
-  party: majority
-  rank: 6
-  bioguide: G000549
-  thomas: '01743'
 - name: Tom Price
   party: majority
-  rank: 7
+  rank: 5
   bioguide: P000591
   thomas: '01778'
 - name: Vern Buchanan
   party: majority
-  rank: 8
+  rank: 6
   bioguide: B001260
   thomas: '01840'
 - name: Adrian Smith
   party: majority
-  rank: 9
+  rank: 7
   bioguide: S001172
   thomas: '01860'
+- name: Lynn Jenkins
+  party: majority
+  rank: 8
+  bioguide: J000290
+  thomas: '01921'
+- name: Kenny Marchant
+  party: majority
+  rank: 9
+  bioguide: M001158
+  thomas: '01806'
+- name: Diane Black
+  party: majority
+  rank: 10
+  bioguide: B001273
+  thomas: '02063'
 - name: Jim McDermott
   party: minority
   rank: 1
@@ -12087,43 +10021,48 @@ HSWM02:
   rank: 5
   bioguide: P000096
   thomas: '01510'
+- name: Danny K. Davis
+  party: minority
+  rank: 6
+  bioguide: D000096
+  thomas: '01477'
 HSWM03:
-- name: David G. Reichert
+- name: Charles W. Boustany Jr.
   party: majority
   rank: 1
   title: Chair
-  bioguide: R000578
-  thomas: '01810'
+  bioguide: B001255
+  thomas: '01787'
 - name: Todd C. Young
   party: majority
   rank: 2
   bioguide: Y000064
   thomas: '02019'
-- name: Mike Kelly
-  party: majority
-  rank: 3
-  bioguide: K000376
-  thomas: '02051'
-- name: Tim Griffin
-  party: majority
-  rank: 4
-  bioguide: G000567
-  thomas: '01990'
-- name: James B. Renacci
-  party: majority
-  rank: 5
-  bioguide: R000586
-  thomas: '02048'
 - name: Tom Reed
   party: majority
-  rank: 6
+  rank: 3
   bioguide: R000585
   thomas: '01982'
-- name: Charles W. Boustany Jr.
+- name: Kristi L. Noem
+  party: majority
+  rank: 4
+  bioguide: N000184
+  thomas: '02060'
+- name: Patrick Meehan
+  party: majority
+  rank: 5
+  bioguide: M001181
+  thomas: '02052'
+- name: George Holding
+  party: majority
+  rank: 6
+  bioguide: H001065
+  thomas: '02143'
+- name: Jason Smith
   party: majority
   rank: 7
-  bioguide: B001255
-  thomas: '01787'
+  bioguide: S001195
+  thomas: '02191'
 - name: Lloyd Doggett
   party: minority
   rank: 1
@@ -12146,52 +10085,57 @@ HSWM03:
   bioguide: D000096
   thomas: '01477'
 HSWM04:
-- name: Devin Nunes
+- name: Patrick J. Tiberi
   party: majority
   rank: 1
   title: Chair
+  bioguide: T000462
+  thomas: '01664'
+- name: Devin Nunes
+  party: majority
+  rank: 2
   bioguide: N000181
   thomas: '01710'
 - name: Kevin Brady
   party: majority
-  rank: 2
+  rank: 3
   bioguide: B000755
   thomas: '01468'
 - name: David G. Reichert
   party: majority
-  rank: 3
+  rank: 4
   bioguide: R000578
   thomas: '01810'
 - name: Vern Buchanan
   party: majority
-  rank: 4
+  rank: 5
   bioguide: B001260
   thomas: '01840'
 - name: Adrian Smith
   party: majority
-  rank: 5
+  rank: 6
   bioguide: S001172
   thomas: '01860'
 - name: Aaron Schock
   party: majority
-  rank: 6
+  rank: 7
   bioguide: S001179
   thomas: '01920'
 - name: Lynn Jenkins
   party: majority
-  rank: 7
+  rank: 8
   bioguide: J000290
   thomas: '01921'
 - name: Charles W. Boustany Jr.
   party: majority
-  rank: 8
+  rank: 9
   bioguide: B001255
   thomas: '01787'
-- name: Peter J. Roskam
+- name: Erik Paulsen
   party: majority
-  rank: 9
-  bioguide: R000580
-  thomas: '01848'
+  rank: 10
+  bioguide: P000594
+  thomas: '01930'
 - name: Charles B. Rangel
   party: minority
   rank: 1
@@ -12203,58 +10147,63 @@ HSWM04:
   rank: 2
   bioguide: N000015
   thomas: '00854'
-- name: John B. Larson
-  party: minority
-  rank: 3
-  bioguide: L000557
-  thomas: '01583'
 - name: Earl Blumenauer
   party: minority
-  rank: 4
+  rank: 3
   bioguide: B000574
   thomas: '00099'
 - name: Ron Kind
   party: minority
-  rank: 5
+  rank: 4
   bioguide: K000188
   thomas: '01498'
+- name: Xavier Becerra
+  party: minority
+  rank: 5
+  bioguide: B000287
+  thomas: '00070'
+- name: Bill Pascrell Jr.
+  party: minority
+  rank: 6
+  bioguide: P000096
+  thomas: '01510'
 HSWM05:
-- name: Patrick J. Tiberi
+- name: David G. Reichert
   party: majority
   rank: 1
   title: Chair
+  bioguide: R000578
+  thomas: '01810'
+- name: Patrick J. Tiberi
+  party: majority
+  rank: 2
   bioguide: T000462
   thomas: '01664'
 - name: Erik Paulsen
   party: majority
-  rank: 2
+  rank: 3
   bioguide: P000594
   thomas: '01930'
-- name: Kenny Marchant
-  party: majority
-  rank: 3
-  bioguide: M001158
-  thomas: '01806'
-- name: Jim Gerlach
-  party: majority
-  rank: 4
-  bioguide: G000549
-  thomas: '01743'
-- name: Aaron Schock
-  party: majority
-  rank: 5
-  bioguide: S001179
-  thomas: '01920'
 - name: Tom Reed
   party: majority
-  rank: 6
+  rank: 4
   bioguide: R000585
   thomas: '01982'
 - name: Todd C. Young
   party: majority
-  rank: 7
+  rank: 5
   bioguide: Y000064
   thomas: '02019'
+- name: Mike Kelly
+  party: majority
+  rank: 6
+  bioguide: K000376
+  thomas: '02051'
+- name: James B. Renacci
+  party: majority
+  rank: 7
+  bioguide: R000586
+  thomas: '02048'
 - name: Richard E. Neal
   party: minority
   rank: 1
@@ -12266,53 +10215,53 @@ HSWM05:
   rank: 2
   bioguide: L000557
   thomas: '01583'
-- name: Allyson Y. Schwartz
-  party: minority
-  rank: 3
-  bioguide: S001162
-  thomas: '01798'
 - name: Linda T. Sánchez
   party: minority
-  rank: 4
+  rank: 3
   bioguide: S001156
   thomas: '01757'
+- name: Mike Thompson
+  party: minority
+  rank: 4
+  bioguide: T000460
+  thomas: '01593'
 HSWM06:
-- name: Charles W. Boustany Jr.
+- name: Peter J. Roskam
   party: majority
   rank: 1
   title: Chair
-  bioguide: B001255
-  thomas: '01787'
-- name: Diane Black
-  party: majority
-  rank: 2
-  bioguide: B001273
-  thomas: '02063'
-- name: Lynn Jenkins
-  party: majority
-  rank: 3
-  bioguide: J000290
-  thomas: '01921'
+  bioguide: R000580
+  thomas: '01848'
 - name: Kenny Marchant
   party: majority
-  rank: 4
+  rank: 2
   bioguide: M001158
   thomas: '01806'
-- name: Tom Reed
-  party: majority
-  rank: 5
-  bioguide: R000585
-  thomas: '01982'
-- name: Erik Paulsen
-  party: majority
-  rank: 6
-  bioguide: P000594
-  thomas: '01930'
 - name: Mike Kelly
   party: majority
-  rank: 7
+  rank: 3
   bioguide: K000376
   thomas: '02051'
+- name: Patrick Meehan
+  party: majority
+  rank: 4
+  bioguide: M001181
+  thomas: '02052'
+- name: George Holding
+  party: majority
+  rank: 5
+  bioguide: H001065
+  thomas: '02143'
+- name: Jason Smith
+  party: majority
+  rank: 6
+  bioguide: S001195
+  thomas: '02191'
+- name: Kristi L. Noem
+  party: majority
+  rank: 7
+  bioguide: N000184
+  thomas: '02060'
 - name: John Lewis
   party: minority
   rank: 1
@@ -12324,71 +10273,59 @@ HSWM06:
   rank: 2
   bioguide: C001038
   thomas: '01604'
-- name: Danny K. Davis
+- name: Charles B. Rangel
   party: minority
   rank: 3
-  bioguide: D000096
-  thomas: '01477'
-- name: Linda T. Sánchez
+  bioguide: R000053
+  thomas: '00944'
+- name: Lloyd Doggett
   party: minority
   rank: 4
-  bioguide: S001156
-  thomas: '01757'
+  bioguide: D000399
+  thomas: '00303'
 JCSE:
-- name: Benjamin L. Cardin
+- name: Roger F. Wicker
   party: majority
   rank: 1
-  title: Chairman
+  title: Cochairman
+  bioguide: W000437
+  thomas: '01226'
+  chamber: senate
+- name: Richard Burr
+  party: majority
+  rank: 2
+  bioguide: B001135
+  thomas: '00153'
+  chamber: senate
+- name: John Boozman
+  party: majority
+  rank: 3
+  bioguide: B001236
+  thomas: '01687'
+  chamber: senate
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 1
   bioguide: C000141
   thomas: '00174'
   chamber: senate
 - name: Sheldon Whitehouse
-  party: majority
+  party: minority
   rank: 2
   bioguide: W000802
   thomas: '01823'
   chamber: senate
 - name: Tom Udall
-  party: majority
+  party: minority
   rank: 3
   bioguide: U000039
   thomas: '01567'
   chamber: senate
 - name: Jeanne Shaheen
-  party: majority
+  party: minority
   rank: 4
   bioguide: S001181
   thomas: '01901'
-  chamber: senate
-- name: Richard Blumenthal
-  party: majority
-  rank: 5
-  bioguide: B001277
-  thomas: '02076'
-  chamber: senate
-- name: Kelly Ayotte
-  party: minority
-  rank: 1
-  bioguide: A000368
-  thomas: '02075'
-  chamber: senate
-- name: Saxby Chambliss
-  party: minority
-  rank: 2
-  bioguide: C000286
-  thomas: '00188'
-  chamber: senate
-- name: Roger F. Wicker
-  party: minority
-  rank: 3
-  bioguide: W000437
-  thomas: '01226'
-  chamber: senate
-- name: John Boozman
-  party: minority
-  rank: 4
-  bioguide: B001236
-  thomas: '01687'
   chamber: senate
 - name: Christopher H. Smith
   party: majority
@@ -12446,66 +10383,65 @@ JCSE:
   thomas: '01878'
   chamber: house
 JSEC:
-- name: Amy Klobuchar
-  party: majority
-  rank: 1
-  title: Vice Chairman
-  bioguide: K000367
-  thomas: '01826'
-  chamber: senate
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 2
-  bioguide: C001070
-  thomas: '01828'
-  chamber: senate
-- name: Bernard Sanders
-  party: majority
-  rank: 3
-  bioguide: S000033
-  thomas: '01010'
-  chamber: senate
-- name: Christopher Murphy
-  party: majority
-  rank: 4
-  bioguide: M001169
-  thomas: '01837'
-  chamber: senate
-- name: Martin Heinrich
-  party: majority
-  rank: 5
-  bioguide: H001046
-  thomas: '01937'
-  chamber: senate
-- name: Mark L. Pryor
-  party: majority
-  rank: 6
-  bioguide: P000590
-  thomas: '01701'
-  chamber: senate
 - name: Daniel Coats
-  party: minority
+  party: majority
   rank: 1
   bioguide: C000542
   thomas: '00209'
   chamber: senate
 - name: Mike Lee
-  party: minority
+  party: majority
   rank: 2
   bioguide: L000577
   thomas: '02080'
   chamber: senate
-- name: Roger F. Wicker
+- name: Tom Cotton
+  party: majority
+  rank: 3
+  bioguide: C001095
+  thomas: '02098'
+  chamber: senate
+- name: Ben Sasse
+  party: majority
+  rank: 4
+  bioguide: S001197
+  thomas: '02289'
+  chamber: senate
+- name: Ted Cruz
+  party: majority
+  rank: 5
+  bioguide: C001098
+  thomas: '02175'
+  chamber: senate
+- name: Bill Cassidy
+  party: majority
+  rank: 6
+  bioguide: C001075
+  thomas: '01925'
+  chamber: senate
+- name: Amy Klobuchar
+  party: minority
+  rank: 1
+  bioguide: K000367
+  thomas: '01826'
+  chamber: senate
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 2
+  bioguide: C001070
+  thomas: '01828'
+  chamber: senate
+- name: Martin Heinrich
   party: minority
   rank: 3
-  bioguide: W000437
-  thomas: '01226'
+  bioguide: H001046
+  thomas: '01937'
   chamber: senate
-- name: Patrick J. Toomey
+- name: Gary Peters
   party: minority
   rank: 4
-  bioguide: T000461
-  thomas: '02085'
+  bioguide: P000595
+  thomas: '01929'
   chamber: senate
 - name: Kevin Brady
   party: majority
@@ -12569,36 +10505,35 @@ JSEC:
   thomas: '02133'
   chamber: house
 JSLC:
-- name: Charles E. Schumer
-  party: majority
-  rank: 1
-  title: Vice Chairman
-  bioguide: S000148
-  thomas: '01036'
-  chamber: senate
-- name: Richard J. Durbin
-  party: majority
-  rank: 2
-  bioguide: D000563
-  thomas: '00326'
-  chamber: senate
-- name: Patrick J. Leahy
-  party: majority
-  rank: 3
-  bioguide: L000174
-  thomas: '01383'
-  chamber: senate
 - name: Pat Roberts
-  party: minority
+  party: majority
   rank: 1
   bioguide: R000307
   thomas: '00968'
   chamber: senate
 - name: Roy Blunt
-  party: minority
+  party: majority
   rank: 2
   bioguide: B000575
   thomas: '01464'
+  chamber: senate
+- name: Charles E. Schumer
+  party: minority
+  rank: 1
+  bioguide: S000148
+  thomas: '01036'
+  chamber: senate
+- name: Richard J. Durbin
+  party: minority
+  rank: 2
+  bioguide: D000563
+  thomas: '00326'
+  chamber: senate
+- name: Patrick J. Leahy
+  party: minority
+  rank: 3
+  bioguide: L000174
+  thomas: '01383'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -12626,36 +10561,29 @@ JSLC:
   thomas: '00701'
   chamber: house
 JSPR:
-- name: Charles E. Schumer
+- name: Pat Roberts
   party: majority
   rank: 1
-  title: Chairman
+  bioguide: R000307
+  thomas: '00968'
+  chamber: senate
+- name: Charles E. Schumer
+  party: minority
+  rank: 1
   bioguide: S000148
   thomas: '01036'
   chamber: senate
 - name: Tom Udall
-  party: majority
+  party: minority
   rank: 2
   bioguide: U000039
   thomas: '01567'
   chamber: senate
 - name: Mark R. Warner
-  party: majority
+  party: minority
   rank: 3
   bioguide: W000805
   thomas: '01897'
-  chamber: senate
-- name: Pat Roberts
-  party: minority
-  rank: 1
-  bioguide: R000307
-  thomas: '00968'
-  chamber: senate
-- name: Saxby Chambliss
-  party: minority
-  rank: 2
-  bioguide: C000286
-  thomas: '00188'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -12689,36 +10617,35 @@ JSPR:
   thomas: '02112'
   chamber: house
 JSTX:
-- name: Ron Wyden
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: W000779
-  thomas: '01247'
-  chamber: senate
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 2
-  bioguide: R000361
-  thomas: '01424'
-  chamber: senate
-- name: Debbie Stabenow
-  party: majority
-  rank: 3
-  bioguide: S000770
-  thomas: '01531'
-  chamber: senate
 - name: Orrin G. Hatch
-  party: minority
+  party: majority
   rank: 1
   bioguide: H000338
   thomas: '01351'
   chamber: senate
 - name: Chuck Grassley
-  party: minority
+  party: majority
   rank: 2
   bioguide: G000386
   thomas: '00457'
+  chamber: senate
+- name: Mike Crapo
+  party: majority
+  rank: 3
+  bioguide: C000880
+  thomas: '00250'
+  chamber: senate
+- name: Ron Wyden
+  party: minority
+  rank: 1
+  bioguide: W000779
+  thomas: '01247'
+  chamber: senate
+- name: Debbie Stabenow
+  party: minority
+  rank: 2
+  bioguide: S000770
+  thomas: '01531'
   chamber: senate
 - name: Dave Camp
   party: majority
@@ -12752,7260 +10679,6764 @@ JSTX:
   thomas: '00944'
   chamber: house
 SCNC:
-- name: Dianne Feinstein
+- name: Chuck Grassley
   party: majority
   rank: 1
   title: Chairman
-  bioguide: F000062
-  thomas: '01332'
-- name: Charles E. Schumer
-  party: majority
-  rank: 2
-  bioguide: S000148
-  thomas: '01036'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 3
-  bioguide: W000802
-  thomas: '01823'
-- name: Tom Udall
-  party: majority
-  rank: 4
-  bioguide: U000039
-  thomas: '01567'
-- name: Chuck Grassley
-  party: minority
-  rank: 1
   bioguide: G000386
   thomas: '00457'
 - name: John Cornyn
-  party: minority
+  party: majority
   rank: 2
   bioguide: C001056
   thomas: '01692'
 - name: James E. Risch
-  party: minority
+  party: majority
   rank: 3
   bioguide: R000584
   thomas: '01896'
+- name: Jeff Sessions
+  party: majority
+  rank: 4
+  bioguide: S001141
+  thomas: '01548'
+- name: Dianne Feinstein
+  party: minority
+  rank: 1
+  bioguide: F000062
+  thomas: '01332'
+- name: Charles E. Schumer
+  party: minority
+  rank: 2
+  bioguide: S000148
+  thomas: '01036'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 3
+  bioguide: W000802
+  thomas: '01823'
 SLET:
-- name: Barbara Boxer
+- name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  bioguide: B000711
-  thomas: '00116'
-- name: Mark L. Pryor
-  party: majority
-  rank: 2
-  bioguide: P000590
-  thomas: '01701'
-- name: Sherrod Brown
-  party: majority
-  rank: 3
-  bioguide: B000944
-  thomas: '00136'
-- name: Johnny Isakson
-  party: minority
-  rank: 1
-  title: Vice Chairman
   bioguide: I000055
   thomas: '01608'
 - name: Pat Roberts
-  party: minority
+  party: majority
   rank: 2
   bioguide: R000307
   thomas: '00968'
 - name: James E. Risch
-  party: minority
+  party: majority
   rank: 3
   bioguide: R000584
   thomas: '01896'
-SLIA:
-- name: Jon Tester
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: T000464
-  thomas: '01829'
-- name: Tim Johnson
-  party: majority
-  rank: 2
-  bioguide: J000177
-  thomas: '00604'
-- name: Maria Cantwell
-  party: majority
-  rank: 3
-  bioguide: C000127
-  thomas: '00172'
-- name: Tom Udall
-  party: majority
-  rank: 4
-  bioguide: U000039
-  thomas: '01567'
-- name: Al Franken
-  party: majority
-  rank: 5
-  bioguide: F000457
-  thomas: '01969'
-- name: Mark Begich
-  party: majority
-  rank: 6
-  bioguide: B001265
-  thomas: '01898'
-- name: Brian Schatz
-  party: majority
-  rank: 7
-  bioguide: S001194
-  thomas: '02173'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 8
-  bioguide: H001069
-  thomas: '02174'
-- name: John Barrasso
+- name: Barbara Boxer
   party: minority
   rank: 1
   title: Vice Chairman
+  bioguide: B000711
+  thomas: '00116'
+- name: Christopher A. Coons
+  party: minority
+  rank: 2
+  bioguide: C001088
+  thomas: '01984'
+- name: Brian Schatz
+  party: minority
+  rank: 3
+  bioguide: S001194
+  thomas: '02173'
+SLIA:
+- name: John Barrasso
+  party: majority
+  rank: 1
+  title: Chairman
   bioguide: B001261
   thomas: '01881'
 - name: John McCain
-  party: minority
+  party: majority
   rank: 2
   bioguide: M000303
   thomas: '00754'
 - name: Lisa Murkowski
-  party: minority
+  party: majority
   rank: 3
   bioguide: M001153
   thomas: '01694'
 - name: John Hoeven
-  party: minority
+  party: majority
   rank: 4
   bioguide: H001061
   thomas: '02079'
-- name: Mike Crapo
-  party: minority
+- name: James Lankford
+  party: majority
   rank: 5
+  bioguide: L000575
+  thomas: '02050'
+- name: Steve Daines
+  party: majority
+  rank: 6
+  bioguide: D000618
+  thomas: '02138'
+- name: Mike Crapo
+  party: majority
+  rank: 7
   bioguide: C000880
   thomas: '00250'
-- name: Deb Fischer
+- name: Jerry Moran
+  party: majority
+  rank: 8
+  bioguide: M000934
+  thomas: '01507'
+- name: Jon Tester
+  party: minority
+  rank: 1
+  title: Vice Chairman
+  bioguide: T000464
+  thomas: '01829'
+- name: Maria Cantwell
+  party: minority
+  rank: 2
+  bioguide: C000127
+  thomas: '00172'
+- name: Tom Udall
+  party: minority
+  rank: 3
+  bioguide: U000039
+  thomas: '01567'
+- name: Al Franken
+  party: minority
+  rank: 4
+  bioguide: F000457
+  thomas: '01969'
+- name: Brian Schatz
+  party: minority
+  rank: 5
+  bioguide: S001194
+  thomas: '02173'
+- name: Heidi Heitkamp
   party: minority
   rank: 6
-  bioguide: F000463
-  thomas: '02179'
+  bioguide: H001069
+  thomas: '02174'
 SLIN:
-- name: Dianne Feinstein
+- name: Richard Burr
   party: majority
   rank: 1
   title: Chairman
-  bioguide: F000062
-  thomas: '01332'
-- name: John D. Rockefeller, IV
+  bioguide: B001135
+  thomas: '00153'
+- name: James E. Risch
   party: majority
   rank: 2
-  bioguide: R000361
-  thomas: '01424'
-- name: Ron Wyden
+  bioguide: R000584
+  thomas: '01896'
+- name: Daniel Coats
   party: majority
   rank: 3
+  bioguide: C000542
+  thomas: '00209'
+- name: Marco Rubio
+  party: majority
+  rank: 4
+  bioguide: R000595
+  thomas: '02084'
+- name: Susan M. Collins
+  party: majority
+  rank: 5
+  bioguide: C001035
+  thomas: '01541'
+- name: Roy Blunt
+  party: majority
+  rank: 6
+  bioguide: B000575
+  thomas: '01464'
+- name: James Lankford
+  party: majority
+  rank: 7
+  bioguide: L000575
+  thomas: '02050'
+- name: Tom Cotton
+  party: majority
+  rank: 8
+  bioguide: C001095
+  thomas: '02098'
+- name: Mitch McConnell
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: M000355
+  thomas: '01395'
+- name: John McCain
+  party: majority
+  rank: 10
+  title: Ex Officio
+  bioguide: M000303
+  thomas: '00754'
+- name: Dianne Feinstein
+  party: minority
+  rank: 1
+  title: Vice Chairman
+  bioguide: F000062
+  thomas: '01332'
+- name: Ron Wyden
+  party: minority
+  rank: 2
   bioguide: W000779
   thomas: '01247'
 - name: Barbara A. Mikulski
-  party: majority
-  rank: 4
+  party: minority
+  rank: 3
   bioguide: M000702
   thomas: '00802'
-- name: Mark Udall
-  party: majority
-  rank: 5
-  bioguide: U000038
-  thomas: '01595'
 - name: Mark R. Warner
-  party: majority
-  rank: 6
+  party: minority
+  rank: 4
   bioguide: W000805
   thomas: '01897'
 - name: Martin Heinrich
-  party: majority
-  rank: 7
+  party: minority
+  rank: 5
   bioguide: H001046
   thomas: '01937'
 - name: Angus S. King, Jr.
-  party: majority
-  rank: 8
+  party: minority
+  rank: 6
   bioguide: K000383
   thomas: '02185'
+- name: Mazie K. Hirono
+  party: minority
+  rank: 7
+  bioguide: H001042
+  thomas: '01844'
 - name: Harry Reid
-  party: majority
-  rank: 9
+  party: minority
+  rank: 8
   title: Ex Officio
   bioguide: R000146
   thomas: '00952'
-- name: Carl Levin
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: L000261
-  thomas: '01384'
-- name: Saxby Chambliss
-  party: minority
-  rank: 1
-  title: Vice Chairman
-  bioguide: C000286
-  thomas: '00188'
-- name: Richard Burr
-  party: minority
-  rank: 2
-  bioguide: B001135
-  thomas: '00153'
-- name: James E. Risch
-  party: minority
-  rank: 3
-  bioguide: R000584
-  thomas: '01896'
-- name: Daniel Coats
-  party: minority
-  rank: 4
-  bioguide: C000542
-  thomas: '00209'
-- name: Marco Rubio
-  party: minority
-  rank: 5
-  bioguide: R000595
-  thomas: '02084'
-- name: Susan M. Collins
-  party: minority
-  rank: 6
-  bioguide: C001035
-  thomas: '01541'
-- name: Tom Coburn
-  party: minority
-  rank: 7
-  bioguide: C000560
-  thomas: '00212'
-- name: Mitch McConnell
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: M000355
-  thomas: '01395'
-- name: James M. Inhofe
+- name: Jack Reed
   party: minority
   rank: 9
   title: Ex Officio
-  bioguide: I000024
-  thomas: '00583'
+  bioguide: R000122
+  thomas: '00949'
 SPAG:
-- name: Bill Nelson
+- name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
+  bioguide: C001035
+  thomas: '01541'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 2
+  bioguide: H000338
+  thomas: '01351'
+- name: Mark Kirk
+  party: majority
+  rank: 3
+  bioguide: K000360
+  thomas: '01647'
+- name: Jeff Flake
+  party: majority
+  rank: 4
+  bioguide: F000444
+  thomas: '01633'
+- name: Tim Scott
+  party: majority
+  rank: 5
+  bioguide: S001184
+  thomas: '02056'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  bioguide: C001071
+  thomas: '01825'
+- name: Dean Heller
+  party: majority
+  rank: 7
+  bioguide: H001041
+  thomas: '01863'
+- name: Tom Cotton
+  party: majority
+  rank: 8
+  bioguide: C001095
+  thomas: '02098'
+- name: David Perdue
+  party: majority
+  rank: 9
+  bioguide: P000612
+  thomas: '02286'
+- name: Thom Tillis
+  party: majority
+  rank: 10
+  bioguide: T000476
+  thomas: '02291'
+- name: Ben Sasse
+  party: majority
+  rank: 11
+  bioguide: S001197
+  thomas: '02289'
+- name: Claire McCaskill
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001170
+  thomas: '01820'
+- name: Bill Nelson
+  party: minority
+  rank: 2
   bioguide: N000032
   thomas: '00859'
 - name: Robert P. Casey, Jr.
-  party: majority
-  rank: 2
+  party: minority
+  rank: 3
   bioguide: C001070
   thomas: '01828'
-- name: Claire McCaskill
-  party: majority
-  rank: 3
-  bioguide: M001170
-  thomas: '01820'
 - name: Sheldon Whitehouse
-  party: majority
+  party: minority
   rank: 4
   bioguide: W000802
   thomas: '01823'
 - name: Kirsten E. Gillibrand
-  party: majority
+  party: minority
   rank: 5
   bioguide: G000555
   thomas: '01866'
-- name: Joe Manchin, III
-  party: majority
-  rank: 6
-  bioguide: M001183
-  thomas: '01983'
 - name: Richard Blumenthal
-  party: majority
-  rank: 7
+  party: minority
+  rank: 6
   bioguide: B001277
   thomas: '02076'
-- name: Tammy Baldwin
-  party: majority
-  rank: 8
-  bioguide: B001230
-  thomas: '01558'
 - name: Joe Donnelly
-  party: majority
-  rank: 9
+  party: minority
+  rank: 7
   bioguide: D000607
   thomas: '01850'
 - name: Elizabeth Warren
-  party: majority
-  rank: 10
+  party: minority
+  rank: 8
   bioguide: W000817
   thomas: '02182'
-- name: John E. Walsh
+- name: Tim Kaine
+  party: minority
+  rank: 9
+  bioguide: K000384
+  thomas: '02176'
+SSAF:
+- name: Pat Roberts
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: R000307
+  thomas: '00968'
+- name: Thad Cochran
+  party: majority
+  rank: 2
+  bioguide: C000567
+  thomas: '00213'
+- name: Mitch McConnell
+  party: majority
+  rank: 3
+  bioguide: M000355
+  thomas: '01395'
+- name: John Boozman
+  party: majority
+  rank: 4
+  bioguide: B001236
+  thomas: '01687'
+- name: John Hoeven
+  party: majority
+  rank: 5
+  bioguide: H001061
+  thomas: '02079'
+- name: David Perdue
+  party: majority
+  rank: 6
+  bioguide: P000612
+  thomas: '02286'
+- name: Joni Ernst
+  party: majority
+  rank: 7
+  bioguide: E000295
+  thomas: '02283'
+- name: Thom Tillis
+  party: majority
+  rank: 8
+  bioguide: T000476
+  thomas: '02291'
+- name: Ben Sasse
+  party: majority
+  rank: 9
+  bioguide: S001197
+  thomas: '02289'
+- name: Chuck Grassley
+  party: majority
+  rank: 10
+  bioguide: G000386
+  thomas: '00457'
+- name: John Thune
   party: majority
   rank: 11
-  bioguide: W000818
-  thomas: '02198'
-- name: Susan M. Collins
+  bioguide: T000250
+  thomas: '01534'
+- name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: S000770
+  thomas: '01531'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 2
+  bioguide: L000174
+  thomas: '01383'
+- name: Sherrod Brown
+  party: minority
+  rank: 3
+  bioguide: B000944
+  thomas: '00136'
+- name: Amy Klobuchar
+  party: minority
+  rank: 4
+  bioguide: K000367
+  thomas: '01826'
+- name: Michael F. Bennet
+  party: minority
+  rank: 5
+  bioguide: B001267
+  thomas: '01965'
+- name: Kirsten E. Gillibrand
+  party: minority
+  rank: 6
+  bioguide: G000555
+  thomas: '01866'
+- name: Joe Donnelly
+  party: minority
+  rank: 7
+  bioguide: D000607
+  thomas: '01850'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 8
+  bioguide: H001069
+  thomas: '02174'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 9
+  bioguide: C001070
+  thomas: '01828'
+SSAF13:
+- name: John Boozman
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: B001236
+  thomas: '01687'
+- name: Thad Cochran
+  party: majority
+  rank: 2
+  bioguide: C000567
+  thomas: '00213'
+- name: John Hoeven
+  party: majority
+  rank: 3
+  bioguide: H001061
+  thomas: '02079'
+- name: David Perdue
+  party: majority
+  rank: 4
+  bioguide: P000612
+  thomas: '02286'
+- name: Chuck Grassley
+  party: majority
+  rank: 5
+  bioguide: G000386
+  thomas: '00457'
+- name: John Thune
+  party: majority
+  rank: 6
+  bioguide: T000250
+  thomas: '01534'
+- name: Pat Roberts
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: R000307
+  thomas: '00968'
+- name: Joe Donnelly
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000607
+  thomas: '01850'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 2
+  bioguide: H001069
+  thomas: '02174'
+- name: Sherrod Brown
+  party: minority
+  rank: 3
+  bioguide: B000944
+  thomas: '00136'
+- name: Kirsten E. Gillibrand
+  party: minority
+  rank: 4
+  bioguide: G000555
+  thomas: '01866'
+- name: Michael F. Bennet
+  party: minority
+  rank: 5
+  bioguide: B001267
+  thomas: '01965'
+- name: Debbie Stabenow
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: S000770
+  thomas: '01531'
+SSAF14:
+- name: David Perdue
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: P000612
+  thomas: '02286'
+- name: Thad Cochran
+  party: majority
+  rank: 2
+  bioguide: C000567
+  thomas: '00213'
+- name: Mitch McConnell
+  party: majority
+  rank: 3
+  bioguide: M000355
+  thomas: '01395'
+- name: John Boozman
+  party: majority
+  rank: 4
+  bioguide: B001236
+  thomas: '01687'
+- name: Ben Sasse
+  party: majority
+  rank: 5
+  bioguide: S001197
+  thomas: '02289'
+- name: Chuck Grassley
+  party: majority
+  rank: 6
+  bioguide: G000386
+  thomas: '00457'
+- name: Pat Roberts
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: R000307
+  thomas: '00968'
+- name: Michael F. Bennet
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001267
+  thomas: '01965'
+- name: Amy Klobuchar
+  party: minority
+  rank: 2
+  bioguide: K000367
+  thomas: '01826'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 3
+  bioguide: L000174
+  thomas: '01383'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 4
+  bioguide: H001069
+  thomas: '02174'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 5
+  bioguide: C001070
+  thomas: '01828'
+- name: Debbie Stabenow
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: S000770
+  thomas: '01531'
+SSAF15:
+- name: Joni Ernst
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: E000295
+  thomas: '02283'
+- name: Thad Cochran
+  party: majority
+  rank: 2
+  bioguide: C000567
+  thomas: '00213'
+- name: John Hoeven
+  party: majority
+  rank: 3
+  bioguide: H001061
+  thomas: '02079'
+- name: David Perdue
+  party: majority
+  rank: 4
+  bioguide: P000612
+  thomas: '02286'
+- name: Thom Tillis
+  party: majority
+  rank: 5
+  bioguide: T000476
+  thomas: '02291'
+- name: John Thune
+  party: majority
+  rank: 6
+  bioguide: T000250
+  thomas: '01534'
+- name: Pat Roberts
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: R000307
+  thomas: '00968'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H001069
+  thomas: '02174'
+- name: Sherrod Brown
+  party: minority
+  rank: 2
+  bioguide: B000944
+  thomas: '00136'
+- name: Amy Klobuchar
+  party: minority
+  rank: 3
+  bioguide: K000367
+  thomas: '01826'
+- name: Michael F. Bennet
+  party: minority
+  rank: 4
+  bioguide: B001267
+  thomas: '01965'
+- name: Joe Donnelly
+  party: minority
+  rank: 5
+  bioguide: D000607
+  thomas: '01850'
+- name: Debbie Stabenow
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: S000770
+  thomas: '01531'
+SSAF16:
+- name: John Hoeven
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: H001061
+  thomas: '02079'
+- name: Mitch McConnell
+  party: majority
+  rank: 2
+  bioguide: M000355
+  thomas: '01395'
+- name: John Boozman
+  party: majority
+  rank: 3
+  bioguide: B001236
+  thomas: '01687'
+- name: Joni Ernst
+  party: majority
+  rank: 4
+  bioguide: E000295
+  thomas: '02283'
+- name: Thom Tillis
+  party: majority
+  rank: 5
+  bioguide: T000476
+  thomas: '02291'
+- name: Ben Sasse
+  party: majority
+  rank: 6
+  bioguide: S001197
+  thomas: '02289'
+- name: Pat Roberts
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: R000307
+  thomas: '00968'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001070
+  thomas: '01828'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 2
+  bioguide: L000174
+  thomas: '01383'
+- name: Sherrod Brown
+  party: minority
+  rank: 3
+  bioguide: B000944
+  thomas: '00136'
+- name: Kirsten E. Gillibrand
+  party: minority
+  rank: 4
+  bioguide: G000555
+  thomas: '01866'
+- name: Michael F. Bennet
+  party: minority
+  rank: 5
+  bioguide: B001267
+  thomas: '01965'
+- name: Debbie Stabenow
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: S000770
+  thomas: '01531'
+SSAF17:
+- name: Ben Sasse
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: S001197
+  thomas: '02289'
+- name: Mitch McConnell
+  party: majority
+  rank: 2
+  bioguide: M000355
+  thomas: '01395'
+- name: Joni Ernst
+  party: majority
+  rank: 3
+  bioguide: E000295
+  thomas: '02283'
+- name: Thom Tillis
+  party: majority
+  rank: 4
+  bioguide: T000476
+  thomas: '02291'
+- name: John Thune
+  party: majority
+  rank: 5
+  bioguide: T000250
+  thomas: '01534'
+- name: Chuck Grassley
+  party: majority
+  rank: 6
+  bioguide: G000386
+  thomas: '00457'
+- name: Pat Roberts
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: R000307
+  thomas: '00968'
+- name: Kirsten E. Gillibrand
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000555
+  thomas: '01866'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 2
+  bioguide: L000174
+  thomas: '01383'
+- name: Amy Klobuchar
+  party: minority
+  rank: 3
+  bioguide: K000367
+  thomas: '01826'
+- name: Joe Donnelly
+  party: minority
+  rank: 4
+  bioguide: D000607
+  thomas: '01850'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 5
+  bioguide: C001070
+  thomas: '01828'
+- name: Debbie Stabenow
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: S000770
+  thomas: '01531'
+SSAP:
+- name: Thad Cochran
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C000567
+  thomas: '00213'
+- name: Mitch McConnell
+  party: majority
+  rank: 2
+  bioguide: M000355
+  thomas: '01395'
+- name: Richard C. Shelby
+  party: majority
+  rank: 3
+  bioguide: S000320
+  thomas: '01049'
+- name: Lamar Alexander
+  party: majority
+  rank: 4
+  bioguide: A000360
+  thomas: '01695'
+- name: Susan M. Collins
+  party: majority
+  rank: 5
   bioguide: C001035
   thomas: '01541'
-- name: Bob Corker
-  party: minority
-  rank: 2
-  bioguide: C001071
-  thomas: '01825'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 3
-  bioguide: H000338
-  thomas: '01351'
+- name: Lisa Murkowski
+  party: majority
+  rank: 6
+  bioguide: M001153
+  thomas: '01694'
+- name: Lindsey Graham
+  party: majority
+  rank: 7
+  bioguide: G000359
+  thomas: '00452'
 - name: Mark Kirk
-  party: minority
-  rank: 4
+  party: majority
+  rank: 8
   bioguide: K000360
   thomas: '01647'
-- name: Dean Heller
-  party: minority
-  rank: 5
-  bioguide: H001041
-  thomas: '01863'
-- name: Jeff Flake
-  party: minority
-  rank: 6
-  bioguide: F000444
-  thomas: '01633'
-- name: Kelly Ayotte
-  party: minority
-  rank: 7
-  bioguide: A000368
-  thomas: '02075'
-- name: Tim Scott
-  party: minority
-  rank: 8
-  bioguide: S001184
-  thomas: '02056'
-- name: Ted Cruz
-  party: minority
-  rank: 9
-  bioguide: C001098
-  thomas: '02175'
-SSAF:
-- name: Debbie Stabenow
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: S000770
-  thomas: '01531'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Tom Harkin
-  party: majority
-  rank: 3
-  bioguide: H000206
-  thomas: '00501'
-- name: Sherrod Brown
-  party: majority
-  rank: 4
-  bioguide: B000944
-  thomas: '00136'
-- name: Amy Klobuchar
-  party: majority
-  rank: 5
-  bioguide: K000367
-  thomas: '01826'
-- name: Michael F. Bennet
-  party: majority
-  rank: 6
-  bioguide: B001267
-  thomas: '01965'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 7
-  bioguide: G000555
-  thomas: '01866'
-- name: Joe Donnelly
-  party: majority
-  rank: 8
-  bioguide: D000607
-  thomas: '01850'
-- name: Heidi Heitkamp
+- name: Roy Blunt
   party: majority
   rank: 9
-  bioguide: H001069
-  thomas: '02174'
-- name: Robert P. Casey, Jr.
+  bioguide: B000575
+  thomas: '01464'
+- name: Jerry Moran
   party: majority
   rank: 10
-  bioguide: C001070
-  thomas: '01828'
-- name: John E. Walsh
+  bioguide: M000934
+  thomas: '01507'
+- name: John Hoeven
   party: majority
   rank: 11
-  bioguide: W000818
-  thomas: '02198'
-- name: Thad Cochran
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C000567
-  thomas: '00213'
-- name: Mitch McConnell
-  party: minority
-  rank: 2
-  bioguide: M000355
-  thomas: '01395'
-- name: Pat Roberts
-  party: minority
-  rank: 3
-  bioguide: R000307
-  thomas: '00968'
-- name: Saxby Chambliss
-  party: minority
-  rank: 4
-  bioguide: C000286
-  thomas: '00188'
-- name: John Boozman
-  party: minority
-  rank: 5
-  bioguide: B001236
-  thomas: '01687'
-- name: John Hoeven
-  party: minority
-  rank: 6
   bioguide: H001061
   thomas: '02079'
-- name: Mike Johanns
-  party: minority
-  rank: 7
-  bioguide: J000291
-  thomas: '01899'
-- name: Chuck Grassley
-  party: minority
-  rank: 8
-  bioguide: G000386
-  thomas: '00457'
-- name: John Thune
-  party: minority
-  rank: 9
-  bioguide: T000250
-  thomas: '01534'
-SSAF13:
-- name: Joe Donnelly
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: D000607
-  thomas: '01850'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 2
-  bioguide: H001069
-  thomas: '02174'
-- name: Tom Harkin
-  party: majority
-  rank: 3
-  bioguide: H000206
-  thomas: '00501'
-- name: Sherrod Brown
-  party: majority
-  rank: 4
-  bioguide: B000944
-  thomas: '00136'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 5
-  bioguide: G000555
-  thomas: '01866'
-- name: John E. Walsh
-  party: majority
-  rank: 6
-  bioguide: W000818
-  thomas: '02198'
-- name: Debbie Stabenow
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: S000770
-  thomas: '01531'
-- name: Saxby Chambliss
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C000286
-  thomas: '00188'
-- name: Pat Roberts
-  party: minority
-  rank: 2
-  bioguide: R000307
-  thomas: '00968'
 - name: John Boozman
-  party: minority
-  rank: 3
-  bioguide: B001236
-  thomas: '01687'
-- name: John Hoeven
-  party: minority
-  rank: 4
-  bioguide: H001061
-  thomas: '02079'
-- name: Mike Johanns
-  party: minority
-  rank: 5
-  bioguide: J000291
-  thomas: '01899'
-- name: Thad Cochran
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: C000567
-  thomas: '00213'
-SSAF14:
-- name: Michael F. Bennet
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B001267
-  thomas: '01965'
-- name: Tom Harkin
-  party: majority
-  rank: 2
-  bioguide: H000206
-  thomas: '00501'
-- name: Amy Klobuchar
-  party: majority
-  rank: 3
-  bioguide: K000367
-  thomas: '01826'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 4
-  bioguide: L000174
-  thomas: '01383'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 5
-  bioguide: H001069
-  thomas: '02174'
-- name: John E. Walsh
-  party: majority
-  rank: 6
-  bioguide: W000818
-  thomas: '02198'
-- name: Debbie Stabenow
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: S000770
-  thomas: '01531'
-- name: John Boozman
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001236
-  thomas: '01687'
-- name: Mitch McConnell
-  party: minority
-  rank: 2
-  bioguide: M000355
-  thomas: '01395'
-- name: Saxby Chambliss
-  party: minority
-  rank: 3
-  bioguide: C000286
-  thomas: '00188'
-- name: John Thune
-  party: minority
-  rank: 4
-  bioguide: T000250
-  thomas: '01534'
-- name: Pat Roberts
-  party: minority
-  rank: 5
-  bioguide: R000307
-  thomas: '00968'
-SSAF15:
-- name: Heidi Heitkamp
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: H001069
-  thomas: '02174'
-- name: Sherrod Brown
-  party: majority
-  rank: 2
-  bioguide: B000944
-  thomas: '00136'
-- name: Amy Klobuchar
-  party: majority
-  rank: 3
-  bioguide: K000367
-  thomas: '01826'
-- name: Michael F. Bennet
-  party: majority
-  rank: 4
-  bioguide: B001267
-  thomas: '01965'
-- name: Joe Donnelly
-  party: majority
-  rank: 5
-  bioguide: D000607
-  thomas: '01850'
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 6
-  bioguide: C001070
-  thomas: '01828'
-- name: Debbie Stabenow
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: S000770
-  thomas: '01531'
-- name: Mike Johanns
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: J000291
-  thomas: '01899'
-- name: John Hoeven
-  party: minority
-  rank: 2
-  bioguide: H001061
-  thomas: '02079'
-- name: Chuck Grassley
-  party: minority
-  rank: 3
-  bioguide: G000386
-  thomas: '00457'
-- name: John Thune
-  party: minority
-  rank: 4
-  bioguide: T000250
-  thomas: '01534'
-- name: John Boozman
-  party: minority
-  rank: 5
-  bioguide: B001236
-  thomas: '01687'
-- name: Thad Cochran
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: C000567
-  thomas: '00213'
-SSAF16:
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C001070
-  thomas: '01828'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Tom Harkin
-  party: majority
-  rank: 3
-  bioguide: H000206
-  thomas: '00501'
-- name: Sherrod Brown
-  party: majority
-  rank: 4
-  bioguide: B000944
-  thomas: '00136'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 5
-  bioguide: G000555
-  thomas: '01866'
-- name: Michael F. Bennet
-  party: majority
-  rank: 6
-  bioguide: B001267
-  thomas: '01965'
-- name: Debbie Stabenow
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: S000770
-  thomas: '01531'
-- name: John Hoeven
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H001061
-  thomas: '02079'
-- name: Mitch McConnell
-  party: minority
-  rank: 2
-  bioguide: M000355
-  thomas: '01395'
-- name: Saxby Chambliss
-  party: minority
-  rank: 3
-  bioguide: C000286
-  thomas: '00188'
-- name: Chuck Grassley
-  party: minority
-  rank: 4
-  bioguide: G000386
-  thomas: '00457'
-- name: John Thune
-  party: minority
-  rank: 5
-  bioguide: T000250
-  thomas: '01534'
-- name: Thad Cochran
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: C000567
-  thomas: '00213'
-SSAF17:
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: G000555
-  thomas: '01866'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Amy Klobuchar
-  party: majority
-  rank: 3
-  bioguide: K000367
-  thomas: '01826'
-- name: Joe Donnelly
-  party: majority
-  rank: 4
-  bioguide: D000607
-  thomas: '01850'
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 5
-  bioguide: C001070
-  thomas: '01828'
-- name: John E. Walsh
-  party: majority
-  rank: 6
-  bioguide: W000818
-  thomas: '02198'
-- name: Debbie Stabenow
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: S000770
-  thomas: '01531'
-- name: Pat Roberts
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: R000307
-  thomas: '00968'
-- name: Mitch McConnell
-  party: minority
-  rank: 2
-  bioguide: M000355
-  thomas: '01395'
-- name: John Boozman
-  party: minority
-  rank: 3
-  bioguide: B001236
-  thomas: '01687'
-- name: Mike Johanns
-  party: minority
-  rank: 4
-  bioguide: J000291
-  thomas: '01899'
-- name: Chuck Grassley
-  party: minority
-  rank: 5
-  bioguide: G000386
-  thomas: '00457'
-- name: Thad Cochran
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: C000567
-  thomas: '00213'
-SSAP:
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M000702
-  thomas: '00802'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Tom Harkin
-  party: majority
-  rank: 3
-  bioguide: H000206
-  thomas: '00501'
-- name: Patty Murray
-  party: majority
-  rank: 4
-  bioguide: M001111
-  thomas: '01409'
-- name: Dianne Feinstein
-  party: majority
-  rank: 5
-  bioguide: F000062
-  thomas: '01332'
-- name: Richard J. Durbin
-  party: majority
-  rank: 6
-  bioguide: D000563
-  thomas: '00326'
-- name: Tim Johnson
-  party: majority
-  rank: 7
-  bioguide: J000177
-  thomas: '00604'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 8
-  bioguide: L000550
-  thomas: '01546'
-- name: Jack Reed
-  party: majority
-  rank: 9
-  bioguide: R000122
-  thomas: '00949'
-- name: Mark L. Pryor
-  party: majority
-  rank: 10
-  bioguide: P000590
-  thomas: '01701'
-- name: Jon Tester
-  party: majority
-  rank: 11
-  bioguide: T000464
-  thomas: '01829'
-- name: Tom Udall
   party: majority
   rank: 12
-  bioguide: U000039
-  thomas: '01567'
-- name: Jeanne Shaheen
+  bioguide: B001236
+  thomas: '01687'
+- name: Shelley Moore Capito
   party: majority
   rank: 13
-  bioguide: S001181
-  thomas: '01901'
-- name: Jeff Merkley
+  bioguide: C001047
+  thomas: '01676'
+- name: Bill Cassidy
   party: majority
   rank: 14
-  bioguide: M001176
-  thomas: '01900'
-- name: Mark Begich
+  bioguide: C001075
+  thomas: '01925'
+- name: James Lankford
   party: majority
   rank: 15
-  bioguide: B001265
-  thomas: '01898'
-- name: Christopher A. Coons
+  bioguide: L000575
+  thomas: '02050'
+- name: Steve Daines
   party: majority
   rank: 16
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard C. Shelby
+  bioguide: D000618
+  thomas: '02138'
+- name: Barbara A. Mikulski
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: S000320
-  thomas: '01049'
-- name: Thad Cochran
+  bioguide: M000702
+  thomas: '00802'
+- name: Patrick J. Leahy
   party: minority
   rank: 2
-  bioguide: C000567
-  thomas: '00213'
-- name: Mitch McConnell
+  bioguide: L000174
+  thomas: '01383'
+- name: Patty Murray
   party: minority
   rank: 3
-  bioguide: M000355
-  thomas: '01395'
-- name: Lamar Alexander
+  bioguide: M001111
+  thomas: '01409'
+- name: Dianne Feinstein
   party: minority
   rank: 4
-  bioguide: A000360
-  thomas: '01695'
-- name: Susan M. Collins
+  bioguide: F000062
+  thomas: '01332'
+- name: Richard J. Durbin
   party: minority
   rank: 5
-  bioguide: C001035
-  thomas: '01541'
-- name: Lisa Murkowski
+  bioguide: D000563
+  thomas: '00326'
+- name: Jack Reed
   party: minority
   rank: 6
-  bioguide: M001153
-  thomas: '01694'
-- name: Lindsey Graham
+  bioguide: R000122
+  thomas: '00949'
+- name: Jon Tester
   party: minority
   rank: 7
-  bioguide: G000359
-  thomas: '00452'
-- name: Mark Kirk
+  bioguide: T000464
+  thomas: '01829'
+- name: Tom Udall
   party: minority
   rank: 8
-  bioguide: K000360
-  thomas: '01647'
-- name: Daniel Coats
+  bioguide: U000039
+  thomas: '01567'
+- name: Jeanne Shaheen
   party: minority
   rank: 9
-  bioguide: C000542
-  thomas: '00209'
-- name: Roy Blunt
+  bioguide: S001181
+  thomas: '01901'
+- name: Jeff Merkley
   party: minority
   rank: 10
-  bioguide: B000575
-  thomas: '01464'
-- name: Jerry Moran
+  bioguide: M001176
+  thomas: '01900'
+- name: Christopher A. Coons
   party: minority
   rank: 11
-  bioguide: M000934
-  thomas: '01507'
-- name: John Hoeven
+  bioguide: C001088
+  thomas: '01984'
+- name: Brian Schatz
   party: minority
   rank: 12
-  bioguide: H001061
-  thomas: '02079'
-- name: Mike Johanns
+  bioguide: S001194
+  thomas: '02173'
+- name: Tammy Baldwin
   party: minority
   rank: 13
-  bioguide: J000291
-  thomas: '01899'
-- name: John Boozman
+  bioguide: B001230
+  thomas: '01558'
+- name: Christopher Murphy
   party: minority
   rank: 14
-  bioguide: B001236
-  thomas: '01687'
+  bioguide: M001169
+  thomas: '01837'
 SSAP01:
-- name: Mark L. Pryor
+- name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  bioguide: P000590
-  thomas: '01701'
-- name: Tom Harkin
+  bioguide: M000934
+  thomas: '01507'
+- name: Roy Blunt
   party: majority
   rank: 2
-  bioguide: H000206
-  thomas: '00501'
-- name: Dianne Feinstein
-  party: majority
-  rank: 3
-  bioguide: F000062
-  thomas: '01332'
-- name: Tim Johnson
-  party: majority
-  rank: 4
-  bioguide: J000177
-  thomas: '00604'
-- name: Jon Tester
-  party: majority
-  rank: 5
-  bioguide: T000464
-  thomas: '01829'
-- name: Tom Udall
-  party: majority
-  rank: 6
-  bioguide: U000039
-  thomas: '01567'
-- name: Jeff Merkley
-  party: majority
-  rank: 7
-  bioguide: M001176
-  thomas: '01900'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: M000702
-  thomas: '00802'
-- name: Roy Blunt
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: B000575
   thomas: '01464'
 - name: Thad Cochran
-  party: minority
-  rank: 2
+  party: majority
+  rank: 3
   bioguide: C000567
   thomas: '00213'
 - name: Mitch McConnell
-  party: minority
-  rank: 3
+  party: majority
+  rank: 4
   bioguide: M000355
   thomas: '01395'
 - name: Susan M. Collins
-  party: minority
-  rank: 4
+  party: majority
+  rank: 5
   bioguide: C001035
   thomas: '01541'
-- name: Jerry Moran
-  party: minority
-  rank: 5
-  bioguide: M000934
-  thomas: '01507'
 - name: John Hoeven
-  party: minority
+  party: majority
   rank: 6
   bioguide: H001061
   thomas: '02079'
-- name: Richard C. Shelby
+- name: Steve Daines
+  party: majority
+  rank: 7
+  bioguide: D000618
+  thomas: '02138'
+- name: Jeff Merkley
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001176
+  thomas: '01900'
+- name: Dianne Feinstein
+  party: minority
+  rank: 2
+  bioguide: F000062
+  thomas: '01332'
+- name: Jon Tester
+  party: minority
+  rank: 3
+  bioguide: T000464
+  thomas: '01829'
+- name: Tom Udall
+  party: minority
+  rank: 4
+  bioguide: U000039
+  thomas: '01567'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 5
+  bioguide: L000174
+  thomas: '01383'
+- name: Tammy Baldwin
+  party: minority
+  rank: 6
+  bioguide: B001230
+  thomas: '01558'
+- name: Barbara A. Mikulski
   party: minority
   rank: 7
   title: Ex Officio
-  bioguide: S000320
-  thomas: '01049'
+  bioguide: M000702
+  thomas: '00802'
 SSAP02:
-- name: Richard J. Durbin
+- name: Thad Cochran
   party: majority
   rank: 1
   title: Chairman
-  bioguide: D000563
-  thomas: '00326'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Tom Harkin
-  party: majority
-  rank: 3
-  bioguide: H000206
-  thomas: '00501'
-- name: Dianne Feinstein
-  party: majority
-  rank: 4
-  bioguide: F000062
-  thomas: '01332'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 5
-  bioguide: M000702
-  thomas: '00802'
-- name: Patty Murray
-  party: majority
-  rank: 6
-  bioguide: M001111
-  thomas: '01409'
-- name: Tim Johnson
-  party: majority
-  rank: 7
-  bioguide: J000177
-  thomas: '00604'
-- name: Jack Reed
-  party: majority
-  rank: 8
-  bioguide: R000122
-  thomas: '00949'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 9
-  bioguide: L000550
-  thomas: '01546'
-- name: Mark L. Pryor
-  party: majority
-  rank: 10
-  bioguide: P000590
-  thomas: '01701'
-- name: Thad Cochran
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: C000567
   thomas: '00213'
 - name: Mitch McConnell
-  party: minority
+  party: majority
   rank: 2
   bioguide: M000355
   thomas: '01395'
 - name: Richard C. Shelby
-  party: minority
+  party: majority
   rank: 3
   bioguide: S000320
   thomas: '01049'
 - name: Lamar Alexander
-  party: minority
+  party: majority
   rank: 4
   bioguide: A000360
   thomas: '01695'
 - name: Susan M. Collins
-  party: minority
+  party: majority
   rank: 5
   bioguide: C001035
   thomas: '01541'
 - name: Lisa Murkowski
-  party: minority
+  party: majority
   rank: 6
   bioguide: M001153
   thomas: '01694'
 - name: Lindsey Graham
-  party: minority
+  party: majority
   rank: 7
   bioguide: G000359
   thomas: '00452'
-- name: Daniel Coats
-  party: minority
-  rank: 8
-  bioguide: C000542
-  thomas: '00209'
 - name: Roy Blunt
-  party: minority
-  rank: 9
+  party: majority
+  rank: 8
   bioguide: B000575
   thomas: '01464'
+- name: Steve Daines
+  party: majority
+  rank: 9
+  bioguide: D000618
+  thomas: '02138'
+- name: Jerry Moran
+  party: majority
+  rank: 10
+  bioguide: M000934
+  thomas: '01507'
+- name: Richard J. Durbin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000563
+  thomas: '00326'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 2
+  bioguide: L000174
+  thomas: '01383'
+- name: Dianne Feinstein
+  party: minority
+  rank: 3
+  bioguide: F000062
+  thomas: '01332'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 4
+  bioguide: M000702
+  thomas: '00802'
+- name: Patty Murray
+  party: minority
+  rank: 5
+  bioguide: M001111
+  thomas: '01409'
+- name: Jack Reed
+  party: minority
+  rank: 6
+  bioguide: R000122
+  thomas: '00949'
+- name: Jon Tester
+  party: minority
+  rank: 7
+  bioguide: T000464
+  thomas: '01829'
+- name: Tom Udall
+  party: minority
+  rank: 8
+  bioguide: U000039
+  thomas: '01567'
+- name: Brian Schatz
+  party: minority
+  rank: 9
+  bioguide: S001194
+  thomas: '02173'
 SSAP08:
-- name: Jeanne Shaheen
+- name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
-  bioguide: S001181
-  thomas: '01901'
-- name: Mark Begich
+  bioguide: C001047
+  thomas: '01676'
+- name: Mark Kirk
   party: majority
   rank: 2
-  bioguide: B001265
-  thomas: '01898'
-- name: Christopher A. Coons
+  bioguide: K000360
+  thomas: '01647'
+- name: Jerry Moran
   party: majority
   rank: 3
-  bioguide: C001088
-  thomas: '01984'
-- name: Barbara A. Mikulski
+  bioguide: M000934
+  thomas: '01507'
+- name: Thad Cochran
   party: majority
   rank: 4
   title: Ex Officio
-  bioguide: M000702
-  thomas: '00802'
-- name: John Hoeven
+  bioguide: C000567
+  thomas: '00213'
+- name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: H001061
-  thomas: '02079'
-- name: John Boozman
+  bioguide: S001194
+  thomas: '02173'
+- name: Christopher Murphy
   party: minority
   rank: 2
-  bioguide: B001236
-  thomas: '01687'
-- name: Richard C. Shelby
+  bioguide: M001169
+  thomas: '01837'
+- name: Barbara A. Mikulski
   party: minority
   rank: 3
   title: Ex Officio
-  bioguide: S000320
-  thomas: '01049'
+  bioguide: M000702
+  thomas: '00802'
 SSAP14:
-- name: Mary L. Landrieu
+- name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
-  bioguide: L000550
-  thomas: '01546'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Patty Murray
-  party: majority
-  rank: 3
-  bioguide: M001111
-  thomas: '01409'
-- name: Jon Tester
-  party: majority
-  rank: 4
-  bioguide: T000464
-  thomas: '01829'
-- name: Mark Begich
-  party: majority
-  rank: 5
-  bioguide: B001265
-  thomas: '01898'
-- name: Christopher A. Coons
-  party: majority
-  rank: 6
-  bioguide: C001088
-  thomas: '01984'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: M000702
-  thomas: '00802'
-- name: Daniel Coats
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C000542
-  thomas: '00209'
+  bioguide: H001061
+  thomas: '02079'
 - name: Thad Cochran
-  party: minority
+  party: majority
   rank: 2
   bioguide: C000567
   thomas: '00213'
 - name: Richard C. Shelby
-  party: minority
+  party: majority
   rank: 3
   bioguide: S000320
   thomas: '01049'
 - name: Lisa Murkowski
-  party: minority
+  party: majority
   rank: 4
   bioguide: M001153
   thomas: '01694'
-- name: Jerry Moran
+- name: Lindsey Graham
+  party: majority
+  rank: 5
+  bioguide: G000359
+  thomas: '00452'
+- name: Bill Cassidy
+  party: majority
+  rank: 6
+  bioguide: C001075
+  thomas: '01925'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001181
+  thomas: '01901'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 2
+  bioguide: L000174
+  thomas: '01383'
+- name: Patty Murray
+  party: minority
+  rank: 3
+  bioguide: M001111
+  thomas: '01409'
+- name: Jon Tester
+  party: minority
+  rank: 4
+  bioguide: T000464
+  thomas: '01829'
+- name: Tammy Baldwin
   party: minority
   rank: 5
-  bioguide: M000934
-  thomas: '01507'
+  bioguide: B001230
+  thomas: '01558'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: M000702
+  thomas: '00802'
 SSAP16:
-- name: Barbara A. Mikulski
+- name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
+  bioguide: S000320
+  thomas: '01049'
+- name: Lamar Alexander
+  party: majority
+  rank: 2
+  bioguide: A000360
+  thomas: '01695'
+- name: Lisa Murkowski
+  party: majority
+  rank: 3
+  bioguide: M001153
+  thomas: '01694'
+- name: Susan M. Collins
+  party: majority
+  rank: 4
+  bioguide: C001035
+  thomas: '01541'
+- name: Lindsey Graham
+  party: majority
+  rank: 5
+  bioguide: G000359
+  thomas: '00452'
+- name: Mark Kirk
+  party: majority
+  rank: 6
+  bioguide: K000360
+  thomas: '01647'
+- name: John Boozman
+  party: majority
+  rank: 7
+  bioguide: B001236
+  thomas: '01687'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 8
+  bioguide: C001047
+  thomas: '01676'
+- name: James Lankford
+  party: majority
+  rank: 9
+  bioguide: L000575
+  thomas: '02050'
+- name: Thad Cochran
+  party: majority
+  rank: 10
+  title: Ex Officio
+  bioguide: C000567
+  thomas: '00213'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 1
+  title: Ranking Member
   bioguide: M000702
   thomas: '00802'
 - name: Patrick J. Leahy
-  party: majority
+  party: minority
   rank: 2
   bioguide: L000174
   thomas: '01383'
 - name: Dianne Feinstein
-  party: majority
+  party: minority
   rank: 3
   bioguide: F000062
   thomas: '01332'
 - name: Jack Reed
-  party: majority
+  party: minority
   rank: 4
   bioguide: R000122
   thomas: '00949'
-- name: Mark L. Pryor
-  party: majority
-  rank: 5
-  bioguide: P000590
-  thomas: '01701'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 6
-  bioguide: L000550
-  thomas: '01546'
 - name: Jeanne Shaheen
-  party: majority
-  rank: 7
+  party: minority
+  rank: 5
   bioguide: S001181
   thomas: '01901'
-- name: Jeff Merkley
-  party: majority
-  rank: 8
-  bioguide: M001176
-  thomas: '01900'
 - name: Christopher A. Coons
-  party: majority
-  rank: 9
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard C. Shelby
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S000320
-  thomas: '01049'
-- name: Mitch McConnell
-  party: minority
-  rank: 2
-  bioguide: M000355
-  thomas: '01395'
-- name: Lamar Alexander
-  party: minority
-  rank: 3
-  bioguide: A000360
-  thomas: '01695'
-- name: Susan M. Collins
-  party: minority
-  rank: 4
-  bioguide: C001035
-  thomas: '01541'
-- name: Lisa Murkowski
-  party: minority
-  rank: 5
-  bioguide: M001153
-  thomas: '01694'
-- name: Lindsey Graham
   party: minority
   rank: 6
-  bioguide: G000359
-  thomas: '00452'
-- name: Mark Kirk
+  bioguide: C001088
+  thomas: '01984'
+- name: Tammy Baldwin
   party: minority
   rank: 7
-  bioguide: K000360
-  thomas: '01647'
-- name: John Boozman
+  bioguide: B001230
+  thomas: '01558'
+- name: Christopher Murphy
   party: minority
   rank: 8
-  bioguide: B001236
-  thomas: '01687'
+  bioguide: M001169
+  thomas: '01837'
 SSAP17:
-- name: Jack Reed
+- name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  bioguide: R000122
-  thomas: '00949'
-- name: Dianne Feinstein
-  party: majority
-  rank: 2
-  bioguide: F000062
-  thomas: '01332'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 3
-  bioguide: L000174
-  thomas: '01383'
-- name: Tim Johnson
-  party: majority
-  rank: 4
-  bioguide: J000177
-  thomas: '00604'
-- name: Jon Tester
-  party: majority
-  rank: 5
-  bioguide: T000464
-  thomas: '01829'
-- name: Tom Udall
-  party: majority
-  rank: 6
-  bioguide: U000039
-  thomas: '01567'
-- name: Jeff Merkley
-  party: majority
-  rank: 7
-  bioguide: M001176
-  thomas: '01900'
-- name: Mark Begich
-  party: majority
-  rank: 8
-  bioguide: B001265
-  thomas: '01898'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: M000702
-  thomas: '00802'
-- name: Lisa Murkowski
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: M001153
   thomas: '01694'
-- name: Thad Cochran
-  party: minority
-  rank: 2
-  bioguide: C000567
-  thomas: '00213'
 - name: Lamar Alexander
-  party: minority
-  rank: 3
+  party: majority
+  rank: 2
   bioguide: A000360
   thomas: '01695'
+- name: Thad Cochran
+  party: majority
+  rank: 3
+  bioguide: C000567
+  thomas: '00213'
 - name: Roy Blunt
-  party: minority
+  party: majority
   rank: 4
   bioguide: B000575
   thomas: '01464'
 - name: John Hoeven
-  party: minority
+  party: majority
   rank: 5
   bioguide: H001061
   thomas: '02079'
-- name: Mike Johanns
+- name: Mitch McConnell
+  party: majority
+  rank: 6
+  bioguide: M000355
+  thomas: '01395'
+- name: Steve Daines
+  party: majority
+  rank: 7
+  bioguide: D000618
+  thomas: '02138'
+- name: Bill Cassidy
+  party: majority
+  rank: 8
+  bioguide: C001075
+  thomas: '01925'
+- name: Tom Udall
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: U000039
+  thomas: '01567'
+- name: Dianne Feinstein
+  party: minority
+  rank: 2
+  bioguide: F000062
+  thomas: '01332'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 3
+  bioguide: L000174
+  thomas: '01383'
+- name: Jack Reed
+  party: minority
+  rank: 4
+  bioguide: R000122
+  thomas: '00949'
+- name: Jon Tester
+  party: minority
+  rank: 5
+  bioguide: T000464
+  thomas: '01829'
+- name: Jeff Merkley
   party: minority
   rank: 6
-  bioguide: J000291
-  thomas: '01899'
-- name: Richard C. Shelby
+  bioguide: M001176
+  thomas: '01900'
+- name: Barbara A. Mikulski
   party: minority
   rank: 7
   title: Ex Officio
-  bioguide: S000320
-  thomas: '01049'
+  bioguide: M000702
+  thomas: '00802'
 SSAP18:
-- name: Tom Harkin
+- name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
-  bioguide: H000206
-  thomas: '00501'
-- name: Patty Murray
+  bioguide: B000575
+  thomas: '01464'
+- name: Jerry Moran
   party: majority
   rank: 2
-  bioguide: M001111
-  thomas: '01409'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 3
-  bioguide: L000550
-  thomas: '01546'
-- name: Richard J. Durbin
-  party: majority
-  rank: 4
-  bioguide: D000563
-  thomas: '00326'
-- name: Jack Reed
-  party: majority
-  rank: 5
-  bioguide: R000122
-  thomas: '00949'
-- name: Mark L. Pryor
-  party: majority
-  rank: 6
-  bioguide: P000590
-  thomas: '01701'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 7
-  bioguide: M000702
-  thomas: '00802'
-- name: Jon Tester
-  party: majority
-  rank: 8
-  bioguide: T000464
-  thomas: '01829'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 9
-  bioguide: S001181
-  thomas: '01901'
-- name: Jeff Merkley
-  party: majority
-  rank: 10
-  bioguide: M001176
-  thomas: '01900'
-- name: Jerry Moran
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: M000934
   thomas: '01507'
-- name: Thad Cochran
-  party: minority
-  rank: 2
-  bioguide: C000567
-  thomas: '00213'
 - name: Richard C. Shelby
-  party: minority
+  party: majority
   rank: 3
   bioguide: S000320
   thomas: '01049'
-- name: Lamar Alexander
-  party: minority
+- name: Thad Cochran
+  party: majority
   rank: 4
+  bioguide: C000567
+  thomas: '00213'
+- name: Lamar Alexander
+  party: majority
+  rank: 5
   bioguide: A000360
   thomas: '01695'
 - name: Lindsey Graham
-  party: minority
-  rank: 5
+  party: majority
+  rank: 6
   bioguide: G000359
   thomas: '00452'
 - name: Mark Kirk
-  party: minority
-  rank: 6
+  party: majority
+  rank: 7
   bioguide: K000360
   thomas: '01647'
-- name: Mike Johanns
+- name: Bill Cassidy
+  party: majority
+  rank: 8
+  bioguide: C001075
+  thomas: '01925'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 9
+  bioguide: C001047
+  thomas: '01676'
+- name: James Lankford
+  party: majority
+  rank: 10
+  bioguide: L000575
+  thomas: '02050'
+- name: Patty Murray
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001111
+  thomas: '01409'
+- name: Richard J. Durbin
+  party: minority
+  rank: 2
+  bioguide: D000563
+  thomas: '00326'
+- name: Jack Reed
+  party: minority
+  rank: 3
+  bioguide: R000122
+  thomas: '00949'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 4
+  bioguide: M000702
+  thomas: '00802'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 5
+  bioguide: S001181
+  thomas: '01901'
+- name: Jeff Merkley
+  party: minority
+  rank: 6
+  bioguide: M001176
+  thomas: '01900'
+- name: Brian Schatz
   party: minority
   rank: 7
-  bioguide: J000291
-  thomas: '01899'
-- name: John Boozman
+  bioguide: S001194
+  thomas: '02173'
+- name: Tammy Baldwin
   party: minority
   rank: 8
-  bioguide: B001236
-  thomas: '01687'
+  bioguide: B001230
+  thomas: '01558'
 SSAP19:
-- name: Tim Johnson
+- name: Mark Kirk
   party: majority
   rank: 1
   title: Chairman
-  bioguide: J000177
-  thomas: '00604'
-- name: Patty Murray
+  bioguide: K000360
+  thomas: '01647'
+- name: Mitch McConnell
   party: majority
+  rank: 2
+  bioguide: M000355
+  thomas: '01395'
+- name: Lisa Murkowski
+  party: majority
+  rank: 3
+  bioguide: M001153
+  thomas: '01694'
+- name: John Hoeven
+  party: majority
+  rank: 4
+  bioguide: H001061
+  thomas: '02079'
+- name: Susan M. Collins
+  party: majority
+  rank: 5
+  bioguide: C001035
+  thomas: '01541'
+- name: John Boozman
+  party: majority
+  rank: 6
+  bioguide: B001236
+  thomas: '01687'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 7
+  bioguide: C001047
+  thomas: '01676'
+- name: Bill Cassidy
+  party: majority
+  rank: 8
+  bioguide: C001075
+  thomas: '01925'
+- name: Thad Cochran
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: C000567
+  thomas: '00213'
+- name: Jon Tester
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: T000464
+  thomas: '01829'
+- name: Patty Murray
+  party: minority
   rank: 2
   bioguide: M001111
   thomas: '01409'
 - name: Jack Reed
-  party: majority
+  party: minority
   rank: 3
   bioguide: R000122
   thomas: '00949'
-- name: Mark L. Pryor
-  party: majority
-  rank: 4
-  bioguide: P000590
-  thomas: '01701'
-- name: Jon Tester
-  party: majority
-  rank: 5
-  bioguide: T000464
-  thomas: '01829'
 - name: Tom Udall
-  party: majority
-  rank: 6
+  party: minority
+  rank: 4
   bioguide: U000039
   thomas: '01567'
-- name: Mark Begich
+- name: Brian Schatz
+  party: minority
+  rank: 5
+  bioguide: S001194
+  thomas: '02173'
+- name: Tammy Baldwin
+  party: minority
+  rank: 6
+  bioguide: B001230
+  thomas: '01558'
+- name: Christopher Murphy
+  party: minority
+  rank: 7
+  bioguide: M001169
+  thomas: '01837'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 8
+  title: Ex Officio
+  bioguide: M000702
+  thomas: '00802'
+SSAP20:
+- name: Lindsey Graham
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: G000359
+  thomas: '00452'
+- name: Mitch McConnell
+  party: majority
+  rank: 2
+  bioguide: M000355
+  thomas: '01395'
+- name: Mark Kirk
+  party: majority
+  rank: 3
+  bioguide: K000360
+  thomas: '01647'
+- name: Roy Blunt
+  party: majority
+  rank: 4
+  bioguide: B000575
+  thomas: '01464'
+- name: John Boozman
+  party: majority
+  rank: 5
+  bioguide: B001236
+  thomas: '01687'
+- name: Jerry Moran
+  party: majority
+  rank: 6
+  bioguide: M000934
+  thomas: '01507'
+- name: James Lankford
   party: majority
   rank: 7
-  bioguide: B001265
-  thomas: '01898'
-- name: Jeff Merkley
+  bioguide: L000575
+  thomas: '02050'
+- name: Steve Daines
   party: majority
   rank: 8
+  bioguide: D000618
+  thomas: '02138'
+- name: Thad Cochran
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: C000567
+  thomas: '00213'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000174
+  thomas: '01383'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 2
+  bioguide: M000702
+  thomas: '00802'
+- name: Richard J. Durbin
+  party: minority
+  rank: 3
+  bioguide: D000563
+  thomas: '00326'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 4
+  bioguide: S001181
+  thomas: '01901'
+- name: Christopher A. Coons
+  party: minority
+  rank: 5
+  bioguide: C001088
+  thomas: '01984'
+- name: Jeff Merkley
+  party: minority
+  rank: 6
   bioguide: M001176
   thomas: '01900'
-- name: Barbara A. Mikulski
+- name: Christopher Murphy
+  party: minority
+  rank: 7
+  bioguide: M001169
+  thomas: '01837'
+SSAP22:
+- name: Lamar Alexander
   party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: M000702
-  thomas: '00802'
-- name: Mark Kirk
-  party: minority
   rank: 1
-  title: Ranking Member
-  bioguide: K000360
-  thomas: '01647'
-- name: Mitch McConnell
-  party: minority
+  title: Chairman
+  bioguide: A000360
+  thomas: '01695'
+- name: Thad Cochran
+  party: majority
   rank: 2
+  bioguide: C000567
+  thomas: '00213'
+- name: Mitch McConnell
+  party: majority
+  rank: 3
   bioguide: M000355
   thomas: '01395'
+- name: Richard C. Shelby
+  party: majority
+  rank: 4
+  bioguide: S000320
+  thomas: '01049'
 - name: Susan M. Collins
-  party: minority
-  rank: 3
+  party: majority
+  rank: 5
   bioguide: C001035
   thomas: '01541'
 - name: Lisa Murkowski
-  party: minority
-  rank: 4
+  party: majority
+  rank: 6
   bioguide: M001153
   thomas: '01694'
-- name: Daniel Coats
-  party: minority
-  rank: 5
-  bioguide: C000542
-  thomas: '00209'
+- name: Lindsey Graham
+  party: majority
+  rank: 7
+  bioguide: G000359
+  thomas: '00452'
 - name: John Hoeven
-  party: minority
-  rank: 6
+  party: majority
+  rank: 8
   bioguide: H001061
   thomas: '02079'
-- name: Mike Johanns
-  party: minority
-  rank: 7
-  bioguide: J000291
-  thomas: '01899'
-- name: Richard C. Shelby
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: S000320
-  thomas: '01049'
-SSAP20:
-- name: Patrick J. Leahy
+- name: James Lankford
   party: majority
-  rank: 1
-  title: Chairman
-  bioguide: L000174
-  thomas: '01383'
-- name: Tom Harkin
-  party: majority
-  rank: 2
-  bioguide: H000206
-  thomas: '00501'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 3
-  bioguide: M000702
-  thomas: '00802'
-- name: Richard J. Durbin
-  party: majority
-  rank: 4
-  bioguide: D000563
-  thomas: '00326'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 5
-  bioguide: L000550
-  thomas: '01546'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 6
-  bioguide: S001181
-  thomas: '01901'
-- name: Mark Begich
-  party: majority
-  rank: 7
-  bioguide: B001265
-  thomas: '01898'
-- name: Christopher A. Coons
-  party: majority
-  rank: 8
-  bioguide: C001088
-  thomas: '01984'
-- name: Lindsey Graham
+  rank: 9
+  bioguide: L000575
+  thomas: '02050'
+- name: Dianne Feinstein
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: G000359
-  thomas: '00452'
-- name: Mitch McConnell
-  party: minority
-  rank: 2
-  bioguide: M000355
-  thomas: '01395'
-- name: Mark Kirk
-  party: minority
-  rank: 3
-  bioguide: K000360
-  thomas: '01647'
-- name: Daniel Coats
-  party: minority
-  rank: 4
-  bioguide: C000542
-  thomas: '00209'
-- name: Roy Blunt
-  party: minority
-  rank: 5
-  bioguide: B000575
-  thomas: '01464'
-- name: Mike Johanns
-  party: minority
-  rank: 6
-  bioguide: J000291
-  thomas: '01899'
-- name: John Boozman
-  party: minority
-  rank: 7
-  bioguide: B001236
-  thomas: '01687'
-- name: Richard C. Shelby
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: S000320
-  thomas: '01049'
-SSAP22:
-- name: Dianne Feinstein
-  party: majority
-  rank: 1
-  title: Chairman
   bioguide: F000062
   thomas: '01332'
 - name: Patty Murray
-  party: majority
+  party: minority
   rank: 2
   bioguide: M001111
   thomas: '01409'
-- name: Tim Johnson
-  party: majority
-  rank: 3
-  bioguide: J000177
-  thomas: '00604'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 4
-  bioguide: L000550
-  thomas: '01546'
-- name: Tom Harkin
-  party: majority
-  rank: 5
-  bioguide: H000206
-  thomas: '00501'
 - name: Jon Tester
-  party: majority
-  rank: 6
+  party: minority
+  rank: 3
   bioguide: T000464
   thomas: '01829'
 - name: Richard J. Durbin
-  party: majority
-  rank: 7
+  party: minority
+  rank: 4
   bioguide: D000563
   thomas: '00326'
 - name: Tom Udall
-  party: majority
-  rank: 8
+  party: minority
+  rank: 5
   bioguide: U000039
   thomas: '01567'
 - name: Jeanne Shaheen
-  party: majority
-  rank: 9
-  bioguide: S001181
-  thomas: '01901'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: M000702
-  thomas: '00802'
-- name: Lamar Alexander
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: A000360
-  thomas: '01695'
-- name: Thad Cochran
-  party: minority
-  rank: 2
-  bioguide: C000567
-  thomas: '00213'
-- name: Mitch McConnell
-  party: minority
-  rank: 3
-  bioguide: M000355
-  thomas: '01395'
-- name: Richard C. Shelby
-  party: minority
-  rank: 4
-  bioguide: S000320
-  thomas: '01049'
-- name: Susan M. Collins
-  party: minority
-  rank: 5
-  bioguide: C001035
-  thomas: '01541'
-- name: Lisa Murkowski
   party: minority
   rank: 6
-  bioguide: M001153
-  thomas: '01694'
-- name: Lindsey Graham
+  bioguide: S001181
+  thomas: '01901'
+- name: Jeff Merkley
   party: minority
   rank: 7
-  bioguide: G000359
-  thomas: '00452'
-- name: John Hoeven
+  bioguide: M001176
+  thomas: '01900'
+- name: Christopher A. Coons
   party: minority
   rank: 8
-  bioguide: H001061
-  thomas: '02079'
-SSAP23:
-- name: Richard J. Durbin
-  party: majority
-  rank: 1
-  bioguide: D000563
-  thomas: '00326'
-- name: Tom Udall
-  party: majority
-  rank: 2
-  title: Chairman
-  bioguide: U000039
-  thomas: '01567'
-- name: Christopher A. Coons
-  party: majority
-  rank: 3
   bioguide: C001088
   thomas: '01984'
 - name: Barbara A. Mikulski
-  party: majority
-  rank: 4
+  party: minority
+  rank: 9
   title: Ex Officio
   bioguide: M000702
   thomas: '00802'
-- name: Mike Johanns
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: J000291
-  thomas: '01899'
-- name: Jerry Moran
-  party: minority
-  rank: 2
-  bioguide: M000934
-  thomas: '01507'
-- name: Richard C. Shelby
-  party: minority
-  rank: 3
-  title: Ex Officio
-  bioguide: S000320
-  thomas: '01049'
-SSAP24:
-- name: Patty Murray
+SSAP23:
+- name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  bioguide: M001111
-  thomas: '01409'
-- name: Barbara A. Mikulski
+  bioguide: B001236
+  thomas: '01687'
+- name: Jerry Moran
   party: majority
   rank: 2
-  bioguide: M000702
-  thomas: '00802'
-- name: Richard J. Durbin
+  bioguide: M000934
+  thomas: '01507'
+- name: James Lankford
   party: majority
   rank: 3
-  bioguide: D000563
-  thomas: '00326'
-- name: Patrick J. Leahy
+  bioguide: L000575
+  thomas: '02050'
+- name: Thad Cochran
   party: majority
   rank: 4
-  bioguide: L000174
-  thomas: '01383'
-- name: Tom Harkin
-  party: majority
-  rank: 5
-  bioguide: H000206
-  thomas: '00501'
-- name: Dianne Feinstein
-  party: majority
-  rank: 6
-  bioguide: F000062
-  thomas: '01332'
-- name: Tim Johnson
-  party: majority
-  rank: 7
-  bioguide: J000177
-  thomas: '00604'
-- name: Mark L. Pryor
-  party: majority
-  rank: 8
-  bioguide: P000590
-  thomas: '01701'
-- name: Jack Reed
-  party: majority
-  rank: 9
-  bioguide: R000122
-  thomas: '00949'
-- name: Tom Udall
-  party: majority
-  rank: 10
-  bioguide: U000039
-  thomas: '01567'
-- name: Susan M. Collins
+  title: Ex Officio
+  bioguide: C000567
+  thomas: '00213'
+- name: Christopher A. Coons
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: C001088
+  thomas: '01984'
+- name: Richard J. Durbin
+  party: minority
+  rank: 2
+  bioguide: D000563
+  thomas: '00326'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 3
+  title: Ex Officio
+  bioguide: M000702
+  thomas: '00802'
+SSAP24:
+- name: Susan M. Collins
+  party: majority
+  rank: 1
+  title: Chairman
   bioguide: C001035
   thomas: '01541'
 - name: Richard C. Shelby
-  party: minority
+  party: majority
   rank: 2
   bioguide: S000320
   thomas: '01049'
 - name: Lamar Alexander
-  party: minority
+  party: majority
   rank: 3
   bioguide: A000360
   thomas: '01695'
-- name: Lindsey Graham
-  party: minority
-  rank: 4
-  bioguide: G000359
-  thomas: '00452'
 - name: Mark Kirk
-  party: minority
-  rank: 5
+  party: majority
+  rank: 4
   bioguide: K000360
   thomas: '01647'
-- name: Daniel Coats
-  party: minority
-  rank: 6
-  bioguide: C000542
-  thomas: '00209'
 - name: Roy Blunt
-  party: minority
-  rank: 7
+  party: majority
+  rank: 5
   bioguide: B000575
   thomas: '01464'
-- name: Jerry Moran
-  party: minority
-  rank: 8
-  bioguide: M000934
-  thomas: '01507'
 - name: John Boozman
-  party: minority
-  rank: 9
+  party: majority
+  rank: 6
   bioguide: B001236
   thomas: '01687'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 7
+  bioguide: C001047
+  thomas: '01676'
+- name: Bill Cassidy
+  party: majority
+  rank: 8
+  bioguide: C001075
+  thomas: '01925'
+- name: Steve Daines
+  party: majority
+  rank: 9
+  bioguide: D000618
+  thomas: '02138'
 - name: Thad Cochran
-  party: minority
+  party: majority
   rank: 10
   title: Ex Officio
   bioguide: C000567
   thomas: '00213'
+- name: Jack Reed
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000122
+  thomas: '00949'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 2
+  bioguide: M000702
+  thomas: '00802'
+- name: Patty Murray
+  party: minority
+  rank: 3
+  bioguide: M001111
+  thomas: '01409'
+- name: Richard J. Durbin
+  party: minority
+  rank: 4
+  bioguide: D000563
+  thomas: '00326'
+- name: Dianne Feinstein
+  party: minority
+  rank: 5
+  bioguide: F000062
+  thomas: '01332'
+- name: Christopher A. Coons
+  party: minority
+  rank: 6
+  bioguide: C001088
+  thomas: '01984'
+- name: Brian Schatz
+  party: minority
+  rank: 7
+  bioguide: S001194
+  thomas: '02173'
+- name: Christopher Murphy
+  party: minority
+  rank: 8
+  bioguide: M001169
+  thomas: '01837'
 SSAS:
-- name: Carl Levin
+- name: John McCain
   party: majority
   rank: 1
   title: Chairman
-  bioguide: L000261
-  thomas: '01384'
-- name: Jack Reed
+  bioguide: M000303
+  thomas: '00754'
+- name: James M. Inhofe
   party: majority
   rank: 2
-  bioguide: R000122
-  thomas: '00949'
-- name: Bill Nelson
+  bioguide: I000024
+  thomas: '00583'
+- name: Jeff Sessions
   party: majority
   rank: 3
-  bioguide: N000032
-  thomas: '00859'
-- name: Claire McCaskill
+  bioguide: S001141
+  thomas: '01548'
+- name: Roger F. Wicker
   party: majority
   rank: 4
-  bioguide: M001170
-  thomas: '01820'
-- name: Mark Udall
+  bioguide: W000437
+  thomas: '01226'
+- name: Kelly Ayotte
   party: majority
   rank: 5
-  bioguide: U000038
-  thomas: '01595'
-- name: Kay R. Hagan
+  bioguide: A000368
+  thomas: '02075'
+- name: Deb Fischer
   party: majority
   rank: 6
-  bioguide: H001049
-  thomas: '01902'
-- name: Joe Manchin, III
+  bioguide: F000463
+  thomas: '02179'
+- name: Tom Cotton
   party: majority
   rank: 7
-  bioguide: M001183
-  thomas: '01983'
-- name: Jeanne Shaheen
+  bioguide: C001095
+  thomas: '02098'
+- name: Mike Rounds
   party: majority
   rank: 8
-  bioguide: S001181
-  thomas: '01901'
-- name: Kirsten E. Gillibrand
+  bioguide: R000605
+  thomas: '02288'
+- name: Joni Ernst
   party: majority
   rank: 9
-  bioguide: G000555
-  thomas: '01866'
-- name: Richard Blumenthal
+  bioguide: E000295
+  thomas: '02283'
+- name: Thom Tillis
   party: majority
   rank: 10
-  bioguide: B001277
-  thomas: '02076'
-- name: Joe Donnelly
+  bioguide: T000476
+  thomas: '02291'
+- name: Daniel Sullivan
   party: majority
   rank: 11
-  bioguide: D000607
-  thomas: '01850'
-- name: Mazie K. Hirono
+  bioguide: S001198
+  thomas: '02290'
+- name: Mike Lee
   party: majority
   rank: 12
-  bioguide: H001042
-  thomas: '01844'
-- name: Tim Kaine
+  bioguide: L000577
+  thomas: '02080'
+- name: Lindsey Graham
   party: majority
   rank: 13
-  bioguide: K000384
-  thomas: '02176'
-- name: Angus S. King, Jr.
+  bioguide: G000359
+  thomas: '00452'
+- name: Ted Cruz
   party: majority
   rank: 14
-  bioguide: K000383
-  thomas: '02185'
-- name: James M. Inhofe
+  bioguide: C001098
+  thomas: '02175'
+- name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: I000024
-  thomas: '00583'
-- name: John McCain
+  bioguide: R000122
+  thomas: '00949'
+- name: Bill Nelson
   party: minority
   rank: 2
-  bioguide: M000303
-  thomas: '00754'
-- name: Jeff Sessions
+  bioguide: N000032
+  thomas: '00859'
+- name: Claire McCaskill
   party: minority
   rank: 3
-  bioguide: S001141
-  thomas: '01548'
-- name: Saxby Chambliss
+  bioguide: M001170
+  thomas: '01820'
+- name: Joe Manchin, III
   party: minority
   rank: 4
-  bioguide: C000286
-  thomas: '00188'
-- name: Roger F. Wicker
+  bioguide: M001183
+  thomas: '01983'
+- name: Jeanne Shaheen
   party: minority
   rank: 5
-  bioguide: W000437
-  thomas: '01226'
-- name: Kelly Ayotte
+  bioguide: S001181
+  thomas: '01901'
+- name: Kirsten E. Gillibrand
   party: minority
   rank: 6
-  bioguide: A000368
-  thomas: '02075'
-- name: Deb Fischer
+  bioguide: G000555
+  thomas: '01866'
+- name: Richard Blumenthal
   party: minority
   rank: 7
-  bioguide: F000463
-  thomas: '02179'
-- name: Lindsey Graham
+  bioguide: B001277
+  thomas: '02076'
+- name: Joe Donnelly
   party: minority
   rank: 8
-  bioguide: G000359
-  thomas: '00452'
-- name: David Vitter
+  bioguide: D000607
+  thomas: '01850'
+- name: Mazie K. Hirono
   party: minority
   rank: 9
-  bioguide: V000127
-  thomas: '01609'
-- name: Roy Blunt
+  bioguide: H001042
+  thomas: '01844'
+- name: Tim Kaine
   party: minority
   rank: 10
-  bioguide: B000575
-  thomas: '01464'
-- name: Mike Lee
+  bioguide: K000384
+  thomas: '02176'
+- name: Angus S. King, Jr.
   party: minority
   rank: 11
-  bioguide: L000577
-  thomas: '02080'
-- name: Ted Cruz
+  bioguide: K000383
+  thomas: '02185'
+- name: Martin Heinrich
   party: minority
   rank: 12
-  bioguide: C001098
-  thomas: '02175'
+  bioguide: H001046
+  thomas: '01937'
 SSAS13:
-- name: Jack Reed
+- name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
-  bioguide: R000122
-  thomas: '00949'
-- name: Bill Nelson
-  party: majority
-  rank: 2
-  bioguide: N000032
-  thomas: '00859'
-- name: Kay R. Hagan
-  party: majority
-  rank: 3
-  bioguide: H001049
-  thomas: '01902'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 4
-  bioguide: S001181
-  thomas: '01901'
-- name: Richard Blumenthal
-  party: majority
-  rank: 5
-  bioguide: B001277
-  thomas: '02076'
-- name: Mazie K. Hirono
-  party: majority
-  rank: 6
-  bioguide: H001042
-  thomas: '01844'
-- name: Tim Kaine
-  party: majority
-  rank: 7
-  bioguide: K000384
-  thomas: '02176'
-- name: Angus S. King, Jr.
-  party: majority
-  rank: 8
-  bioguide: K000383
-  thomas: '02185'
-- name: Carl Levin
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: L000261
-  thomas: '01384'
-- name: John McCain
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M000303
-  thomas: '00754'
+  bioguide: W000437
+  thomas: '01226'
 - name: Jeff Sessions
-  party: minority
+  party: majority
   rank: 2
   bioguide: S001141
   thomas: '01548'
-- name: Roger F. Wicker
-  party: minority
-  rank: 3
-  bioguide: W000437
-  thomas: '01226'
 - name: Kelly Ayotte
-  party: minority
-  rank: 4
+  party: majority
+  rank: 3
   bioguide: A000368
   thomas: '02075'
-- name: Lindsey Graham
-  party: minority
+- name: Mike Rounds
+  party: majority
+  rank: 4
+  bioguide: R000605
+  thomas: '02288'
+- name: Thom Tillis
+  party: majority
   rank: 5
-  bioguide: G000359
-  thomas: '00452'
-- name: David Vitter
-  party: minority
+  bioguide: T000476
+  thomas: '02291'
+- name: Daniel Sullivan
+  party: majority
   rank: 6
-  bioguide: V000127
-  thomas: '01609'
+  bioguide: S001198
+  thomas: '02290'
 - name: Ted Cruz
-  party: minority
+  party: majority
   rank: 7
   bioguide: C001098
   thomas: '02175'
-- name: James M. Inhofe
-  party: minority
+- name: John McCain
+  party: majority
   rank: 8
   title: Ex Officio
-  bioguide: I000024
-  thomas: '00583'
+  bioguide: M000303
+  thomas: '00754'
+- name: Mazie K. Hirono
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H001042
+  thomas: '01844'
+- name: Bill Nelson
+  party: minority
+  rank: 2
+  bioguide: N000032
+  thomas: '00859'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 3
+  bioguide: S001181
+  thomas: '01901'
+- name: Richard Blumenthal
+  party: minority
+  rank: 4
+  bioguide: B001277
+  thomas: '02076'
+- name: Tim Kaine
+  party: minority
+  rank: 5
+  bioguide: K000384
+  thomas: '02176'
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 6
+  bioguide: K000383
+  thomas: '02185'
+- name: Jack Reed
+  party: minority
+  rank: 7
+  title: Ex Officio
+  bioguide: R000122
+  thomas: '00949'
 SSAS14:
-- name: Richard Blumenthal
+- name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
-  bioguide: B001277
-  thomas: '02076'
-- name: Bill Nelson
+  bioguide: C001095
+  thomas: '02098'
+- name: James M. Inhofe
   party: majority
   rank: 2
-  bioguide: N000032
-  thomas: '00859'
-- name: Claire McCaskill
-  party: majority
-  rank: 3
-  bioguide: M001170
-  thomas: '01820'
-- name: Joe Manchin, III
-  party: majority
-  rank: 4
-  bioguide: M001183
-  thomas: '01983'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 5
-  bioguide: G000555
-  thomas: '01866'
-- name: Joe Donnelly
-  party: majority
-  rank: 6
-  bioguide: D000607
-  thomas: '01850'
-- name: Carl Levin
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: L000261
-  thomas: '01384'
-- name: Roger F. Wicker
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: W000437
-  thomas: '01226'
-- name: John McCain
-  party: minority
-  rank: 2
-  bioguide: M000303
-  thomas: '00754'
+  bioguide: I000024
+  thomas: '00583'
 - name: Jeff Sessions
-  party: minority
+  party: majority
   rank: 3
   bioguide: S001141
   thomas: '01548'
-- name: Saxby Chambliss
+- name: Roger F. Wicker
+  party: majority
+  rank: 4
+  bioguide: W000437
+  thomas: '01226'
+- name: Mike Rounds
+  party: majority
+  rank: 5
+  bioguide: R000605
+  thomas: '02288'
+- name: Joni Ernst
+  party: majority
+  rank: 6
+  bioguide: E000295
+  thomas: '02283'
+- name: Daniel Sullivan
+  party: majority
+  rank: 7
+  bioguide: S001198
+  thomas: '02290'
+- name: Mike Lee
+  party: majority
+  rank: 8
+  bioguide: L000577
+  thomas: '02080'
+- name: John McCain
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: M000303
+  thomas: '00754'
+- name: Joe Manchin, III
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001183
+  thomas: '01983'
+- name: Claire McCaskill
+  party: minority
+  rank: 2
+  bioguide: M001170
+  thomas: '01820'
+- name: Kirsten E. Gillibrand
+  party: minority
+  rank: 3
+  bioguide: G000555
+  thomas: '01866'
+- name: Richard Blumenthal
   party: minority
   rank: 4
-  bioguide: C000286
-  thomas: '00188'
-- name: Roy Blunt
+  bioguide: B001277
+  thomas: '02076'
+- name: Joe Donnelly
   party: minority
   rank: 5
-  bioguide: B000575
-  thomas: '01464'
-- name: James M. Inhofe
+  bioguide: D000607
+  thomas: '01850'
+- name: Mazie K. Hirono
   party: minority
   rank: 6
+  bioguide: H001042
+  thomas: '01844'
+- name: Martin Heinrich
+  party: minority
+  rank: 7
+  bioguide: H001046
+  thomas: '01937'
+- name: Jack Reed
+  party: minority
+  rank: 8
   title: Ex Officio
-  bioguide: I000024
-  thomas: '00583'
+  bioguide: R000122
+  thomas: '00949'
 SSAS15:
-- name: Jeanne Shaheen
+- name: Kelly Ayotte
   party: majority
   rank: 1
   title: Chairman
-  bioguide: S001181
-  thomas: '01901'
-- name: Claire McCaskill
-  party: majority
-  rank: 2
-  bioguide: M001170
-  thomas: '01820'
-- name: Mark Udall
-  party: majority
-  rank: 3
-  bioguide: U000038
-  thomas: '01595'
-- name: Joe Manchin, III
-  party: majority
-  rank: 4
-  bioguide: M001183
-  thomas: '01983'
-- name: Joe Donnelly
-  party: majority
-  rank: 5
-  bioguide: D000607
-  thomas: '01850'
-- name: Mazie K. Hirono
-  party: majority
-  rank: 6
-  bioguide: H001042
-  thomas: '01844'
-- name: Tim Kaine
-  party: majority
-  rank: 7
-  bioguide: K000384
-  thomas: '02176'
-- name: Carl Levin
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: L000261
-  thomas: '01384'
-- name: Kelly Ayotte
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: A000368
   thomas: '02075'
-- name: Saxby Chambliss
-  party: minority
+- name: James M. Inhofe
+  party: majority
   rank: 2
-  bioguide: C000286
-  thomas: '00188'
+  bioguide: I000024
+  thomas: '00583'
 - name: Deb Fischer
-  party: minority
+  party: majority
   rank: 3
   bioguide: F000463
   thomas: '02179'
-- name: Roy Blunt
-  party: minority
+- name: Mike Rounds
+  party: majority
   rank: 4
-  bioguide: B000575
-  thomas: '01464'
-- name: Mike Lee
-  party: minority
+  bioguide: R000605
+  thomas: '02288'
+- name: Joni Ernst
+  party: majority
   rank: 5
+  bioguide: E000295
+  thomas: '02283'
+- name: Mike Lee
+  party: majority
+  rank: 6
   bioguide: L000577
   thomas: '02080'
-- name: Ted Cruz
-  party: minority
-  rank: 6
-  bioguide: C001098
-  thomas: '02175'
-- name: James M. Inhofe
-  party: minority
+- name: John McCain
+  party: majority
   rank: 7
   title: Ex Officio
-  bioguide: I000024
-  thomas: '00583'
+  bioguide: M000303
+  thomas: '00754'
+- name: Tim Kaine
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: K000384
+  thomas: '02176'
+- name: Claire McCaskill
+  party: minority
+  rank: 2
+  bioguide: M001170
+  thomas: '01820'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 3
+  bioguide: S001181
+  thomas: '01901'
+- name: Mazie K. Hirono
+  party: minority
+  rank: 4
+  bioguide: H001042
+  thomas: '01844'
+- name: Martin Heinrich
+  party: minority
+  rank: 5
+  bioguide: H001046
+  thomas: '01937'
+- name: Jack Reed
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: R000122
+  thomas: '00949'
 SSAS16:
-- name: Mark Udall
+- name: Jeff Sessions
   party: majority
   rank: 1
   title: Chairman
-  bioguide: U000038
-  thomas: '01595'
-- name: Jack Reed
+  bioguide: S001141
+  thomas: '01548'
+- name: James M. Inhofe
   party: majority
   rank: 2
-  bioguide: R000122
-  thomas: '00949'
-- name: Claire McCaskill
+  bioguide: I000024
+  thomas: '00583'
+- name: Deb Fischer
   party: majority
   rank: 3
-  bioguide: M001170
-  thomas: '01820'
-- name: Joe Donnelly
+  bioguide: F000463
+  thomas: '02179'
+- name: Mike Lee
   party: majority
   rank: 4
+  bioguide: L000577
+  thomas: '02080'
+- name: Lindsey Graham
+  party: majority
+  rank: 5
+  bioguide: G000359
+  thomas: '00452'
+- name: Ted Cruz
+  party: majority
+  rank: 6
+  bioguide: C001098
+  thomas: '02175'
+- name: John McCain
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: M000303
+  thomas: '00754'
+- name: Joe Donnelly
+  party: minority
+  rank: 1
+  title: Ranking Member
   bioguide: D000607
   thomas: '01850'
-- name: Angus S. King, Jr.
-  party: majority
-  rank: 5
-  bioguide: K000383
-  thomas: '02185'
-- name: Carl Levin
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: L000261
-  thomas: '01384'
-- name: Jeff Sessions
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001141
-  thomas: '01548'
-- name: Deb Fischer
+- name: Bill Nelson
   party: minority
   rank: 2
-  bioguide: F000463
-  thomas: '02179'
-- name: David Vitter
+  bioguide: N000032
+  thomas: '00859'
+- name: Joe Manchin, III
   party: minority
   rank: 3
-  bioguide: V000127
-  thomas: '01609'
-- name: Mike Lee
+  bioguide: M001183
+  thomas: '01983'
+- name: Angus S. King, Jr.
   party: minority
   rank: 4
-  bioguide: L000577
-  thomas: '02080'
-- name: James M. Inhofe
+  bioguide: K000383
+  thomas: '02185'
+- name: Martin Heinrich
   party: minority
   rank: 5
+  bioguide: H001046
+  thomas: '01937'
+- name: Jack Reed
+  party: minority
+  rank: 6
   title: Ex Officio
-  bioguide: I000024
-  thomas: '00583'
+  bioguide: R000122
+  thomas: '00949'
 SSAS17:
-- name: Kirsten E. Gillibrand
+- name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
-  bioguide: G000555
-  thomas: '01866'
-- name: Kay R. Hagan
+  bioguide: G000359
+  thomas: '00452'
+- name: Roger F. Wicker
   party: majority
   rank: 2
-  bioguide: H001049
-  thomas: '01902'
-- name: Richard Blumenthal
+  bioguide: W000437
+  thomas: '01226'
+- name: Tom Cotton
   party: majority
   rank: 3
-  bioguide: B001277
-  thomas: '02076'
-- name: Mazie K. Hirono
+  bioguide: C001095
+  thomas: '02098'
+- name: Thom Tillis
   party: majority
   rank: 4
-  bioguide: H001042
-  thomas: '01844'
-- name: Tim Kaine
+  bioguide: T000476
+  thomas: '02291'
+- name: Daniel Sullivan
   party: majority
   rank: 5
-  bioguide: K000384
-  thomas: '02176'
-- name: Angus S. King, Jr.
+  bioguide: S001198
+  thomas: '02290'
+- name: John McCain
   party: majority
   rank: 6
-  bioguide: K000383
-  thomas: '02185'
-- name: Carl Levin
-  party: majority
-  rank: 7
   title: Ex Officio
-  bioguide: L000261
-  thomas: '01384'
-- name: Lindsey Graham
+  bioguide: M000303
+  thomas: '00754'
+- name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: G000359
-  thomas: '00452'
-- name: Saxby Chambliss
+  bioguide: G000555
+  thomas: '01866'
+- name: Claire McCaskill
   party: minority
   rank: 2
-  bioguide: C000286
-  thomas: '00188'
-- name: Kelly Ayotte
+  bioguide: M001170
+  thomas: '01820'
+- name: Richard Blumenthal
   party: minority
   rank: 3
-  bioguide: A000368
-  thomas: '02075'
-- name: Roy Blunt
+  bioguide: B001277
+  thomas: '02076'
+- name: Angus S. King, Jr.
   party: minority
   rank: 4
-  bioguide: B000575
-  thomas: '01464'
-- name: Mike Lee
+  bioguide: K000383
+  thomas: '02185'
+- name: Jack Reed
   party: minority
   rank: 5
-  bioguide: L000577
-  thomas: '02080'
-- name: James M. Inhofe
-  party: minority
-  rank: 6
   title: Ex Officio
-  bioguide: I000024
-  thomas: '00583'
+  bioguide: R000122
+  thomas: '00949'
 SSAS20:
-- name: Kay R. Hagan
+- name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  bioguide: H001049
-  thomas: '01902'
-- name: Jack Reed
+  bioguide: F000463
+  thomas: '02179'
+- name: Kelly Ayotte
   party: majority
   rank: 2
-  bioguide: R000122
-  thomas: '00949'
-- name: Bill Nelson
+  bioguide: A000368
+  thomas: '02075'
+- name: Tom Cotton
   party: majority
   rank: 3
-  bioguide: N000032
-  thomas: '00859'
-- name: Mark Udall
+  bioguide: C001095
+  thomas: '02098'
+- name: Joni Ernst
   party: majority
   rank: 4
-  bioguide: U000038
-  thomas: '01595'
-- name: Joe Manchin, III
+  bioguide: E000295
+  thomas: '02283'
+- name: Thom Tillis
   party: majority
   rank: 5
-  bioguide: M001183
-  thomas: '01983'
-- name: Jeanne Shaheen
+  bioguide: T000476
+  thomas: '02291'
+- name: Lindsey Graham
   party: majority
   rank: 6
-  bioguide: S001181
-  thomas: '01901'
-- name: Kirsten E. Gillibrand
+  bioguide: G000359
+  thomas: '00452'
+- name: Ted Cruz
   party: majority
   rank: 7
-  bioguide: G000555
-  thomas: '01866'
-- name: Carl Levin
+  bioguide: C001098
+  thomas: '02175'
+- name: John McCain
   party: majority
   rank: 8
   title: Ex Officio
-  bioguide: L000261
-  thomas: '01384'
-- name: Deb Fischer
+  bioguide: M000303
+  thomas: '00754'
+- name: Bill Nelson
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: F000463
-  thomas: '02179'
-- name: John McCain
+  bioguide: N000032
+  thomas: '00859'
+- name: Joe Manchin, III
   party: minority
   rank: 2
-  bioguide: M000303
-  thomas: '00754'
-- name: Roger F. Wicker
+  bioguide: M001183
+  thomas: '01983'
+- name: Jeanne Shaheen
   party: minority
   rank: 3
-  bioguide: W000437
-  thomas: '01226'
-- name: Lindsey Graham
+  bioguide: S001181
+  thomas: '01901'
+- name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  bioguide: G000359
-  thomas: '00452'
-- name: David Vitter
+  bioguide: G000555
+  thomas: '01866'
+- name: Joe Donnelly
   party: minority
   rank: 5
-  bioguide: V000127
-  thomas: '01609'
-- name: Ted Cruz
+  bioguide: D000607
+  thomas: '01850'
+- name: Tim Kaine
   party: minority
   rank: 6
-  bioguide: C001098
-  thomas: '02175'
-- name: James M. Inhofe
+  bioguide: K000384
+  thomas: '02176'
+- name: Jack Reed
   party: minority
   rank: 7
   title: Ex Officio
-  bioguide: I000024
-  thomas: '00583'
+  bioguide: R000122
+  thomas: '00949'
 SSBK:
-- name: Tim Johnson
+- name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
-  bioguide: J000177
-  thomas: '00604'
-- name: Jack Reed
-  party: majority
-  rank: 2
-  bioguide: R000122
-  thomas: '00949'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Robert Menendez
-  party: majority
-  rank: 4
-  bioguide: M000639
-  thomas: '00791'
-- name: Sherrod Brown
-  party: majority
-  rank: 5
-  bioguide: B000944
-  thomas: '00136'
-- name: Jon Tester
-  party: majority
-  rank: 6
-  bioguide: T000464
-  thomas: '01829'
-- name: Mark R. Warner
-  party: majority
-  rank: 7
-  bioguide: W000805
-  thomas: '01897'
-- name: Jeff Merkley
-  party: majority
-  rank: 8
-  bioguide: M001176
-  thomas: '01900'
-- name: Kay R. Hagan
-  party: majority
-  rank: 9
-  bioguide: H001049
-  thomas: '01902'
-- name: Joe Manchin, III
-  party: majority
-  rank: 10
-  bioguide: M001183
-  thomas: '01983'
-- name: Elizabeth Warren
-  party: majority
-  rank: 11
-  bioguide: W000817
-  thomas: '02182'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 12
-  bioguide: H001069
-  thomas: '02174'
-- name: Mike Crapo
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C000880
-  thomas: '00250'
-- name: Richard C. Shelby
-  party: minority
-  rank: 2
   bioguide: S000320
   thomas: '01049'
+- name: Mike Crapo
+  party: majority
+  rank: 2
+  bioguide: C000880
+  thomas: '00250'
 - name: Bob Corker
-  party: minority
+  party: majority
   rank: 3
   bioguide: C001071
   thomas: '01825'
 - name: David Vitter
-  party: minority
+  party: majority
   rank: 4
   bioguide: V000127
   thomas: '01609'
-- name: Mike Johanns
-  party: minority
-  rank: 5
-  bioguide: J000291
-  thomas: '01899'
 - name: Patrick J. Toomey
-  party: minority
-  rank: 6
+  party: majority
+  rank: 5
   bioguide: T000461
   thomas: '02085'
 - name: Mark Kirk
-  party: minority
-  rank: 7
+  party: majority
+  rank: 6
   bioguide: K000360
   thomas: '01647'
-- name: Jerry Moran
-  party: minority
-  rank: 8
-  bioguide: M000934
-  thomas: '01507'
-- name: Tom Coburn
-  party: minority
-  rank: 9
-  bioguide: C000560
-  thomas: '00212'
 - name: Dean Heller
-  party: minority
-  rank: 10
+  party: majority
+  rank: 7
   bioguide: H001041
   thomas: '01863'
+- name: Tim Scott
+  party: majority
+  rank: 8
+  bioguide: S001184
+  thomas: '02056'
+- name: Ben Sasse
+  party: majority
+  rank: 9
+  bioguide: S001197
+  thomas: '02289'
+- name: Tom Cotton
+  party: majority
+  rank: 10
+  bioguide: C001095
+  thomas: '02098'
+- name: Mike Rounds
+  party: majority
+  rank: 11
+  bioguide: R000605
+  thomas: '02288'
+- name: Jerry Moran
+  party: majority
+  rank: 12
+  bioguide: M000934
+  thomas: '01507'
+- name: Sherrod Brown
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B000944
+  thomas: '00136'
+- name: Jack Reed
+  party: minority
+  rank: 2
+  bioguide: R000122
+  thomas: '00949'
+- name: Charles E. Schumer
+  party: minority
+  rank: 3
+  bioguide: S000148
+  thomas: '01036'
+- name: Robert Menendez
+  party: minority
+  rank: 4
+  bioguide: M000639
+  thomas: '00791'
+- name: Jon Tester
+  party: minority
+  rank: 5
+  bioguide: T000464
+  thomas: '01829'
+- name: Mark R. Warner
+  party: minority
+  rank: 6
+  bioguide: W000805
+  thomas: '01897'
+- name: Jeff Merkley
+  party: minority
+  rank: 7
+  bioguide: M001176
+  thomas: '01900'
+- name: Elizabeth Warren
+  party: minority
+  rank: 8
+  bioguide: W000817
+  thomas: '02182'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 9
+  bioguide: H001069
+  thomas: '02174'
+- name: Joe Donnelly
+  party: minority
+  rank: 10
+  bioguide: D000607
+  thomas: '01850'
 SSBK04:
-- name: Mark R. Warner
+- name: Mike Crapo
   party: majority
   rank: 1
   title: Chairman
+  bioguide: C000880
+  thomas: '00250'
+- name: Bob Corker
+  party: majority
+  rank: 2
+  bioguide: C001071
+  thomas: '01825'
+- name: David Vitter
+  party: majority
+  rank: 3
+  bioguide: V000127
+  thomas: '01609'
+- name: Patrick J. Toomey
+  party: majority
+  rank: 4
+  bioguide: T000461
+  thomas: '02085'
+- name: Mark Kirk
+  party: majority
+  rank: 5
+  bioguide: K000360
+  thomas: '01647'
+- name: Tim Scott
+  party: majority
+  rank: 6
+  bioguide: S001184
+  thomas: '02056'
+- name: Ben Sasse
+  party: majority
+  rank: 7
+  bioguide: S001197
+  thomas: '02289'
+- name: Jerry Moran
+  party: majority
+  rank: 8
+  bioguide: M000934
+  thomas: '01507'
+- name: Richard C. Shelby
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: S000320
+  thomas: '01049'
+- name: Mark R. Warner
+  party: minority
+  rank: 1
+  title: Ranking Member
   bioguide: W000805
   thomas: '01897'
 - name: Jack Reed
-  party: majority
+  party: minority
   rank: 2
   bioguide: R000122
   thomas: '00949'
 - name: Charles E. Schumer
-  party: majority
+  party: minority
   rank: 3
   bioguide: S000148
   thomas: '01036'
 - name: Robert Menendez
-  party: majority
+  party: minority
   rank: 4
   bioguide: M000639
   thomas: '00791'
 - name: Jon Tester
-  party: majority
+  party: minority
   rank: 5
   bioguide: T000464
   thomas: '01829'
-- name: Kay R. Hagan
-  party: majority
-  rank: 6
-  bioguide: H001049
-  thomas: '01902'
 - name: Elizabeth Warren
-  party: majority
-  rank: 7
+  party: minority
+  rank: 6
   bioguide: W000817
   thomas: '02182'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 8
-  bioguide: H001069
-  thomas: '02174'
-- name: Tim Johnson
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: J000177
-  thomas: '00604'
-- name: Mike Johanns
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: J000291
-  thomas: '01899'
-- name: Bob Corker
-  party: minority
-  rank: 2
-  bioguide: C001071
-  thomas: '01825'
-- name: Richard C. Shelby
-  party: minority
-  rank: 3
-  bioguide: S000320
-  thomas: '01049'
-- name: David Vitter
-  party: minority
-  rank: 4
-  bioguide: V000127
-  thomas: '01609'
-- name: Patrick J. Toomey
-  party: minority
-  rank: 5
-  bioguide: T000461
-  thomas: '02085'
-- name: Mark Kirk
-  party: minority
-  rank: 6
-  bioguide: K000360
-  thomas: '01647'
-- name: Tom Coburn
+- name: Joe Donnelly
   party: minority
   rank: 7
-  bioguide: C000560
-  thomas: '00212'
-- name: Mike Crapo
+  bioguide: D000607
+  thomas: '01850'
+- name: Sherrod Brown
   party: minority
   rank: 8
   title: Ex Officio
-  bioguide: C000880
-  thomas: '00250'
+  bioguide: B000944
+  thomas: '00136'
 SSBK05:
-- name: Joe Manchin, III
+- name: Mark Kirk
   party: majority
   rank: 1
   title: Chairman
-  bioguide: M001183
-  thomas: '01983'
-- name: Sherrod Brown
+  bioguide: K000360
+  thomas: '01647'
+- name: Tom Cotton
   party: majority
   rank: 2
-  bioguide: B000944
-  thomas: '00136'
-- name: Mark R. Warner
+  bioguide: C001095
+  thomas: '02098'
+- name: Ben Sasse
   party: majority
   rank: 3
-  bioguide: W000805
-  thomas: '01897'
-- name: Tim Johnson
+  bioguide: S001197
+  thomas: '02289'
+- name: Richard C. Shelby
   party: majority
   rank: 4
   title: Ex Officio
-  bioguide: J000177
-  thomas: '00604'
-- name: Mark Kirk
+  bioguide: S000320
+  thomas: '01049'
+- name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: K000360
-  thomas: '01647'
-- name: Jerry Moran
+  bioguide: H001069
+  thomas: '02174'
+- name: Mark R. Warner
   party: minority
   rank: 2
-  bioguide: M000934
-  thomas: '01507'
-- name: Mike Crapo
+  bioguide: W000805
+  thomas: '01897'
+- name: Sherrod Brown
   party: minority
   rank: 3
   title: Ex Officio
-  bioguide: C000880
-  thomas: '00250'
+  bioguide: B000944
+  thomas: '00136'
 SSBK08:
-- name: Sherrod Brown
+- name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
-  bioguide: B000944
-  thomas: '00136'
-- name: Jack Reed
+  bioguide: T000461
+  thomas: '02085'
+- name: Mike Crapo
   party: majority
+  rank: 2
+  bioguide: C000880
+  thomas: '00250'
+- name: Dean Heller
+  party: majority
+  rank: 3
+  bioguide: H001041
+  thomas: '01863'
+- name: Mike Rounds
+  party: majority
+  rank: 4
+  bioguide: R000605
+  thomas: '02288'
+- name: Bob Corker
+  party: majority
+  rank: 5
+  bioguide: C001071
+  thomas: '01825'
+- name: David Vitter
+  party: majority
+  rank: 6
+  bioguide: V000127
+  thomas: '01609'
+- name: Mark Kirk
+  party: majority
+  rank: 7
+  bioguide: K000360
+  thomas: '01647'
+- name: Tim Scott
+  party: majority
+  rank: 8
+  bioguide: S001184
+  thomas: '02056'
+- name: Richard C. Shelby
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: S000320
+  thomas: '01049'
+- name: Jeff Merkley
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001176
+  thomas: '01900'
+- name: Jack Reed
+  party: minority
   rank: 2
   bioguide: R000122
   thomas: '00949'
 - name: Charles E. Schumer
-  party: majority
+  party: minority
   rank: 3
   bioguide: S000148
   thomas: '01036'
 - name: Robert Menendez
-  party: majority
+  party: minority
   rank: 4
   bioguide: M000639
   thomas: '00791'
-- name: Jon Tester
-  party: majority
+- name: Mark R. Warner
+  party: minority
   rank: 5
-  bioguide: T000464
-  thomas: '01829'
-- name: Jeff Merkley
-  party: majority
-  rank: 6
-  bioguide: M001176
-  thomas: '01900'
-- name: Kay R. Hagan
-  party: majority
-  rank: 7
-  bioguide: H001049
-  thomas: '01902'
+  bioguide: W000805
+  thomas: '01897'
 - name: Elizabeth Warren
-  party: majority
-  rank: 8
+  party: minority
+  rank: 6
   bioguide: W000817
   thomas: '02182'
-- name: Tim Johnson
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: J000177
-  thomas: '00604'
-- name: Patrick J. Toomey
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: T000461
-  thomas: '02085'
-- name: Richard C. Shelby
-  party: minority
-  rank: 2
-  bioguide: S000320
-  thomas: '01049'
-- name: David Vitter
-  party: minority
-  rank: 3
-  bioguide: V000127
-  thomas: '01609'
-- name: Mike Johanns
-  party: minority
-  rank: 4
-  bioguide: J000291
-  thomas: '01899'
-- name: Jerry Moran
-  party: minority
-  rank: 5
-  bioguide: M000934
-  thomas: '01507'
-- name: Dean Heller
-  party: minority
-  rank: 6
-  bioguide: H001041
-  thomas: '01863'
-- name: Bob Corker
+- name: Joe Donnelly
   party: minority
   rank: 7
-  bioguide: C001071
-  thomas: '01825'
-- name: Mike Crapo
+  bioguide: D000607
+  thomas: '01850'
+- name: Sherrod Brown
   party: minority
   rank: 8
   title: Ex Officio
-  bioguide: C000880
-  thomas: '00250'
+  bioguide: B000944
+  thomas: '00136'
 SSBK09:
-- name: Robert Menendez
+- name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
+  bioguide: S001184
+  thomas: '02056'
+- name: Mike Crapo
+  party: majority
+  rank: 2
+  bioguide: C000880
+  thomas: '00250'
+- name: Dean Heller
+  party: majority
+  rank: 3
+  bioguide: H001041
+  thomas: '01863'
+- name: Jerry Moran
+  party: majority
+  rank: 4
+  bioguide: M000934
+  thomas: '01507'
+- name: Bob Corker
+  party: majority
+  rank: 5
+  bioguide: C001071
+  thomas: '01825'
+- name: Tom Cotton
+  party: majority
+  rank: 6
+  bioguide: C001095
+  thomas: '02098'
+- name: Mike Rounds
+  party: majority
+  rank: 7
+  bioguide: R000605
+  thomas: '02288'
+- name: David Vitter
+  party: majority
+  rank: 8
+  bioguide: V000127
+  thomas: '01609'
+- name: Richard C. Shelby
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: S000320
+  thomas: '01049'
+- name: Robert Menendez
+  party: minority
+  rank: 1
+  title: Ranking Member
   bioguide: M000639
   thomas: '00791'
 - name: Jack Reed
-  party: majority
+  party: minority
   rank: 2
   bioguide: R000122
   thomas: '00949'
 - name: Charles E. Schumer
-  party: majority
+  party: minority
   rank: 3
   bioguide: S000148
   thomas: '01036'
-- name: Sherrod Brown
-  party: majority
+- name: Jon Tester
+  party: minority
   rank: 4
-  bioguide: B000944
-  thomas: '00136'
+  bioguide: T000464
+  thomas: '01829'
 - name: Jeff Merkley
-  party: majority
+  party: minority
   rank: 5
   bioguide: M001176
   thomas: '01900'
-- name: Joe Manchin, III
-  party: majority
-  rank: 6
-  bioguide: M001183
-  thomas: '01983'
-- name: Elizabeth Warren
-  party: majority
-  rank: 7
-  bioguide: W000817
-  thomas: '02182'
 - name: Heidi Heitkamp
-  party: majority
-  rank: 8
+  party: minority
+  rank: 6
   bioguide: H001069
   thomas: '02174'
-- name: Tim Johnson
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: J000177
-  thomas: '00604'
-- name: Jerry Moran
+- name: Joe Donnelly
   party: minority
+  rank: 7
+  bioguide: D000607
+  thomas: '01850'
+- name: Sherrod Brown
+  party: minority
+  rank: 8
+  title: Ex Officio
+  bioguide: B000944
+  thomas: '00136'
+SSBK12:
+- name: Dean Heller
+  party: majority
   rank: 1
-  title: Ranking Member
+  title: Chairman
+  bioguide: H001041
+  thomas: '01863'
+- name: Patrick J. Toomey
+  party: majority
+  rank: 2
+  bioguide: T000461
+  thomas: '02085'
+- name: Tom Cotton
+  party: majority
+  rank: 3
+  bioguide: C001095
+  thomas: '02098'
+- name: Mike Rounds
+  party: majority
+  rank: 4
+  bioguide: R000605
+  thomas: '02288'
+- name: Ben Sasse
+  party: majority
+  rank: 5
+  bioguide: S001197
+  thomas: '02289'
+- name: Jerry Moran
+  party: majority
+  rank: 6
   bioguide: M000934
   thomas: '01507'
-- name: Bob Corker
-  party: minority
-  rank: 2
-  bioguide: C001071
-  thomas: '01825'
-- name: Patrick J. Toomey
-  party: minority
-  rank: 3
-  bioguide: T000461
-  thomas: '02085'
-- name: Mark Kirk
-  party: minority
-  rank: 4
-  bioguide: K000360
-  thomas: '01647'
-- name: Tom Coburn
-  party: minority
-  rank: 5
-  bioguide: C000560
-  thomas: '00212'
-- name: Dean Heller
-  party: minority
-  rank: 6
-  bioguide: H001041
-  thomas: '01863'
 - name: Richard C. Shelby
-  party: minority
+  party: majority
   rank: 7
+  title: Ex Officio
   bioguide: S000320
   thomas: '01049'
-- name: Mike Crapo
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: C000880
-  thomas: '00250'
-SSBK12:
-- name: Jeff Merkley
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M001176
-  thomas: '01900'
-- name: Jon Tester
-  party: majority
-  rank: 2
-  bioguide: T000464
-  thomas: '01829'
-- name: Mark R. Warner
-  party: majority
-  rank: 3
-  bioguide: W000805
-  thomas: '01897'
-- name: Kay R. Hagan
-  party: majority
-  rank: 4
-  bioguide: H001049
-  thomas: '01902'
-- name: Joe Manchin, III
-  party: majority
-  rank: 5
-  bioguide: M001183
-  thomas: '01983'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 6
-  bioguide: H001069
-  thomas: '02174'
-- name: Tim Johnson
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: J000177
-  thomas: '00604'
-- name: Dean Heller
+- name: Elizabeth Warren
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: H001041
-  thomas: '01863'
-- name: Tom Coburn
+  bioguide: W000817
+  thomas: '02182'
+- name: Jon Tester
   party: minority
   rank: 2
-  bioguide: C000560
-  thomas: '00212'
-- name: David Vitter
+  bioguide: T000464
+  thomas: '01829'
+- name: Jeff Merkley
   party: minority
   rank: 3
-  bioguide: V000127
-  thomas: '01609'
-- name: Mike Johanns
+  bioguide: M001176
+  thomas: '01900'
+- name: Heidi Heitkamp
   party: minority
   rank: 4
-  bioguide: J000291
-  thomas: '01899'
-- name: Mike Crapo
+  bioguide: H001069
+  thomas: '02174'
+- name: Sherrod Brown
   party: minority
   rank: 5
-  bioguide: C000880
-  thomas: '00250'
+  title: Ex Officio
+  bioguide: B000944
+  thomas: '00136'
 SSBU:
-- name: Patty Murray
+- name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
-  bioguide: M001111
-  thomas: '01409'
-- name: Ron Wyden
-  party: majority
-  rank: 2
-  bioguide: W000779
-  thomas: '01247'
-- name: Bill Nelson
-  party: majority
-  rank: 3
-  bioguide: N000032
-  thomas: '00859'
-- name: Debbie Stabenow
-  party: majority
-  rank: 4
-  bioguide: S000770
-  thomas: '01531'
-- name: Bernard Sanders
-  party: majority
-  rank: 5
-  bioguide: S000033
-  thomas: '01010'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 6
-  bioguide: W000802
-  thomas: '01823'
-- name: Mark R. Warner
-  party: majority
-  rank: 7
-  bioguide: W000805
-  thomas: '01897'
-- name: Jeff Merkley
-  party: majority
-  rank: 8
-  bioguide: M001176
-  thomas: '01900'
-- name: Christopher A. Coons
-  party: majority
-  rank: 9
-  bioguide: C001088
-  thomas: '01984'
-- name: Tammy Baldwin
-  party: majority
-  rank: 10
-  bioguide: B001230
-  thomas: '01558'
-- name: Tim Kaine
-  party: majority
-  rank: 11
-  bioguide: K000384
-  thomas: '02176'
-- name: Angus S. King, Jr.
-  party: majority
-  rank: 12
-  bioguide: K000383
-  thomas: '02185'
-- name: Jeff Sessions
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001141
-  thomas: '01548'
+  bioguide: E000285
+  thomas: '01542'
 - name: Chuck Grassley
-  party: minority
+  party: majority
   rank: 2
   bioguide: G000386
   thomas: '00457'
-- name: Michael B. Enzi
-  party: minority
+- name: Jeff Sessions
+  party: majority
   rank: 3
-  bioguide: E000285
-  thomas: '01542'
+  bioguide: S001141
+  thomas: '01548'
 - name: Mike Crapo
-  party: minority
+  party: majority
   rank: 4
   bioguide: C000880
   thomas: '00250'
 - name: Lindsey Graham
-  party: minority
+  party: majority
   rank: 5
   bioguide: G000359
   thomas: '00452'
 - name: Rob Portman
-  party: minority
+  party: majority
   rank: 6
   bioguide: P000449
   thomas: '00924'
 - name: Patrick J. Toomey
-  party: minority
+  party: majority
   rank: 7
   bioguide: T000461
   thomas: '02085'
 - name: Ron Johnson
-  party: minority
+  party: majority
   rank: 8
   bioguide: J000293
   thomas: '02086'
 - name: Kelly Ayotte
-  party: minority
+  party: majority
   rank: 9
   bioguide: A000368
   thomas: '02075'
 - name: Roger F. Wicker
-  party: minority
+  party: majority
   rank: 10
   bioguide: W000437
   thomas: '01226'
+- name: Bob Corker
+  party: majority
+  rank: 11
+  bioguide: C001071
+  thomas: '01825'
+- name: David Perdue
+  party: majority
+  rank: 12
+  bioguide: P000612
+  thomas: '02286'
+- name: Bernard Sanders
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S000033
+  thomas: '01010'
+- name: Patty Murray
+  party: minority
+  rank: 2
+  bioguide: M001111
+  thomas: '01409'
+- name: Ron Wyden
+  party: minority
+  rank: 3
+  bioguide: W000779
+  thomas: '01247'
+- name: Debbie Stabenow
+  party: minority
+  rank: 4
+  bioguide: S000770
+  thomas: '01531'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 5
+  bioguide: W000802
+  thomas: '01823'
+- name: Mark R. Warner
+  party: minority
+  rank: 6
+  bioguide: W000805
+  thomas: '01897'
+- name: Jeff Merkley
+  party: minority
+  rank: 7
+  bioguide: M001176
+  thomas: '01900'
+- name: Tammy Baldwin
+  party: minority
+  rank: 8
+  bioguide: B001230
+  thomas: '01558'
+- name: Tim Kaine
+  party: minority
+  rank: 9
+  bioguide: K000384
+  thomas: '02176'
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 10
+  bioguide: K000383
+  thomas: '02185'
 SSCM:
-- name: John D. Rockefeller, IV
+- name: John Thune
   party: majority
   rank: 1
   title: Chairman
-  bioguide: R000361
-  thomas: '01424'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Bill Nelson
-  party: majority
-  rank: 3
-  bioguide: N000032
-  thomas: '00859'
-- name: Maria Cantwell
-  party: majority
-  rank: 4
-  bioguide: C000127
-  thomas: '00172'
-- name: Mark L. Pryor
-  party: majority
-  rank: 5
-  bioguide: P000590
-  thomas: '01701'
-- name: Claire McCaskill
-  party: majority
-  rank: 6
-  bioguide: M001170
-  thomas: '01820'
-- name: Amy Klobuchar
-  party: majority
-  rank: 7
-  bioguide: K000367
-  thomas: '01826'
-- name: Mark Begich
-  party: majority
-  rank: 8
-  bioguide: B001265
-  thomas: '01898'
-- name: Richard Blumenthal
-  party: majority
-  rank: 9
-  bioguide: B001277
-  thomas: '02076'
-- name: Brian Schatz
-  party: majority
-  rank: 10
-  bioguide: S001194
-  thomas: '02173'
-- name: Edward J. Markey
-  party: majority
-  rank: 11
-  bioguide: M000133
-  thomas: '00735'
-- name: Cory A. Booker
-  party: majority
-  rank: 12
-  bioguide: B001288
-  thomas: '02194'
-- name: John E. Walsh
-  party: majority
-  rank: 13
-  bioguide: W000818
-  thomas: '02198'
-- name: John Thune
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: T000250
   thomas: '01534'
 - name: Roger F. Wicker
-  party: minority
+  party: majority
   rank: 2
   bioguide: W000437
   thomas: '01226'
 - name: Roy Blunt
-  party: minority
+  party: majority
   rank: 3
   bioguide: B000575
   thomas: '01464'
 - name: Marco Rubio
-  party: minority
+  party: majority
   rank: 4
   bioguide: R000595
   thomas: '02084'
 - name: Kelly Ayotte
-  party: minority
+  party: majority
   rank: 5
   bioguide: A000368
   thomas: '02075'
-- name: Dean Heller
-  party: minority
-  rank: 6
-  bioguide: H001041
-  thomas: '01863'
-- name: Daniel Coats
-  party: minority
-  rank: 7
-  bioguide: C000542
-  thomas: '00209'
-- name: Tim Scott
-  party: minority
-  rank: 8
-  bioguide: S001184
-  thomas: '02056'
 - name: Ted Cruz
-  party: minority
-  rank: 9
+  party: majority
+  rank: 6
   bioguide: C001098
   thomas: '02175'
 - name: Deb Fischer
-  party: minority
-  rank: 10
+  party: majority
+  rank: 7
   bioguide: F000463
   thomas: '02179'
+- name: Jerry Moran
+  party: majority
+  rank: 8
+  bioguide: M000934
+  thomas: '01507'
+- name: Daniel Sullivan
+  party: majority
+  rank: 9
+  bioguide: S001198
+  thomas: '02290'
 - name: Ron Johnson
-  party: minority
-  rank: 11
+  party: majority
+  rank: 10
   bioguide: J000293
   thomas: '02086'
+- name: Dean Heller
+  party: majority
+  rank: 11
+  bioguide: H001041
+  thomas: '01863'
+- name: Cory Gardner
+  party: majority
+  rank: 12
+  bioguide: G000562
+  thomas: '01998'
+- name: Steve Daines
+  party: majority
+  rank: 13
+  bioguide: D000618
+  thomas: '02138'
+- name: Bill Nelson
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: N000032
+  thomas: '00859'
+- name: Maria Cantwell
+  party: minority
+  rank: 2
+  bioguide: C000127
+  thomas: '00172'
+- name: Claire McCaskill
+  party: minority
+  rank: 3
+  bioguide: M001170
+  thomas: '01820'
+- name: Amy Klobuchar
+  party: minority
+  rank: 4
+  bioguide: K000367
+  thomas: '01826'
+- name: Richard Blumenthal
+  party: minority
+  rank: 5
+  bioguide: B001277
+  thomas: '02076'
+- name: Brian Schatz
+  party: minority
+  rank: 6
+  bioguide: S001194
+  thomas: '02173'
+- name: Edward J. Markey
+  party: minority
+  rank: 7
+  bioguide: M000133
+  thomas: '00735'
+- name: Cory A. Booker
+  party: minority
+  rank: 8
+  bioguide: B001288
+  thomas: '02194'
+- name: Tom Udall
+  party: minority
+  rank: 9
+  bioguide: U000039
+  thomas: '01567'
+- name: Joe Manchin, III
+  party: minority
+  rank: 10
+  bioguide: M001183
+  thomas: '01983'
+- name: Gary Peters
+  party: minority
+  rank: 11
+  bioguide: P000595
+  thomas: '01929'
 SSCM01:
-- name: Maria Cantwell
+- name: Kelly Ayotte
   party: majority
   rank: 1
   title: Chairman
-  bioguide: C000127
-  thomas: '00172'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Bill Nelson
-  party: majority
-  rank: 3
-  bioguide: N000032
-  thomas: '00859'
-- name: Mark L. Pryor
-  party: majority
-  rank: 4
-  bioguide: P000590
-  thomas: '01701'
-- name: Amy Klobuchar
-  party: majority
-  rank: 5
-  bioguide: K000367
-  thomas: '01826'
-- name: Mark Begich
-  party: majority
-  rank: 6
-  bioguide: B001265
-  thomas: '01898'
-- name: Brian Schatz
-  party: majority
-  rank: 7
-  bioguide: S001194
-  thomas: '02173'
-- name: Cory A. Booker
-  party: majority
-  rank: 8
-  bioguide: B001288
-  thomas: '02194'
-- name: John E. Walsh
-  party: majority
-  rank: 9
-  bioguide: W000818
-  thomas: '02198'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: R000361
-  thomas: '01424'
-- name: Kelly Ayotte
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: A000368
   thomas: '02075'
 - name: Roger F. Wicker
-  party: minority
+  party: majority
   rank: 2
   bioguide: W000437
   thomas: '01226'
 - name: Roy Blunt
-  party: minority
+  party: majority
   rank: 3
   bioguide: B000575
   thomas: '01464'
 - name: Marco Rubio
-  party: minority
+  party: majority
   rank: 4
   bioguide: R000595
   thomas: '02084'
-- name: Dean Heller
-  party: minority
-  rank: 5
-  bioguide: H001041
-  thomas: '01863'
-- name: Tim Scott
-  party: minority
-  rank: 6
-  bioguide: S001184
-  thomas: '02056'
 - name: Ted Cruz
-  party: minority
-  rank: 7
+  party: majority
+  rank: 5
   bioguide: C001098
   thomas: '02175'
 - name: Deb Fischer
-  party: minority
-  rank: 8
+  party: majority
+  rank: 6
   bioguide: F000463
   thomas: '02179'
+- name: Jerry Moran
+  party: majority
+  rank: 7
+  bioguide: M000934
+  thomas: '01507'
+- name: Daniel Sullivan
+  party: majority
+  rank: 8
+  bioguide: S001198
+  thomas: '02290'
 - name: Ron Johnson
-  party: minority
+  party: majority
   rank: 9
   bioguide: J000293
   thomas: '02086'
-- name: John Thune
-  party: minority
+- name: Dean Heller
+  party: majority
   rank: 10
+  bioguide: H001041
+  thomas: '01863'
+- name: Cory Gardner
+  party: majority
+  rank: 11
+  bioguide: G000562
+  thomas: '01998'
+- name: John Thune
+  party: majority
+  rank: 12
   title: Ex Officio
   bioguide: T000250
   thomas: '01534'
+- name: Maria Cantwell
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C000127
+  thomas: '00172'
+- name: Amy Klobuchar
+  party: minority
+  rank: 2
+  bioguide: K000367
+  thomas: '01826'
+- name: Richard Blumenthal
+  party: minority
+  rank: 3
+  bioguide: B001277
+  thomas: '02076'
+- name: Brian Schatz
+  party: minority
+  rank: 4
+  bioguide: S001194
+  thomas: '02173'
+- name: Edward J. Markey
+  party: minority
+  rank: 5
+  bioguide: M000133
+  thomas: '00735'
+- name: Cory A. Booker
+  party: minority
+  rank: 6
+  bioguide: B001288
+  thomas: '02194'
+- name: Tom Udall
+  party: minority
+  rank: 7
+  bioguide: U000039
+  thomas: '01567'
+- name: Joe Manchin, III
+  party: minority
+  rank: 8
+  bioguide: M001183
+  thomas: '01983'
+- name: Gary Peters
+  party: minority
+  rank: 9
+  bioguide: P000595
+  thomas: '01929'
+- name: Bill Nelson
+  party: minority
+  rank: 10
+  title: Ex Officio
+  bioguide: N000032
+  thomas: '00859'
 SSCM20:
-- name: Claire McCaskill
+- name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  bioguide: M001170
-  thomas: '01820'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Mark L. Pryor
-  party: majority
-  rank: 3
-  bioguide: P000590
-  thomas: '01701'
-- name: Amy Klobuchar
-  party: majority
-  rank: 4
-  bioguide: K000367
-  thomas: '01826'
-- name: Richard Blumenthal
-  party: majority
-  rank: 5
-  bioguide: B001277
-  thomas: '02076'
-- name: Brian Schatz
-  party: majority
-  rank: 6
-  bioguide: S001194
-  thomas: '02173'
-- name: Cory A. Booker
-  party: majority
-  rank: 7
-  bioguide: B001288
-  thomas: '02194'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: R000361
-  thomas: '01424'
-- name: Dean Heller
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H001041
-  thomas: '01863'
+  bioguide: M000934
+  thomas: '01507'
 - name: Roy Blunt
-  party: minority
+  party: majority
   rank: 2
   bioguide: B000575
   thomas: '01464'
-- name: Kelly Ayotte
-  party: minority
-  rank: 3
-  bioguide: A000368
-  thomas: '02075'
-- name: Daniel Coats
-  party: minority
-  rank: 4
-  bioguide: C000542
-  thomas: '00209'
 - name: Ted Cruz
-  party: minority
-  rank: 5
+  party: majority
+  rank: 3
   bioguide: C001098
   thomas: '02175'
 - name: Deb Fischer
-  party: minority
-  rank: 6
+  party: majority
+  rank: 4
   bioguide: F000463
   thomas: '02179'
-- name: John Thune
-  party: minority
+- name: Dean Heller
+  party: majority
+  rank: 5
+  bioguide: H001041
+  thomas: '01863'
+- name: Cory Gardner
+  party: majority
+  rank: 6
+  bioguide: G000562
+  thomas: '01998'
+- name: Steve Daines
+  party: majority
   rank: 7
+  bioguide: D000618
+  thomas: '02138'
+- name: John Thune
+  party: majority
+  rank: 8
   title: Ex Officio
   bioguide: T000250
   thomas: '01534'
+- name: Richard Blumenthal
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001277
+  thomas: '02076'
+- name: Claire McCaskill
+  party: minority
+  rank: 2
+  bioguide: M001170
+  thomas: '01820'
+- name: Amy Klobuchar
+  party: minority
+  rank: 3
+  bioguide: K000367
+  thomas: '01826'
+- name: Edward J. Markey
+  party: minority
+  rank: 4
+  bioguide: M000133
+  thomas: '00735'
+- name: Cory A. Booker
+  party: minority
+  rank: 5
+  bioguide: B001288
+  thomas: '02194'
+- name: Tom Udall
+  party: minority
+  rank: 6
+  bioguide: U000039
+  thomas: '01567'
+- name: Bill Nelson
+  party: minority
+  rank: 7
+  title: Ex Officio
+  bioguide: N000032
+  thomas: '00859'
 SSCM22:
-- name: Mark Begich
+- name: Marco Rubio
   party: majority
   rank: 1
   title: Chairman
-  bioguide: B001265
-  thomas: '01898'
-- name: Bill Nelson
-  party: majority
-  rank: 2
-  bioguide: N000032
-  thomas: '00859'
-- name: Maria Cantwell
-  party: majority
-  rank: 3
-  bioguide: C000127
-  thomas: '00172'
-- name: Richard Blumenthal
-  party: majority
-  rank: 4
-  bioguide: B001277
-  thomas: '02076'
-- name: Brian Schatz
-  party: majority
-  rank: 5
-  bioguide: S001194
-  thomas: '02173'
-- name: Edward J. Markey
-  party: majority
-  rank: 6
-  bioguide: M000133
-  thomas: '00735'
-- name: Cory A. Booker
-  party: majority
-  rank: 7
-  bioguide: B001288
-  thomas: '02194'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: R000361
-  thomas: '01424'
-- name: Marco Rubio
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: R000595
   thomas: '02084'
 - name: Roger F. Wicker
-  party: minority
+  party: majority
   rank: 2
   bioguide: W000437
   thomas: '01226'
 - name: Kelly Ayotte
-  party: minority
+  party: majority
   rank: 3
   bioguide: A000368
   thomas: '02075'
-- name: Daniel Coats
-  party: minority
-  rank: 4
-  bioguide: C000542
-  thomas: '00209'
-- name: Tim Scott
-  party: minority
-  rank: 5
-  bioguide: S001184
-  thomas: '02056'
 - name: Ted Cruz
-  party: minority
-  rank: 6
+  party: majority
+  rank: 4
   bioguide: C001098
   thomas: '02175'
+- name: Daniel Sullivan
+  party: majority
+  rank: 5
+  bioguide: S001198
+  thomas: '02290'
+- name: Ron Johnson
+  party: majority
+  rank: 6
+  bioguide: J000293
+  thomas: '02086'
 - name: John Thune
-  party: minority
+  party: majority
   rank: 7
   title: Ex Officio
   bioguide: T000250
   thomas: '01534'
+- name: Gary Peters
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: P000595
+  thomas: '01929'
+- name: Maria Cantwell
+  party: minority
+  rank: 2
+  bioguide: C000127
+  thomas: '00172'
+- name: Richard Blumenthal
+  party: minority
+  rank: 3
+  bioguide: B001277
+  thomas: '02076'
+- name: Edward J. Markey
+  party: minority
+  rank: 4
+  bioguide: M000133
+  thomas: '00735'
+- name: Brian Schatz
+  party: minority
+  rank: 5
+  bioguide: S001194
+  thomas: '02173'
+- name: Bill Nelson
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: N000032
+  thomas: '00859'
 SSCM24:
-- name: Bill Nelson
+- name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
-  bioguide: N000032
-  thomas: '00859'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Mark L. Pryor
-  party: majority
-  rank: 3
-  bioguide: P000590
-  thomas: '01701'
-- name: Amy Klobuchar
-  party: majority
-  rank: 4
-  bioguide: K000367
-  thomas: '01826'
-- name: Richard Blumenthal
-  party: majority
-  rank: 5
-  bioguide: B001277
-  thomas: '02076'
-- name: Edward J. Markey
-  party: majority
-  rank: 6
-  bioguide: M000133
-  thomas: '00735'
-- name: John E. Walsh
-  party: majority
-  rank: 7
-  bioguide: W000818
-  thomas: '02198'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: R000361
-  thomas: '01424'
-- name: Ted Cruz
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: C001098
   thomas: '02175'
-- name: Roger F. Wicker
-  party: minority
-  rank: 2
-  bioguide: W000437
-  thomas: '01226'
 - name: Marco Rubio
-  party: minority
-  rank: 3
+  party: majority
+  rank: 2
   bioguide: R000595
   thomas: '02084'
-- name: Dean Heller
-  party: minority
+- name: Jerry Moran
+  party: majority
+  rank: 3
+  bioguide: M000934
+  thomas: '01507'
+- name: Daniel Sullivan
+  party: majority
   rank: 4
-  bioguide: H001041
-  thomas: '01863'
-- name: Daniel Coats
-  party: minority
+  bioguide: S001198
+  thomas: '02290'
+- name: Cory Gardner
+  party: majority
   rank: 5
-  bioguide: C000542
-  thomas: '00209'
-- name: Ron Johnson
-  party: minority
+  bioguide: G000562
+  thomas: '01998'
+- name: Steve Daines
+  party: majority
   rank: 6
-  bioguide: J000293
-  thomas: '02086'
+  bioguide: D000618
+  thomas: '02138'
 - name: John Thune
-  party: minority
+  party: majority
   rank: 7
   title: Ex Officio
   bioguide: T000250
   thomas: '01534'
+- name: Tom Udall
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: U000039
+  thomas: '01567'
+- name: Edward J. Markey
+  party: minority
+  rank: 2
+  bioguide: M000133
+  thomas: '00735'
+- name: Cory A. Booker
+  party: minority
+  rank: 3
+  bioguide: B001288
+  thomas: '02194'
+- name: Gary Peters
+  party: minority
+  rank: 4
+  bioguide: P000595
+  thomas: '01929'
+- name: Brian Schatz
+  party: minority
+  rank: 5
+  bioguide: S001194
+  thomas: '02173'
+- name: Bill Nelson
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: N000032
+  thomas: '00859'
 SSCM25:
-- name: Richard Blumenthal
+- name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  bioguide: B001277
-  thomas: '02076'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Maria Cantwell
-  party: majority
-  rank: 3
-  bioguide: C000127
-  thomas: '00172'
-- name: Mark L. Pryor
-  party: majority
-  rank: 4
-  bioguide: P000590
-  thomas: '01701'
-- name: Claire McCaskill
-  party: majority
-  rank: 5
-  bioguide: M001170
-  thomas: '01820'
-- name: Amy Klobuchar
-  party: majority
-  rank: 6
-  bioguide: K000367
-  thomas: '01826'
-- name: Mark Begich
-  party: majority
-  rank: 7
-  bioguide: B001265
-  thomas: '01898'
-- name: Brian Schatz
-  party: majority
-  rank: 8
-  bioguide: S001194
-  thomas: '02173'
-- name: Edward J. Markey
-  party: majority
-  rank: 9
-  bioguide: M000133
-  thomas: '00735'
-- name: Cory A. Booker
-  party: majority
-  rank: 10
-  bioguide: B001288
-  thomas: '02194'
-- name: John E. Walsh
-  party: majority
-  rank: 11
-  bioguide: W000818
-  thomas: '02198'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 12
-  title: Ex Officio
-  bioguide: R000361
-  thomas: '01424'
-- name: Roy Blunt
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B000575
-  thomas: '01464'
+  bioguide: F000463
+  thomas: '02179'
 - name: Roger F. Wicker
-  party: minority
+  party: majority
   rank: 2
   bioguide: W000437
   thomas: '01226'
-- name: Marco Rubio
-  party: minority
+- name: Roy Blunt
+  party: majority
   rank: 3
-  bioguide: R000595
-  thomas: '02084'
+  bioguide: B000575
+  thomas: '01464'
 - name: Kelly Ayotte
-  party: minority
+  party: majority
   rank: 4
   bioguide: A000368
   thomas: '02075'
-- name: Dean Heller
-  party: minority
+- name: Jerry Moran
+  party: majority
   rank: 5
-  bioguide: H001041
-  thomas: '01863'
-- name: Daniel Coats
-  party: minority
+  bioguide: M000934
+  thomas: '01507'
+- name: Daniel Sullivan
+  party: majority
   rank: 6
-  bioguide: C000542
-  thomas: '00209'
-- name: Tim Scott
-  party: minority
-  rank: 7
-  bioguide: S001184
-  thomas: '02056'
-- name: Ted Cruz
-  party: minority
-  rank: 8
-  bioguide: C001098
-  thomas: '02175'
-- name: Deb Fischer
-  party: minority
-  rank: 9
-  bioguide: F000463
-  thomas: '02179'
+  bioguide: S001198
+  thomas: '02290'
 - name: Ron Johnson
-  party: minority
-  rank: 10
+  party: majority
+  rank: 7
   bioguide: J000293
   thomas: '02086'
+- name: Dean Heller
+  party: majority
+  rank: 8
+  bioguide: H001041
+  thomas: '01863'
+- name: Steve Daines
+  party: majority
+  rank: 9
+  bioguide: D000618
+  thomas: '02138'
 - name: John Thune
-  party: minority
-  rank: 11
+  party: majority
+  rank: 10
   title: Ex Officio
   bioguide: T000250
   thomas: '01534'
+- name: Cory A. Booker
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001288
+  thomas: '02194'
+- name: Maria Cantwell
+  party: minority
+  rank: 2
+  bioguide: C000127
+  thomas: '00172'
+- name: Claire McCaskill
+  party: minority
+  rank: 3
+  bioguide: M001170
+  thomas: '01820'
+- name: Amy Klobuchar
+  party: minority
+  rank: 4
+  bioguide: K000367
+  thomas: '01826'
+- name: Richard Blumenthal
+  party: minority
+  rank: 5
+  bioguide: B001277
+  thomas: '02076'
+- name: Brian Schatz
+  party: minority
+  rank: 6
+  bioguide: S001194
+  thomas: '02173'
+- name: Edward J. Markey
+  party: minority
+  rank: 7
+  bioguide: M000133
+  thomas: '00735'
+- name: Tom Udall
+  party: minority
+  rank: 8
+  bioguide: U000039
+  thomas: '01567'
+- name: Bill Nelson
+  party: minority
+  rank: 9
+  title: Ex Officio
+  bioguide: N000032
+  thomas: '00859'
 SSCM26:
-- name: Mark L. Pryor
+- name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
-  bioguide: P000590
-  thomas: '01701'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Bill Nelson
-  party: majority
-  rank: 3
-  bioguide: N000032
-  thomas: '00859'
-- name: Maria Cantwell
-  party: majority
-  rank: 4
-  bioguide: C000127
-  thomas: '00172'
-- name: Claire McCaskill
-  party: majority
-  rank: 5
-  bioguide: M001170
-  thomas: '01820'
-- name: Amy Klobuchar
-  party: majority
-  rank: 6
-  bioguide: K000367
-  thomas: '01826'
-- name: Mark Begich
-  party: majority
-  rank: 7
-  bioguide: B001265
-  thomas: '01898'
-- name: Richard Blumenthal
-  party: majority
-  rank: 8
-  bioguide: B001277
-  thomas: '02076'
-- name: Brian Schatz
-  party: majority
-  rank: 9
-  bioguide: S001194
-  thomas: '02173'
-- name: Edward J. Markey
-  party: majority
-  rank: 10
-  bioguide: M000133
-  thomas: '00735'
-- name: Cory A. Booker
-  party: majority
-  rank: 11
-  bioguide: B001288
-  thomas: '02194'
-- name: John E. Walsh
-  party: majority
-  rank: 12
-  bioguide: W000818
-  thomas: '02198'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 13
-  title: Ex Officio
-  bioguide: R000361
-  thomas: '01424'
-- name: Roger F. Wicker
-  party: minority
-  rank: 1
-  title: Ranking Member
   bioguide: W000437
   thomas: '01226'
 - name: Roy Blunt
-  party: minority
+  party: majority
   rank: 2
   bioguide: B000575
   thomas: '01464'
 - name: Marco Rubio
-  party: minority
+  party: majority
   rank: 3
   bioguide: R000595
   thomas: '02084'
 - name: Kelly Ayotte
-  party: minority
+  party: majority
   rank: 4
   bioguide: A000368
   thomas: '02075'
-- name: Dean Heller
-  party: minority
-  rank: 5
-  bioguide: H001041
-  thomas: '01863'
-- name: Daniel Coats
-  party: minority
-  rank: 6
-  bioguide: C000542
-  thomas: '00209'
-- name: Tim Scott
-  party: minority
-  rank: 7
-  bioguide: S001184
-  thomas: '02056'
 - name: Ted Cruz
-  party: minority
-  rank: 8
+  party: majority
+  rank: 5
   bioguide: C001098
   thomas: '02175'
 - name: Deb Fischer
-  party: minority
-  rank: 9
+  party: majority
+  rank: 6
   bioguide: F000463
   thomas: '02179'
+- name: Jerry Moran
+  party: majority
+  rank: 7
+  bioguide: M000934
+  thomas: '01507'
+- name: Daniel Sullivan
+  party: majority
+  rank: 8
+  bioguide: S001198
+  thomas: '02290'
 - name: Ron Johnson
-  party: minority
-  rank: 10
+  party: majority
+  rank: 9
   bioguide: J000293
   thomas: '02086'
-- name: John Thune
-  party: minority
+- name: Dean Heller
+  party: majority
+  rank: 10
+  bioguide: H001041
+  thomas: '01863'
+- name: Cory Gardner
+  party: majority
   rank: 11
+  bioguide: G000562
+  thomas: '01998'
+- name: Steve Daines
+  party: majority
+  rank: 12
+  bioguide: D000618
+  thomas: '02138'
+- name: John Thune
+  party: majority
+  rank: 13
   title: Ex Officio
   bioguide: T000250
   thomas: '01534'
-SSCM27:
 - name: Brian Schatz
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: S001194
-  thomas: '02173'
-- name: Bill Nelson
-  party: majority
-  rank: 2
-  bioguide: N000032
-  thomas: '00859'
-- name: Mark L. Pryor
-  party: majority
-  rank: 3
-  bioguide: P000590
-  thomas: '01701'
-- name: Amy Klobuchar
-  party: majority
-  rank: 4
-  bioguide: K000367
-  thomas: '01826'
-- name: Mark Begich
-  party: majority
-  rank: 5
-  bioguide: B001265
-  thomas: '01898'
-- name: Edward J. Markey
-  party: majority
-  rank: 6
-  bioguide: M000133
-  thomas: '00735'
-- name: John E. Walsh
-  party: majority
-  rank: 7
-  bioguide: W000818
-  thomas: '02198'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: R000361
-  thomas: '01424'
-- name: Tim Scott
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: S001184
-  thomas: '02056'
-- name: Roy Blunt
+  bioguide: S001194
+  thomas: '02173'
+- name: Maria Cantwell
   party: minority
   rank: 2
-  bioguide: B000575
-  thomas: '01464'
-- name: Dean Heller
+  bioguide: C000127
+  thomas: '00172'
+- name: Claire McCaskill
   party: minority
   rank: 3
-  bioguide: H001041
-  thomas: '01863'
-- name: Daniel Coats
+  bioguide: M001170
+  thomas: '01820'
+- name: Amy Klobuchar
   party: minority
   rank: 4
-  bioguide: C000542
-  thomas: '00209'
-- name: Deb Fischer
+  bioguide: K000367
+  thomas: '01826'
+- name: Richard Blumenthal
   party: minority
   rank: 5
-  bioguide: F000463
-  thomas: '02179'
-- name: Ron Johnson
+  bioguide: B001277
+  thomas: '02076'
+- name: Edward J. Markey
   party: minority
   rank: 6
-  bioguide: J000293
-  thomas: '02086'
-- name: John Thune
+  bioguide: M000133
+  thomas: '00735'
+- name: Cory A. Booker
   party: minority
   rank: 7
+  bioguide: B001288
+  thomas: '02194'
+- name: Tom Udall
+  party: minority
+  rank: 8
+  bioguide: U000039
+  thomas: '01567'
+- name: Joe Manchin, III
+  party: minority
+  rank: 9
+  bioguide: M001183
+  thomas: '01983'
+- name: Gary Peters
+  party: minority
+  rank: 10
+  bioguide: P000595
+  thomas: '01929'
+- name: Bill Nelson
+  party: minority
+  rank: 11
   title: Ex Officio
-  bioguide: T000250
-  thomas: '01534'
+  bioguide: N000032
+  thomas: '00859'
 SSEG:
-- name: Mary L. Landrieu
+- name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  bioguide: L000550
-  thomas: '01546'
-- name: Ron Wyden
+  bioguide: M001153
+  thomas: '01694'
+- name: John Barrasso
   party: majority
   rank: 2
-  bioguide: W000779
-  thomas: '01247'
-- name: Tim Johnson
+  bioguide: B001261
+  thomas: '01881'
+- name: James E. Risch
   party: majority
   rank: 3
-  bioguide: J000177
-  thomas: '00604'
-- name: Maria Cantwell
+  bioguide: R000584
+  thomas: '01896'
+- name: Mike Lee
   party: majority
   rank: 4
-  bioguide: C000127
-  thomas: '00172'
-- name: Bernard Sanders
+  bioguide: L000577
+  thomas: '02080'
+- name: Jeff Flake
   party: majority
   rank: 5
-  bioguide: S000033
-  thomas: '01010'
-- name: Debbie Stabenow
+  bioguide: F000444
+  thomas: '01633'
+- name: Steve Daines
   party: majority
   rank: 6
-  bioguide: S000770
-  thomas: '01531'
-- name: Mark Udall
+  bioguide: D000618
+  thomas: '02138'
+- name: Bill Cassidy
   party: majority
   rank: 7
-  bioguide: U000038
-  thomas: '01595'
-- name: Al Franken
+  bioguide: C001075
+  thomas: '01925'
+- name: Cory Gardner
   party: majority
   rank: 8
-  bioguide: F000457
-  thomas: '01969'
-- name: Joe Manchin, III
+  bioguide: G000562
+  thomas: '01998'
+- name: Rob Portman
   party: majority
   rank: 9
-  bioguide: M001183
-  thomas: '01983'
-- name: Brian Schatz
+  bioguide: P000449
+  thomas: '00924'
+- name: John Hoeven
   party: majority
   rank: 10
-  bioguide: S001194
-  thomas: '02173'
-- name: Martin Heinrich
+  bioguide: H001061
+  thomas: '02079'
+- name: Lamar Alexander
   party: majority
   rank: 11
-  bioguide: H001046
-  thomas: '01937'
-- name: Tammy Baldwin
+  bioguide: A000360
+  thomas: '01695'
+- name: Shelley Moore Capito
   party: majority
   rank: 12
-  bioguide: B001230
-  thomas: '01558'
-- name: Lisa Murkowski
+  bioguide: C001047
+  thomas: '01676'
+- name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: M001153
-  thomas: '01694'
-- name: John Barrasso
-  party: minority
-  rank: 2
-  bioguide: B001261
-  thomas: '01881'
-- name: James E. Risch
-  party: minority
-  rank: 3
-  bioguide: R000584
-  thomas: '01896'
-- name: Mike Lee
-  party: minority
-  rank: 4
-  bioguide: L000577
-  thomas: '02080'
-- name: Dean Heller
-  party: minority
-  rank: 5
-  bioguide: H001041
-  thomas: '01863'
-- name: Jeff Flake
-  party: minority
-  rank: 6
-  bioguide: F000444
-  thomas: '01633'
-- name: Tim Scott
-  party: minority
-  rank: 7
-  bioguide: S001184
-  thomas: '02056'
-- name: Lamar Alexander
-  party: minority
-  rank: 8
-  bioguide: A000360
-  thomas: '01695'
-- name: Rob Portman
-  party: minority
-  rank: 9
-  bioguide: P000449
-  thomas: '00924'
-- name: John Hoeven
-  party: minority
-  rank: 10
-  bioguide: H001061
-  thomas: '02079'
-SSEG01:
-- name: Al Franken
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: F000457
-  thomas: '01969'
+  bioguide: C000127
+  thomas: '00172'
 - name: Ron Wyden
-  party: majority
+  party: minority
   rank: 2
   bioguide: W000779
   thomas: '01247'
-- name: Tim Johnson
-  party: majority
-  rank: 3
-  bioguide: J000177
-  thomas: '00604'
-- name: Maria Cantwell
-  party: majority
-  rank: 4
-  bioguide: C000127
-  thomas: '00172'
 - name: Bernard Sanders
-  party: majority
-  rank: 5
+  party: minority
+  rank: 3
   bioguide: S000033
   thomas: '01010'
 - name: Debbie Stabenow
-  party: majority
-  rank: 6
+  party: minority
+  rank: 4
   bioguide: S000770
   thomas: '01531'
-- name: Mark Udall
-  party: majority
-  rank: 7
-  bioguide: U000038
-  thomas: '01595'
+- name: Al Franken
+  party: minority
+  rank: 5
+  bioguide: F000457
+  thomas: '01969'
 - name: Joe Manchin, III
-  party: majority
-  rank: 8
+  party: minority
+  rank: 6
   bioguide: M001183
   thomas: '01983'
 - name: Martin Heinrich
-  party: majority
-  rank: 9
+  party: minority
+  rank: 7
   bioguide: H001046
   thomas: '01937'
-- name: Tammy Baldwin
-  party: majority
-  rank: 10
-  bioguide: B001230
-  thomas: '01558'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 11
-  title: Ex Officio
-  bioguide: L000550
-  thomas: '01546'
-- name: James E. Risch
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: R000584
-  thomas: '01896'
-- name: Dean Heller
-  party: minority
-  rank: 2
-  bioguide: H001041
-  thomas: '01863'
-- name: Jeff Flake
-  party: minority
-  rank: 3
-  bioguide: F000444
-  thomas: '01633'
-- name: Lamar Alexander
-  party: minority
-  rank: 4
-  bioguide: A000360
-  thomas: '01695'
-- name: Rob Portman
-  party: minority
-  rank: 5
-  bioguide: P000449
-  thomas: '00924'
-- name: John Hoeven
-  party: minority
-  rank: 6
-  bioguide: H001061
-  thomas: '02079'
-- name: Lisa Murkowski
-  party: minority
-  rank: 7
-  title: Ex Officio
-  bioguide: M001153
-  thomas: '01694'
-SSEG03:
-- name: Joe Manchin, III
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M001183
-  thomas: '01983'
-- name: Ron Wyden
-  party: majority
-  rank: 2
-  bioguide: W000779
-  thomas: '01247'
-- name: Tim Johnson
-  party: majority
-  rank: 3
-  bioguide: J000177
-  thomas: '00604'
-- name: Maria Cantwell
-  party: majority
-  rank: 4
-  bioguide: C000127
-  thomas: '00172'
-- name: Mark Udall
-  party: majority
-  rank: 5
-  bioguide: U000038
-  thomas: '01595'
-- name: Al Franken
-  party: majority
-  rank: 6
-  bioguide: F000457
-  thomas: '01969'
-- name: Brian Schatz
-  party: majority
-  rank: 7
-  bioguide: S001194
-  thomas: '02173'
-- name: Martin Heinrich
-  party: majority
-  rank: 8
-  bioguide: H001046
-  thomas: '01937'
-- name: Tammy Baldwin
-  party: majority
-  rank: 9
-  bioguide: B001230
-  thomas: '01558'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: L000550
-  thomas: '01546'
-- name: John Barrasso
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001261
-  thomas: '01881'
-- name: James E. Risch
-  party: minority
-  rank: 2
-  bioguide: R000584
-  thomas: '01896'
-- name: Mike Lee
-  party: minority
-  rank: 3
-  bioguide: L000577
-  thomas: '02080'
-- name: Dean Heller
-  party: minority
-  rank: 4
-  bioguide: H001041
-  thomas: '01863'
-- name: Jeff Flake
-  party: minority
-  rank: 5
-  bioguide: F000444
-  thomas: '01633'
-- name: Tim Scott
-  party: minority
-  rank: 6
-  bioguide: S001184
-  thomas: '02056'
-- name: Lamar Alexander
-  party: minority
-  rank: 7
-  bioguide: A000360
-  thomas: '01695'
-- name: John Hoeven
-  party: minority
-  rank: 8
-  bioguide: H001061
-  thomas: '02079'
-- name: Lisa Murkowski
-  party: minority
-  rank: 9
-  title: Ex Officio
-  bioguide: M001153
-  thomas: '01694'
-SSEG04:
-- name: Mark Udall
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: U000038
-  thomas: '01595'
-- name: Ron Wyden
-  party: majority
-  rank: 2
-  bioguide: W000779
-  thomas: '01247'
-- name: Bernard Sanders
-  party: majority
-  rank: 3
-  bioguide: S000033
-  thomas: '01010'
-- name: Debbie Stabenow
-  party: majority
-  rank: 4
-  bioguide: S000770
-  thomas: '01531'
-- name: Brian Schatz
-  party: majority
-  rank: 5
-  bioguide: S001194
-  thomas: '02173'
-- name: Martin Heinrich
-  party: majority
-  rank: 6
-  bioguide: H001046
-  thomas: '01937'
-- name: Tammy Baldwin
-  party: majority
-  rank: 7
-  bioguide: B001230
-  thomas: '01558'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: L000550
-  thomas: '01546'
-- name: Rob Portman
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000449
-  thomas: '00924'
-- name: John Barrasso
-  party: minority
-  rank: 2
-  bioguide: B001261
-  thomas: '01881'
-- name: Mike Lee
-  party: minority
-  rank: 3
-  bioguide: L000577
-  thomas: '02080'
-- name: Lamar Alexander
-  party: minority
-  rank: 4
-  bioguide: A000360
-  thomas: '01695'
-- name: John Hoeven
-  party: minority
-  rank: 5
-  bioguide: H001061
-  thomas: '02079'
-- name: Lisa Murkowski
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: M001153
-  thomas: '01694'
-SSEG07:
-- name: Brian Schatz
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: S001194
-  thomas: '02173'
-- name: Tim Johnson
-  party: majority
-  rank: 2
-  bioguide: J000177
-  thomas: '00604'
-- name: Maria Cantwell
-  party: majority
-  rank: 3
-  bioguide: C000127
-  thomas: '00172'
-- name: Bernard Sanders
-  party: majority
-  rank: 4
-  bioguide: S000033
-  thomas: '01010'
-- name: Debbie Stabenow
-  party: majority
-  rank: 5
-  bioguide: S000770
-  thomas: '01531'
-- name: Joe Manchin, III
-  party: majority
-  rank: 6
-  bioguide: M001183
-  thomas: '01983'
-- name: Al Franken
-  party: majority
-  rank: 7
-  bioguide: F000457
-  thomas: '01969'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: L000550
-  thomas: '01546'
-- name: Mike Lee
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000577
-  thomas: '02080'
-- name: John Barrasso
-  party: minority
-  rank: 2
-  bioguide: B001261
-  thomas: '01881'
-- name: James E. Risch
-  party: minority
-  rank: 3
-  bioguide: R000584
-  thomas: '01896'
-- name: Dean Heller
-  party: minority
-  rank: 4
-  bioguide: H001041
-  thomas: '01863'
-- name: Jeff Flake
-  party: minority
-  rank: 5
-  bioguide: F000444
-  thomas: '01633'
-- name: Tim Scott
-  party: minority
-  rank: 6
-  bioguide: S001184
-  thomas: '02056'
-- name: Lisa Murkowski
-  party: minority
-  rank: 7
-  title: Ex Officio
-  bioguide: M001153
-  thomas: '01694'
-SSEV:
-- name: Barbara Boxer
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B000711
-  thomas: '00116'
-- name: Thomas R. Carper
-  party: majority
-  rank: 2
-  bioguide: C000174
-  thomas: '00179'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 3
-  bioguide: C000141
-  thomas: '00174'
-- name: Bernard Sanders
-  party: majority
-  rank: 4
-  bioguide: S000033
-  thomas: '01010'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 5
-  bioguide: W000802
-  thomas: '01823'
-- name: Tom Udall
-  party: majority
-  rank: 6
-  bioguide: U000039
-  thomas: '01567'
-- name: Jeff Merkley
-  party: majority
-  rank: 7
-  bioguide: M001176
-  thomas: '01900'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 8
-  bioguide: G000555
-  thomas: '01866'
-- name: Cory A. Booker
-  party: majority
-  rank: 9
-  bioguide: B001288
-  thomas: '02194'
-- name: Edward J. Markey
-  party: majority
-  rank: 10
-  bioguide: M000133
-  thomas: '00735'
-- name: David Vitter
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: V000127
-  thomas: '01609'
-- name: James M. Inhofe
-  party: minority
-  rank: 2
-  bioguide: I000024
-  thomas: '00583'
-- name: John Barrasso
-  party: minority
-  rank: 3
-  bioguide: B001261
-  thomas: '01881'
-- name: Jeff Sessions
-  party: minority
-  rank: 4
-  bioguide: S001141
-  thomas: '01548'
-- name: Mike Crapo
-  party: minority
-  rank: 5
-  bioguide: C000880
-  thomas: '00250'
-- name: Roger F. Wicker
-  party: minority
-  rank: 6
-  bioguide: W000437
-  thomas: '01226'
-- name: John Boozman
-  party: minority
-  rank: 7
-  bioguide: B001236
-  thomas: '01687'
-- name: Deb Fischer
-  party: minority
-  rank: 8
-  bioguide: F000463
-  thomas: '02179'
-SSEV08:
-- name: Thomas R. Carper
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C000174
-  thomas: '00179'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 2
-  bioguide: C000141
-  thomas: '00174'
-- name: Bernard Sanders
-  party: majority
-  rank: 3
-  bioguide: S000033
-  thomas: '01010'
-- name: Tom Udall
-  party: majority
-  rank: 4
-  bioguide: U000039
-  thomas: '01567'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 5
-  bioguide: G000555
-  thomas: '01866'
-- name: Cory A. Booker
-  party: majority
-  rank: 6
-  bioguide: B001288
-  thomas: '02194'
-- name: Edward J. Markey
-  party: majority
-  rank: 7
-  bioguide: M000133
-  thomas: '00735'
-- name: Barbara Boxer
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: B000711
-  thomas: '00116'
-- name: John Barrasso
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001261
-  thomas: '01881'
-- name: James M. Inhofe
-  party: minority
-  rank: 2
-  bioguide: I000024
-  thomas: '00583'
-- name: Jeff Sessions
-  party: minority
-  rank: 3
-  bioguide: S001141
-  thomas: '01548'
-- name: Mike Crapo
-  party: minority
-  rank: 4
-  bioguide: C000880
-  thomas: '00250'
-- name: Roger F. Wicker
-  party: minority
-  rank: 5
-  bioguide: W000437
-  thomas: '01226'
-- name: Deb Fischer
-  party: minority
-  rank: 6
-  bioguide: F000463
-  thomas: '02179'
-- name: David Vitter
-  party: minority
-  rank: 7
-  title: Ex Officio
-  bioguide: V000127
-  thomas: '01609'
-SSEV09:
-- name: Tom Udall
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: U000039
-  thomas: '01567'
-- name: Jeff Merkley
-  party: majority
-  rank: 2
-  bioguide: M001176
-  thomas: '01900'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 3
-  bioguide: G000555
-  thomas: '01866'
-- name: Cory A. Booker
-  party: majority
-  rank: 4
-  bioguide: B001288
-  thomas: '02194'
-- name: Edward J. Markey
-  party: majority
-  rank: 5
-  bioguide: M000133
-  thomas: '00735'
-- name: Barbara Boxer
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: B000711
-  thomas: '00116'
-- name: Mike Crapo
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C000880
-  thomas: '00250'
-- name: James M. Inhofe
-  party: minority
-  rank: 2
-  bioguide: I000024
-  thomas: '00583'
-- name: Roger F. Wicker
-  party: minority
-  rank: 3
-  bioguide: W000437
-  thomas: '01226'
-- name: Deb Fischer
-  party: minority
-  rank: 4
-  bioguide: F000463
-  thomas: '02179'
-- name: David Vitter
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: V000127
-  thomas: '01609'
-SSEV10:
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: W000802
-  thomas: '01823'
-- name: Thomas R. Carper
-  party: majority
-  rank: 2
-  bioguide: C000174
-  thomas: '00179'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 3
-  bioguide: C000141
-  thomas: '00174'
-- name: Bernard Sanders
-  party: majority
-  rank: 4
-  bioguide: S000033
-  thomas: '01010'
-- name: Tom Udall
-  party: majority
-  rank: 5
-  bioguide: U000039
-  thomas: '01567'
-- name: Edward J. Markey
-  party: majority
-  rank: 6
-  bioguide: M000133
-  thomas: '00735'
-- name: Barbara Boxer
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: B000711
-  thomas: '00116'
-- name: Jeff Sessions
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001141
-  thomas: '01548'
-- name: John Barrasso
-  party: minority
-  rank: 2
-  bioguide: B001261
-  thomas: '01881'
-- name: Mike Crapo
-  party: minority
-  rank: 3
-  bioguide: C000880
-  thomas: '00250'
-- name: Roger F. Wicker
-  party: minority
-  rank: 4
-  bioguide: W000437
-  thomas: '01226'
-- name: John Boozman
-  party: minority
-  rank: 5
-  bioguide: B001236
-  thomas: '01687'
-- name: David Vitter
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: V000127
-  thomas: '01609'
-SSEV15:
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C000141
-  thomas: '00174'
-- name: Thomas R. Carper
-  party: majority
-  rank: 2
-  bioguide: C000174
-  thomas: '00179'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 3
-  bioguide: W000802
-  thomas: '01823'
-- name: Jeff Merkley
-  party: majority
-  rank: 4
-  bioguide: M001176
-  thomas: '01900'
-- name: Kirsten E. Gillibrand
-  party: majority
-  rank: 5
-  bioguide: G000555
-  thomas: '01866'
-- name: Cory A. Booker
-  party: majority
-  rank: 6
-  bioguide: B001288
-  thomas: '02194'
-- name: Barbara Boxer
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: B000711
-  thomas: '00116'
-- name: John Boozman
-  party: minority
-  rank: 1
-  bioguide: B001236
-  thomas: '01687'
-- name: James M. Inhofe
-  party: minority
-  rank: 2
-  bioguide: I000024
-  thomas: '00583'
-- name: John Barrasso
-  party: minority
-  rank: 3
-  bioguide: B001261
-  thomas: '01881'
-- name: Jeff Sessions
-  party: minority
-  rank: 4
-  bioguide: S001141
-  thomas: '01548'
-- name: Deb Fischer
-  party: minority
-  rank: 5
-  bioguide: F000463
-  thomas: '02179'
-- name: David Vitter
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: V000127
-  thomas: '01609'
-SSEV16:
-- name: Jeff Merkley
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M001176
-  thomas: '01900'
-- name: Thomas R. Carper
-  party: majority
-  rank: 2
-  bioguide: C000174
-  thomas: '00179'
-- name: Bernard Sanders
-  party: majority
-  rank: 3
-  bioguide: S000033
-  thomas: '01010'
-- name: Barbara Boxer
-  party: majority
-  rank: 4
-  title: Ex Officio
-  bioguide: B000711
-  thomas: '00116'
-- name: Roger F. Wicker
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: W000437
-  thomas: '01226'
-- name: Jeff Sessions
-  party: minority
-  rank: 2
-  bioguide: S001141
-  thomas: '01548'
-SSEV18:
-- name: Cory A. Booker
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B001288
-  thomas: '02194'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 2
-  bioguide: W000802
-  thomas: '01823'
-- name: Edward J. Markey
-  party: majority
-  rank: 3
-  bioguide: M000133
-  thomas: '00735'
-- name: Barbara Boxer
-  party: majority
-  rank: 4
-  title: Ex Officio
-  bioguide: B000711
-  thomas: '00116'
-- name: James M. Inhofe
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: I000024
-  thomas: '00583'
-- name: John Boozman
-  party: minority
-  rank: 2
-  bioguide: B001236
-  thomas: '01687'
-- name: David Vitter
-  party: minority
-  rank: 3
-  title: Ex Officio
-  bioguide: V000127
-  thomas: '01609'
-SSFI:
-- name: Ron Wyden
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: W000779
-  thomas: '01247'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 2
-  bioguide: R000361
-  thomas: '01424'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Debbie Stabenow
-  party: majority
-  rank: 4
-  bioguide: S000770
-  thomas: '01531'
-- name: Maria Cantwell
-  party: majority
-  rank: 5
-  bioguide: C000127
-  thomas: '00172'
-- name: Bill Nelson
-  party: majority
-  rank: 6
-  bioguide: N000032
-  thomas: '00859'
-- name: Robert Menendez
-  party: majority
-  rank: 7
-  bioguide: M000639
-  thomas: '00791'
-- name: Thomas R. Carper
-  party: majority
-  rank: 8
-  bioguide: C000174
-  thomas: '00179'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 9
-  bioguide: C000141
-  thomas: '00174'
-- name: Sherrod Brown
-  party: majority
-  rank: 10
-  bioguide: B000944
-  thomas: '00136'
-- name: Michael F. Bennet
-  party: majority
-  rank: 11
-  bioguide: B001267
-  thomas: '01965'
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 12
-  bioguide: C001070
-  thomas: '01828'
-- name: Mark R. Warner
-  party: majority
-  rank: 13
-  bioguide: W000805
-  thomas: '01897'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H000338
-  thomas: '01351'
-- name: Chuck Grassley
-  party: minority
-  rank: 2
-  bioguide: G000386
-  thomas: '00457'
-- name: Mike Crapo
-  party: minority
-  rank: 3
-  bioguide: C000880
-  thomas: '00250'
-- name: Pat Roberts
-  party: minority
-  rank: 4
-  bioguide: R000307
-  thomas: '00968'
-- name: Michael B. Enzi
-  party: minority
-  rank: 5
-  bioguide: E000285
-  thomas: '01542'
-- name: John Cornyn
-  party: minority
-  rank: 6
-  bioguide: C001056
-  thomas: '01692'
-- name: John Thune
-  party: minority
-  rank: 7
-  bioguide: T000250
-  thomas: '01534'
-- name: Richard Burr
-  party: minority
-  rank: 8
-  bioguide: B001135
-  thomas: '00153'
-- name: Johnny Isakson
-  party: minority
-  rank: 9
-  bioguide: I000055
-  thomas: '01608'
-- name: Rob Portman
-  party: minority
-  rank: 10
-  bioguide: P000449
-  thomas: '00924'
-- name: Patrick J. Toomey
-  party: minority
-  rank: 11
-  bioguide: T000461
-  thomas: '02085'
-SSFI02:
-- name: Sherrod Brown
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B000944
-  thomas: '00136'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 2
-  bioguide: R000361
-  thomas: '01424'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Bill Nelson
-  party: majority
-  rank: 4
-  bioguide: N000032
-  thomas: '00859'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 5
-  bioguide: C000141
-  thomas: '00174'
-- name: Ron Wyden
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: W000779
-  thomas: '01247'
-- name: Patrick J. Toomey
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: T000461
-  thomas: '02085'
-- name: Mike Crapo
-  party: minority
-  rank: 2
-  bioguide: C000880
-  thomas: '00250'
-- name: Johnny Isakson
-  party: minority
-  rank: 3
-  bioguide: I000055
-  thomas: '01608'
-- name: Rob Portman
-  party: minority
-  rank: 4
-  bioguide: P000449
-  thomas: '00924'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: H000338
-  thomas: '01351'
-SSFI10:
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: R000361
-  thomas: '01424'
-- name: Debbie Stabenow
-  party: majority
-  rank: 2
-  bioguide: S000770
-  thomas: '01531'
-- name: Maria Cantwell
-  party: majority
-  rank: 3
-  bioguide: C000127
-  thomas: '00172'
-- name: Bill Nelson
-  party: majority
-  rank: 4
-  bioguide: N000032
-  thomas: '00859'
-- name: Robert Menendez
-  party: majority
-  rank: 5
-  bioguide: M000639
-  thomas: '00791'
-- name: Thomas R. Carper
-  party: majority
-  rank: 6
-  bioguide: C000174
-  thomas: '00179'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 7
-  bioguide: C000141
-  thomas: '00174'
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 8
-  bioguide: C001070
-  thomas: '01828'
-- name: Ron Wyden
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: W000779
-  thomas: '01247'
-- name: Pat Roberts
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: R000307
-  thomas: '00968'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 2
-  bioguide: H000338
-  thomas: '01351'
-- name: Chuck Grassley
-  party: minority
-  rank: 3
-  bioguide: G000386
-  thomas: '00457'
-- name: Michael B. Enzi
-  party: minority
-  rank: 4
-  bioguide: E000285
-  thomas: '01542'
-- name: John Cornyn
-  party: minority
-  rank: 5
-  bioguide: C001056
-  thomas: '01692'
-- name: Richard Burr
-  party: minority
-  rank: 6
-  bioguide: B001135
-  thomas: '00153'
-- name: Patrick J. Toomey
-  party: minority
-  rank: 7
-  bioguide: T000461
-  thomas: '02085'
-SSFI11:
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C001070
-  thomas: '01828'
-- name: Ron Wyden
-  party: majority
-  rank: 2
-  bioguide: W000779
-  thomas: '01247'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Robert Menendez
-  party: majority
-  rank: 4
-  bioguide: M000639
-  thomas: '00791'
-- name: Thomas R. Carper
-  party: majority
-  rank: 5
-  bioguide: C000174
-  thomas: '00179'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 6
-  bioguide: C000141
-  thomas: '00174'
-- name: Michael F. Bennet
-  party: majority
-  rank: 7
-  bioguide: B001267
-  thomas: '01965'
-- name: Mark R. Warner
-  party: majority
-  rank: 8
-  bioguide: W000805
-  thomas: '01897'
-- name: Michael B. Enzi
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: E000285
-  thomas: '01542'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 2
-  bioguide: H000338
-  thomas: '01351'
-- name: Mike Crapo
-  party: minority
-  rank: 3
-  bioguide: C000880
-  thomas: '00250'
-- name: Pat Roberts
-  party: minority
-  rank: 4
-  bioguide: R000307
-  thomas: '00968'
-- name: John Cornyn
-  party: minority
-  rank: 5
-  bioguide: C001056
-  thomas: '01692'
-- name: John Thune
-  party: minority
-  rank: 6
-  bioguide: T000250
-  thomas: '01534'
-- name: Patrick J. Toomey
-  party: minority
-  rank: 7
-  bioguide: T000461
-  thomas: '02085'
-SSFI12:
-- name: Michael F. Bennet
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B001267
-  thomas: '01965'
-- name: Ron Wyden
-  party: majority
-  rank: 2
-  bioguide: W000779
-  thomas: '01247'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 3
-  bioguide: R000361
-  thomas: '01424'
-- name: Debbie Stabenow
-  party: majority
-  rank: 4
-  bioguide: S000770
-  thomas: '01531'
-- name: Robert Menendez
-  party: majority
-  rank: 5
-  bioguide: M000639
-  thomas: '00791'
-- name: Maria Cantwell
-  party: majority
-  rank: 6
-  bioguide: C000127
-  thomas: '00172'
-- name: Bill Nelson
-  party: majority
-  rank: 7
-  bioguide: N000032
-  thomas: '00859'
-- name: Thomas R. Carper
-  party: majority
-  rank: 8
-  bioguide: C000174
-  thomas: '00179'
-- name: John Cornyn
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001056
-  thomas: '01692'
-- name: Chuck Grassley
-  party: minority
-  rank: 2
-  bioguide: G000386
-  thomas: '00457'
-- name: Mike Crapo
-  party: minority
-  rank: 3
-  bioguide: C000880
-  thomas: '00250'
-- name: Michael B. Enzi
-  party: minority
-  rank: 4
-  bioguide: E000285
-  thomas: '01542'
-- name: John Thune
-  party: minority
-  rank: 5
-  bioguide: T000250
-  thomas: '01534'
-- name: Richard Burr
-  party: minority
-  rank: 6
-  bioguide: B001135
-  thomas: '00153'
-- name: Johnny Isakson
-  party: minority
-  rank: 7
-  bioguide: I000055
-  thomas: '01608'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: H000338
-  thomas: '01351'
-SSFI13:
-- name: Debbie Stabenow
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: S000770
-  thomas: '01531'
-- name: John D. Rockefeller, IV
-  party: majority
-  rank: 2
-  bioguide: R000361
-  thomas: '01424'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Maria Cantwell
-  party: majority
-  rank: 4
-  bioguide: C000127
-  thomas: '00172'
-- name: Robert Menendez
-  party: majority
-  rank: 5
-  bioguide: M000639
-  thomas: '00791'
-- name: Sherrod Brown
-  party: majority
-  rank: 6
-  bioguide: B000944
-  thomas: '00136'
-- name: Michael F. Bennet
-  party: majority
-  rank: 7
-  bioguide: B001267
-  thomas: '01965'
-- name: Mark R. Warner
-  party: majority
-  rank: 8
-  bioguide: W000805
-  thomas: '01897'
-- name: Ron Wyden
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: W000779
-  thomas: '01247'
-- name: Johnny Isakson
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: I000055
-  thomas: '01608'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 2
-  bioguide: H000338
-  thomas: '01351'
-- name: Chuck Grassley
-  party: minority
-  rank: 3
-  bioguide: G000386
-  thomas: '00457'
-- name: Pat Roberts
-  party: minority
-  rank: 4
-  bioguide: R000307
-  thomas: '00968'
-- name: John Thune
-  party: minority
-  rank: 5
-  bioguide: T000250
-  thomas: '01534'
-- name: Rob Portman
-  party: minority
-  rank: 6
-  bioguide: P000449
-  thomas: '00924'
-SSFI14:
-- name: Mark R. Warner
-  party: majority
-  rank: 1
-  bioguide: W000805
-  thomas: '01897'
-- name: Sherrod Brown
-  party: majority
-  rank: 2
-  bioguide: B000944
-  thomas: '00136'
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 3
-  bioguide: C001070
-  thomas: '01828'
-- name: Ron Wyden
-  party: majority
-  rank: 4
-  title: Ex Officio
-  bioguide: W000779
-  thomas: '01247'
-- name: Rob Portman
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000449
-  thomas: '00924'
-- name: Richard Burr
-  party: minority
-  rank: 2
-  bioguide: B001135
-  thomas: '00153'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 3
-  title: Ex Officio
-  bioguide: H000338
-  thomas: '01351'
-SSFR:
-- name: Robert Menendez
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M000639
-  thomas: '00791'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 3
-  bioguide: C000141
-  thomas: '00174'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 4
-  bioguide: S001181
-  thomas: '01901'
-- name: Christopher A. Coons
-  party: majority
-  rank: 5
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard J. Durbin
-  party: majority
-  rank: 6
-  bioguide: D000563
-  thomas: '00326'
-- name: Tom Udall
-  party: majority
-  rank: 7
-  bioguide: U000039
-  thomas: '01567'
-- name: Christopher Murphy
-  party: majority
-  rank: 8
-  bioguide: M001169
-  thomas: '01837'
-- name: Tim Kaine
-  party: majority
-  rank: 9
-  bioguide: K000384
-  thomas: '02176'
-- name: Edward J. Markey
-  party: majority
-  rank: 10
-  bioguide: M000133
-  thomas: '00735'
-- name: Bob Corker
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001071
-  thomas: '01825'
-- name: James E. Risch
-  party: minority
-  rank: 2
-  bioguide: R000584
-  thomas: '01896'
-- name: Marco Rubio
-  party: minority
-  rank: 3
-  bioguide: R000595
-  thomas: '02084'
-- name: Ron Johnson
-  party: minority
-  rank: 4
-  bioguide: J000293
-  thomas: '02086'
-- name: Jeff Flake
-  party: minority
-  rank: 5
-  bioguide: F000444
-  thomas: '01633'
-- name: John McCain
-  party: minority
-  rank: 6
-  bioguide: M000303
-  thomas: '00754'
-- name: John Barrasso
-  party: minority
-  rank: 7
-  bioguide: B001261
-  thomas: '01881'
-- name: Rand Paul
-  party: minority
-  rank: 8
-  bioguide: P000603
-  thomas: '02082'
-SSFR01:
-- name: Christopher Murphy
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M001169
-  thomas: '01837'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 2
-  bioguide: S001181
-  thomas: '01901'
-- name: Edward J. Markey
-  party: majority
-  rank: 3
-  bioguide: M000133
-  thomas: '00735'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 4
-  bioguide: C000141
-  thomas: '00174'
-- name: Richard J. Durbin
-  party: majority
-  rank: 5
-  bioguide: D000563
-  thomas: '00326'
-- name: Robert Menendez
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: M000639
-  thomas: '00791'
-- name: Ron Johnson
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: J000293
-  thomas: '02086'
-- name: James E. Risch
-  party: minority
-  rank: 2
-  bioguide: R000584
-  thomas: '01896'
-- name: Jeff Flake
-  party: minority
-  rank: 3
-  bioguide: F000444
-  thomas: '01633'
-- name: John Barrasso
-  party: minority
-  rank: 4
-  bioguide: B001261
-  thomas: '01881'
-- name: Bob Corker
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C001071
-  thomas: '01825'
-SSFR02:
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C000141
-  thomas: '00174'
-- name: Christopher Murphy
-  party: majority
-  rank: 2
-  bioguide: M001169
-  thomas: '01837'
-- name: Barbara Boxer
-  party: majority
-  rank: 3
-  bioguide: B000711
-  thomas: '00116'
-- name: Tom Udall
-  party: majority
-  rank: 4
-  bioguide: U000039
-  thomas: '01567'
-- name: Edward J. Markey
-  party: majority
-  rank: 5
-  bioguide: M000133
-  thomas: '00735'
-- name: Robert Menendez
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: M000639
-  thomas: '00791'
-- name: Marco Rubio
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: R000595
-  thomas: '02084'
-- name: Ron Johnson
-  party: minority
-  rank: 2
-  bioguide: J000293
-  thomas: '02086'
-- name: Jeff Flake
-  party: minority
-  rank: 3
-  bioguide: F000444
-  thomas: '01633'
-- name: John McCain
-  party: minority
-  rank: 4
-  bioguide: M000303
-  thomas: '00754'
-- name: Bob Corker
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C001071
-  thomas: '01825'
-SSFR06:
-- name: Tom Udall
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: U000039
-  thomas: '01567'
-- name: Tim Kaine
-  party: majority
-  rank: 2
-  bioguide: K000384
-  thomas: '02176'
-- name: Barbara Boxer
-  party: majority
-  rank: 3
-  bioguide: B000711
-  thomas: '00116'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 4
-  bioguide: S001181
-  thomas: '01901'
-- name: Christopher Murphy
-  party: majority
-  rank: 5
-  bioguide: M001169
-  thomas: '01837'
-- name: Robert Menendez
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: M000639
-  thomas: '00791'
-- name: John McCain
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M000303
-  thomas: '00754'
-- name: Marco Rubio
-  party: minority
-  rank: 2
-  bioguide: R000595
-  thomas: '02084'
-- name: John Barrasso
-  party: minority
-  rank: 3
-  bioguide: B001261
-  thomas: '01881'
-- name: Rand Paul
-  party: minority
-  rank: 4
-  bioguide: P000603
-  thomas: '02082'
-- name: Bob Corker
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C001071
-  thomas: '01825'
-SSFR07:
-- name: Tim Kaine
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: K000384
-  thomas: '02176'
-- name: Barbara Boxer
-  party: majority
-  rank: 2
-  bioguide: B000711
-  thomas: '00116'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 3
-  bioguide: C000141
-  thomas: '00174'
-- name: Christopher A. Coons
-  party: majority
-  rank: 4
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard J. Durbin
-  party: majority
-  rank: 5
-  bioguide: D000563
-  thomas: '00326'
-- name: Robert Menendez
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: M000639
-  thomas: '00791'
-- name: James E. Risch
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: R000584
-  thomas: '01896'
-- name: Marco Rubio
-  party: minority
-  rank: 2
-  bioguide: R000595
-  thomas: '02084'
-- name: Ron Johnson
-  party: minority
-  rank: 3
-  bioguide: J000293
-  thomas: '02086'
-- name: John McCain
-  party: minority
-  rank: 4
-  bioguide: M000303
-  thomas: '00754'
-- name: Bob Corker
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C001071
-  thomas: '01825'
-SSFR09:
-- name: Christopher A. Coons
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard J. Durbin
-  party: majority
-  rank: 2
-  bioguide: D000563
-  thomas: '00326'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 3
-  bioguide: C000141
-  thomas: '00174'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 4
-  bioguide: S001181
-  thomas: '01901'
-- name: Tom Udall
-  party: majority
-  rank: 5
-  bioguide: U000039
-  thomas: '01567'
-- name: Robert Menendez
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: M000639
-  thomas: '00791'
-- name: Jeff Flake
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: F000444
-  thomas: '01633'
-- name: John McCain
-  party: minority
-  rank: 2
-  bioguide: M000303
-  thomas: '00754'
-- name: John Barrasso
-  party: minority
-  rank: 3
-  bioguide: B001261
-  thomas: '01881'
-- name: Rand Paul
-  party: minority
-  rank: 4
-  bioguide: P000603
-  thomas: '02082'
-- name: Bob Corker
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C001071
-  thomas: '01825'
-SSFR12:
-- name: Edward J. Markey
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M000133
-  thomas: '00735'
-- name: Tom Udall
-  party: majority
-  rank: 2
-  bioguide: U000039
-  thomas: '01567'
-- name: Christopher A. Coons
-  party: majority
-  rank: 3
-  bioguide: C001088
-  thomas: '01984'
-- name: Christopher Murphy
-  party: majority
-  rank: 4
-  bioguide: M001169
-  thomas: '01837'
-- name: Tim Kaine
-  party: majority
-  rank: 5
-  bioguide: K000384
-  thomas: '02176'
-- name: Robert Menendez
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: M000639
-  thomas: '00791'
-- name: John Barrasso
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001261
-  thomas: '01881'
-- name: James E. Risch
-  party: minority
-  rank: 2
-  bioguide: R000584
-  thomas: '01896'
-- name: Jeff Flake
-  party: minority
-  rank: 3
-  bioguide: F000444
-  thomas: '01633'
-- name: Rand Paul
-  party: minority
-  rank: 4
-  bioguide: P000603
-  thomas: '02082'
-- name: Bob Corker
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C001071
-  thomas: '01825'
-SSFR13:
-- name: Barbara Boxer
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B000711
-  thomas: '00116'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 2
-  bioguide: S001181
-  thomas: '01901'
-- name: Richard J. Durbin
-  party: majority
-  rank: 3
-  bioguide: D000563
-  thomas: '00326'
-- name: Christopher A. Coons
-  party: majority
-  rank: 4
-  bioguide: C001088
-  thomas: '01984'
-- name: Tim Kaine
-  party: majority
-  rank: 5
-  bioguide: K000384
-  thomas: '02176'
-- name: Robert Menendez
-  party: majority
-  rank: 6
-  title: Ex Officio
-  bioguide: M000639
-  thomas: '00791'
-- name: Rand Paul
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000603
-  thomas: '02082'
-- name: Marco Rubio
-  party: minority
-  rank: 2
-  bioguide: R000595
-  thomas: '02084'
-- name: James E. Risch
-  party: minority
-  rank: 3
-  bioguide: R000584
-  thomas: '01896'
-- name: Ron Johnson
-  party: minority
-  rank: 4
-  bioguide: J000293
-  thomas: '02086'
-- name: Bob Corker
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C001071
-  thomas: '01825'
-SSGA:
-- name: Thomas R. Carper
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C000174
-  thomas: '00179'
-- name: Carl Levin
-  party: majority
-  rank: 2
-  bioguide: L000261
-  thomas: '01384'
-- name: Mark L. Pryor
-  party: majority
-  rank: 3
-  bioguide: P000590
-  thomas: '01701'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 4
-  bioguide: L000550
-  thomas: '01546'
-- name: Claire McCaskill
-  party: majority
-  rank: 5
-  bioguide: M001170
-  thomas: '01820'
-- name: Jon Tester
-  party: majority
-  rank: 6
-  bioguide: T000464
-  thomas: '01829'
-- name: Mark Begich
-  party: majority
-  rank: 7
-  bioguide: B001265
-  thomas: '01898'
-- name: Tammy Baldwin
-  party: majority
-  rank: 8
-  bioguide: B001230
-  thomas: '01558'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 9
-  bioguide: H001069
-  thomas: '02174'
-- name: Tom Coburn
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C000560
-  thomas: '00212'
-- name: John McCain
-  party: minority
-  rank: 2
-  bioguide: M000303
-  thomas: '00754'
-- name: Ron Johnson
-  party: minority
-  rank: 3
-  bioguide: J000293
-  thomas: '02086'
-- name: Rob Portman
-  party: minority
-  rank: 4
-  bioguide: P000449
-  thomas: '00924'
-- name: Rand Paul
-  party: minority
-  rank: 5
-  bioguide: P000603
-  thomas: '02082'
-- name: Michael B. Enzi
-  party: minority
-  rank: 6
-  bioguide: E000285
-  thomas: '01542'
-- name: Kelly Ayotte
-  party: minority
-  rank: 7
-  bioguide: A000368
-  thomas: '02075'
-SSGA01:
-- name: Carl Levin
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: L000261
-  thomas: '01384'
-- name: Mark L. Pryor
-  party: majority
-  rank: 2
-  bioguide: P000590
-  thomas: '01701'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 3
-  bioguide: L000550
-  thomas: '01546'
-- name: Claire McCaskill
-  party: majority
-  rank: 4
-  bioguide: M001170
-  thomas: '01820'
-- name: Jon Tester
-  party: majority
-  rank: 5
-  bioguide: T000464
-  thomas: '01829'
-- name: Tammy Baldwin
-  party: majority
-  rank: 6
-  bioguide: B001230
-  thomas: '01558'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 7
-  bioguide: H001069
-  thomas: '02174'
-- name: Thomas R. Carper
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: C000174
-  thomas: '00179'
-- name: John McCain
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M000303
-  thomas: '00754'
-- name: Ron Johnson
-  party: minority
-  rank: 2
-  bioguide: J000293
-  thomas: '02086'
-- name: Rob Portman
-  party: minority
-  rank: 3
-  bioguide: P000449
-  thomas: '00924'
-- name: Rand Paul
-  party: minority
-  rank: 4
-  bioguide: P000603
-  thomas: '02082'
-- name: Kelly Ayotte
-  party: minority
-  rank: 5
-  bioguide: A000368
-  thomas: '02075'
-- name: Tom Coburn
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: C000560
-  thomas: '00212'
-SSGA15:
-- name: Claire McCaskill
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: M001170
-  thomas: '01820'
-- name: Carl Levin
-  party: majority
-  rank: 2
-  bioguide: L000261
-  thomas: '01384'
-- name: Mark L. Pryor
-  party: majority
-  rank: 3
-  bioguide: P000590
-  thomas: '01701'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 4
-  bioguide: L000550
-  thomas: '01546'
-- name: Mark Begich
-  party: majority
-  rank: 5
-  bioguide: B001265
-  thomas: '01898'
-- name: Tammy Baldwin
-  party: majority
-  rank: 6
-  bioguide: B001230
-  thomas: '01558'
-- name: Thomas R. Carper
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: C000174
-  thomas: '00179'
-- name: Ron Johnson
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: J000293
-  thomas: '02086'
-- name: John McCain
-  party: minority
-  rank: 2
-  bioguide: M000303
-  thomas: '00754'
-- name: Michael B. Enzi
-  party: minority
-  rank: 3
-  bioguide: E000285
-  thomas: '01542'
-- name: Kelly Ayotte
-  party: minority
-  rank: 4
-  bioguide: A000368
-  thomas: '02075'
-- name: Tom Coburn
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C000560
-  thomas: '00212'
-SSGA16:
-- name: Jon Tester
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: T000464
-  thomas: '01829'
-- name: Mark L. Pryor
-  party: majority
-  rank: 2
-  bioguide: P000590
-  thomas: '01701'
-- name: Claire McCaskill
-  party: majority
-  rank: 3
-  bioguide: M001170
-  thomas: '01820'
-- name: Mark Begich
-  party: majority
-  rank: 4
-  bioguide: B001265
-  thomas: '01898'
-- name: Tammy Baldwin
-  party: majority
-  rank: 5
-  bioguide: B001230
-  thomas: '01558'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 6
-  bioguide: H001069
-  thomas: '02174'
-- name: Thomas R. Carper
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: C000174
-  thomas: '00179'
-- name: Rob Portman
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000449
-  thomas: '00924'
-- name: Ron Johnson
-  party: minority
-  rank: 2
-  bioguide: J000293
-  thomas: '02086'
-- name: Rand Paul
-  party: minority
-  rank: 3
-  bioguide: P000603
-  thomas: '02082'
-- name: Michael B. Enzi
-  party: minority
-  rank: 4
-  bioguide: E000285
-  thomas: '01542'
-- name: Tom Coburn
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C000560
-  thomas: '00212'
-SSGA17:
-- name: Mark Begich
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B001265
-  thomas: '01898'
-- name: Carl Levin
-  party: majority
-  rank: 2
-  bioguide: L000261
-  thomas: '01384'
-- name: Mark L. Pryor
-  party: majority
-  rank: 3
-  bioguide: P000590
-  thomas: '01701'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 4
-  bioguide: L000550
-  thomas: '01546'
-- name: Jon Tester
-  party: majority
-  rank: 5
-  bioguide: T000464
-  thomas: '01829'
-- name: Heidi Heitkamp
-  party: majority
-  rank: 6
-  bioguide: H001069
-  thomas: '02174'
-- name: Thomas R. Carper
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: C000174
-  thomas: '00179'
-- name: Rand Paul
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000603
-  thomas: '02082'
-- name: John McCain
-  party: minority
-  rank: 2
-  bioguide: M000303
-  thomas: '00754'
-- name: Rob Portman
-  party: minority
-  rank: 3
-  bioguide: P000449
-  thomas: '00924'
-- name: Michael B. Enzi
-  party: minority
-  rank: 4
-  bioguide: E000285
-  thomas: '01542'
-- name: Tom Coburn
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: C000560
-  thomas: '00212'
-SSHR:
-- name: Tom Harkin
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: H000206
-  thomas: '00501'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 2
-  bioguide: M000702
-  thomas: '00802'
-- name: Patty Murray
-  party: majority
-  rank: 3
-  bioguide: M001111
-  thomas: '01409'
-- name: Bernard Sanders
-  party: majority
-  rank: 4
-  bioguide: S000033
-  thomas: '01010'
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 5
-  bioguide: C001070
-  thomas: '01828'
-- name: Kay R. Hagan
-  party: majority
-  rank: 6
-  bioguide: H001049
-  thomas: '01902'
-- name: Al Franken
-  party: majority
-  rank: 7
-  bioguide: F000457
-  thomas: '01969'
-- name: Michael F. Bennet
-  party: majority
-  rank: 8
-  bioguide: B001267
-  thomas: '01965'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 9
-  bioguide: W000802
-  thomas: '01823'
-- name: Tammy Baldwin
-  party: majority
-  rank: 10
-  bioguide: B001230
-  thomas: '01558'
-- name: Christopher Murphy
-  party: majority
-  rank: 11
-  bioguide: M001169
-  thomas: '01837'
-- name: Elizabeth Warren
-  party: majority
-  rank: 12
-  bioguide: W000817
-  thomas: '02182'
-- name: Lamar Alexander
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: A000360
-  thomas: '01695'
-- name: Michael B. Enzi
-  party: minority
-  rank: 2
-  bioguide: E000285
-  thomas: '01542'
-- name: Richard Burr
-  party: minority
-  rank: 3
-  bioguide: B001135
-  thomas: '00153'
-- name: Johnny Isakson
-  party: minority
-  rank: 4
-  bioguide: I000055
-  thomas: '01608'
-- name: Rand Paul
-  party: minority
-  rank: 5
-  bioguide: P000603
-  thomas: '02082'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 6
-  bioguide: H000338
-  thomas: '01351'
-- name: Pat Roberts
-  party: minority
-  rank: 7
-  bioguide: R000307
-  thomas: '00968'
-- name: Lisa Murkowski
-  party: minority
-  rank: 8
-  bioguide: M001153
-  thomas: '01694'
-- name: Mark Kirk
-  party: minority
-  rank: 9
-  bioguide: K000360
-  thomas: '01647'
-- name: Tim Scott
-  party: minority
-  rank: 10
-  bioguide: S001184
-  thomas: '02056'
-SSHR09:
-- name: Kay R. Hagan
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: H001049
-  thomas: '01902'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 2
-  bioguide: M000702
-  thomas: '00802'
-- name: Patty Murray
-  party: majority
-  rank: 3
-  bioguide: M001111
-  thomas: '01409'
-- name: Bernard Sanders
-  party: majority
-  rank: 4
-  bioguide: S000033
-  thomas: '01010'
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 5
-  bioguide: C001070
-  thomas: '01828'
-- name: Al Franken
-  party: majority
-  rank: 6
-  bioguide: F000457
-  thomas: '01969'
-- name: Michael F. Bennet
-  party: majority
-  rank: 7
-  bioguide: B001267
-  thomas: '01965'
-- name: Christopher Murphy
-  party: majority
-  rank: 8
-  bioguide: M001169
-  thomas: '01837'
-- name: Elizabeth Warren
-  party: majority
-  rank: 9
-  bioguide: W000817
-  thomas: '02182'
-- name: Tom Harkin
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: H000206
-  thomas: '00501'
-- name: Michael B. Enzi
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: E000285
-  thomas: '01542'
-- name: Mark Kirk
-  party: minority
-  rank: 2
-  bioguide: K000360
-  thomas: '01647'
-- name: Richard Burr
-  party: minority
-  rank: 3
-  bioguide: B001135
-  thomas: '00153'
-- name: Johnny Isakson
-  party: minority
-  rank: 4
-  bioguide: I000055
-  thomas: '01608'
-- name: Rand Paul
-  party: minority
-  rank: 5
-  bioguide: P000603
-  thomas: '02082'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 6
-  bioguide: H000338
-  thomas: '01351'
-- name: Pat Roberts
-  party: minority
-  rank: 7
-  bioguide: R000307
-  thomas: '00968'
-- name: Lamar Alexander
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: A000360
-  thomas: '01695'
-SSHR11:
-- name: Robert P. Casey, Jr.
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C001070
-  thomas: '01828'
-- name: Patty Murray
-  party: majority
-  rank: 2
-  bioguide: M001111
-  thomas: '01409'
-- name: Al Franken
-  party: majority
-  rank: 3
-  bioguide: F000457
-  thomas: '01969'
-- name: Michael F. Bennet
-  party: majority
-  rank: 4
-  bioguide: B001267
-  thomas: '01965'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 5
-  bioguide: W000802
-  thomas: '01823'
-- name: Tammy Baldwin
-  party: majority
-  rank: 6
-  bioguide: B001230
-  thomas: '01558'
-- name: Tom Harkin
-  party: majority
-  rank: 7
-  title: Ex Officio
-  bioguide: H000206
-  thomas: '00501'
-- name: Johnny Isakson
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: I000055
-  thomas: '01608'
-- name: Rand Paul
-  party: minority
-  rank: 2
-  bioguide: P000603
-  thomas: '02082'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 3
-  bioguide: H000338
-  thomas: '01351'
-- name: Tim Scott
-  party: minority
-  rank: 4
-  bioguide: S001184
-  thomas: '02056'
-- name: Lamar Alexander
-  party: minority
-  rank: 5
-  title: Ex Officio
-  bioguide: A000360
-  thomas: '01695'
-- name: Michael B. Enzi
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: E000285
-  thomas: '01542'
-SSHR12:
-- name: Bernard Sanders
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: S000033
-  thomas: '01010'
-- name: Barbara A. Mikulski
-  party: majority
-  rank: 2
-  bioguide: M000702
-  thomas: '00802'
-- name: Kay R. Hagan
-  party: majority
-  rank: 3
-  bioguide: H001049
-  thomas: '01902'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 4
-  bioguide: W000802
-  thomas: '01823'
-- name: Tammy Baldwin
-  party: majority
-  rank: 5
-  bioguide: B001230
-  thomas: '01558'
-- name: Christopher Murphy
-  party: majority
-  rank: 6
-  bioguide: M001169
-  thomas: '01837'
-- name: Elizabeth Warren
-  party: majority
-  rank: 7
-  bioguide: W000817
-  thomas: '02182'
-- name: Tom Harkin
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: H000206
-  thomas: '00501'
-- name: Richard Burr
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001135
-  thomas: '00153'
-- name: Pat Roberts
-  party: minority
-  rank: 2
-  bioguide: R000307
-  thomas: '00968'
-- name: Lisa Murkowski
-  party: minority
-  rank: 3
-  bioguide: M001153
-  thomas: '01694'
-- name: Michael B. Enzi
-  party: minority
-  rank: 4
-  bioguide: E000285
-  thomas: '01542'
-- name: Mark Kirk
-  party: minority
-  rank: 5
-  bioguide: K000360
-  thomas: '01647'
-- name: Lamar Alexander
-  party: minority
-  rank: 6
-  title: Ex Officio
-  bioguide: A000360
-  thomas: '01695'
-SSJU:
-- name: Patrick J. Leahy
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: L000174
-  thomas: '01383'
-- name: Dianne Feinstein
-  party: majority
-  rank: 2
-  bioguide: F000062
-  thomas: '01332'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Richard J. Durbin
-  party: majority
-  rank: 4
-  bioguide: D000563
-  thomas: '00326'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 5
-  bioguide: W000802
-  thomas: '01823'
-- name: Amy Klobuchar
-  party: majority
-  rank: 6
-  bioguide: K000367
-  thomas: '01826'
-- name: Al Franken
-  party: majority
-  rank: 7
-  bioguide: F000457
-  thomas: '01969'
-- name: Christopher A. Coons
-  party: majority
-  rank: 8
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard Blumenthal
-  party: majority
-  rank: 9
-  bioguide: B001277
-  thomas: '02076'
 - name: Mazie K. Hirono
-  party: majority
-  rank: 10
+  party: minority
+  rank: 8
   bioguide: H001042
   thomas: '01844'
-- name: Chuck Grassley
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: G000386
-  thomas: '00457'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 2
-  bioguide: H000338
-  thomas: '01351'
-- name: Jeff Sessions
-  party: minority
-  rank: 3
-  bioguide: S001141
-  thomas: '01548'
-- name: Lindsey Graham
-  party: minority
-  rank: 4
-  bioguide: G000359
-  thomas: '00452'
-- name: John Cornyn
-  party: minority
-  rank: 5
-  bioguide: C001056
-  thomas: '01692'
-- name: Mike Lee
-  party: minority
-  rank: 6
-  bioguide: L000577
-  thomas: '02080'
-- name: Ted Cruz
-  party: minority
-  rank: 7
-  bioguide: C001098
-  thomas: '02175'
-- name: Jeff Flake
-  party: minority
-  rank: 8
-  bioguide: F000444
-  thomas: '01633'
-SSJU01:
-- name: Amy Klobuchar
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: K000367
-  thomas: '01826'
-- name: Charles E. Schumer
-  party: majority
-  rank: 2
-  bioguide: S000148
-  thomas: '01036'
-- name: Al Franken
-  party: majority
-  rank: 3
-  bioguide: F000457
-  thomas: '01969'
-- name: Christopher A. Coons
-  party: majority
-  rank: 4
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard Blumenthal
-  party: majority
-  rank: 5
-  bioguide: B001277
-  thomas: '02076'
-- name: Mike Lee
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000577
-  thomas: '02080'
-- name: Lindsey Graham
-  party: minority
-  rank: 2
-  bioguide: G000359
-  thomas: '00452'
-- name: Chuck Grassley
-  party: minority
-  rank: 3
-  bioguide: G000386
-  thomas: '00457'
-- name: Jeff Flake
-  party: minority
-  rank: 4
-  bioguide: F000444
-  thomas: '01633'
-SSJU04:
-- name: Charles E. Schumer
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: S000148
-  thomas: '01036'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Dianne Feinstein
-  party: majority
-  rank: 3
-  bioguide: F000062
-  thomas: '01332'
-- name: Richard J. Durbin
-  party: majority
-  rank: 4
-  bioguide: D000563
-  thomas: '00326'
-- name: Amy Klobuchar
-  party: majority
-  rank: 5
-  bioguide: K000367
-  thomas: '01826'
-- name: Richard Blumenthal
-  party: majority
-  rank: 6
-  bioguide: B001277
-  thomas: '02076'
-- name: Mazie K. Hirono
-  party: majority
-  rank: 7
-  bioguide: H001042
-  thomas: '01844'
-- name: John Cornyn
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001056
-  thomas: '01692'
-- name: Chuck Grassley
-  party: minority
-  rank: 2
-  bioguide: G000386
-  thomas: '00457'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 3
-  bioguide: H000338
-  thomas: '01351'
-- name: Jeff Sessions
-  party: minority
-  rank: 4
-  bioguide: S001141
-  thomas: '01548'
-- name: Jeff Flake
-  party: minority
-  rank: 5
-  bioguide: F000444
-  thomas: '01633'
-- name: Ted Cruz
-  party: minority
-  rank: 6
-  bioguide: C001098
-  thomas: '02175'
-SSJU21:
-- name: Richard J. Durbin
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: D000563
-  thomas: '00326'
-- name: Al Franken
-  party: majority
-  rank: 2
-  bioguide: F000457
-  thomas: '01969'
-- name: Christopher A. Coons
-  party: majority
-  rank: 3
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard Blumenthal
-  party: majority
-  rank: 4
-  bioguide: B001277
-  thomas: '02076'
-- name: Mazie K. Hirono
-  party: majority
-  rank: 5
-  bioguide: H001042
-  thomas: '01844'
-- name: Ted Cruz
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001098
-  thomas: '02175'
-- name: Lindsey Graham
-  party: minority
-  rank: 2
-  bioguide: G000359
-  thomas: '00452'
-- name: John Cornyn
-  party: minority
-  rank: 3
-  bioguide: C001056
-  thomas: '01692'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 4
-  bioguide: H000338
-  thomas: '01351'
-SSJU22:
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: W000802
-  thomas: '01823'
-- name: Dianne Feinstein
-  party: majority
-  rank: 2
-  bioguide: F000062
-  thomas: '01332'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Richard J. Durbin
-  party: majority
-  rank: 4
-  bioguide: D000563
-  thomas: '00326'
-- name: Amy Klobuchar
-  party: majority
-  rank: 5
-  bioguide: K000367
-  thomas: '01826'
-- name: Lindsey Graham
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: G000359
-  thomas: '00452'
-- name: Ted Cruz
-  party: minority
-  rank: 2
-  bioguide: C001098
-  thomas: '02175'
-- name: Jeff Sessions
-  party: minority
-  rank: 3
-  bioguide: S001141
-  thomas: '01548'
-- name: Mike Lee
-  party: minority
-  rank: 4
-  bioguide: L000577
-  thomas: '02080'
-SSJU23:
-- name: Al Franken
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: F000457
-  thomas: '01969'
-- name: Dianne Feinstein
-  party: majority
-  rank: 2
-  bioguide: F000062
-  thomas: '01332'
-- name: Charles E. Schumer
-  party: majority
-  rank: 3
-  bioguide: S000148
-  thomas: '01036'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 4
-  bioguide: W000802
-  thomas: '01823'
-- name: Christopher A. Coons
-  party: majority
-  rank: 5
-  bioguide: C001088
-  thomas: '01984'
-- name: Mazie K. Hirono
-  party: majority
-  rank: 6
-  bioguide: H001042
-  thomas: '01844'
-- name: Jeff Flake
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: F000444
-  thomas: '01633'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 2
-  bioguide: H000338
-  thomas: '01351'
-- name: Mike Lee
-  party: minority
-  rank: 3
-  bioguide: L000577
-  thomas: '02080'
-- name: John Cornyn
-  party: minority
-  rank: 4
-  bioguide: C001056
-  thomas: '01692'
-- name: Lindsey Graham
-  party: minority
-  rank: 5
-  bioguide: G000359
-  thomas: '00452'
-SSJU24:
-- name: Christopher A. Coons
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C001088
-  thomas: '01984'
-- name: Richard J. Durbin
-  party: majority
-  rank: 2
-  bioguide: D000563
-  thomas: '00326'
-- name: Sheldon Whitehouse
-  party: majority
-  rank: 3
-  bioguide: W000802
-  thomas: '01823'
-- name: Amy Klobuchar
-  party: majority
-  rank: 4
-  bioguide: K000367
-  thomas: '01826'
-- name: Al Franken
-  party: majority
-  rank: 5
-  bioguide: F000457
-  thomas: '01969'
-- name: Jeff Sessions
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001141
-  thomas: '01548'
-- name: Chuck Grassley
-  party: minority
-  rank: 2
-  bioguide: G000386
-  thomas: '00457'
-- name: Jeff Flake
-  party: minority
-  rank: 3
-  bioguide: F000444
-  thomas: '01633'
-- name: Ted Cruz
-  party: minority
-  rank: 4
-  bioguide: C001098
-  thomas: '02175'
-SSJU25:
-- name: Richard Blumenthal
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B001277
-  thomas: '02076'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 2
-  bioguide: L000174
-  thomas: '01383'
-- name: Amy Klobuchar
-  party: majority
-  rank: 3
-  bioguide: K000367
-  thomas: '01826'
-- name: Orrin G. Hatch
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H000338
-  thomas: '01351'
-- name: Jeff Flake
-  party: minority
-  rank: 2
-  bioguide: F000444
-  thomas: '01633'
-SSRA:
-- name: Charles E. Schumer
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: S000148
-  thomas: '01036'
-- name: Dianne Feinstein
-  party: majority
-  rank: 2
-  bioguide: F000062
-  thomas: '01332'
-- name: Richard J. Durbin
-  party: majority
-  rank: 3
-  bioguide: D000563
-  thomas: '00326'
-- name: Mark L. Pryor
-  party: majority
-  rank: 4
-  bioguide: P000590
-  thomas: '01701'
-- name: Tom Udall
-  party: majority
-  rank: 5
-  bioguide: U000039
-  thomas: '01567'
-- name: Mark R. Warner
-  party: majority
-  rank: 6
-  bioguide: W000805
-  thomas: '01897'
-- name: Patrick J. Leahy
-  party: majority
-  rank: 7
-  bioguide: L000174
-  thomas: '01383'
-- name: Amy Klobuchar
-  party: majority
-  rank: 8
-  bioguide: K000367
-  thomas: '01826'
 - name: Angus S. King, Jr.
-  party: majority
+  party: minority
   rank: 9
   bioguide: K000383
   thomas: '02185'
-- name: John E. Walsh
+- name: Elizabeth Warren
+  party: minority
+  rank: 10
+  bioguide: W000817
+  thomas: '02182'
+SSEG01:
+- name: James E. Risch
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: R000584
+  thomas: '01896'
+- name: Jeff Flake
+  party: majority
+  rank: 2
+  bioguide: F000444
+  thomas: '01633'
+- name: Steve Daines
+  party: majority
+  rank: 3
+  bioguide: D000618
+  thomas: '02138'
+- name: Bill Cassidy
+  party: majority
+  rank: 4
+  bioguide: C001075
+  thomas: '01925'
+- name: Cory Gardner
+  party: majority
+  rank: 5
+  bioguide: G000562
+  thomas: '01998'
+- name: John Hoeven
+  party: majority
+  rank: 6
+  bioguide: H001061
+  thomas: '02079'
+- name: Lamar Alexander
+  party: majority
+  rank: 7
+  bioguide: A000360
+  thomas: '01695'
+- name: Rob Portman
+  party: majority
+  rank: 8
+  bioguide: P000449
+  thomas: '00924'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 9
+  bioguide: C001047
+  thomas: '01676'
+- name: Lisa Murkowski
   party: majority
   rank: 10
-  bioguide: W000818
-  thomas: '02198'
-- name: Pat Roberts
+  title: Ex Officio
+  bioguide: M001153
+  thomas: '01694'
+- name: Joe Manchin, III
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: R000307
-  thomas: '00968'
-- name: Mitch McConnell
+  bioguide: M001183
+  thomas: '01983'
+- name: Bernard Sanders
   party: minority
   rank: 2
+  bioguide: S000033
+  thomas: '01010'
+- name: Debbie Stabenow
+  party: minority
+  rank: 3
+  bioguide: S000770
+  thomas: '01531'
+- name: Al Franken
+  party: minority
+  rank: 4
+  bioguide: F000457
+  thomas: '01969'
+- name: Martin Heinrich
+  party: minority
+  rank: 5
+  bioguide: H001046
+  thomas: '01937'
+- name: Mazie K. Hirono
+  party: minority
+  rank: 6
+  bioguide: H001042
+  thomas: '01844'
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 7
+  bioguide: K000383
+  thomas: '02185'
+- name: Elizabeth Warren
+  party: minority
+  rank: 8
+  bioguide: W000817
+  thomas: '02182'
+- name: Maria Cantwell
+  party: minority
+  rank: 9
+  title: Ex Officio
+  bioguide: C000127
+  thomas: '00172'
+SSEG03:
+- name: John Barrasso
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: B001261
+  thomas: '01881'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 2
+  bioguide: C001047
+  thomas: '01676'
+- name: James E. Risch
+  party: majority
+  rank: 3
+  bioguide: R000584
+  thomas: '01896'
+- name: Mike Lee
+  party: majority
+  rank: 4
+  bioguide: L000577
+  thomas: '02080'
+- name: Steve Daines
+  party: majority
+  rank: 5
+  bioguide: D000618
+  thomas: '02138'
+- name: Bill Cassidy
+  party: majority
+  rank: 6
+  bioguide: C001075
+  thomas: '01925'
+- name: Cory Gardner
+  party: majority
+  rank: 7
+  bioguide: G000562
+  thomas: '01998'
+- name: John Hoeven
+  party: majority
+  rank: 8
+  bioguide: H001061
+  thomas: '02079'
+- name: Jeff Flake
+  party: majority
+  rank: 9
+  bioguide: F000444
+  thomas: '01633'
+- name: Lamar Alexander
+  party: majority
+  rank: 10
+  bioguide: A000360
+  thomas: '01695'
+- name: Lisa Murkowski
+  party: majority
+  rank: 11
+  title: Ex Officio
+  bioguide: M001153
+  thomas: '01694'
+- name: Ron Wyden
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000779
+  thomas: '01247'
+- name: Debbie Stabenow
+  party: minority
+  rank: 2
+  bioguide: S000770
+  thomas: '01531'
+- name: Al Franken
+  party: minority
+  rank: 3
+  bioguide: F000457
+  thomas: '01969'
+- name: Joe Manchin, III
+  party: minority
+  rank: 4
+  bioguide: M001183
+  thomas: '01983'
+- name: Martin Heinrich
+  party: minority
+  rank: 5
+  bioguide: H001046
+  thomas: '01937'
+- name: Mazie K. Hirono
+  party: minority
+  rank: 6
+  bioguide: H001042
+  thomas: '01844'
+- name: Elizabeth Warren
+  party: minority
+  rank: 7
+  bioguide: W000817
+  thomas: '02182'
+- name: Maria Cantwell
+  party: minority
+  rank: 8
+  title: Ex Officio
+  bioguide: C000127
+  thomas: '00172'
+SSEG04:
+- name: Bill Cassidy
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C001075
+  thomas: '01925'
+- name: Rob Portman
+  party: majority
+  rank: 2
+  bioguide: P000449
+  thomas: '00924'
+- name: John Barrasso
+  party: majority
+  rank: 3
+  bioguide: B001261
+  thomas: '01881'
+- name: Lamar Alexander
+  party: majority
+  rank: 4
+  bioguide: A000360
+  thomas: '01695'
+- name: Mike Lee
+  party: majority
+  rank: 5
+  bioguide: L000577
+  thomas: '02080'
+- name: John Hoeven
+  party: majority
+  rank: 6
+  bioguide: H001061
+  thomas: '02079'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 7
+  bioguide: C001047
+  thomas: '01676'
+- name: Lisa Murkowski
+  party: majority
+  rank: 8
+  title: Ex Officio
+  bioguide: M001153
+  thomas: '01694'
+- name: Martin Heinrich
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H001046
+  thomas: '01937'
+- name: Ron Wyden
+  party: minority
+  rank: 2
+  bioguide: W000779
+  thomas: '01247'
+- name: Bernard Sanders
+  party: minority
+  rank: 3
+  bioguide: S000033
+  thomas: '01010'
+- name: Debbie Stabenow
+  party: minority
+  rank: 4
+  bioguide: S000770
+  thomas: '01531'
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 5
+  bioguide: K000383
+  thomas: '02185'
+- name: Elizabeth Warren
+  party: minority
+  rank: 6
+  bioguide: W000817
+  thomas: '02182'
+- name: Maria Cantwell
+  party: minority
+  rank: 7
+  title: Ex Officio
+  bioguide: C000127
+  thomas: '00172'
+SSEG07:
+- name: Mike Lee
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: L000577
+  thomas: '02080'
+- name: Jeff Flake
+  party: majority
+  rank: 2
+  bioguide: F000444
+  thomas: '01633'
+- name: John Barrasso
+  party: majority
+  rank: 3
+  bioguide: B001261
+  thomas: '01881'
+- name: James E. Risch
+  party: majority
+  rank: 4
+  bioguide: R000584
+  thomas: '01896'
+- name: Steve Daines
+  party: majority
+  rank: 5
+  bioguide: D000618
+  thomas: '02138'
+- name: Cory Gardner
+  party: majority
+  rank: 6
+  bioguide: G000562
+  thomas: '01998'
+- name: Rob Portman
+  party: majority
+  rank: 7
+  bioguide: P000449
+  thomas: '00924'
+- name: Lisa Murkowski
+  party: majority
+  rank: 8
+  title: Ex Officio
+  bioguide: M001153
+  thomas: '01694'
+- name: Mazie K. Hirono
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H001042
+  thomas: '01844'
+- name: Ron Wyden
+  party: minority
+  rank: 2
+  bioguide: W000779
+  thomas: '01247'
+- name: Bernard Sanders
+  party: minority
+  rank: 3
+  bioguide: S000033
+  thomas: '01010'
+- name: Al Franken
+  party: minority
+  rank: 4
+  bioguide: F000457
+  thomas: '01969'
+- name: Joe Manchin, III
+  party: minority
+  rank: 5
+  bioguide: M001183
+  thomas: '01983'
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 6
+  bioguide: K000383
+  thomas: '02185'
+- name: Maria Cantwell
+  party: minority
+  rank: 7
+  title: Ranking Member
+  bioguide: C000127
+  thomas: '00172'
+SSEV:
+- name: James M. Inhofe
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: I000024
+  thomas: '00583'
+- name: David Vitter
+  party: majority
+  rank: 2
+  bioguide: V000127
+  thomas: '01609'
+- name: John Barrasso
+  party: majority
+  rank: 3
+  bioguide: B001261
+  thomas: '01881'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 4
+  bioguide: C001047
+  thomas: '01676'
+- name: Mike Crapo
+  party: majority
+  rank: 5
+  bioguide: C000880
+  thomas: '00250'
+- name: John Boozman
+  party: majority
+  rank: 6
+  bioguide: B001236
+  thomas: '01687'
+- name: Jeff Sessions
+  party: majority
+  rank: 7
+  bioguide: S001141
+  thomas: '01548'
+- name: Roger F. Wicker
+  party: majority
+  rank: 8
+  bioguide: W000437
+  thomas: '01226'
+- name: Deb Fischer
+  party: majority
+  rank: 9
+  bioguide: F000463
+  thomas: '02179'
+- name: Mike Rounds
+  party: majority
+  rank: 10
+  bioguide: R000605
+  thomas: '02288'
+- name: Daniel Sullivan
+  party: majority
+  rank: 11
+  bioguide: S001198
+  thomas: '02290'
+- name: Barbara Boxer
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B000711
+  thomas: '00116'
+- name: Thomas R. Carper
+  party: minority
+  rank: 2
+  bioguide: C000174
+  thomas: '00179'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 3
+  bioguide: C000141
+  thomas: '00174'
+- name: Bernard Sanders
+  party: minority
+  rank: 4
+  bioguide: S000033
+  thomas: '01010'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 5
+  bioguide: W000802
+  thomas: '01823'
+- name: Jeff Merkley
+  party: minority
+  rank: 6
+  bioguide: M001176
+  thomas: '01900'
+- name: Kirsten E. Gillibrand
+  party: minority
+  rank: 7
+  bioguide: G000555
+  thomas: '01866'
+- name: Cory A. Booker
+  party: minority
+  rank: 8
+  bioguide: B001288
+  thomas: '02194'
+- name: Edward J. Markey
+  party: minority
+  rank: 9
+  bioguide: M000133
+  thomas: '00735'
+SSEV08: []
+SSEV09: []
+SSEV10: []
+SSEV15: []
+SSEV16: []
+SSEV18: []
+SSFI:
+- name: Orrin G. Hatch
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: H000338
+  thomas: '01351'
+- name: Chuck Grassley
+  party: majority
+  rank: 2
+  bioguide: G000386
+  thomas: '00457'
+- name: Mike Crapo
+  party: majority
+  rank: 3
+  bioguide: C000880
+  thomas: '00250'
+- name: Pat Roberts
+  party: majority
+  rank: 4
+  bioguide: R000307
+  thomas: '00968'
+- name: Michael B. Enzi
+  party: majority
+  rank: 5
+  bioguide: E000285
+  thomas: '01542'
+- name: John Cornyn
+  party: majority
+  rank: 6
+  bioguide: C001056
+  thomas: '01692'
+- name: John Thune
+  party: majority
+  rank: 7
+  bioguide: T000250
+  thomas: '01534'
+- name: Richard Burr
+  party: majority
+  rank: 8
+  bioguide: B001135
+  thomas: '00153'
+- name: Johnny Isakson
+  party: majority
+  rank: 9
+  bioguide: I000055
+  thomas: '01608'
+- name: Rob Portman
+  party: majority
+  rank: 10
+  bioguide: P000449
+  thomas: '00924'
+- name: Patrick J. Toomey
+  party: majority
+  rank: 11
+  bioguide: T000461
+  thomas: '02085'
+- name: Daniel Coats
+  party: majority
+  rank: 12
+  bioguide: C000542
+  thomas: '00209'
+- name: Dean Heller
+  party: majority
+  rank: 13
+  bioguide: H001041
+  thomas: '01863'
+- name: Tim Scott
+  party: majority
+  rank: 14
+  bioguide: S001184
+  thomas: '02056'
+- name: Ron Wyden
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000779
+  thomas: '01247'
+- name: Charles E. Schumer
+  party: minority
+  rank: 2
+  bioguide: S000148
+  thomas: '01036'
+- name: Debbie Stabenow
+  party: minority
+  rank: 3
+  bioguide: S000770
+  thomas: '01531'
+- name: Maria Cantwell
+  party: minority
+  rank: 4
+  bioguide: C000127
+  thomas: '00172'
+- name: Bill Nelson
+  party: minority
+  rank: 5
+  bioguide: N000032
+  thomas: '00859'
+- name: Robert Menendez
+  party: minority
+  rank: 6
+  bioguide: M000639
+  thomas: '00791'
+- name: Thomas R. Carper
+  party: minority
+  rank: 7
+  bioguide: C000174
+  thomas: '00179'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 8
+  bioguide: C000141
+  thomas: '00174'
+- name: Sherrod Brown
+  party: minority
+  rank: 9
+  bioguide: B000944
+  thomas: '00136'
+- name: Michael F. Bennet
+  party: minority
+  rank: 10
+  bioguide: B001267
+  thomas: '01965'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 11
+  bioguide: C001070
+  thomas: '01828'
+- name: Mark R. Warner
+  party: minority
+  rank: 12
+  bioguide: W000805
+  thomas: '01897'
+SSFI02:
+- name: Dean Heller
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: H001041
+  thomas: '01863'
+- name: Johnny Isakson
+  party: majority
+  rank: 2
+  bioguide: I000055
+  thomas: '01608'
+- name: Patrick J. Toomey
+  party: majority
+  rank: 3
+  bioguide: T000461
+  thomas: '02085'
+- name: Tim Scott
+  party: majority
+  rank: 4
+  bioguide: S001184
+  thomas: '02056'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 5
+  title: Ex Officio
+  bioguide: H000338
+  thomas: '01351'
+- name: Sherrod Brown
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B000944
+  thomas: '00136'
+- name: Charles E. Schumer
+  party: minority
+  rank: 2
+  bioguide: S000148
+  thomas: '01036'
+- name: Ron Wyden
+  party: minority
+  rank: 3
+  title: Ex Officio
+  bioguide: W000779
+  thomas: '01247'
+SSFI10:
+- name: Patrick J. Toomey
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: T000461
+  thomas: '02085'
+- name: Chuck Grassley
+  party: majority
+  rank: 2
+  bioguide: G000386
+  thomas: '00457'
+- name: Pat Roberts
+  party: majority
+  rank: 3
+  bioguide: R000307
+  thomas: '00968'
+- name: Michael B. Enzi
+  party: majority
+  rank: 4
+  bioguide: E000285
+  thomas: '01542'
+- name: Richard Burr
+  party: majority
+  rank: 5
+  bioguide: B001135
+  thomas: '00153'
+- name: Daniel Coats
+  party: majority
+  rank: 6
+  bioguide: C000542
+  thomas: '00209'
+- name: Dean Heller
+  party: majority
+  rank: 7
+  bioguide: H001041
+  thomas: '01863'
+- name: Tim Scott
+  party: majority
+  rank: 8
+  bioguide: S001184
+  thomas: '02056'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: H000338
+  thomas: '01351'
+- name: Debbie Stabenow
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S000770
+  thomas: '01531'
+- name: Maria Cantwell
+  party: minority
+  rank: 2
+  bioguide: C000127
+  thomas: '00172'
+- name: Robert Menendez
+  party: minority
+  rank: 3
+  bioguide: M000639
+  thomas: '00791'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 4
+  bioguide: C000141
+  thomas: '00174'
+- name: Sherrod Brown
+  party: minority
+  rank: 5
+  bioguide: B000944
+  thomas: '00136'
+- name: Mark R. Warner
+  party: minority
+  rank: 6
+  bioguide: W000805
+  thomas: '01897'
+- name: Ron Wyden
+  party: minority
+  rank: 7
+  title: Ex Officio
+  bioguide: W000779
+  thomas: '01247'
+SSFI11:
+- name: Mike Crapo
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C000880
+  thomas: '00250'
+- name: Pat Roberts
+  party: majority
+  rank: 2
+  bioguide: R000307
+  thomas: '00968'
+- name: Michael B. Enzi
+  party: majority
+  rank: 3
+  bioguide: E000285
+  thomas: '01542'
+- name: John Cornyn
+  party: majority
+  rank: 4
+  bioguide: C001056
+  thomas: '01692'
+- name: John Thune
+  party: majority
+  rank: 5
+  bioguide: T000250
+  thomas: '01534'
+- name: Johnny Isakson
+  party: majority
+  rank: 6
+  bioguide: I000055
+  thomas: '01608'
+- name: Rob Portman
+  party: majority
+  rank: 7
+  bioguide: P000449
+  thomas: '00924'
+- name: Patrick J. Toomey
+  party: majority
+  rank: 8
+  bioguide: T000461
+  thomas: '02085'
+- name: Daniel Coats
+  party: majority
+  rank: 9
+  bioguide: C000542
+  thomas: '00209'
+- name: Dean Heller
+  party: majority
+  rank: 10
+  bioguide: H001041
+  thomas: '01863'
+- name: Tim Scott
+  party: majority
+  rank: 11
+  bioguide: S001184
+  thomas: '02056'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 12
+  title: Ex Officio
+  bioguide: H000338
+  thomas: '01351'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001070
+  thomas: '01828'
+- name: Charles E. Schumer
+  party: minority
+  rank: 2
+  bioguide: S000148
+  thomas: '01036'
+- name: Bill Nelson
+  party: minority
+  rank: 3
+  bioguide: N000032
+  thomas: '00859'
+- name: Robert Menendez
+  party: minority
+  rank: 4
+  bioguide: M000639
+  thomas: '00791'
+- name: Thomas R. Carper
+  party: minority
+  rank: 5
+  bioguide: C000174
+  thomas: '00179'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 6
+  bioguide: C000141
+  thomas: '00174'
+- name: Michael F. Bennet
+  party: minority
+  rank: 7
+  bioguide: B001267
+  thomas: '01965'
+- name: Mark R. Warner
+  party: minority
+  rank: 8
+  bioguide: W000805
+  thomas: '01897'
+- name: Ron Wyden
+  party: minority
+  rank: 9
+  bioguide: W000779
+  thomas: '01247'
+SSFI12:
+- name: Daniel Coats
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C000542
+  thomas: '00209'
+- name: Chuck Grassley
+  party: majority
+  rank: 2
+  bioguide: G000386
+  thomas: '00457'
+- name: Mike Crapo
+  party: majority
+  rank: 3
+  bioguide: C000880
+  thomas: '00250'
+- name: Michael B. Enzi
+  party: majority
+  rank: 4
+  bioguide: E000285
+  thomas: '01542'
+- name: John Cornyn
+  party: majority
+  rank: 5
+  bioguide: C001056
+  thomas: '01692'
+- name: John Thune
+  party: majority
+  rank: 6
+  bioguide: T000250
+  thomas: '01534'
+- name: Richard Burr
+  party: majority
+  rank: 7
+  bioguide: B001135
+  thomas: '00153'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 8
+  title: Ex Officio
+  bioguide: H000338
+  thomas: '01351'
+- name: Michael F. Bennet
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001267
+  thomas: '01965'
+- name: Maria Cantwell
+  party: minority
+  rank: 2
+  bioguide: C000127
+  thomas: '00172'
+- name: Bill Nelson
+  party: minority
+  rank: 3
+  bioguide: N000032
+  thomas: '00859'
+- name: Thomas R. Carper
+  party: minority
+  rank: 4
+  bioguide: C000174
+  thomas: '00179'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 5
+  bioguide: C001070
+  thomas: '01828'
+- name: Ron Wyden
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: W000779
+  thomas: '01247'
+SSFI13:
+- name: John Cornyn
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C001056
+  thomas: '01692'
+- name: Chuck Grassley
+  party: majority
+  rank: 2
+  bioguide: G000386
+  thomas: '00457'
+- name: Pat Roberts
+  party: majority
+  rank: 3
+  bioguide: R000307
+  thomas: '00968'
+- name: John Thune
+  party: majority
+  rank: 4
+  bioguide: T000250
+  thomas: '01534'
+- name: Johnny Isakson
+  party: majority
+  rank: 5
+  bioguide: I000055
+  thomas: '01608'
+- name: Rob Portman
+  party: majority
+  rank: 6
+  bioguide: P000449
+  thomas: '00924'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: H000338
+  thomas: '01351'
+- name: Ron Wyden
+  party: minority
+  rank: 1
+  title: Chairman
+  bioguide: W000779
+  thomas: '01247'
+- name: Charles E. Schumer
+  party: minority
+  rank: 2
+  bioguide: S000148
+  thomas: '01036'
+- name: Debbie Stabenow
+  party: minority
+  rank: 3
+  bioguide: S000770
+  thomas: '01531'
+- name: Bill Nelson
+  party: minority
+  rank: 4
+  bioguide: N000032
+  thomas: '00859'
+SSFI14:
+- name: Rob Portman
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: P000449
+  thomas: '00924'
+- name: Mike Crapo
+  party: majority
+  rank: 2
+  bioguide: C000880
+  thomas: '00250'
+- name: Richard Burr
+  party: majority
+  rank: 3
+  bioguide: B001135
+  thomas: '00153'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 4
+  title: Ex Officio
+  bioguide: H000338
+  thomas: '01351'
+- name: Mark R. Warner
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000805
+  thomas: '01897'
+- name: Ron Wyden
+  party: minority
+  rank: 2
+  title: Ex Officio
+  bioguide: W000779
+  thomas: '01247'
+SSFR:
+- name: Bob Corker
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C001071
+  thomas: '01825'
+- name: James E. Risch
+  party: majority
+  rank: 2
+  bioguide: R000584
+  thomas: '01896'
+- name: Marco Rubio
+  party: majority
+  rank: 3
+  bioguide: R000595
+  thomas: '02084'
+- name: Ron Johnson
+  party: majority
+  rank: 4
+  bioguide: J000293
+  thomas: '02086'
+- name: Jeff Flake
+  party: majority
+  rank: 5
+  bioguide: F000444
+  thomas: '01633'
+- name: Cory Gardner
+  party: majority
+  rank: 6
+  bioguide: G000562
+  thomas: '01998'
+- name: David Perdue
+  party: majority
+  rank: 7
+  bioguide: P000612
+  thomas: '02286'
+- name: Johnny Isakson
+  party: majority
+  rank: 8
+  bioguide: I000055
+  thomas: '01608'
+- name: Rand Paul
+  party: majority
+  rank: 9
+  bioguide: P000603
+  thomas: '02082'
+- name: John Barrasso
+  party: majority
+  rank: 10
+  bioguide: B001261
+  thomas: '01881'
+- name: Robert Menendez
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M000639
+  thomas: '00791'
+- name: Barbara Boxer
+  party: minority
+  rank: 2
+  bioguide: B000711
+  thomas: '00116'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 3
+  bioguide: C000141
+  thomas: '00174'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 4
+  bioguide: S001181
+  thomas: '01901'
+- name: Christopher A. Coons
+  party: minority
+  rank: 5
+  bioguide: C001088
+  thomas: '01984'
+- name: Tom Udall
+  party: minority
+  rank: 6
+  bioguide: U000039
+  thomas: '01567'
+- name: Christopher Murphy
+  party: minority
+  rank: 7
+  bioguide: M001169
+  thomas: '01837'
+- name: Tim Kaine
+  party: minority
+  rank: 8
+  bioguide: K000384
+  thomas: '02176'
+- name: Edward J. Markey
+  party: minority
+  rank: 9
+  bioguide: M000133
+  thomas: '00735'
+SSFR01:
+- name: Ron Johnson
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: J000293
+  thomas: '02086'
+- name: Rand Paul
+  party: majority
+  rank: 2
+  bioguide: P000603
+  thomas: '02082'
+- name: James E. Risch
+  party: majority
+  rank: 3
+  bioguide: R000584
+  thomas: '01896'
+- name: Cory Gardner
+  party: majority
+  rank: 4
+  bioguide: G000562
+  thomas: '01998'
+- name: John Barrasso
+  party: majority
+  rank: 5
+  bioguide: B001261
+  thomas: '01881'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001071
+  thomas: '01825'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001181
+  thomas: '01901'
+- name: Christopher Murphy
+  party: minority
+  rank: 2
+  bioguide: M001169
+  thomas: '01837'
+- name: Tim Kaine
+  party: minority
+  rank: 3
+  bioguide: K000384
+  thomas: '02176'
+- name: Edward J. Markey
+  party: minority
+  rank: 4
+  bioguide: M000133
+  thomas: '00735'
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M000639
+  thomas: '00791'
+SSFR02:
+- name: Cory Gardner
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: G000562
+  thomas: '01998'
+- name: Marco Rubio
+  party: majority
+  rank: 2
+  bioguide: R000595
+  thomas: '02084'
+- name: Ron Johnson
+  party: majority
+  rank: 3
+  bioguide: J000293
+  thomas: '02086'
+- name: Johnny Isakson
+  party: majority
+  rank: 4
+  bioguide: I000055
+  thomas: '01608'
+- name: Jeff Flake
+  party: majority
+  rank: 5
+  bioguide: F000444
+  thomas: '01633'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001071
+  thomas: '01825'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C000141
+  thomas: '00174'
+- name: Barbara Boxer
+  party: minority
+  rank: 2
+  bioguide: B000711
+  thomas: '00116'
+- name: Christopher A. Coons
+  party: minority
+  rank: 3
+  bioguide: C001088
+  thomas: '01984'
+- name: Tom Udall
+  party: minority
+  rank: 4
+  bioguide: U000039
+  thomas: '01567'
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M000639
+  thomas: '00791'
+SSFR06:
+- name: Marco Rubio
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: R000595
+  thomas: '02084'
+- name: Jeff Flake
+  party: majority
+  rank: 2
+  bioguide: F000444
+  thomas: '01633'
+- name: Cory Gardner
+  party: majority
+  rank: 3
+  bioguide: G000562
+  thomas: '01998'
+- name: David Perdue
+  party: majority
+  rank: 4
+  bioguide: P000612
+  thomas: '02286'
+- name: Johnny Isakson
+  party: majority
+  rank: 5
+  bioguide: I000055
+  thomas: '01608'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001071
+  thomas: '01825'
+- name: Barbara Boxer
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B000711
+  thomas: '00116'
+- name: Tom Udall
+  party: minority
+  rank: 2
+  bioguide: U000039
+  thomas: '01567'
+- name: Tim Kaine
+  party: minority
+  rank: 3
+  bioguide: K000384
+  thomas: '02176'
+- name: Edward J. Markey
+  party: minority
+  rank: 4
+  bioguide: M000133
+  thomas: '00735'
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M000639
+  thomas: '00791'
+SSFR07:
+- name: James E. Risch
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: R000584
+  thomas: '01896'
+- name: David Perdue
+  party: majority
+  rank: 2
+  bioguide: P000612
+  thomas: '02286'
+- name: Rand Paul
+  party: majority
+  rank: 3
+  bioguide: P000603
+  thomas: '02082'
+- name: Marco Rubio
+  party: majority
+  rank: 4
+  bioguide: R000595
+  thomas: '02084'
+- name: Ron Johnson
+  party: majority
+  rank: 5
+  bioguide: J000293
+  thomas: '02086'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001071
+  thomas: '01825'
+- name: Christopher Murphy
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001169
+  thomas: '01837'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 2
+  bioguide: C000141
+  thomas: '00174'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 3
+  bioguide: S001181
+  thomas: '01901'
+- name: Tim Kaine
+  party: minority
+  rank: 4
+  bioguide: K000384
+  thomas: '02176'
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M000639
+  thomas: '00791'
+SSFR09:
+- name: Jeff Flake
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: F000444
+  thomas: '01633'
+- name: Johnny Isakson
+  party: majority
+  rank: 2
+  bioguide: I000055
+  thomas: '01608'
+- name: Rand Paul
+  party: majority
+  rank: 3
+  bioguide: P000603
+  thomas: '02082'
+- name: John Barrasso
+  party: majority
+  rank: 4
+  bioguide: B001261
+  thomas: '01881'
+- name: Marco Rubio
+  party: majority
+  rank: 5
+  bioguide: R000595
+  thomas: '02084'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001071
+  thomas: '01825'
+- name: Edward J. Markey
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M000133
+  thomas: '00735'
+- name: Christopher A. Coons
+  party: minority
+  rank: 2
+  bioguide: C001088
+  thomas: '01984'
+- name: Tom Udall
+  party: minority
+  rank: 3
+  bioguide: U000039
+  thomas: '01567'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 4
+  bioguide: C000141
+  thomas: '00174'
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M000639
+  thomas: '00791'
+SSFR14:
+- name: David Perdue
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: P000612
+  thomas: '02286'
+- name: James E. Risch
+  party: majority
+  rank: 2
+  bioguide: R000584
+  thomas: '01896'
+- name: Johnny Isakson
+  party: majority
+  rank: 3
+  bioguide: I000055
+  thomas: '01608'
+- name: Ron Johnson
+  party: majority
+  rank: 4
+  bioguide: J000293
+  thomas: '02086'
+- name: Rand Paul
+  party: majority
+  rank: 5
+  bioguide: P000603
+  thomas: '02082'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001071
+  thomas: '01825'
+- name: Tim Kaine
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: K000384
+  thomas: '02176'
+- name: Barbara Boxer
+  party: minority
+  rank: 2
+  bioguide: B000711
+  thomas: '00116'
+- name: Christopher A. Coons
+  party: minority
+  rank: 3
+  bioguide: C001088
+  thomas: '01984'
+- name: Christopher Murphy
+  party: minority
+  rank: 4
+  bioguide: M001169
+  thomas: '01837'
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M000639
+  thomas: '00791'
+SSFR15:
+- name: John Barrasso
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: B001261
+  thomas: '01881'
+- name: David Perdue
+  party: majority
+  rank: 2
+  bioguide: P000612
+  thomas: '02286'
+- name: James E. Risch
+  party: majority
+  rank: 3
+  bioguide: R000584
+  thomas: '01896'
+- name: Jeff Flake
+  party: majority
+  rank: 4
+  bioguide: F000444
+  thomas: '01633'
+- name: Cory Gardner
+  party: majority
+  rank: 5
+  bioguide: G000562
+  thomas: '01998'
+- name: Bob Corker
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001071
+  thomas: '01825'
+- name: Tom Udall
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: U000039
+  thomas: '01567'
+- name: Barbara Boxer
+  party: minority
+  rank: 2
+  bioguide: B000711
+  thomas: '00116'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 3
+  bioguide: S001181
+  thomas: '01901'
+- name: Edward J. Markey
+  party: minority
+  rank: 4
+  bioguide: M000133
+  thomas: '00735'
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M000639
+  thomas: '00791'
+SSGA:
+- name: Ron Johnson
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: J000293
+  thomas: '02086'
+- name: John McCain
+  party: majority
+  rank: 2
+  bioguide: M000303
+  thomas: '00754'
+- name: Rob Portman
+  party: majority
+  rank: 3
+  bioguide: P000449
+  thomas: '00924'
+- name: Rand Paul
+  party: majority
+  rank: 4
+  bioguide: P000603
+  thomas: '02082'
+- name: James Lankford
+  party: majority
+  rank: 5
+  bioguide: L000575
+  thomas: '02050'
+- name: Kelly Ayotte
+  party: majority
+  rank: 6
+  bioguide: A000368
+  thomas: '02075'
+- name: Michael B. Enzi
+  party: majority
+  rank: 7
+  bioguide: E000285
+  thomas: '01542'
+- name: Joni Ernst
+  party: majority
+  rank: 8
+  bioguide: E000295
+  thomas: '02283'
+- name: Ben Sasse
+  party: majority
+  rank: 9
+  bioguide: S001197
+  thomas: '02289'
+- name: Thomas R. Carper
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C000174
+  thomas: '00179'
+- name: Claire McCaskill
+  party: minority
+  rank: 2
+  bioguide: M001170
+  thomas: '01820'
+- name: Jon Tester
+  party: minority
+  rank: 3
+  bioguide: T000464
+  thomas: '01829'
+- name: Tammy Baldwin
+  party: minority
+  rank: 4
+  bioguide: B001230
+  thomas: '01558'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 5
+  bioguide: H001069
+  thomas: '02174'
+- name: Cory A. Booker
+  party: minority
+  rank: 6
+  bioguide: B001288
+  thomas: '02194'
+- name: Gary Peters
+  party: minority
+  rank: 7
+  bioguide: P000595
+  thomas: '01929'
+SSGA01:
+- name: Rob Portman
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: P000449
+  thomas: '00924'
+- name: John McCain
+  party: majority
+  rank: 2
+  bioguide: M000303
+  thomas: '00754'
+- name: Rand Paul
+  party: majority
+  rank: 3
+  bioguide: P000603
+  thomas: '02082'
+- name: James Lankford
+  party: majority
+  rank: 4
+  bioguide: L000575
+  thomas: '02050'
+- name: Kelly Ayotte
+  party: majority
+  rank: 5
+  bioguide: A000368
+  thomas: '02075'
+- name: Ben Sasse
+  party: majority
+  rank: 6
+  bioguide: S001197
+  thomas: '02289'
+- name: Ron Johnson
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: J000293
+  thomas: '02086'
+- name: Claire McCaskill
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001170
+  thomas: '01820'
+- name: Jon Tester
+  party: minority
+  rank: 2
+  bioguide: T000464
+  thomas: '01829'
+- name: Tammy Baldwin
+  party: minority
+  rank: 3
+  bioguide: B001230
+  thomas: '01558'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 4
+  bioguide: H001069
+  thomas: '02174'
+- name: Thomas R. Carper
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: C000174
+  thomas: '00179'
+SSGA18:
+- name: Rand Paul
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: P000603
+  thomas: '02082'
+- name: James Lankford
+  party: majority
+  rank: 2
+  bioguide: L000575
+  thomas: '02050'
+- name: Michael B. Enzi
+  party: majority
+  rank: 3
+  bioguide: E000285
+  thomas: '01542'
+- name: Kelly Ayotte
+  party: majority
+  rank: 4
+  bioguide: A000368
+  thomas: '02075'
+- name: Joni Ernst
+  party: majority
+  rank: 5
+  bioguide: E000295
+  thomas: '02283'
+- name: Ben Sasse
+  party: majority
+  rank: 6
+  bioguide: S001197
+  thomas: '02289'
+- name: Ron Johnson
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: J000293
+  thomas: '02086'
+- name: Tammy Baldwin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001230
+  thomas: '01558'
+- name: Claire McCaskill
+  party: minority
+  rank: 2
+  bioguide: M001170
+  thomas: '01820'
+- name: Cory A. Booker
+  party: minority
+  rank: 3
+  bioguide: B001288
+  thomas: '02194'
+- name: Gary Peters
+  party: minority
+  rank: 4
+  bioguide: P000595
+  thomas: '01929'
+- name: Thomas R. Carper
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: C000174
+  thomas: '00179'
+SSGA19:
+- name: James Lankford
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: L000575
+  thomas: '02050'
+- name: John McCain
+  party: majority
+  rank: 2
+  bioguide: M000303
+  thomas: '00754'
+- name: Rob Portman
+  party: majority
+  rank: 3
+  bioguide: P000449
+  thomas: '00924'
+- name: Michael B. Enzi
+  party: majority
+  rank: 4
+  bioguide: E000285
+  thomas: '01542'
+- name: Joni Ernst
+  party: majority
+  rank: 5
+  bioguide: E000295
+  thomas: '02283'
+- name: Ben Sasse
+  party: majority
+  rank: 6
+  bioguide: S001197
+  thomas: '02289'
+- name: Ron Johnson
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: J000293
+  thomas: '02086'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H001069
+  thomas: '02174'
+- name: Jon Tester
+  party: minority
+  rank: 2
+  bioguide: T000464
+  thomas: '01829'
+- name: Cory A. Booker
+  party: minority
+  rank: 3
+  bioguide: B001288
+  thomas: '02194'
+- name: Gary Peters
+  party: minority
+  rank: 4
+  bioguide: P000595
+  thomas: '01929'
+- name: Thomas R. Carper
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: C000174
+  thomas: '00179'
+SSHR:
+- name: Lamar Alexander
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: A000360
+  thomas: '01695'
+- name: Michael B. Enzi
+  party: majority
+  rank: 2
+  bioguide: E000285
+  thomas: '01542'
+- name: Richard Burr
+  party: majority
+  rank: 3
+  bioguide: B001135
+  thomas: '00153'
+- name: Johnny Isakson
+  party: majority
+  rank: 4
+  bioguide: I000055
+  thomas: '01608'
+- name: Rand Paul
+  party: majority
+  rank: 5
+  bioguide: P000603
+  thomas: '02082'
+- name: Susan M. Collins
+  party: majority
+  rank: 6
+  bioguide: C001035
+  thomas: '01541'
+- name: Lisa Murkowski
+  party: majority
+  rank: 7
+  bioguide: M001153
+  thomas: '01694'
+- name: Mark Kirk
+  party: majority
+  rank: 8
+  bioguide: K000360
+  thomas: '01647'
+- name: Tim Scott
+  party: majority
+  rank: 9
+  bioguide: S001184
+  thomas: '02056'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 10
+  bioguide: H000338
+  thomas: '01351'
+- name: Pat Roberts
+  party: majority
+  rank: 11
+  bioguide: R000307
+  thomas: '00968'
+- name: Bill Cassidy
+  party: majority
+  rank: 12
+  bioguide: C001075
+  thomas: '01925'
+- name: Patty Murray
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001111
+  thomas: '01409'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 2
+  bioguide: M000702
+  thomas: '00802'
+- name: Bernard Sanders
+  party: minority
+  rank: 3
+  bioguide: S000033
+  thomas: '01010'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 4
+  bioguide: C001070
+  thomas: '01828'
+- name: Al Franken
+  party: minority
+  rank: 5
+  bioguide: F000457
+  thomas: '01969'
+- name: Michael F. Bennet
+  party: minority
+  rank: 6
+  bioguide: B001267
+  thomas: '01965'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 7
+  bioguide: W000802
+  thomas: '01823'
+- name: Tammy Baldwin
+  party: minority
+  rank: 8
+  bioguide: B001230
+  thomas: '01558'
+- name: Christopher Murphy
+  party: minority
+  rank: 9
+  bioguide: M001169
+  thomas: '01837'
+- name: Elizabeth Warren
+  party: minority
+  rank: 10
+  bioguide: W000817
+  thomas: '02182'
+SSHR09:
+- name: Rand Paul
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: P000603
+  thomas: '02082'
+- name: Lisa Murkowski
+  party: majority
+  rank: 2
+  bioguide: M001153
+  thomas: '01694'
+- name: Richard Burr
+  party: majority
+  rank: 3
+  bioguide: B001135
+  thomas: '00153'
+- name: Mark Kirk
+  party: majority
+  rank: 4
+  bioguide: K000360
+  thomas: '01647'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 5
+  bioguide: H000338
+  thomas: '01351'
+- name: Pat Roberts
+  party: majority
+  rank: 6
+  bioguide: R000307
+  thomas: '00968'
+- name: Bill Cassidy
+  party: majority
+  rank: 7
+  bioguide: C001075
+  thomas: '01925'
+- name: Lamar Alexander
+  party: majority
+  rank: 8
+  title: Ex Officio
+  bioguide: A000360
+  thomas: '01695'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001070
+  thomas: '01828'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 2
+  bioguide: M000702
+  thomas: '00802'
+- name: Bernard Sanders
+  party: minority
+  rank: 3
+  bioguide: S000033
+  thomas: '01010'
+- name: Al Franken
+  party: minority
+  rank: 4
+  bioguide: F000457
+  thomas: '01969'
+- name: Michael F. Bennet
+  party: minority
+  rank: 5
+  bioguide: B001267
+  thomas: '01965'
+- name: Patty Murray
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: M001111
+  thomas: '01409'
+SSHR11:
+- name: Johnny Isakson
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: I000055
+  thomas: '01608'
+- name: Rand Paul
+  party: majority
+  rank: 2
+  bioguide: P000603
+  thomas: '02082'
+- name: Tim Scott
+  party: majority
+  rank: 3
+  bioguide: S001184
+  thomas: '02056'
+- name: Mark Kirk
+  party: majority
+  rank: 4
+  bioguide: K000360
+  thomas: '01647'
+- name: Pat Roberts
+  party: majority
+  rank: 5
+  bioguide: R000307
+  thomas: '00968'
+- name: Bill Cassidy
+  party: majority
+  rank: 6
+  bioguide: C001075
+  thomas: '01925'
+- name: Lamar Alexander
+  party: majority
+  rank: 7
+  title: Ex Officio
+  bioguide: A000360
+  thomas: '01695'
+- name: Al Franken
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: F000457
+  thomas: '01969'
+- name: Robert P. Casey, Jr.
+  party: minority
+  rank: 2
+  bioguide: C001070
+  thomas: '01828'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 3
+  bioguide: W000802
+  thomas: '01823'
+- name: Tammy Baldwin
+  party: minority
+  rank: 4
+  bioguide: B001230
+  thomas: '01558'
+- name: Patty Murray
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: M001111
+  thomas: '01409'
+SSHR12:
+- name: Michael B. Enzi
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: E000285
+  thomas: '01542'
+- name: Richard Burr
+  party: majority
+  rank: 2
+  bioguide: B001135
+  thomas: '00153'
+- name: Susan M. Collins
+  party: majority
+  rank: 3
+  bioguide: C001035
+  thomas: '01541'
+- name: Mark Kirk
+  party: majority
+  rank: 4
+  bioguide: K000360
+  thomas: '01647'
+- name: Tim Scott
+  party: majority
+  rank: 5
+  bioguide: S001184
+  thomas: '02056'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 6
+  bioguide: H000338
+  thomas: '01351'
+- name: Pat Roberts
+  party: majority
+  rank: 7
+  bioguide: R000307
+  thomas: '00968'
+- name: Bill Cassidy
+  party: majority
+  rank: 8
+  bioguide: C001075
+  thomas: '01925'
+- name: Lisa Murkowski
+  party: majority
+  rank: 9
+  bioguide: M001153
+  thomas: '01694'
+- name: Lamar Alexander
+  party: majority
+  rank: 10
+  title: Ex Officio
+  bioguide: A000360
+  thomas: '01695'
+- name: Bernard Sanders
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S000033
+  thomas: '01010'
+- name: Barbara A. Mikulski
+  party: minority
+  rank: 2
+  bioguide: M000702
+  thomas: '00802'
+- name: Michael F. Bennet
+  party: minority
+  rank: 3
+  bioguide: B001267
+  thomas: '01965'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 4
+  bioguide: W000802
+  thomas: '01823'
+- name: Tammy Baldwin
+  party: minority
+  rank: 5
+  bioguide: B001230
+  thomas: '01558'
+- name: Christopher Murphy
+  party: minority
+  rank: 6
+  bioguide: M001169
+  thomas: '01837'
+- name: Elizabeth Warren
+  party: minority
+  rank: 7
+  bioguide: W000817
+  thomas: '02182'
+- name: Patty Murray
+  party: minority
+  rank: 8
+  title: Ex Officio
+  bioguide: M001111
+  thomas: '01409'
+SSJU:
+- name: Chuck Grassley
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: G000386
+  thomas: '00457'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 2
+  bioguide: H000338
+  thomas: '01351'
+- name: Jeff Sessions
+  party: majority
+  rank: 3
+  bioguide: S001141
+  thomas: '01548'
+- name: Lindsey Graham
+  party: majority
+  rank: 4
+  bioguide: G000359
+  thomas: '00452'
+- name: John Cornyn
+  party: majority
+  rank: 5
+  bioguide: C001056
+  thomas: '01692'
+- name: Mike Lee
+  party: majority
+  rank: 6
+  bioguide: L000577
+  thomas: '02080'
+- name: Ted Cruz
+  party: majority
+  rank: 7
+  bioguide: C001098
+  thomas: '02175'
+- name: David Vitter
+  party: majority
+  rank: 8
+  bioguide: V000127
+  thomas: '01609'
+- name: Jeff Flake
+  party: majority
+  rank: 9
+  bioguide: F000444
+  thomas: '01633'
+- name: David Perdue
+  party: majority
+  rank: 10
+  bioguide: P000612
+  thomas: '02286'
+- name: Thom Tillis
+  party: majority
+  rank: 11
+  bioguide: T000476
+  thomas: '02291'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000174
+  thomas: '01383'
+- name: Dianne Feinstein
+  party: minority
+  rank: 2
+  bioguide: F000062
+  thomas: '01332'
+- name: Charles E. Schumer
+  party: minority
+  rank: 3
+  bioguide: S000148
+  thomas: '01036'
+- name: Richard J. Durbin
+  party: minority
+  rank: 4
+  bioguide: D000563
+  thomas: '00326'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 5
+  bioguide: W000802
+  thomas: '01823'
+- name: Amy Klobuchar
+  party: minority
+  rank: 6
+  bioguide: K000367
+  thomas: '01826'
+- name: Al Franken
+  party: minority
+  rank: 7
+  bioguide: F000457
+  thomas: '01969'
+- name: Christopher A. Coons
+  party: minority
+  rank: 8
+  bioguide: C001088
+  thomas: '01984'
+- name: Richard Blumenthal
+  party: minority
+  rank: 9
+  bioguide: B001277
+  thomas: '02076'
+SSJU01:
+- name: Mike Lee
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: L000577
+  thomas: '02080'
+- name: David Perdue
+  party: majority
+  rank: 2
+  bioguide: P000612
+  thomas: '02286'
+- name: Thom Tillis
+  party: majority
+  rank: 3
+  bioguide: T000476
+  thomas: '02291'
+- name: Chuck Grassley
+  party: majority
+  rank: 4
+  bioguide: G000386
+  thomas: '00457'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 5
+  bioguide: H000338
+  thomas: '01351'
+- name: Amy Klobuchar
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: K000367
+  thomas: '01826'
+- name: Christopher A. Coons
+  party: minority
+  rank: 2
+  bioguide: C001088
+  thomas: '01984'
+- name: Al Franken
+  party: minority
+  rank: 3
+  bioguide: F000457
+  thomas: '01969'
+- name: Richard Blumenthal
+  party: minority
+  rank: 4
+  bioguide: B001277
+  thomas: '02076'
+SSJU04:
+- name: Jeff Sessions
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: S001141
+  thomas: '01548'
+- name: David Vitter
+  party: majority
+  rank: 2
+  bioguide: V000127
+  thomas: '01609'
+- name: David Perdue
+  party: majority
+  rank: 3
+  bioguide: P000612
+  thomas: '02286'
+- name: Chuck Grassley
+  party: majority
+  rank: 4
+  bioguide: G000386
+  thomas: '00457'
+- name: John Cornyn
+  party: majority
+  rank: 5
+  bioguide: C001056
+  thomas: '01692'
+- name: Mike Lee
+  party: majority
+  rank: 6
+  bioguide: L000577
+  thomas: '02080'
+- name: Ted Cruz
+  party: majority
+  rank: 7
+  bioguide: C001098
+  thomas: '02175'
+- name: Thom Tillis
+  party: majority
+  rank: 8
+  bioguide: T000476
+  thomas: '02291'
+- name: Charles E. Schumer
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S000148
+  thomas: '01036'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 2
+  bioguide: L000174
+  thomas: '01383'
+- name: Dianne Feinstein
+  party: minority
+  rank: 3
+  bioguide: F000062
+  thomas: '01332'
+- name: Richard J. Durbin
+  party: minority
+  rank: 4
+  bioguide: D000563
+  thomas: '00326'
+- name: Amy Klobuchar
+  party: minority
+  rank: 5
+  bioguide: K000367
+  thomas: '01826'
+- name: Al Franken
+  party: minority
+  rank: 6
+  bioguide: F000457
+  thomas: '01969'
+- name: Richard Blumenthal
+  party: minority
+  rank: 7
+  bioguide: B001277
+  thomas: '02076'
+SSJU21:
+- name: John Cornyn
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C001056
+  thomas: '01692'
+- name: Thom Tillis
+  party: majority
+  rank: 2
+  bioguide: T000476
+  thomas: '02291'
+- name: Lindsey Graham
+  party: majority
+  rank: 3
+  bioguide: G000359
+  thomas: '00452'
+- name: Ted Cruz
+  party: majority
+  rank: 4
+  bioguide: C001098
+  thomas: '02175'
+- name: David Vitter
+  party: majority
+  rank: 5
+  bioguide: V000127
+  thomas: '01609'
+- name: Richard J. Durbin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000563
+  thomas: '00326'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 2
+  bioguide: W000802
+  thomas: '01823'
+- name: Christopher A. Coons
+  party: minority
+  rank: 3
+  bioguide: C001088
+  thomas: '01984'
+- name: Al Franken
+  party: minority
+  rank: 4
+  bioguide: F000457
+  thomas: '01969'
+SSJU22:
+- name: Lindsey Graham
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: G000359
+  thomas: '00452'
+- name: David Vitter
+  party: majority
+  rank: 2
+  bioguide: V000127
+  thomas: '01609'
+- name: Jeff Sessions
+  party: majority
+  rank: 3
+  bioguide: S001141
+  thomas: '01548'
+- name: John Cornyn
+  party: majority
+  rank: 4
+  bioguide: C001056
+  thomas: '01692'
+- name: Jeff Flake
+  party: majority
+  rank: 5
+  bioguide: F000444
+  thomas: '01633'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000802
+  thomas: '01823'
+- name: Charles E. Schumer
+  party: minority
+  rank: 2
+  bioguide: S000148
+  thomas: '01036'
+- name: Amy Klobuchar
+  party: minority
+  rank: 3
+  bioguide: K000367
+  thomas: '01826'
+- name: Al Franken
+  party: minority
+  rank: 4
+  bioguide: F000457
+  thomas: '01969'
+SSJU23:
+- name: Jeff Flake
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: F000444
+  thomas: '01633'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 2
+  bioguide: H000338
+  thomas: '01351'
+- name: David Perdue
+  party: majority
+  rank: 3
+  bioguide: P000612
+  thomas: '02286'
+- name: Mike Lee
+  party: majority
+  rank: 4
+  bioguide: L000577
+  thomas: '02080'
+- name: Thom Tillis
+  party: majority
+  rank: 5
+  bioguide: T000476
+  thomas: '02291'
+- name: Lindsey Graham
+  party: majority
+  rank: 6
+  bioguide: G000359
+  thomas: '00452'
+- name: Al Franken
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: F000457
+  thomas: '01969'
+- name: Dianne Feinstein
+  party: minority
+  rank: 2
+  bioguide: F000062
+  thomas: '01332'
+- name: Charles E. Schumer
+  party: minority
+  rank: 3
+  bioguide: S000148
+  thomas: '01036'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 4
+  bioguide: W000802
+  thomas: '01823'
+- name: Christopher A. Coons
+  party: minority
+  rank: 5
+  bioguide: C001088
+  thomas: '01984'
+SSJU25:
+- name: Ted Cruz
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C001098
+  thomas: '02175'
+- name: Chuck Grassley
+  party: majority
+  rank: 2
+  bioguide: G000386
+  thomas: '00457'
+- name: Orrin G. Hatch
+  party: majority
+  rank: 3
+  bioguide: H000338
+  thomas: '01351'
+- name: Jeff Sessions
+  party: majority
+  rank: 4
+  bioguide: S001141
+  thomas: '01548'
+- name: Jeff Flake
+  party: majority
+  rank: 5
+  bioguide: F000444
+  thomas: '01633'
+- name: Lindsey Graham
+  party: majority
+  rank: 6
+  bioguide: G000359
+  thomas: '00452'
+- name: Mike Lee
+  party: majority
+  rank: 7
+  bioguide: L000577
+  thomas: '02080'
+- name: David Vitter
+  party: majority
+  rank: 8
+  bioguide: V000127
+  thomas: '01609'
+- name: Christopher A. Coons
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001088
+  thomas: '01984'
+- name: Dianne Feinstein
+  party: minority
+  rank: 2
+  bioguide: F000062
+  thomas: '01332'
+- name: Richard J. Durbin
+  party: minority
+  rank: 3
+  bioguide: D000563
+  thomas: '00326'
+- name: Charles E. Schumer
+  party: minority
+  rank: 4
+  bioguide: S000148
+  thomas: '01036'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 5
+  bioguide: W000802
+  thomas: '01823'
+- name: Amy Klobuchar
+  party: minority
+  rank: 6
+  bioguide: K000367
+  thomas: '01826'
+- name: Richard Blumenthal
+  party: minority
+  rank: 7
+  bioguide: B001277
+  thomas: '02076'
+SSRA:
+- name: Roy Blunt
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: B000575
+  thomas: '01464'
+- name: Lamar Alexander
+  party: majority
+  rank: 2
+  bioguide: A000360
+  thomas: '01695'
+- name: Mitch McConnell
+  party: majority
+  rank: 3
   bioguide: M000355
   thomas: '01395'
 - name: Thad Cochran
-  party: minority
-  rank: 3
+  party: majority
+  rank: 4
   bioguide: C000567
   thomas: '00213'
-- name: Saxby Chambliss
-  party: minority
-  rank: 4
-  bioguide: C000286
-  thomas: '00188'
-- name: Lamar Alexander
-  party: minority
+- name: Pat Roberts
+  party: majority
   rank: 5
-  bioguide: A000360
-  thomas: '01695'
+  bioguide: R000307
+  thomas: '00968'
 - name: Richard C. Shelby
-  party: minority
+  party: majority
   rank: 6
   bioguide: S000320
   thomas: '01049'
-- name: Roy Blunt
-  party: minority
-  rank: 7
-  bioguide: B000575
-  thomas: '01464'
 - name: Ted Cruz
-  party: minority
-  rank: 8
+  party: majority
+  rank: 7
   bioguide: C001098
   thomas: '02175'
-SSSB:
-- name: Maria Cantwell
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C000127
-  thomas: '00172'
-- name: Carl Levin
-  party: majority
-  rank: 2
-  bioguide: L000261
-  thomas: '01384'
-- name: Mary L. Landrieu
-  party: majority
-  rank: 3
-  bioguide: L000550
-  thomas: '01546'
-- name: Mark L. Pryor
-  party: majority
-  rank: 4
-  bioguide: P000590
-  thomas: '01701'
-- name: Benjamin L. Cardin
-  party: majority
-  rank: 5
-  bioguide: C000141
-  thomas: '00174'
-- name: Jeanne Shaheen
-  party: majority
-  rank: 6
-  bioguide: S001181
-  thomas: '01901'
-- name: Kay R. Hagan
-  party: majority
-  rank: 7
-  bioguide: H001049
-  thomas: '01902'
-- name: Heidi Heitkamp
+- name: Shelley Moore Capito
   party: majority
   rank: 8
-  bioguide: H001069
-  thomas: '02174'
-- name: Edward J. Markey
+  bioguide: C001047
+  thomas: '01676'
+- name: John Boozman
   party: majority
   rank: 9
-  bioguide: M000133
-  thomas: '00735'
-- name: Cory A. Booker
+  bioguide: B001236
+  thomas: '01687'
+- name: Roger F. Wicker
   party: majority
   rank: 10
-  bioguide: B001288
-  thomas: '02194'
-- name: James E. Risch
+  bioguide: W000437
+  thomas: '01226'
+- name: Charles E. Schumer
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: R000584
-  thomas: '01896'
-- name: David Vitter
+  bioguide: S000148
+  thomas: '01036'
+- name: Dianne Feinstein
   party: minority
   rank: 2
+  bioguide: F000062
+  thomas: '01332'
+- name: Richard J. Durbin
+  party: minority
+  rank: 3
+  bioguide: D000563
+  thomas: '00326'
+- name: Tom Udall
+  party: minority
+  rank: 4
+  bioguide: U000039
+  thomas: '01567'
+- name: Mark R. Warner
+  party: minority
+  rank: 5
+  bioguide: W000805
+  thomas: '01897'
+- name: Patrick J. Leahy
+  party: minority
+  rank: 6
+  bioguide: L000174
+  thomas: '01383'
+- name: Amy Klobuchar
+  party: minority
+  rank: 7
+  bioguide: K000367
+  thomas: '01826'
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 8
+  bioguide: K000383
+  thomas: '02185'
+SSSB:
+- name: David Vitter
+  party: majority
+  rank: 1
+  title: Chairman
   bioguide: V000127
   thomas: '01609'
+- name: James E. Risch
+  party: majority
+  rank: 2
+  bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
-  party: minority
+  party: majority
   rank: 3
   bioguide: R000595
   thomas: '02084'
 - name: Rand Paul
-  party: minority
+  party: majority
   rank: 4
   bioguide: P000603
   thomas: '02082'
 - name: Tim Scott
-  party: minority
+  party: majority
   rank: 5
   bioguide: S001184
   thomas: '02056'
 - name: Deb Fischer
-  party: minority
+  party: majority
   rank: 6
   bioguide: F000463
   thomas: '02179'
-- name: Michael B. Enzi
-  party: minority
+- name: Cory Gardner
+  party: majority
   rank: 7
+  bioguide: G000562
+  thomas: '01998'
+- name: Joni Ernst
+  party: majority
+  rank: 8
+  bioguide: E000295
+  thomas: '02283'
+- name: Kelly Ayotte
+  party: majority
+  rank: 9
+  bioguide: A000368
+  thomas: '02075'
+- name: Michael B. Enzi
+  party: majority
+  rank: 10
   bioguide: E000285
   thomas: '01542'
-- name: Ron Johnson
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C000141
+  thomas: '00174'
+- name: Maria Cantwell
+  party: minority
+  rank: 2
+  bioguide: C000127
+  thomas: '00172'
+- name: Jeanne Shaheen
+  party: minority
+  rank: 3
+  bioguide: S001181
+  thomas: '01901'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 4
+  bioguide: H001069
+  thomas: '02174'
+- name: Edward J. Markey
+  party: minority
+  rank: 5
+  bioguide: M000133
+  thomas: '00735'
+- name: Cory A. Booker
+  party: minority
+  rank: 6
+  bioguide: B001288
+  thomas: '02194'
+- name: Christopher A. Coons
+  party: minority
+  rank: 7
+  bioguide: C001088
+  thomas: '01984'
+- name: Mazie K. Hirono
   party: minority
   rank: 8
-  bioguide: J000293
-  thomas: '02086'
+  bioguide: H001042
+  thomas: '01844'
+- name: Gary Peters
+  party: minority
+  rank: 9
+  bioguide: P000595
+  thomas: '01929'
 SSVA:
-- name: Bernard Sanders
+- name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  bioguide: S000033
-  thomas: '01010'
-- name: John D. Rockefeller, IV
+  bioguide: I000055
+  thomas: '01608'
+- name: Jerry Moran
   party: majority
   rank: 2
-  bioguide: R000361
-  thomas: '01424'
-- name: Patty Murray
+  bioguide: M000934
+  thomas: '01507'
+- name: John Boozman
   party: majority
   rank: 3
+  bioguide: B001236
+  thomas: '01687'
+- name: Dean Heller
+  party: majority
+  rank: 4
+  bioguide: H001041
+  thomas: '01863'
+- name: Bill Cassidy
+  party: majority
+  rank: 5
+  bioguide: C001075
+  thomas: '01925'
+- name: Mike Rounds
+  party: majority
+  rank: 6
+  bioguide: R000605
+  thomas: '02288'
+- name: Thom Tillis
+  party: majority
+  rank: 7
+  bioguide: T000476
+  thomas: '02291'
+- name: Daniel Sullivan
+  party: majority
+  rank: 8
+  bioguide: S001198
+  thomas: '02290'
+- name: Richard Blumenthal
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001277
+  thomas: '02076'
+- name: Patty Murray
+  party: minority
+  rank: 2
   bioguide: M001111
   thomas: '01409'
+- name: Bernard Sanders
+  party: minority
+  rank: 3
+  bioguide: S000033
+  thomas: '01010'
 - name: Sherrod Brown
-  party: majority
+  party: minority
   rank: 4
   bioguide: B000944
   thomas: '00136'
 - name: Jon Tester
-  party: majority
+  party: minority
   rank: 5
   bioguide: T000464
   thomas: '01829'
-- name: Mark Begich
-  party: majority
-  rank: 6
-  bioguide: B001265
-  thomas: '01898'
-- name: Richard Blumenthal
-  party: majority
-  rank: 7
-  bioguide: B001277
-  thomas: '02076'
 - name: Mazie K. Hirono
-  party: majority
-  rank: 8
+  party: minority
+  rank: 6
   bioguide: H001042
   thomas: '01844'
-- name: Richard Burr
+- name: Joe Manchin, III
   party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001135
-  thomas: '00153'
-- name: Johnny Isakson
-  party: minority
-  rank: 2
-  bioguide: I000055
-  thomas: '01608'
-- name: Mike Johanns
-  party: minority
-  rank: 3
-  bioguide: J000291
-  thomas: '01899'
-- name: Jerry Moran
-  party: minority
-  rank: 4
-  bioguide: M000934
-  thomas: '01507'
-- name: John Boozman
-  party: minority
-  rank: 5
-  bioguide: B001236
-  thomas: '01687'
-- name: Dean Heller
-  party: minority
-  rank: 6
-  bioguide: H001041
-  thomas: '01863'
+  rank: 7
+  bioguide: M001183
+  thomas: '01983'

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -4,11 +4,11 @@
   thomas_id: HSAG
   house_committee_id: AG
   subcommittees:
-  - name: Conservation, Energy, and Forestry
+  - name: Conservation and Forestry
     thomas_id: '15'
     address: 1301 LHOB; Washington, DC 20515
     phone: (202) 225-2171
-  - name: Department Operations, Oversight, and Nutrition
+  - name: Commodity Exchanges, Energy, and Credit
     thomas_id: '22'
     address: 1301 LHOB; Washington, DC 20515
     phone: (202) 225-2171
@@ -16,12 +16,16 @@
     thomas_id: '16'
     address: 1301 LHOB; Washington, DC 20515
     phone: (202) 225-2171
-  - name: Livestock, Rural Development, and Credit
+  - name: Livestock and Foreign Agriculture
     thomas_id: '29'
     address: 1301 LHOB; Washington, DC 20515
     phone: (202) 225-2171
-  - name: Horticulture, Research, Biotechnology, and Foreign Agriculture
+  - name: Biotechnology, Horticulture, and Research
     thomas_id: '14'
+    address: 1301 LHOB; Washington, DC 20515
+    phone: (202) 225-2171
+  - name: Nutrition
+    thomas_id: '03'
     address: 1301 LHOB; Washington, DC 20515
     phone: (202) 225-2171
   address: 1301 LHOB; Washington, DC 20515-6001
@@ -126,7 +130,7 @@
     thomas_id: '29'
     address: 2340 RHOB; Washington, DC 20515
     phone: (202) 225-1967
-  - name: Intelligence, Emerging Threats and Capabilities
+  - name: Emerging Threats and Capabilities
     thomas_id: '26'
     address: 2340 RHOB; Washington, DC 20515
     phone: (202) 226-2843
@@ -276,7 +280,7 @@
     thomas_id: '06'
     address: 2157 RHOB; Washington, DC 20515
     phone: (202) 225-5074
-  - name: Energy Policy, Health Care and Entitlements
+  - name: Health Care, Benefits and Administrative Rules
     thomas_id: '27'
     address: 2157 RHOB; Washington, DC 20515
     phone: (202) 225-5074
@@ -313,7 +317,7 @@
     thomas_id: '11'
     address: 176 FHOB; Washington, DC 20515
     phone: (202) 226-8417
-  - name: Emergency Preparedness, Response and Communications
+  - name: Emergency Preparedness, Response, and Communications
     thomas_id: '12'
     address: 176 FHOB; Washington, DC 20515
     phone: (202) 226-8417
@@ -770,7 +774,7 @@
   thomas_id: SSAF
   senate_committee_id: SSAF
   subcommittees:
-  - name: Commodities, Markets, Trade and Risk Management
+  - name: Commodities, Risk Management and Trade
     thomas_id: '13'
     wikipedia: United States Senate Agriculture Subcommittee on Commodities, Markets,
       Trade and Risk Management
@@ -778,15 +782,15 @@
     thomas_id: '14'
     wikipedia: United States Senate Agriculture Subcommittee on Conservation, Forestry
       and Natural Resources
-  - name: Jobs, Rural Economic Growth and Energy Innovation
+  - name: Rural Development and Energy
     thomas_id: '15'
     wikipedia: United States Senate Agriculture Subcommittee on Jobs, Rural Economic
       Growth and Energy Innovation
-  - name: Nutrition, Specialty Crops, Food and Agricultural Research
+  - name: Nutrition, Specialty Crops, and Agricultural Research
     thomas_id: '16'
     wikipedia: United States Senate Agriculture Subcommittee on Nutrition, Specialty
       Crops, Food and Agricultural Research
-  - name: Livestock, Dairy, Poultry, Marketing and Agriculture Security
+  - name: Livestock, Marketing and Agriculture Security
     thomas_id: '17'
     wikipedia: United States Senate Agriculture Subcommittee on Livestock, Dairy,
       Poultry, Marketing and Agriculture Security
@@ -915,7 +919,7 @@
   thomas_id: SSCM
   senate_committee_id: SSCM
   subcommittees:
-  - name: Communications, Technology, and the Internet
+  - name: Communications, Technology, Innovation, and the Internet
     thomas_id: '26'
     wikipedia: United States Senate Commerce Subcommittee on Communications, Technology,
       and the Internet
@@ -923,7 +927,7 @@
     thomas_id: '27'
     wikipedia: United States Senate Commerce Subcommittee on Competitiveness, Innovation,
       and Export Promotion
-  - name: Consumer Protection, Product Safety, and Insurance
+  - name: Consumer Protection, Product Safety, Insurance, and Data Security
     thomas_id: '20'
     wikipedia: United States Senate Commerce Subcommittee on Consumer Protection,
       Product Safety, and Insurance
@@ -931,7 +935,7 @@
     thomas_id: '22'
     wikipedia: United States Senate Commerce Subcommittee on Oceans, Atmosphere, Fisheries,
       and Coast Guard
-  - name: Science and Space
+  - name: Space, Science, and Competitiveness
     thomas_id: '24'
     wikipedia: United States Senate Commerce Subcommittee on Science and Space
   - name: Surface Transportation and Merchant Marine Infrastructure, Safety, and Security
@@ -1046,24 +1050,31 @@
     thomas_id: '13'
     wikipedia: United States Senate Foreign Relations Subcommittee on International
       Operations and Organizations, Human Rights, Democracy and Global Women's Issues
-  - name: European Affairs
+  - name: Europe and Regional Security Cooperation
     thomas_id: '01'
     wikipedia: United States Senate Foreign Relations Subcommittee on European Affairs
-  - name: African Affairs
+  - name: Africa and Global Health Policy
     thomas_id: '09'
     wikipedia: United States Senate Foreign Relations Subcommittee on African Affairs
-  - name: East Asian and Pacific Affairs
+  - name: East Asia, the Pacific, and International Cybersecurity Policy
     thomas_id: '02'
     wikipedia: United States Senate Foreign Relations Subcommittee on East Asian and
       Pacific Affairs
-  - name: Near Eastern and South and Central Asian Affairs
+  - name: Near East, South Asia, Central Asia, and Counterterrorism
     thomas_id: '07'
     wikipedia: United States Senate Foreign Relations Subcommittee on Near Eastern
       and South and Central Asian Affairs
-  - name: Western Hemisphere and Global Narcotics Affairs
+  - name: Western Hemisphere, Transnational Crime, Civilian Security, Democracy, Human
+      Rights, and Global Women's Issues
     thomas_id: '06'
     wikipedia: United States Senate Foreign Relations Subcommittee on Western Hemisphere
       and Global Narcotics Affairs
+  - thomas_id: '15'
+    name: Multilateral International Development, Multilateral Institutions, and International
+      Economic, Energy, and Environmental Policy
+  - thomas_id: '14'
+    name: State Department and USAID Management, International Operations, and Bilateral
+      International Development
   rss_url: http://www.foreign.senate.gov/rss/feed/chair/
   minority_rss_url: http://www.foreign.senate.gov/rss/feed/ranking/
   wikipedia: United States Senate Committee on Foreign Relations
@@ -1082,6 +1093,10 @@
     name: Financial and Contracting Oversight
   - thomas_id: '16'
     name: the Efficiency and Effectiveness of Federal Programs and the Federal Workforce
+  - thomas_id: '18'
+    name: Federal Spending Oversight and Emergency Management
+  - thomas_id: '19'
+    name: Regulatory Affairs and Federal Management
   wikipedia: United States Senate Committee on Homeland Security and Governmental
     Affairs
 - type: senate
@@ -1094,7 +1109,7 @@
     thomas_id: '11'
     wikipedia: United States Senate Health Subcommittee on Employment and Workplace
       Safety
-  - name: Primary Health and Aging
+  - name: Primary Health and Retirement Security
     thomas_id: '12'
     wikipedia: United States Senate Health Subcommittee on Primary Health and Aging
   - name: Children and Families
@@ -1109,7 +1124,7 @@
   thomas_id: SSJU
   senate_committee_id: SSJU
   subcommittees:
-  - name: the Constitution, Civil Rights and Human Rights
+  - name: the Constitution
     thomas_id: '21'
     wikipedia: United States Senate Judiciary Subcommittee on the Constitution, Civil
       Rights and Human Rights
@@ -1124,14 +1139,14 @@
     thomas_id: '01'
     wikipedia: United States Senate Judiciary Subcommittee on Antitrust, Competition
       Policy and Consumer Rights
-  - name: Immigration, Refugees and Border Security
+  - name: Immigration and the National Interest
     thomas_id: '04'
     wikipedia: United States Senate Judiciary Subcommittee on Immigration, Refugees
       and Border Security
   - thomas_id: '24'
     name: Bankruptcy and the Courts
   - thomas_id: '25'
-    name: Oversight, Federal Rights and Agency Action
+    name: Oversight, Agency Action, Federal Rights and Federal Courts
   wikipedia: United States Senate Committee on the Judiciary
 - type: senate
   name: Senate Committee on Rules and Administration


### PR DESCRIPTION
This is the output of `committee_membership.py`, run with `scrape_house_alt()` instead of the deprecated `scrape_house()`. I spot checked quite a few of the committee and subcommittee member lists, and they looked pretty good, with the following exceptions:

* House Committee on Natural Resources (`HSII`) subcommittees only have ex officio members.
* Senate Committee on Environment and Public Works (`SSEV`) subcommittees still have no members.
* **Some committees may have outdated House members**, since the House [doesn't publish joint committee members](https://github.com/unitedstates/congress-legislators/blob/master/scripts/committee_membership.py#L285). I manually cleaned up Commission on Security and Cooperation in Europe (`JCSE`) ([data source](http://www.csce.gov/index.cfm?FuseAction=AboutCommission.WorkOfCommission)), Joint Committee on the Library (`JSLC`) ([data source](http://cha.house.gov/jointcommittees/joint-committee-library)), and the Joint Committee on Taxation (`JSTX`) ([data source](https://www.jct.gov/)). The Joint Economic Committee's website's roster has [not been updated for the 114th](http://www.jec.senate.gov/public/index.cfm?p=HouseMembers), nor has the [Joint Committee on Printing's](http://cha.house.gov/jointcommittees/joint-committee-on-printing).

Would love to get a sanity check on this, but it seems OK to me!