### PR TITLE
Update Sen. Cantwell's Twitter account

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -3367,7 +3367,7 @@
     thomas: '00172'
     govtrack: 300018
   social:
-    twitter: CantwellPress
+    twitter: SenatorCantwell
     youtube: SenatorCantwell
     youtube_id: UCN52UDqKgvHRk39ncySrIMw
 - id:


### PR DESCRIPTION
It appears as if Sen. Cantwell's Twitter screen name has changed and unsavory elements have taken over her old one.