### PR TITLE
Instagram handles [needs discussion]

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Each record has two sections: `id` and `social`. The `id` section identifies the
 * twitter: The current official Twitter handle of the legislator.
 * youtube: The current official YouTube username of the legislator.
 * youtube_id: The current official YouTube channel ID of the legislator.
+* instagram: The current official Instagram handle of the legislator.
 * facebook: The username of the current official Facebook presence of the legislator.
 * facebook_id: The numeric ID of the current official Facebook presence of the legislator.
 
@@ -215,6 +216,7 @@ All values can be turned into URLs by preceding them with the domain name of the
 * `http://twitter.com/[twitter]`
 * `http://youtube.com/user/[youtube]`
 * `http://youtube.com/channel/[youtube_id]`
+* `http://instagram/[instagram]`
 * `http://facebook.com/[facebook or facebook_id]`
 
 Legislators are only present when they have one or more social media accounts known. Fields are omitted when the account is unknown.

--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -35,6 +35,7 @@
     facebook: senjoniernst
     facebook_id: '351671691660938'
     youtube_id: UCLwrmtF_84FIcK3TyMs4MIw
+    instagram: senjoniernst
 - id:
     bioguide: T000476
     thomas: '02291'
@@ -114,6 +115,7 @@
     youtube: SenatorMarkWarner
     facebook_id: '7935122852'
     youtube_id: UCwyivNlEGf4sGd1oDLfY5jw
+    instagram: senatorwarner
 - id:
     bioguide: W000804
     thomas: '01886'
@@ -134,6 +136,7 @@
     facebook_id: '194172833926853'
     youtube: SenatorWhitehouse
     youtube_id: UCnG0N70SNBkNqvIMLodPTIA
+    instagram: SenWhitehouse
 - id:
     bioguide: W000800
     thomas: '01879'
@@ -144,6 +147,7 @@
     facebook_id: '72680720883'
     youtube_id: UC0YfApJx6qNaAQ-ir93U8xA
     twitter: PeterWelch
+    instagram: peterwelchvt
 - id:
     bioguide: W000798
     thomas: '01855'
@@ -164,6 +168,7 @@
     youtube: RepWassermanSchultz
     facebook_id: '88904724121'
     youtube_id: UCfHQiJVvMlYbVAxrMSLdO4w
+    instagram: RepDWSTweets
 - id:
     bioguide: W000796
     thomas: '01779'
@@ -184,6 +189,7 @@
     twitter: RepJoeWilson
     facebook_id: '70150469414'
     youtube_id: UC3aR1B8m7Z1uycO65yDnpCg
+    instagram: repjoewilson
 - id:
     bioguide: W000791
     thomas: '01596'
@@ -194,6 +200,7 @@
     youtube: RepGregWalden
     facebook_id: '313301365382225'
     youtube_id: UCyaDp6ANSM9tvW7Y3LT_4KQ
+    instagram: repgregwalden
 - id:
     bioguide: W000779
     thomas: '01247'
@@ -202,6 +209,7 @@
     twitter: RonWyden
     youtube: senronwyden
     youtube_id: UCsd3UEaoLoqX60P88BdpGGw
+    instagram: wydenpress
 - id:
     bioguide: W000437
     thomas: '01226'
@@ -212,6 +220,7 @@
     youtube: SenatorWicker
     facebook_id: ~
     youtube_id: UCIlKHiTjSkcQP_knBcXHWSg
+    instagram: senatorwicker
 - id:
     bioguide: W000413
     thomas: '01222'
@@ -242,6 +251,7 @@
     youtube: RepChrisVanHollen
     facebook_id: '109304033877'
     youtube_id: UCkpfJWu1N9Okd6PE_NidtBQ
+    instagram: chrisvanhollen
 - id:
     bioguide: V000108
     thomas: '01188'
@@ -312,6 +322,7 @@
     youtube: CongresswomanTitus
     facebook_id: '120660834778561'
     youtube_id: UC_US4jNqECuMSNrB7yVCbbw
+    instagram: dinatitusnv
 - id:
     bioguide: T000467
     thomas: '01952'
@@ -362,6 +373,7 @@
     youtube: PatTiberi
     facebook_id: '90452932937'
     youtube_id: UCr9reyLip23im9SVDJ9IGAg
+    instagram: pattiberi
 - id:
     bioguide: T000461
     thomas: '02085'
@@ -410,6 +422,7 @@
     youtube: RepBennieThompson
     facebook_id: '7259193379'
     youtube_id: UCzt2pBxh0dI24kYrWretXRw
+    instagram: benniegthompson
 - id:
     bioguide: S001189
     thomas: '02009'
@@ -440,6 +453,7 @@
     youtube: RepSteveStivers
     facebook_id: '116058275133542'
     youtube_id: UCfZrE20pIcR-LeFUV7r2Ixw
+    instagram: RepSteveStivers
 - id:
     bioguide: S001185
     thomas: '01988'
@@ -460,6 +474,7 @@
     youtube: SenatorTimScott
     facebook_id: '163207553711385'
     youtube_id: UCSfAsbG80CNInSKrtpKoL-w
+    instagram: SenatorTimScott
 - id:
     bioguide: S001183
     thomas: '01994'
@@ -470,6 +485,7 @@
     youtube: RepDavidSchweikert
     facebook_id: '150338151681908'
     youtube_id: UCVvuNVzkOUp7p_Pzkc6Zuvw
+    instagram: repdavid
 - id:
     bioguide: S001181
     thomas: '01901'
@@ -519,6 +535,7 @@
     twitter: SteveScalise
     facebook_id: '50936151681'
     youtube_id: UCmYveHBVXVBRxl7GiCL-gjw
+    instagram: stevescalise
 - id:
     bioguide: S001175
     thomas: '01890'
@@ -703,6 +720,7 @@
     twitter: RepJoseSerrano
     facebook: RepJoseSerrano
     facebook_id: '273446508512'
+    instagram: repjoseserrano
 - id:
     bioguide: S000244
     thomas: '01041'
@@ -723,6 +741,7 @@
     youtube: repbobbyscott
     facebook_id: '123839200978190'
     youtube_id: UCdNNcpw8arCsUp55JwK_QAA
+    instagram: repbobbyscott
 - id:
     bioguide: S000148
     thomas: '01036'
@@ -783,6 +802,7 @@
     youtube: reptoddrokita
     facebook_id: '183180288372896'
     youtube_id: UCl_wYwGYw1AXiUoqNmwLxzA
+    instagram: RepToddRokita
 - id:
     bioguide: R000591
     thomas: '01986'
@@ -911,6 +931,7 @@
     youtube: MikeRogersAL03
     facebook_id: '171770326187035'
     youtube_id: UCH-WUWuY0_dlKwJDSqKTJsg
+    instagram: repmikerogersal
 - id:
     bioguide: R000570
     thomas: '01560'
@@ -1021,6 +1042,7 @@
     youtube: RepMikeQuigley
     facebook_id: '158963645688'
     youtube_id: UCDP13XegdoZ4bxYHxM34yAA
+    instagram: repmikequigley
 - id:
     bioguide: P000603
     thomas: '02082'
@@ -1031,6 +1053,7 @@
     youtube: SenatorRandPaul
     facebook_id: '161355253917286'
     youtube_id: UCeM9I-20oWUs8daIIpsNHoQ
+    instagram: senatorrandpaul
 - id:
     bioguide: P000602
     thomas: '02022'
@@ -1101,6 +1124,7 @@
     youtube: RepGaryPeters
     facebook_id: '88851604323'
     youtube_id: UC7LYNbnKSK2VZqQ98YROWHQ
+    instagram: sengarypeters
 - id:
     bioguide: P000594
     thomas: '01930'
@@ -1131,6 +1155,7 @@
     youtube: CongressmanTedPoe
     facebook_id: '106631626049851'
     youtube_id: UCGdNUkVP16hOyL-fUDV1Knw
+    instagram: judgetedpoe
 - id:
     bioguide: P000591
     thomas: '01778'
@@ -1169,6 +1194,7 @@
     youtube: SenRobPortman
     facebook_id: '45243961073'
     youtube_id: UCwunkd8Zs-yAWKQwnwBp7ew
+    instagram: senrobportman
 - id:
     bioguide: P000373
     thomas: '01514'
@@ -1361,6 +1387,7 @@
     youtube: RepMarino
     facebook_id: '144408762280226'
     youtube_id: UCL8AvZKY5KuPk0T7G0jv7HA
+    instagram: reptommarino
 - id:
     bioguide: M001177
     thomas: '01908'
@@ -1381,6 +1408,7 @@
     youtube: SenatorJeffMerkley
     facebook_id: '74374931545'
     youtube_id: UCRoXttCJhMnLVCxCaa6VnNQ
+    instagram: senjeffmerkley
 - id:
     bioguide: M001170
     thomas: '01820'
@@ -1391,6 +1419,7 @@
     youtube: SenatorMcCaskill
     facebook_id: '131498087618'
     youtube_id: UCnarZ9jmNhI-eDcEPBwqMFw
+    instagram: clairecmc
 - id:
     bioguide: M001166
     thomas: '01832'
@@ -1411,6 +1440,7 @@
     youtube: repkevinmccarthy
     facebook_id: '51052893175'
     youtube_id: UCdJUZUFSLJRlUpE-91-6DsA
+    instagram: RepKevinMcCarthy
 - id:
     bioguide: M001163
     thomas: '01814'
@@ -1471,6 +1501,7 @@
     youtube: CongressmanMcHenry
     facebook_id: '8045519803'
     youtube_id: UCY3PTRhkSH-eoltxPVZKD-w
+    instagram: reppatrickmchenry
 - id:
     bioguide: M001153
     thomas: '01694'
@@ -1501,6 +1532,7 @@
     youtube: candicemi10
     facebook_id: '210401648605'
     youtube_id: UCbILX1A8Hj3LiB_g8eZplGg
+    instagram: repcandicemiller
 - id:
     bioguide: M001144
     thomas: '01685'
@@ -1536,6 +1568,7 @@
     twitter: PattyMurray
     youtube: SenatorPattyMurray
     youtube_id: UCb8jq3TvQ3AzKsexhWfFLoA
+    instagram: senpattymurray
 - id:
     bioguide: M000934
     thomas: '01507'
@@ -1546,6 +1579,7 @@
     youtube: senatorjerrymoran
     facebook_id: '171578807105'
     youtube_id: UC1oRxeUPam6-53wPBZ3N02A
+    instagram: senjerrymoran
 - id:
     bioguide: M000702
     thomas: '00802'
@@ -1575,6 +1609,7 @@
     youtube: SenatorMenendezNJ
     facebook_id: '349744811357'
     youtube_id: UC0PV0K9Z5a9p3D5917KF5fw
+    instagram: senatormenendez
 - id:
     bioguide: M000404
     thomas: '00766'
@@ -1613,6 +1648,7 @@
     youtube: SenatorJohnMcCain
     facebook_id: '6425923706'
     youtube_id: UC9IJssXDUaKHzwx6gW4wEoA
+    instagram: senjohnmccain
 - id:
     bioguide: M000133
     thomas: '00735'
@@ -1641,6 +1677,7 @@
     youtube: senatormikelee
     facebook_id: '178081365556898'
     youtube_id: UCplVxs_j_sLAt0fkplXcl4A
+    instagram: senmikelee
 - id:
     bioguide: L000576
     thomas: '02033'
@@ -1661,6 +1698,7 @@
     youtube: replankford
     facebook_id: '130873066975024'
     youtube_id: UCGoONKppCBdPUt8_yF15Waw
+    instagram: senatorlankford
 - id:
     bioguide: L000573
     thomas: '02011'
@@ -1691,6 +1729,7 @@
     youtube: Repbenraylujan
     facebook_id: '112962521120'
     youtube_id: UCcO5AmF8HuJo4d0awEbst7Q
+    instagram: repbenraylujan
 - id:
     bioguide: L000569
     thomas: '01931'
@@ -1721,6 +1760,7 @@
     youtube: CongressmanBobLatta
     facebook_id: '100000004848334'
     youtube_id: UCVSBVHoWu-eWnBBQaMKZ_sQ
+    instagram: boblatta
 - id:
     bioguide: L000565
     thomas: '01846'
@@ -1811,6 +1851,7 @@
     youtube: RepLee
     facebook_id: '92190287786'
     youtube_id: UCnRgK2MXAQOUau0JXqseeNA
+    instagram: repbarbaralee
 - id:
     bioguide: L000491
     thomas: '00711'
@@ -1851,6 +1892,7 @@
     youtube: repjohnlewis
     facebook_id: '82737208404'
     youtube_id: UC_jpkZzdyGhTBGBZ3UTNwjA
+    instagram: RepJohnLewis
 - id:
     bioguide: L000263
     thomas: '00683'
@@ -1931,6 +1973,7 @@
     youtube: SenatorKirk
     facebook_id: '116381528428230'
     youtube_id: UCJ-pgDYehtW_7VdKtNuv7EA
+    instagram: senatorkirk
 - id:
     bioguide: K000210
     thomas: '00635'
@@ -1979,6 +2022,7 @@
     youtube: RepBillJohnson
     facebook_id: '170477096312258'
     youtube_id: UCtF08Ay71haDRoJosRN2P_Q
+    instagram: repbilljohnson
 - id:
     bioguide: J000290
     thomas: '01921'
@@ -2099,6 +2143,7 @@
     youtube: senatorjohnhoevennd
     facebook_id: '194483057244478'
     youtube_id: UC1kQIC2Q_Fq9_NRqdb6eHiw
+    instagram: senjohnhoeven
 - id:
     bioguide: H001060
     thomas: '02069'
@@ -2169,6 +2214,7 @@
     youtube: repvickyhartzler
     facebook_id: '183580061667324'
     youtube_id: UCAvttUz6qBVEJiFt7p_MZxw
+    instagram: rephartzler
 - id:
     bioguide: H001051
     thomas: '02044'
@@ -2209,6 +2255,7 @@
     youtube: SenMartinHeinrich
     facebook_id: '137523189213'
     youtube_id: UCBxh8IK5sMxY0Ln_0G2NYcg
+    instagram: senatormartinheinrich
 - id:
     bioguide: H001045
     thomas: '01933'
@@ -2227,6 +2274,7 @@
     twitter: MazieHirono
     youtube: CongresswomanHirono
     youtube_id: UCcoKhxad156flzPYJ8JMFOA
+    instagram: maziehirono
 - id:
     bioguide: H001041
     thomas: '01863'
@@ -2267,6 +2315,7 @@
     youtube: RepMikeHonda
     facebook_id: '15675385380'
     youtube_id: UC_WqGAzksPJbvjkhlK08xcw
+    instagram: repmikehonda
 - id:
     bioguide: H000874
     thomas: '00566'
@@ -2277,6 +2326,7 @@
     youtube: LeaderHoyer
     facebook_id: '282861997886'
     youtube_id: UCvxgqX65cdhHNjJn64cgY9g
+    instagram: repstenyhoyer
 - id:
     bioguide: H000636
     thomas: '01490'
@@ -2364,6 +2414,7 @@
     facebook: SenCoryGardner
     facebook_id: '160924893954206'
     youtube_id: UC7Vi5vAFb7piu_BNwrYDBxQ
+    instagram: sencorygardner
 - id:
     bioguide: G000560
     thomas: '01979'
@@ -2374,6 +2425,7 @@
     youtube: CongressmanGraves
     facebook_id: '104548906262119'
     youtube_id: UCBxeA4MWCmfUox57bUTEH0g
+    instagram: reptomgraves
 - id:
     bioguide: G000559
     thomas: '01973'
@@ -2424,6 +2476,7 @@
     youtube: repscottgarrett
     facebook_id: '6756553401'
     youtube_id: UC5DG4Otnhpd3ZnUiEairZTg
+    instagram: repscottgarrett
 - id:
     bioguide: G000535
     thomas: '00478'
@@ -2504,6 +2557,7 @@
     youtube: BlakeFarenthold
     facebook_id: '186894244673001'
     youtube_id: UC-xQNCjaivVnqozyXtjcqww
+    instagram: Farenthold
 - id:
     bioguide: F000459
     thomas: '02061'
@@ -2524,6 +2578,7 @@
     youtube: CongressmanFincher
     facebook_id: '128861763849209'
     youtube_id: UCDOY7qdLPB7nQuQSWrQPalw
+    instagram: RepFincherTN08
 - id:
     bioguide: F000456
     thomas: '01924'
@@ -2544,6 +2599,7 @@
     youtube: marcialfudge
     facebook_id: '279006440801'
     youtube_id: UClmYIIhIcL-WwtBAy1Dhokg
+    instagram: repmarciafudge
 - id:
     bioguide: F000451
     thomas: '01797'
@@ -2622,6 +2678,7 @@
     youtube: ChakaFattah
     facebook_id: '165961823475034'
     youtube_id: UCkTfk-NcVzE1hk-svI6mclw
+    instagram: chakafattah
 - id:
     bioguide: F000030
     thomas: '00368'
@@ -2632,6 +2689,7 @@
     youtube: CongressmanSamFarr
     facebook_id: '7018136294'
     youtube_id: UCoSsBwU28xzKM8lKeeHXEzQ
+    instagram: RepSamFarr
 - id:
     bioguide: E000291
     thomas: '02036'
@@ -2682,6 +2740,7 @@
     youtube: RepAnnaEshoo
     facebook_id: '174979964227'
     youtube_id: UCjRvhco2d59GBgA78IIIaYQ
+    instagram: RepAnnaEshoo
 - id:
     bioguide: E000179
     thomas: '00344'
@@ -2702,6 +2761,7 @@
     youtube: ScottDesJarlaisTN04
     facebook_id: ~
     youtube_id: UCvjuSLoi3hS0ECQvJLhwOkA
+    instagram: desjarlaistn04
 - id:
     bioguide: D000615
     thomas: '02057'
@@ -2712,6 +2772,7 @@
     youtube: congjeffduncan
     facebook_id: '187268144624279'
     youtube_id: UC1tuXL6ymImdpKYGEAH83QA
+    instagram: repjeffduncan
 - id:
     bioguide: D000614
     thomas: '02072'
@@ -2722,6 +2783,7 @@
     youtube: RepSeanDuffy
     facebook_id: '119657691436457'
     youtube_id: UChq-eV2HnV7Kr2zmj0yua7g
+    instagram: repseanduffy
 - id:
     bioguide: D000612
     thomas: '01995'
@@ -2732,6 +2794,7 @@
     youtube: repjeffdenham
     facebook_id: '133714040028137'
     youtube_id: UCm59PEM_tgTvhm5-wIfnrRg
+    instagram: repjeffdenham
 - id:
     bioguide: D000610
     thomas: '01976'
@@ -2752,6 +2815,7 @@
     facebook_id: '168059529893610'
     youtube: sendonnelly
     youtube_id: UC7H5Lz0BUaTRlWXk9QsIwsg
+    instagram: sendonnelly
 - id:
     bioguide: D000604
     thomas: '01799'
@@ -2771,6 +2835,7 @@
     youtube: MarioDiazBalart
     facebook_id: '119538428117878'
     youtube_id: UCpEEd0Plxx5D78pI4a4mFTQ
+    instagram: repmariodb
 - id:
     bioguide: D000563
     thomas: '00326'
@@ -2851,6 +2916,7 @@
     youtube: senatorchriscoons
     facebook_id: '254950754518205'
     youtube_id: UC2lOVbsddn1HIkcDnmCw6tA
+    instagram: senatorchriscoons
 - id:
     bioguide: C001087
     thomas: '01989'
@@ -2861,6 +2927,7 @@
     youtube: RepRickCrawford
     facebook_id: '143344975723788'
     youtube_id: UCLKAkVl4BHRK73lmDiIgPYg
+    instagram: reprickcrawford
 - id:
     bioguide: C001084
     thomas: '02055'
@@ -2911,6 +2978,7 @@
     youtube_id: UCPRdJWDBUYfZaMYaPQfoNnQ
     facebook: CongressmanJasonChaffetz
     facebook_id: '390419731073316'
+    instagram: jasoninthehouse
 - id:
     bioguide: C001072
     thomas: '01889'
@@ -2931,6 +2999,7 @@
     youtube: senatorcorker
     facebook_id: '109251415789533'
     youtube_id: UCm7if_szz7DxfcdYGrywHSA
+    instagram: senbobcorker
 - id:
     bioguide: C001070
     thomas: '01828'
@@ -3030,6 +3099,7 @@
     youtube: reptomcole
     facebook_id: '146497782066300'
     youtube_id: UCvqzPm_YnNkfEHpm3SEMJMQ
+    instagram: TomColeOK04
 - id:
     bioguide: C001051
     thomas: '01752'
@@ -3040,6 +3110,7 @@
     youtube: repjohncarter
     facebook_id: '1287257083'
     youtube_id: UC9pkaOrhPfouzkJ8oAdI-1w
+    instagram: repcarter
 - id:
     bioguide: C001049
     thomas: '01654'
@@ -3069,6 +3140,7 @@
     youtube: RepShelleyCapito
     facebook_id: '8057864757'
     youtube_id: UCftKT5ENIKjqidj9Xz6b_Yw
+    instagram: sencapito
 - id:
     bioguide: C001045
     thomas: '01643'
@@ -3138,6 +3210,7 @@
     youtube: senatorcrapo
     facebook_id: '80335332266'
     youtube_id: UCMHzKHg1BE7dEcFjnayw1lA
+    instagram: mikecrapo
 - id:
     bioguide: C000754
     thomas: '00231'
@@ -3148,6 +3221,7 @@
     youtube: RepJimCooper
     facebook_id: ~
     youtube_id: UCjplyIIQbNZcl013AyDfPNg
+    instagram: repjimcooper
 - id:
     bioguide: C000714
     thomas: '00229'
@@ -3188,6 +3262,7 @@
     youtube: congressmanchabot
     facebook_id: '204705339555378'
     youtube_id: UCJpzm2DZDE1B6ruQLQc7q4g
+    instagram: repstevechabot
 - id:
     bioguide: C000174
     thomas: '00179'
@@ -3266,6 +3341,7 @@
     youtube: RepDianeBlack
     facebook_id: '186436274719648'
     youtube_id: UCREZGYWeFh6-gfodmoWVUFg
+    instagram: repdianeblack
 - id:
     bioguide: B001271
     thomas: '02027'
@@ -3324,6 +3400,7 @@
     youtube: vernbuchanan
     facebook_id: '67106719910'
     youtube_id: UCY4DEy41NxOTdcF8_XAVZvw
+    instagram: repvern
 - id:
     bioguide: B001257
     thomas: '01838'
@@ -3404,6 +3481,7 @@
     youtube: BradyPA01
     facebook_id: '118845109487'
     youtube_id: UCHbTbPH6iCtaA_AKPwDy04A
+    instagram: repbrady
 - id:
     bioguide: B001135
     thomas: '00153'
@@ -3432,6 +3510,7 @@
     youtube: KBrady8
     facebook_id: '9307301412'
     youtube_id: UC6Ng0uMQEBVgXO_HF0NbfXA
+    instagram: repkevinbrady
 - id:
     bioguide: B000711
     thomas: '00116'
@@ -3442,6 +3521,7 @@
     youtube: SenatorBoxer
     facebook_id: '116513005087055'
     youtube_id: UCWDQBlCBh67UgfNvSXDvbmw
+    instagram: senatorboxer
 - id:
     bioguide: B000589
     thomas: '00102'
@@ -3452,6 +3532,7 @@
     youtube: johnboehner
     youtube_id: UC-cxqz-2fBOekclLlaERLJQ
     facebook_id: '175082565865743'
+    instagram: speakerboehner
 - id:
     bioguide: B000575
     thomas: '01464'
@@ -3462,6 +3543,7 @@
     youtube: SenatorBlunt
     facebook_id: '142473042477322'
     youtube_id: UCFeLRzjhThTmaWzuh5qjpGA
+    instagram: royblunt
 - id:
     bioguide: B000574
     thomas: '00099'
@@ -3490,6 +3572,7 @@
     youtube: XavierBecerra
     facebook_id: '90311772229'
     youtube_id: UCoY0rJzkgkl1TmoKTUKTI6w
+    instagram: repbecerra
 - id:
     bioguide: B000213
     thomas: '00062'
@@ -3529,6 +3612,7 @@
     facebook: senatorlamaralexander
     facebook_id: '89927603836'
     youtube_id: UChDLBjn5RWqgMmCSswT05IQ
+    instagram: senlamaralexander
 - id:
     bioguide: A000055
     thomas: '01460'
@@ -3559,6 +3643,7 @@
     youtube: RepJohnCarney
     facebook_id: '156024857781159'
     youtube_id: UCT9yU36lD-zOTJKhmX_w_dA
+    instagram: johncarneyde
 - id:
     bioguide: B001245
     thomas: '01723'
@@ -3612,6 +3697,7 @@
     youtube: markamodeinv2
     facebook_id: '307227745970624'
     youtube_id: UCjOGx2iqSn1r3BQxaVgYhYw
+    instagram: MarkAmodeiNV2
 - id:
     bioguide: L000580
     thomas: '02146'
@@ -3622,6 +3708,7 @@
     youtube: RepLujanGrisham
     facebook_id: '191640657646128'
     youtube_id: UCS_N-wEnUBEbVYCD-CXpNjw
+    instagram: replujangrisham
 - id:
     bioguide: D000621
     thomas: '02116'
@@ -3652,6 +3739,7 @@
     youtube: ericswalwell
     facebook_id: '450130878375355'
     youtube_id: UCKvwsFNGD4sDkE_9g-2ft0w
+    instagram: repswalwell
 - id:
     bioguide: M001190
     thomas: '02156'
@@ -3669,6 +3757,7 @@
     facebook: '301936109927957'
     facebook_id: '301936109927957'
     youtube_id: UCgfHlaGqxD8p-2V_YlNIqrA
+    instagram: repkennedy
 - id:
     bioguide: B001284
     thomas: '02129'
@@ -3679,6 +3768,7 @@
     facebook_id: '517697358277175'
     youtube: SusanWBrooks
     youtube_id: UCMd7LzaBcbQ06aKHoj9KkSQ
+    instagram: susanwbrooks
 - id:
     bioguide: W000813
     thomas: '02128'
@@ -3786,6 +3876,7 @@
     facebook_id: '404318572981934'
     youtube: repdavejoyce
     youtube_id: UCTu9xz2VYk-jtQv0TVsLyYA
+    instagram: repdavejoyce
 - id:
     bioguide: L000579
     thomas: '02111'
@@ -3844,6 +3935,7 @@
     youtube: SteveDainesMT
     facebook_id: '185361254941832'
     youtube_id: UC-ny-W5mEUGytiyMdXbQ20Q
+    instagram: stevedaines
 - id:
     bioguide: Y000065
     thomas: '02115'
@@ -3884,6 +3976,7 @@
     facebook: RepDanKildee
     facebook_id: '484166588292670'
     youtube_id: UC_KpQ-n3IT5dL5ul21XA9Yw
+    instagram: repdankildee
 - id:
     bioguide: C001090
     thomas: '02159'
@@ -3983,6 +4076,7 @@
     youtube: marcveasey
     facebook_id: '394849110600016'
     youtube_id: UC2CRp1KF5uljZyhDRPR-72Q
+    instagram: repveasey
 - id:
     bioguide: V000132
     thomas: '02167'
@@ -4001,6 +4095,7 @@
     youtube: RepScottPerry
     facebook_id: '376801102416184'
     youtube_id: UCzgrU5PT_HHRgf5hXPen4dQ
+    instagram: repscottperry
 - id:
     bioguide: R000599
     thomas: '02109'
@@ -4051,6 +4146,7 @@
     facebook_id: '467047586692268'
     youtube: RepChrisCollins
     youtube_id: UCSwQQJaKI4TzuYDUwHwwnxQ
+    instagram: repchriscollins
 - id:
     bioguide: W000812
     thomas: '02137'
@@ -4100,6 +4196,7 @@
     youtube: repchrisstewart
     facebook_id: '242042855928904'
     youtube_id: UCKYqzTvmQVWys-WhrCkbyPw
+    instagram: repChrisStewart
 - id:
     bioguide: B001282
     thomas: '02131'
@@ -4140,6 +4237,7 @@
     youtube: RepPatrickMurphyFL
     facebook_id: '317735028342371'
     youtube_id: UCcsbPwHksrcVLP5TZH0qkAQ
+    instagram: PatrickMurphyFL
 - id:
     bioguide: G000546
     thomas: '01656'
@@ -4157,6 +4255,7 @@
     youtube: RepJimBridenstine
     facebook_id: '460003650715961'
     youtube_id: UC4uUpWvIK-fiOfTG_D3rX8g
+    instagram: repjbridenstine
 - id:
     bioguide: B001230
     thomas: '01558'
@@ -4203,6 +4302,7 @@
     facebook_id: '112300955610529'
     youtube_id: UCYRWRvUxtjaHnFMCbdd94tg
     youtube: repduckworth
+    instagram: repduckworth
 - id:
     bioguide: O000170
     thomas: '02162'
@@ -4243,6 +4343,7 @@
     facebook_id: '501810613175643'
     youtube: senatorheidiheitkamp
     youtube_id: UCsIiu6s5KJ_VYzpT_b1Jh4g
+    instagram: senatorheitkamp
 - id:
     bioguide: H001052
     thomas: '02026'
@@ -4290,6 +4391,7 @@
     facebook_id: '326420614138023'
     youtube: JoaquinCastroTX
     youtube_id: UCsRxWnFdRiV2od1O5v5nEeQ
+    instagram: joaquincastrotx
 - id:
     bioguide: W000815
     thomas: '02152'
@@ -4300,6 +4402,7 @@
     youtube: repbradwenstrup
     facebook_id: '124462944390458'
     youtube_id: UCaK7SeUvmHdHTMtF3HXb-jA
+    instagram: repbradwenstrup
 - id:
     bioguide: V000129
     thomas: '02105'
@@ -4402,6 +4505,7 @@
     youtube_id: UCm6ug1-yvYGL0F6DvYxfFBA
     facebook: repcardenas
     facebook_id: '485493954794945'
+    instagram: repcardenas
 - id:
     bioguide: W000799
     thomas: '01856'
@@ -4420,6 +4524,7 @@
     facebook_id: '436881033058309'
     youtube_id: UCz5b47WER_u3dUGV_Zi70dQ
     youtube: repmarkpocan
+    instagram: repmarkpocan
 - id:
     bioguide: V000130
     thomas: '02112'
@@ -4503,6 +4608,7 @@
     twitter: RepBeatty
     facebook: RepJoyceBeatty
     youtube_id: UCtVl3kb7Xvt3pY7l6x-M6LA
+    instagram: repbeatty
 - id:
     bioguide: S000051
     govtrack: 400607
@@ -4569,6 +4675,7 @@
     facebook: RepByrne
     facebook_id: '1374832002773142'
     youtube_id: UCRUXmqQbrKo0T6xi_GT7TEA
+    instagram: repbyrne
 - id:
     bioguide: J000296
     govtrack: 412603
@@ -4596,12 +4703,14 @@
     thomas: '02278'
   social:
     twitter: RepEvanJenkins
+    instagram: RepEvanJenkins
 - id:
     bioguide: R000601
     govtrack: 412653
     thomas: '02268'
   social:
     twitter: RepRatcliffe
+    instagram: rep_ratcliffe
 - id:
     bioguide: L000583
     govtrack: 412624
@@ -4680,6 +4789,7 @@
     thomas: '02266'
   social:
     twitter: RepRyanCostello
+    instagram: RepRyanCostello
 - id:
     bioguide: R000603
     govtrack: 412641
@@ -4692,6 +4802,7 @@
     thomas: '02221'
   social:
     twitter: USRepGaryPalmer
+    instagram: usrepgarypalmer
 - id:
     bioguide: M001197
     govtrack: 412611
@@ -4704,6 +4815,7 @@
     thomas: '02253'
   social:
     twitter: RepTomEmmer
+    instagram: reptomemmer
 - id:
     bioguide: R000604
     govtrack: 412650
@@ -4824,6 +4936,7 @@
     thomas: '02289'
   social:
     twitter: SenSasse
+    instagram: senatorsasse
 - id:
     bioguide: K000387
     govtrack: 412614
@@ -4836,6 +4949,7 @@
     thomas: '02290'
   social:
     twitter: SenDanSullivan
+    instagram: sen_dansullivan
 - id:
     bioguide: L000584
     govtrack: 412656
@@ -4848,6 +4962,7 @@
     thomas: '02239'
   social:
     twitter: reprickallen
+    instagram: reprickallen
 - id:
     bioguide: R000605
     govtrack: 412669
@@ -4860,6 +4975,7 @@
     thomas: '02232'
   social:
     twitter: RepMimiWalters
+    instagram: rep_mimiwalters
 - id:
     bioguide: B001296
     govtrack: 412652
@@ -4890,6 +5006,7 @@
     thomas: '02286'
   social:
     twitter: sendavidperdue
+    instagram: sendavidperdue
 - id:
     bioguide: P000610
     govtrack: 412659
@@ -4932,3 +5049,10 @@
     thomas: '02240'
   social:
     twitter: RepMarkTakai
+    instagram: repmarktakai
+- id:
+    bioguide: W000819
+    govtrack: 412670
+    thomas: '02255'
+  social:
+    instagram: repmarkwalker

--- a/scripts/data/social_media_blacklist.csv
+++ b/scripts/data/social_media_blacklist.csv
@@ -65,3 +65,5 @@ twitter,^USRepJoeWilson$,404s
 twitter,^FraminghamPatch$,not the right one
 twitter,^CandiceMiller$,"we have it already, blacklisted because it shows up elsewhere mistakenly"
 facebook,^billnelson$,"campaign account, even though listed on official page"
+instagram,republicanconference, not an individual's account
+instagram,housedemocrats, not an individual's account

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -209,7 +209,12 @@ def download(url, destination=None, force=False, options=None):
     # the downloader can optionally parse the body as HTML
     # and look for meta redirects. a bit expensive, so opt-in.
     if options.get('check_redirects', False):
-      html_tree = lxml.html.fromstring(body)
+      try:
+        html_tree = lxml.html.fromstring(body)
+      except ValueError:
+        log("Error parsing source from url {0}".format(url))
+        return None
+
       meta = html_tree.xpath("//meta[translate(@http-equiv, 'REFSH', 'refsh') = 'refresh']/@content")
       if meta:
         attr = meta[0]


### PR DESCRIPTION
So it looks like about a quarter of members link to their Instagram account on their official page. I made this PR to track work on the `instagram` branch and provide a place for discussion/review.

All of the Instagram accounts added in `legislators-social-media.yaml` come from a scrape of members' official websites (see update to `social_media.py`). Assuming that we're willing to regard an Instagram linked from an elected official's page as — well — official, these just need a once over to make sure the scraper's Instagram regex didn't grab a false account. If presence on a member's official homepage != official Instagram account status, we should hammer out details for what constitutes an "official" Instagram account and then figure out how to verify these. Unfortunately, I don't see any [verified](https://help.instagram.com/854227311295302/) badges on the accounts @nickom linked to [here](https://github.com/unitedstates/congress-legislators/issues/245), but maybe they just don't show up on Instagram's desktop GUI.

Also, make sure to note the change I snuck into `utils.py`.

ref #245 