### PR TITLE
Don't include trailing paths in official members' website URLs

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -7783,7 +7783,7 @@
     state: MI
     party: Democrat
     district: 13
-    url: https://conyers.house.gov/index.cfm/home
+    url: https://conyers.house.gov
     address: 2426 Rayburn HOB; Washington DC 20515-2213
     phone: 202-225-5126
     fax: 202-225-0072
@@ -8295,7 +8295,7 @@
     state: FL
     party: Republican
     district: 4
-    url: https://crenshaw.house.gov/index.cfm/home
+    url: https://crenshaw.house.gov
     address: 2161 Rayburn HOB; Washington DC 20515-0904
     phone: 202-225-2501
     fax: 202-225-2504
@@ -8799,7 +8799,7 @@
     state: IL
     party: Democrat
     district: 7
-    url: http://www.davis.house.gov
+    url: http://davis.house.gov
     address: 2159 Rayburn HOB; Washington DC 20515-1307
     phone: 202-225-5006
     fax: 202-225-5641
@@ -14555,7 +14555,7 @@
     state: CA
     party: Democrat
     district: 17
-    url: http://honda.house.gov
+    url: https://honda.house.gov
     address: 1713 Longworth HOB; Washington DC 20515-0517
     phone: 202-225-2631
     fax: 202-225-2699
@@ -15043,7 +15043,7 @@
     state: VA
     party: Republican
     district: 5
-    url: https://hurt.house.gov/index.cfm/home
+    url: https://hurt.house.gov
     address: 125 Cannon HOB; Washington DC 20515-4605
     phone: 202-225-4711
     fax: 202-225-5681
@@ -16250,7 +16250,7 @@
     state: OH
     party: Democrat
     district: 9
-    url: http://www.kaptur.house.gov
+    url: http://kaptur.house.gov
     address: 2186 Rayburn HOB; Washington DC 20515-3509
     phone: 202-225-4146
     fax: 202-225-7711
@@ -17478,7 +17478,7 @@
     state: CT
     party: Democrat
     district: 1
-    url: http://www.larson.house.gov
+    url: http://larson.house.gov
     address: 1501 Longworth HOB; Washington DC 20515-0701
     phone: 202-225-2265
     fax: 202-225-1031
@@ -18152,7 +18152,7 @@
     state: IL
     party: Democrat
     district: 3
-    url: http://www.lipinski.house.gov
+    url: http://lipinski.house.gov
     address: 2346 Rayburn HOB; Washington DC 20515-1303
     phone: 202-225-5701
     fax: 202-225-1012
@@ -21367,7 +21367,7 @@
     state: SC
     party: Republican
     district: 5
-    url: http://mulvaney.house.gov
+    url: https://mulvaney.house.gov
     address: 2419 Rayburn HOB; Washington DC 20515-4005
     phone: 202-225-5501
     fax: 202-225-0464
@@ -22149,7 +22149,7 @@
     state: SD
     party: Republican
     district: 0
-    url: https://noem.house.gov/index.cfm/home
+    url: https://noem.house.gov
     address: 2422 Rayburn HOB; Washington DC 20515-4100
     phone: 202-225-2801
     fax: 202-225-5823
@@ -23718,7 +23718,7 @@
     state: TX
     party: Republican
     district: 2
-    url: https://poe.house.gov/home
+    url: https://poe.house.gov
     address: 2412 Rayburn HOB; Washington DC 20515-4302
     phone: 202-225-6565
     fax: 202-225-5547
@@ -24213,7 +24213,7 @@
     state: GA
     party: Republican
     district: 6
-    url: http://tomprice.house.gov
+    url: https://tomprice.house.gov
     address: 100 Cannon HOB; Washington DC 20515-1006
     phone: 202-225-4501
     fax: 202-225-4656
@@ -24775,7 +24775,7 @@
     state: OH
     party: Republican
     district: 16
-    url: https://renacci.house.gov/index.cfm/home
+    url: https://renacci.house.gov
     address: 328 Cannon HOB; Washington DC 20515-3516
     phone: 202-225-3876
     fax: 202-225-3059
@@ -28071,7 +28071,7 @@
     state: TX
     party: Republican
     district: 32
-    url: https://sessions.house.gov/index.cfm/home
+    url: https://sessions.house.gov
     address: 2233 Rayburn HOB; Washington DC 20515-4332
     phone: 202-225-2231
     fax: 202-225-5878
@@ -31712,7 +31712,7 @@
     state: VT
     party: Democrat
     district: 0
-    url: http://www.welch.house.gov
+    url: http://welch.house.gov
     address: 2303 Rayburn HOB; Washington DC 20515-4500
     phone: 202-225-4115
     fax: 202-225-6790
@@ -32143,7 +32143,7 @@
     state: VA
     party: Republican
     district: 1
-    url: http://wittman.house.gov
+    url: https://wittman.house.gov
     address: 2454 Rayburn HOB; Washington DC 20515-4601
     phone: 202-225-4261
     fax: 202-225-4382
@@ -33628,7 +33628,7 @@
     office: 1530 Longworth House Office Building
     address: 1530 Longworth HOB; Washington DC 20515-0309
     phone: 202-225-9888
-    url: https://sinema.house.gov/index.cfm/home
+    url: https://sinema.house.gov
     rss_url: http://sinema.house.gov/index.cfm/rss/feed
     contact_form: https://sinemaforms.house.gov/forms/writeyourrep/
     fax: 202-225-9731
@@ -34056,7 +34056,7 @@
     office: 1319 Longworth House Office Building
     address: 1319 Longworth HOB; Washington DC 20515-0536
     phone: 202-225-5330
-    url: http://ruiz.house.gov
+    url: https://ruiz.house.gov
     rss_url: http://ruiz.house.gov/rss.xml
     contact_form: https://ruiz.house.gov/email-me
     fax: 202-225-1238
@@ -34103,7 +34103,7 @@
     office: 1507 Longworth House Office Building
     address: 1507 Longworth HOB; Washington DC 20515-0541
     phone: 202-225-2305
-    url: http://takano.house.gov
+    url: https://takano.house.gov
     rss_url: http://takano.house.gov/rss.xml
     contact_form: https://takano.house.gov/contact/email-me
     fax: 202-225-7018
@@ -37164,7 +37164,7 @@
     state: MA
     party: Democrat
     district: 5
-    url: https://katherineclark.house.gov/index.cfm/home
+    url: https://katherineclark.house.gov
     address: 1721 Longworth HOB; Washington DC 20515-2105
     office: 1721 Longworth House Office Building
     phone: 202-225-2836
@@ -37467,7 +37467,7 @@
     address: 221 Cannon HOB; Washington DC 20515-1310
     office: 221 Cannon House Office Building
     phone: 202-225-4835
-    url: https://dold.house.gov/home
+    url: https://dold.house.gov
 - id:
     bioguide: G000570
     thomas: '02038'

--- a/scripts/house_websites.py
+++ b/scripts/house_websites.py
@@ -37,7 +37,7 @@ def run():
         states.append(state)
 
   destination = "legislators/house.html"
-  url = "http://house.gov/representatives/"
+  url = "http://www.house.gov/representatives/"
   body = utils.download(url, destination, force)
   if not body:
     print("Couldn't download House listing!")
@@ -69,18 +69,26 @@ def run():
 
       url = cells[1].cssselect("a")[0].get("href")
 
-      # hit the URL to resolve any redirects to get the canonical URL,
-      # since the listing on house.gov sometimes gives URLs that redirect.
+      # The House uses subdomains now, and occasionally the directory
+      # uses URLs with some trailing redirected-to page, like /home.
+      # We can safely use the subdomain as the root, to be future-proof
+      # against redirects changing mid-session.
+
+      # We should still follow any redirects, and not just trust the
+      # directory to have the current active subdomain. As an example,
+      # the directory lists randyforbes.house.gov, which redirects to
+      # forbes.house.gov.
       resp = urllib.request.urlopen(url)
       url = resp.geturl()
 
-      # kill trailing slashes
-      url = re.sub("/$", "", url)
+      # kill everything after the domain
+      url = re.sub(".gov/.*$", ".gov", url)
 
       if state == "AQ":
         state = "AS"
       full_district = "%s%02d" % (state, int(district))
       if full_district in by_district:
+        print("[%s] %s" % (full_district, url))
         by_district[full_district]['terms'][-1]['url'] = url
       else:
         print("[%s] No current legislator" % full_district)


### PR DESCRIPTION
House MoC URLs used to occasionally be subpaths, in earlier times, but today they're always subdomains. We can safely omit everything after the `.gov`.

We still don't naively trust the official directory, and follow redirects from whatever domain is given. This has the effect of occasionally fixing out-of-date domains (e.g. the directory lists `randyforbes.house.gov` which redirects to `forbes.house.gov`). 

This also removes some `www` subdomains and moves some URLs to `https://` (though these could also be a function of just not having run this script in a while).

Fixes #300. Thanks to @gmj2053 for reporting this and motivating the fix!