### PR TITLE
Adding Rep. Cresent Hardy

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -17,6 +17,16 @@
 # When it's ambiguous, we'll actually make phone calls to the office and
 # have the press staff confirm their official account.
 - id:
+    bioguide: H001070
+    thomas: '02260'
+    govtrack: 412645
+  social:
+    twitter: RepHardy
+    facebook: RepCresentHardy
+    youtube: RepHardy
+    facebook_id: '320612381469421'
+    youtube_id: UCc8E6NWCdgrXjBVI2NNPYdA
+- id:
     bioguide: G000546
     thomas: '01656'
     govtrack: 400158


### PR DESCRIPTION
Added all social media accounts of Rep. Hardy following an email request from his communications director, Scott Knuteson. The official Twitter and Facebook accounts are linked here: https://hardy.house.gov/

While the Youtube account is not linked from the homepage, it was specifically mentioned by Knuteson in the email and can be seen used on this page: https://hardy.house.gov/media-center/videos/womens-history-month-remarks-recognizing-betty-wall