### PR TITLE
Corrected Rick Allen's FEC ID

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -38013,7 +38013,7 @@
 - id:
     bioguide: A000372
     fec:
-    - H0GA02241
+    - H2GA12121
     govtrack: 412625
     opensecrets: N00033720
     thomas: '02239'

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -38013,7 +38013,7 @@
 - id:
     bioguide: A000372
     fec:
-    - H0GA02241
+	- H2GA12121
     govtrack: 412625
     opensecrets: N00033720
     thomas: '02239'

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -38013,7 +38013,7 @@
 - id:
     bioguide: A000372
     fec:
-	- H2GA12121
+    - H0GA02241
     govtrack: 412625
     opensecrets: N00033720
     thomas: '02239'


### PR DESCRIPTION
Added Rick Allen's correct FEC ID H2GA12121 and removed FEC ID H0GA02241. 

Pretty sure about this, but would love it if someone could confirm: H0GA02241 is a different Rick Allen who lost in the Republican primary for GA-02 in 2012. H2GA12121 is the correct FEC ID for the Rick Allen elected to GA-12 in 2014.

http://ballotpedia.org/Rick_Allen vs.
http://ballotpedia.org/Rick_Allen_(Georgia_2nd)