### PR TITLE
Rep. Justin Amash no longer has an official Twitter account

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -3684,7 +3684,6 @@
     thomas: '02029'
     govtrack: 412438
   social:
-    twitter: RepJustinAmash
     facebook: repjustinamash
     youtube: repjustinamash
     facebook_id: '173604349345646'


### PR DESCRIPTION
[@RepJustinAmash](https://twitter.com/repjustinamash) is now a private account and there's no Twitter accounts linked from [Amash.house.gov](http://amash.house.gov/)