### PR TITLE
Correct term end dates in historical terms, per #7

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -26,44 +26,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: OH
     district: 13
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OH
     district: 13
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OH
     district: 13
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OH
     district: 13
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OH
     district: 13
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 13
     party: Democrat
     url: http://www.house.gov/sherrodbrown
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OH
     district: 13
     party: Democrat
@@ -122,13 +122,13 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: WA
     district: 1
     party: Democrat
   - type: sen
     start: '2001-01-03'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WA
     class: 1
     party: Democrat
@@ -188,62 +188,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MD
     district: 3
     party: Democrat
     url: http://www.house.gov/cardin
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MD
     district: 3
     party: Democrat
@@ -302,37 +302,37 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: DE
     district: 0
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: DE
     district: 0
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: DE
     district: 0
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: DE
     district: 0
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: DE
     district: 0
     party: Democrat
   - type: sen
     start: '2001-01-03'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: DE
     class: 1
     party: Democrat
@@ -492,19 +492,19 @@
   terms:
   - type: sen
     start: '1992-11-10'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     class: 1
     party: Democrat
   - type: sen
     start: '1995-01-04'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     class: 1
     party: Democrat
   - type: sen
     start: '2001-01-03'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     class: 1
     party: Democrat
@@ -563,31 +563,31 @@
   terms:
   - type: sen
     start: '1977-01-04'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: UT
     class: 1
     party: Republican
   - type: sen
     start: '1983-01-03'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: UT
     class: 1
     party: Republican
   - type: sen
     start: '1989-01-03'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: UT
     class: 1
     party: Republican
   - type: sen
     start: '1995-01-04'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: UT
     class: 1
     party: Republican
   - type: sen
     start: '2001-01-03'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: UT
     class: 1
     party: Republican
@@ -750,37 +750,37 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NJ
     district: 13
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NJ
     district: 13
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NJ
     district: 13
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NJ
     district: 13
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NJ
     district: 13
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NJ
     district: 13
     party: Democrat
@@ -794,7 +794,7 @@
     url: http://menendez.house.gov
   - type: sen
     start: '2006-01-18'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     class: 1
     party: Democrat
@@ -852,43 +852,43 @@
   terms:
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: FL
     district: 9
     party: Democrat
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: FL
     district: 9
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: FL
     district: 11
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: FL
     district: 11
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: FL
     district: 11
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: FL
     district: 11
     party: Democrat
   - type: sen
     start: '2001-01-03'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     class: 1
     party: Democrat
@@ -947,50 +947,50 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: VT
     district: 0
     party: Independent
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: VT
     district: 0
     party: Independent
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: VT
     district: 0
     party: Independent
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: VT
     district: 0
     party: Independent
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: VT
     district: 0
     party: Independent
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: VT
     district: 0
     party: Independent
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: VT
     district: 0
     party: Independent
     url: http://bernie.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: VT
     district: 0
     party: Independent
@@ -1051,19 +1051,19 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MI
     district: 8
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MI
     district: 8
     party: Democrat
   - type: sen
     start: '2001-01-03'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MI
     class: 1
     party: Democrat
@@ -1271,38 +1271,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MS
     district: 1
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MS
     district: 1
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MS
     district: 1
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MS
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MS
     district: 1
     party: Republican
     url: http://www.house.gov/wicker
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MS
     district: 1
     party: Republican
@@ -1426,43 +1426,43 @@
   terms:
   - type: rep
     start: '1973-01-03'
-    end: '1974-12-20'
+    end: '1975-01-03'
     state: MS
     district: 4
     party: Republican
   - type: rep
     start: '1975-01-14'
-    end: '1976-10-01'
+    end: '1977-01-03'
     state: MS
     district: 4
     party: Republican
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: MS
     district: 4
     party: Republican
   - type: sen
     start: '1979-01-15'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: MS
     class: 2
     party: Republican
   - type: sen
     start: '1985-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MS
     class: 2
     party: Republican
   - type: sen
     start: '1991-01-03'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MS
     class: 2
     party: Republican
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MS
     class: 2
     party: Republican
@@ -1529,7 +1529,7 @@
   terms:
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: ME
     class: 2
     party: Republican
@@ -1602,7 +1602,7 @@
   terms:
   - type: sen
     start: '2002-01-01'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     class: 2
     party: Republican
@@ -1671,7 +1671,7 @@
   - title: Minority Whip
     chamber: senate
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
   - title: Majority Whip
     chamber: senate
     start: '2007-01-04'
@@ -1694,49 +1694,49 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: IL
     district: 20
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: IL
     district: 20
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: IL
     district: 20
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: IL
     district: 20
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: IL
     district: 20
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: IL
     district: 20
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: IL
     district: 20
     party: Democrat
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IL
     class: 2
     party: Democrat
@@ -1802,7 +1802,7 @@
   terms:
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WY
     class: 2
     party: Republican
@@ -1870,25 +1870,25 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: SC
     district: 3
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: SC
     district: 3
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: SC
     district: 3
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: SC
     district: 3
     party: Republican
@@ -1957,19 +1957,19 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: OK
     district: 1
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: OK
     district: 1
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: OK
     district: 1
     party: Republican
@@ -1981,13 +1981,13 @@
     party: Republican
   - type: sen
     start: '1994-01-01'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OK
     class: 2
     party: Republican
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OK
     class: 2
     party: Republican
@@ -2072,19 +2072,19 @@
   terms:
   - type: sen
     start: '1985-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: KY
     class: 2
     party: Republican
   - type: sen
     start: '1991-01-03'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: KY
     class: 2
     party: Republican
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: KY
     class: 2
     party: Republican
@@ -2204,25 +2204,25 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: RI
     district: 2
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: RI
     district: 2
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: RI
     district: 2
     party: Democrat
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: RI
     class: 2
     party: Democrat
@@ -2338,55 +2338,55 @@
   terms:
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: KS
     district: 1
     party: Republican
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: KS
     class: 2
     party: Republican
@@ -2453,7 +2453,7 @@
   terms:
   - type: sen
     start: '1997-01-07'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: AL
     class: 2
     party: Republican
@@ -2573,26 +2573,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NM
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NM
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NM
     district: 3
     party: Democrat
     url: http://www.house.gov/tomudall
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NM
     district: 3
     party: Democrat
@@ -2935,32 +2935,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: AL
     district: 4
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: AL
     district: 4
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: AL
     district: 4
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AL
     district: 4
     party: Republican
     url: http://www.house.gov/aderholt
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: AL
     district: 4
     party: Republican
@@ -2974,7 +2974,7 @@
     url: http://aderholt.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AL
     district: 4
     party: Republican
@@ -3142,26 +3142,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: WI
     district: 2
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WI
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WI
     district: 2
     party: Democrat
     url: http://tammybaldwin.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WI
     district: 2
     party: Democrat
@@ -3175,7 +3175,7 @@
     url: http://tammybaldwin.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WI
     district: 2
     party: Democrat
@@ -3293,68 +3293,68 @@
   terms:
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 6
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 6
     party: Republican
     url: http://www.house.gov/barton
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 6
     party: Republican
@@ -3368,7 +3368,7 @@
     url: http://joebarton.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 6
     party: Republican
@@ -3496,44 +3496,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 30
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 30
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 30
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 30
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 30
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 31
     party: Democrat
     url: http://www.house.gov/becerra
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 31
     party: Democrat
@@ -3547,7 +3547,7 @@
     url: http://becerra.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 31
     party: Democrat
@@ -3676,7 +3676,7 @@
   terms:
   - type: sen
     start: '2009-01-22'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CO
     class: 3
     party: Democrat
@@ -3728,7 +3728,7 @@
     url: http://bilirakis.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 9
     party: Republican
@@ -3800,14 +3800,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: UT
     district: 1
     party: Republican
     url: http://www.house.gov/robbishop
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: UT
     district: 1
     party: Republican
@@ -3821,7 +3821,7 @@
     url: http://www.house.gov/robbishop
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: UT
     district: 1
     party: Republican
@@ -3891,44 +3891,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: GA
     district: 2
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: GA
     district: 2
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: GA
     district: 2
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: GA
     district: 2
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: GA
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: GA
     district: 2
     party: Democrat
     url: http://www.house.gov/bishop
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: GA
     district: 2
     party: Democrat
@@ -3942,7 +3942,7 @@
     url: http://bishop.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     district: 2
     party: Democrat
@@ -4071,14 +4071,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TN
     district: 7
     party: Republican
     url: http://www.house.gov/blackburn
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TN
     district: 7
     party: Republican
@@ -4092,7 +4092,7 @@
     url: http://www.house.gov/blackburn
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TN
     district: 7
     party: Republican
@@ -4160,38 +4160,38 @@
   terms:
   - type: rep
     start: '1996-05-21'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OR
     district: 3
     party: Democrat
     url: http://www.house.gov/blumenauer
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OR
     district: 3
     party: Democrat
@@ -4205,7 +4205,7 @@
     url: http://blumenauer.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OR
     district: 3
     party: Democrat
@@ -4313,32 +4313,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MO
     district: 7
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MO
     district: 7
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MO
     district: 7
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MO
     district: 7
     party: Republican
     url: http://www.house.gov/blunt
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MO
     district: 7
     party: Republican
@@ -4352,7 +4352,7 @@
     url: http://www.house.gov/blunt
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MO
     district: 7
     party: Republican
@@ -4410,50 +4410,50 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: OH
     district: 8
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: OH
     district: 8
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OH
     district: 8
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OH
     district: 8
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OH
     district: 8
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OH
     district: 8
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 8
     party: Republican
     url: http://johnboehner.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OH
     district: 8
     party: Republican
@@ -4467,7 +4467,7 @@
     url: http://johnboehner.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 8
     party: Republican
@@ -4537,20 +4537,20 @@
   terms:
   - type: rep
     start: '2001-11-29'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: AR
     district: 3
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AR
     district: 3
     party: Republican
     url: http://www.house.gov/boozman
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: AR
     district: 3
     party: Republican
@@ -4564,7 +4564,7 @@
     url: http://www.house.gov/boozman
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AR
     district: 3
     party: Republican
@@ -4607,14 +4607,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: GU
     district: 0
     party: Democrat
     url: http://www.house.gov/bordallo
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: GU
     district: 0
     party: Democrat
@@ -4628,7 +4628,7 @@
     url: http://www.house.gov/bordallo
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GU
     district: 0
     party: Democrat
@@ -4698,7 +4698,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: LA
     district: 7
     party: Republican
@@ -4711,7 +4711,7 @@
     url: http://www.house.gov/boustany
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: LA
     district: 7
     party: Republican
@@ -4783,50 +4783,50 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: CA
     district: 6
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: CA
     district: 6
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: CA
     district: 6
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: CA
     district: 6
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: CA
     district: 6
     party: Democrat
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     class: 3
     party: Democrat
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     class: 3
     party: Democrat
     url: http://boxer.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     class: 3
     party: Democrat
@@ -4870,32 +4870,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 8
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 8
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 8
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 8
     party: Republican
     url: http://www.house.gov/brady
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 8
     party: Republican
@@ -4909,7 +4909,7 @@
     url: http://www.house.gov/brady
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 8
     party: Republican
@@ -4978,32 +4978,32 @@
   terms:
   - type: rep
     start: '1998-05-19'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: PA
     district: 1
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: PA
     district: 1
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: PA
     district: 1
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: PA
     district: 1
     party: Democrat
     url: http://www.house.gov/robertbrady
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 1
     party: Democrat
@@ -5017,7 +5017,7 @@
     url: http://www.house.gov/robertbrady
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 1
     party: Democrat
@@ -5147,44 +5147,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: FL
     district: 3
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: FL
     district: 3
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: FL
     district: 3
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: FL
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: FL
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: FL
     district: 3
     party: Democrat
     url: http://www.house.gov/corrinebrown
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 3
     party: Democrat
@@ -5198,7 +5198,7 @@
     url: http://www.house.gov/corrinebrown
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 3
     party: Democrat
@@ -5273,7 +5273,7 @@
     url: http://buchanan.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 13
     party: Republican
@@ -5402,14 +5402,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 26
     party: Republican
     url: http://www.house.gov/burgess
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 26
     party: Republican
@@ -5423,7 +5423,7 @@
     url: http://burgess.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 26
     party: Republican
@@ -5495,38 +5495,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NC
     district: 5
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NC
     district: 5
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NC
     district: 5
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NC
     district: 5
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NC
     district: 5
     party: Republican
     url: http://www.house.gov/burr
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NC
     class: 3
     party: Republican
@@ -5574,14 +5574,14 @@
   terms:
   - type: rep
     start: '2004-07-21'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NC
     district: 1
     party: Democrat
     url: http://www.house.gov/butterfield/
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NC
     district: 1
     party: Democrat
@@ -5594,7 +5594,7 @@
     url: http://www.house.gov/butterfield
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NC
     district: 1
     party: Democrat
@@ -5663,44 +5663,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 43
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 43
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 43
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 43
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 43
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 44
     party: Republican
     url: http://www.house.gov/calvert
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 44
     party: Republican
@@ -5714,7 +5714,7 @@
     url: http://calvert.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 44
     party: Republican
@@ -5786,20 +5786,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WV
     district: 2
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WV
     district: 2
     party: Republican
     url: http://www.house.gov/capito
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WV
     district: 2
     party: Republican
@@ -5813,7 +5813,7 @@
     url: http://capito.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WV
     district: 2
     party: Republican
@@ -5882,32 +5882,32 @@
   terms:
   - type: rep
     start: '1998-03-10'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 22
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 22
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 22
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 23
     party: Democrat
     url: http://www.house.gov/capps
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 23
     party: Democrat
@@ -5921,7 +5921,7 @@
     url: http://www.house.gov/capps
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 23
     party: Democrat
@@ -5995,26 +5995,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MA
     district: 8
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MA
     district: 8
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MA
     district: 8
     party: Democrat
     url: http://www.house.gov/capuano
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MA
     district: 8
     party: Democrat
@@ -6028,7 +6028,7 @@
     url: http://www.house.gov/capuano
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MA
     district: 8
     party: Democrat
@@ -6163,7 +6163,7 @@
     url: http://carson.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IN
     district: 7
     party: Democrat
@@ -6236,14 +6236,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 31
     party: Republican
     url: http://www.house.gov/carter
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 31
     party: Republican
@@ -6257,7 +6257,7 @@
     url: http://carter.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 31
     party: Republican
@@ -6326,7 +6326,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: LA
     district: 6
     party: Republican
@@ -6400,7 +6400,7 @@
     url: http://castor.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 11
     party: Democrat
@@ -6470,38 +6470,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OH
     district: 1
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OH
     district: 1
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OH
     district: 1
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OH
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 1
     party: Republican
     url: http://www.house.gov/chabot
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OH
     district: 1
     party: Republican
@@ -6575,7 +6575,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: UT
     district: 3
     party: Republican
@@ -6643,7 +6643,7 @@
   terms:
   - type: rep
     start: '2009-07-16'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 32
     party: Democrat
@@ -6780,7 +6780,7 @@
     url: http://clarke.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 11
     party: Democrat
@@ -6850,20 +6850,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MO
     district: 1
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MO
     district: 1
     party: Democrat
     url: http://www.house.gov/clay
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MO
     district: 1
     party: Democrat
@@ -6877,7 +6877,7 @@
     url: http://www.house.gov/clay
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MO
     district: 1
     party: Democrat
@@ -6946,7 +6946,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MO
     district: 5
     party: Democrat
@@ -6959,7 +6959,7 @@
     url: http://www.house.gov/cleaver
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MO
     district: 5
     party: Democrat
@@ -7030,44 +7030,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: SC
     district: 6
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: SC
     district: 6
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: SC
     district: 6
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: SC
     district: 6
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: SC
     district: 6
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: SC
     district: 6
     party: Democrat
     url: http://www.house.gov/clyburn
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: SC
     district: 6
     party: Democrat
@@ -7081,7 +7081,7 @@
     url: http://clyburn.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: SC
     district: 6
     party: Democrat
@@ -7154,37 +7154,37 @@
   terms:
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: IN
     district: 4
     party: Republican
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: IN
     district: 4
     party: Republican
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: IN
     district: 4
     party: Republican
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: IN
     district: 4
     party: Republican
   - type: sen
     start: '1989-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: IN
     class: 3
     party: Republican
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: IN
     class: 3
     party: Republican
@@ -7228,7 +7228,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CO
     district: 6
     party: Republican
@@ -7302,7 +7302,7 @@
     url: http://cohen.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TN
     district: 9
     party: Democrat
@@ -7371,14 +7371,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OK
     district: 4
     party: Republican
     url: http://www.house.gov/cole
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OK
     district: 4
     party: Republican
@@ -7392,7 +7392,7 @@
     url: http://www.house.gov/cole
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OK
     district: 4
     party: Republican
@@ -7463,7 +7463,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 11
     party: Republican
@@ -7476,7 +7476,7 @@
     url: http://www.house.gov/conaway
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 11
     party: Republican
@@ -7542,7 +7542,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: VA
     district: 11
     party: Democrat
@@ -7612,128 +7612,128 @@
   terms:
   - type: rep
     start: '1965-01-04'
-    end: '1966-10-22'
+    end: '1967-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1967-01-10'
-    end: '1968-10-14'
+    end: '1969-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1969-01-03'
-    end: '1971-01-02'
+    end: '1971-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1971-01-21'
-    end: '1972-10-18'
+    end: '1973-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1973-01-03'
-    end: '1974-12-20'
+    end: '1975-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1975-01-14'
-    end: '1976-10-01'
+    end: '1977-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MI
     district: 1
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MI
     district: 14
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MI
     district: 14
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MI
     district: 14
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MI
     district: 14
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MI
     district: 14
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MI
     district: 14
     party: Democrat
     url: http://www.house.gov/conyers
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MI
     district: 14
     party: Democrat
@@ -7747,7 +7747,7 @@
     url: http://www.house.gov/conyers
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MI
     district: 14
     party: Democrat
@@ -7818,50 +7818,50 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: TN
     district: 4
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: TN
     district: 4
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: TN
     district: 4
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: TN
     district: 4
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: TN
     district: 4
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: TN
     district: 4
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TN
     district: 5
     party: Democrat
     url: http://www.house.gov/cooper
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TN
     district: 5
     party: Democrat
@@ -7875,7 +7875,7 @@
     url: http://cooper.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TN
     district: 5
     party: Democrat
@@ -7942,7 +7942,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 20
     party: Democrat
@@ -7955,7 +7955,7 @@
     url: http://www.house.gov/costa
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 20
     party: Democrat
@@ -8030,7 +8030,7 @@
     url: http://courtney.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CT
     district: 2
     party: Democrat
@@ -8102,32 +8102,32 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: ID
     district: 2
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: ID
     district: 2
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: ID
     district: 2
     party: Republican
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: ID
     class: 3
     party: Republican
     url: http://crapo.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: ID
     class: 3
     party: Republican
@@ -8233,20 +8233,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: FL
     district: 4
     party: Independent
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: FL
     district: 4
     party: Republican
     url: http://crenshaw.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 4
     party: Republican
@@ -8260,7 +8260,7 @@
     url: http://crenshaw.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 4
     party: Republican
@@ -8328,26 +8328,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 7
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 7
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 7
     party: Democrat
     url: http://www.house.gov/crowley
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 7
     party: Democrat
@@ -8361,7 +8361,7 @@
     url: http://www.house.gov/crowley
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 7
     party: Democrat
@@ -8429,7 +8429,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 28
     party: Democrat
@@ -8442,7 +8442,7 @@
     url: http://www.house.gov/cuellar
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 28
     party: Democrat
@@ -8512,20 +8512,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 7
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 7
     party: Republican
     url: http://www.culberson.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 7
     party: Republican
@@ -8539,7 +8539,7 @@
     url: http://culberson.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 7
     party: Republican
@@ -8609,38 +8609,38 @@
   terms:
   - type: rep
     start: '1996-04-16'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MD
     district: 7
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MD
     district: 7
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MD
     district: 7
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MD
     district: 7
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MD
     district: 7
     party: Democrat
     url: http://www.house.gov/cummings
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MD
     district: 7
     party: Democrat
@@ -8654,7 +8654,7 @@
     url: http://www.house.gov/cummings
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MD
     district: 7
     party: Democrat
@@ -8724,32 +8724,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: IL
     district: 7
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: IL
     district: 7
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IL
     district: 7
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IL
     district: 7
     party: Democrat
     url: http://www.house.gov/davis
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IL
     district: 7
     party: Democrat
@@ -8763,7 +8763,7 @@
     url: http://www.house.gov/davis
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 7
     party: Democrat
@@ -8832,20 +8832,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 49
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 53
     party: Democrat
     url: http://www.house.gov/susandavis
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 53
     party: Democrat
@@ -8859,7 +8859,7 @@
     url: http://www.house.gov/susandavis
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 53
     party: Democrat
@@ -8928,62 +8928,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OR
     district: 4
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OR
     district: 4
     party: Democrat
     url: http://www.house.gov/defazio/
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OR
     district: 4
     party: Democrat
@@ -8997,7 +8997,7 @@
     url: http://defazio.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OR
     district: 4
     party: Democrat
@@ -9065,32 +9065,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CO
     district: 1
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CO
     district: 1
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CO
     district: 1
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CO
     district: 1
     party: Democrat
     url: http://www.house.gov/degette
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CO
     district: 1
     party: Democrat
@@ -9104,7 +9104,7 @@
     url: http://www.house.gov/degette
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CO
     district: 1
     party: Democrat
@@ -9174,50 +9174,50 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: CT
     district: 3
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CT
     district: 3
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CT
     district: 3
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CT
     district: 3
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CT
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CT
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CT
     district: 3
     party: Democrat
     url: http://www.house.gov/delauro
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CT
     district: 3
     party: Democrat
@@ -9231,7 +9231,7 @@
     url: http://www.house.gov/delauro
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CT
     district: 3
     party: Democrat
@@ -9359,7 +9359,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 15
     party: Republican
@@ -9372,7 +9372,7 @@
     url: http://dent.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 15
     party: Republican
@@ -9500,7 +9500,7 @@
   terms:
   - type: rep
     start: '2010-04-15'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 19
     party: Democrat
@@ -9569,14 +9569,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: FL
     district: 25
     party: Republican
     url: http://www.house.gov/mariodiaz-balart
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 25
     party: Republican
@@ -9590,7 +9590,7 @@
     url: http://www.house.gov/mariodiaz-balart
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 25
     party: Republican
@@ -9662,38 +9662,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 10
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 10
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 10
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 10
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 10
     party: Democrat
     url: http://www.house.gov/doggett
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 25
     party: Democrat
@@ -9707,7 +9707,7 @@
     url: http://www.house.gov/doggett
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 25
     party: Democrat
@@ -9784,7 +9784,7 @@
     url: http://donnelly.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IN
     district: 2
     party: Democrat
@@ -9844,38 +9844,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: PA
     district: 18
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: PA
     district: 18
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: PA
     district: 18
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: PA
     district: 18
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: PA
     district: 14
     party: Democrat
     url: http://www.house.gov/doyle
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 14
     party: Democrat
@@ -9889,7 +9889,7 @@
     url: http://www.house.gov/doyle
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 14
     party: Democrat
@@ -10086,56 +10086,56 @@
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: TN
     district: 2
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: TN
     district: 2
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: TN
     district: 2
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TN
     district: 2
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TN
     district: 2
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TN
     district: 2
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TN
     district: 2
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TN
     district: 2
     party: Republican
     url: http://www.house.gov/duncan
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TN
     district: 2
     party: Republican
@@ -10149,7 +10149,7 @@
     url: http://www.house.gov/duncan/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TN
     district: 2
     party: Republican
@@ -10227,7 +10227,7 @@
     url: http://donnaedwards.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MD
     district: 4
     party: Democrat
@@ -10303,7 +10303,7 @@
     url: http://ellison.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MN
     district: 5
     party: Democrat
@@ -10433,56 +10433,56 @@
   terms:
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NY
     district: 19
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NY
     district: 19
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 17
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 17
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 17
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 17
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 17
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 17
     party: Democrat
     url: http://www.house.gov/engel
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 17
     party: Democrat
@@ -10496,7 +10496,7 @@
     url: http://www.house.gov/engel
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 17
     party: Democrat
@@ -10563,44 +10563,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 14
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 14
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 14
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 14
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 14
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 14
     party: Democrat
     url: http://www-eshoo.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 14
     party: Democrat
@@ -10614,7 +10614,7 @@
     url: http://eshoo.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 14
     party: Democrat
@@ -10742,44 +10742,44 @@
   terms:
   - type: rep
     start: '1993-06-08'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 17
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 17
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 17
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 17
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 17
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 17
     party: Democrat
     url: http://www.house.gov/farr
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 17
     party: Democrat
@@ -10793,7 +10793,7 @@
     url: http://www.house.gov/farr
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 17
     party: Democrat
@@ -10862,38 +10862,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: PA
     district: 2
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: PA
     district: 2
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: PA
     district: 2
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: PA
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: PA
     district: 2
     party: Democrat
     url: http://www.house.gov/fattah
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 2
     party: Democrat
@@ -10907,7 +10907,7 @@
     url: http://www.house.gov/fattah
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 2
     party: Democrat
@@ -11035,7 +11035,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 8
     party: Republican
@@ -11104,20 +11104,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: AZ
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AZ
     district: 6
     party: Republican
     url: http://www.house.gov/flake
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: AZ
     district: 6
     party: Republican
@@ -11131,7 +11131,7 @@
     url: http://flake.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AZ
     district: 6
     party: Republican
@@ -11248,7 +11248,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: LA
     district: 4
     party: Republican
@@ -11382,20 +11382,20 @@
   terms:
   - type: rep
     start: '2001-06-26'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: VA
     district: 4
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: VA
     district: 4
     party: Republican
     url: http://www.house.gov/forbes
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: VA
     district: 4
     party: Republican
@@ -11409,7 +11409,7 @@
     url: http://www.house.gov/forbes
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: VA
     district: 4
     party: Republican
@@ -11478,7 +11478,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NE
     district: 1
     party: Republican
@@ -11491,7 +11491,7 @@
     url: http://fortenberry.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NE
     district: 1
     party: Republican
@@ -11560,7 +11560,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NC
     district: 5
     party: Republican
@@ -11573,7 +11573,7 @@
     url: http://foxx.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NC
     district: 5
     party: Republican
@@ -11642,14 +11642,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AZ
     district: 2
     party: Republican
     url: http://www.house.gov/franks
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: AZ
     district: 2
     party: Republican
@@ -11663,7 +11663,7 @@
     url: http://www.house.gov/franks
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AZ
     district: 2
     party: Republican
@@ -11732,38 +11732,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NJ
     district: 11
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NJ
     district: 11
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NJ
     district: 11
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NJ
     district: 11
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NJ
     district: 11
     party: Republican
     url: http://www.house.gov/frelinghuysen
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     district: 11
     party: Republican
@@ -11777,7 +11777,7 @@
     url: http://frelinghuysen.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 11
     party: Republican
@@ -11860,7 +11860,7 @@
     url: http://fudge.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 11
     party: Democrat
@@ -11927,7 +11927,7 @@
   terms:
   - type: rep
     start: '2009-11-03'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 10
     party: Democrat
@@ -12053,14 +12053,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NJ
     district: 5
     party: Republican
     url: http://www.house.gov/garrett
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     district: 5
     party: Republican
@@ -12074,7 +12074,7 @@
     url: http://garrett.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 5
     party: Republican
@@ -12265,7 +12265,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 1
     party: Republican
@@ -12278,7 +12278,7 @@
     url: http://gohmert.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 1
     party: Republican
@@ -12348,44 +12348,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: VA
     district: 6
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: VA
     district: 6
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: VA
     district: 6
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: VA
     district: 6
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: VA
     district: 6
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: VA
     district: 6
     party: Republican
     url: http://www.house.gov/goodlatte
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: VA
     district: 6
     party: Republican
@@ -12399,7 +12399,7 @@
     url: http://www.house.gov/goodlatte
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: VA
     district: 6
     party: Republican
@@ -12588,32 +12588,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 12
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 12
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 12
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 12
     party: Republican
     url: http://kaygranger.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 12
     party: Republican
@@ -12627,7 +12627,7 @@
     url: http://kaygranger.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 12
     party: Republican
@@ -12699,50 +12699,50 @@
   terms:
   - type: rep
     start: '1975-01-14'
-    end: '1976-10-01'
+    end: '1977-01-03'
     state: IA
     district: 3
     party: Republican
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: IA
     district: 3
     party: Republican
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: IA
     district: 3
     party: Republican
   - type: sen
     start: '1981-01-05'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: IA
     class: 3
     party: Republican
   - type: sen
     start: '1987-01-06'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: IA
     class: 3
     party: Republican
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: IA
     class: 3
     party: Republican
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IA
     class: 3
     party: Republican
     url: http://grassley.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IA
     class: 3
     party: Republican
@@ -12787,20 +12787,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MO
     district: 6
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MO
     district: 6
     party: Republican
     url: http://www.house.gov/graves
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MO
     district: 6
     party: Republican
@@ -12814,7 +12814,7 @@
     url: http://www.house.gov/graves
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MO
     district: 6
     party: Republican
@@ -12882,7 +12882,7 @@
   terms:
   - type: rep
     start: '2010-06-08'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     district: 9
     party: Republican
@@ -12951,7 +12951,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 9
     party: Democrat
@@ -12964,7 +12964,7 @@
     url: http://www.house.gov/algreen
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 9
     party: Democrat
@@ -13033,44 +13033,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: TX
     district: 29
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 29
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 29
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 29
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 29
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 29
     party: Democrat
     url: http://www.house.gov/green
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 29
     party: Democrat
@@ -13084,7 +13084,7 @@
     url: http://www.house.gov/green
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 29
     party: Democrat
@@ -13215,14 +13215,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AZ
     district: 7
     party: Democrat
     url: http://www.house.gov/grijalva
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: AZ
     district: 7
     party: Democrat
@@ -13236,7 +13236,7 @@
     url: http://www.house.gov/grijalva
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AZ
     district: 7
     party: Democrat
@@ -13304,7 +13304,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: KY
     district: 2
     party: Republican
@@ -13374,44 +13374,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: IL
     district: 4
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: IL
     district: 4
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: IL
     district: 4
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: IL
     district: 4
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IL
     district: 4
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IL
     district: 4
     party: Democrat
     url: http://www.house.gov/gutierrez
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IL
     district: 4
     party: Democrat
@@ -13425,7 +13425,7 @@
     url: http://www.house.gov/gutierrez
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 4
     party: Democrat
@@ -13552,7 +13552,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MS
     district: 3
     party: Republican
@@ -13741,44 +13741,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: FL
     district: 23
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: FL
     district: 23
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: FL
     district: 23
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: FL
     district: 23
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: FL
     district: 23
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: FL
     district: 23
     party: Democrat
     url: http://www.house.gov/alceehastings
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 23
     party: Democrat
@@ -13792,7 +13792,7 @@
     url: http://alceehastings.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 23
     party: Democrat
@@ -13923,7 +13923,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NM
     district: 1
     party: Democrat
@@ -13979,14 +13979,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 5
     party: Republican
     url: http://www.house.gov/hensarling
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 5
     party: Republican
@@ -14000,7 +14000,7 @@
     url: http://www.house.gov/hensarling
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 5
     party: Republican
@@ -14128,7 +14128,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 27
     party: Democrat
@@ -14141,7 +14141,7 @@
     url: http://www.house.gov/higgins
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 27
     party: Democrat
@@ -14210,7 +14210,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CT
     district: 4
     party: Democrat
@@ -14280,32 +14280,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 15
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 15
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 15
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 15
     party: Democrat
     url: http://www.house.gov/hinojosa
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 15
     party: Democrat
@@ -14319,7 +14319,7 @@
     url: http://hinojosa.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 15
     party: Democrat
@@ -14397,7 +14397,7 @@
     url: http://hirono.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: HI
     district: 2
     party: Democrat
@@ -14492,20 +14492,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 15
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 15
     party: Democrat
     url: http://www.house.gov/honda
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 15
     party: Democrat
@@ -14519,7 +14519,7 @@
     url: http://www.house.gov/honda
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 15
     party: Democrat
@@ -14590,11 +14590,11 @@
   - title: Minority Whip
     chamber: house
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
   - title: Minority Whip
     chamber: house
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
   - title: Minority Whip
     chamber: house
     start: '2011-01-05'
@@ -14609,80 +14609,80 @@
   terms:
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MD
     district: 5
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MD
     district: 5
     party: Democrat
     url: http://www.house.gov/hoyer
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MD
     district: 5
     party: Democrat
@@ -14696,7 +14696,7 @@
     url: http://hoyer.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MD
     district: 5
     party: Democrat
@@ -14944,7 +14944,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 52
     party: Republican
@@ -15080,26 +15080,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: GA
     district: 6
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: GA
     district: 6
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: GA
     district: 6
     party: Republican
     url: http://isakson.house.gov
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     class: 3
     party: Republican
@@ -15145,20 +15145,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 2
     party: Democrat
     url: http://www.house.gov/israel
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 2
     party: Democrat
@@ -15172,7 +15172,7 @@
     url: http://www.house.gov/israel
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 2
     party: Democrat
@@ -15242,20 +15242,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 48
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 49
     party: Republican
     url: http://www.house.gov/issa
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 49
     party: Republican
@@ -15269,7 +15269,7 @@
     url: http://www.house.gov/issa
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 49
     party: Republican
@@ -15337,38 +15337,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 18
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 18
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 18
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 18
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 18
     party: Democrat
     url: http://www.house.gov/jacksonlee
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 18
     party: Democrat
@@ -15382,7 +15382,7 @@
     url: http://www.jacksonlee.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 18
     party: Democrat
@@ -15450,7 +15450,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: KS
     district: 2
     party: Republican
@@ -15579,44 +15579,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: TX
     district: 30
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 30
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 30
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 30
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 30
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 30
     party: Democrat
     url: http://www.house.gov/ebjohnson
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 30
     party: Democrat
@@ -15630,7 +15630,7 @@
     url: http://www.house.gov/ebjohnson
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 30
     party: Democrat
@@ -15708,7 +15708,7 @@
     url: http://hankjohnson.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     district: 4
     party: Democrat
@@ -15814,50 +15814,50 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: TX
     district: 3
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: TX
     district: 3
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 3
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 3
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 3
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 3
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 3
     party: Republican
     url: http://www.house.gov/samjohnson
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 3
     party: Republican
@@ -15871,7 +15871,7 @@
     url: http://www.house.gov/samjohnson
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 3
     party: Republican
@@ -15942,38 +15942,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NC
     district: 3
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NC
     district: 3
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NC
     district: 3
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NC
     district: 3
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NC
     district: 3
     party: Republican
     url: http://jones.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NC
     district: 3
     party: Republican
@@ -15987,7 +15987,7 @@
     url: http://jones.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NC
     district: 3
     party: Republican
@@ -16065,7 +16065,7 @@
     url: http://jordan.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 4
     party: Republican
@@ -16133,74 +16133,74 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OH
     district: 9
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 9
     party: Democrat
     url: http://www.house.gov/kaptur
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OH
     district: 9
     party: Democrat
@@ -16214,7 +16214,7 @@
     url: http://kaptur.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 9
     party: Democrat
@@ -16404,32 +16404,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: WI
     district: 3
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: WI
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WI
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WI
     district: 3
     party: Democrat
     url: http://www.house.gov/kind
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WI
     district: 3
     party: Democrat
@@ -16443,7 +16443,7 @@
     url: http://www.house.gov/kind
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WI
     district: 3
     party: Democrat
@@ -16514,44 +16514,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 3
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 3
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 3
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 3
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 3
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 3
     party: Republican
     url: http://www.house.gov/king
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 3
     party: Republican
@@ -16565,7 +16565,7 @@
     url: http://peteking.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 3
     party: Republican
@@ -16635,14 +16635,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IA
     district: 5
     party: Republican
     url: http://www.house.gov/steveking
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IA
     district: 5
     party: Republican
@@ -16656,7 +16656,7 @@
     url: http://www.house.gov/steveking
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IA
     district: 5
     party: Republican
@@ -16787,20 +16787,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IL
     district: 10
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IL
     district: 10
     party: Republican
     url: http://www.house.gov/kirk
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IL
     district: 10
     party: Republican
@@ -16821,7 +16821,7 @@
     url: http://www.house.gov/kirk
   - type: sen
     start: '2010-11-29'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     class: 3
     party: Republican
@@ -16866,14 +16866,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MN
     district: 2
     party: Republican
     url: http://www.house.gov/kline
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MN
     district: 2
     party: Republican
@@ -16887,7 +16887,7 @@
     url: http://kline.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MN
     district: 2
     party: Republican
@@ -17023,7 +17023,7 @@
     url: http://lamborn.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CO
     district: 5
     party: Republican
@@ -17091,7 +17091,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 7
     party: Republican
@@ -17161,20 +17161,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: RI
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: RI
     district: 2
     party: Democrat
     url: http://www.house.gov/langevin
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: RI
     district: 2
     party: Democrat
@@ -17188,7 +17188,7 @@
     url: http://www.house.gov/langevin
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: RI
     district: 2
     party: Democrat
@@ -17313,20 +17313,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WA
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WA
     district: 2
     party: Democrat
     url: http://www.house.gov/larsen
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WA
     district: 2
     party: Democrat
@@ -17340,7 +17340,7 @@
     url: http://www.house.gov/larsen
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WA
     district: 2
     party: Democrat
@@ -17409,26 +17409,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CT
     district: 1
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CT
     district: 1
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CT
     district: 1
     party: Democrat
     url: http://www.house.gov/larson
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CT
     district: 1
     party: Democrat
@@ -17442,7 +17442,7 @@
     url: http://www.house.gov/larson
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CT
     district: 1
     party: Democrat
@@ -17518,7 +17518,7 @@
     url: http://latta.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 5
     party: Republican
@@ -17591,38 +17591,38 @@
   terms:
   - type: sen
     start: '1975-01-14'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: VT
     class: 3
     party: Democrat
   - type: sen
     start: '1981-01-05'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: VT
     class: 3
     party: Democrat
   - type: sen
     start: '1987-01-06'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: VT
     class: 3
     party: Democrat
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: VT
     class: 3
     party: Democrat
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: VT
     class: 3
     party: Democrat
     url: http://leahy.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: VT
     class: 3
     party: Democrat
@@ -17666,32 +17666,32 @@
   terms:
   - type: rep
     start: '1998-04-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 9
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 9
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 9
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 9
     party: Democrat
     url: http://www.house.gov/lee
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 9
     party: Democrat
@@ -17705,7 +17705,7 @@
     url: http://lee.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 9
     party: Democrat
@@ -17811,74 +17811,74 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: MI
     district: 17
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: MI
     district: 17
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: MI
     district: 17
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MI
     district: 17
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MI
     district: 17
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MI
     district: 12
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MI
     district: 12
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MI
     district: 12
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MI
     district: 12
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MI
     district: 12
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MI
     district: 12
     party: Democrat
     url: http://www.house.gov/levin
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MI
     district: 12
     party: Democrat
@@ -17892,7 +17892,7 @@
     url: http://www.house.gov/levin
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MI
     district: 12
     party: Democrat
@@ -17965,62 +17965,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: GA
     district: 5
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: GA
     district: 5
     party: Democrat
     url: http://www.house.gov/johnlewis
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: GA
     district: 5
     party: Democrat
@@ -18034,7 +18034,7 @@
     url: http://www.house.gov/johnlewis
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     district: 5
     party: Democrat
@@ -18103,7 +18103,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IL
     district: 3
     party: Democrat
@@ -18116,7 +18116,7 @@
     url: http://www.lipinski.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 3
     party: Democrat
@@ -18189,38 +18189,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NJ
     district: 2
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NJ
     district: 2
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NJ
     district: 2
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NJ
     district: 2
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NJ
     district: 2
     party: Republican
     url: http://www.house.gov/lobiondo
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     district: 2
     party: Republican
@@ -18234,7 +18234,7 @@
     url: http://www.house.gov/lobiondo
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 2
     party: Republican
@@ -18309,7 +18309,7 @@
     url: http://loebsack.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IA
     district: 2
     party: Democrat
@@ -18378,38 +18378,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 16
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 16
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 16
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 16
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 16
     party: Democrat
     url: http://zoelofgren.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 16
     party: Democrat
@@ -18423,7 +18423,7 @@
     url: http://www.house.gov/lofgren
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 16
     party: Democrat
@@ -18552,56 +18552,56 @@
   terms:
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NY
     district: 20
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NY
     district: 20
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 18
     party: Democrat
     url: http://www.house.gov/lowey
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 18
     party: Democrat
@@ -18615,7 +18615,7 @@
     url: http://www.house.gov/lowey
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 18
     party: Democrat
@@ -18685,44 +18685,44 @@
   terms:
   - type: rep
     start: '1993-05-10'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: OK
     district: 6
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OK
     district: 6
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OK
     district: 6
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OK
     district: 6
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OK
     district: 6
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OK
     district: 3
     party: Republican
     url: http://www.house.gov/lucas
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OK
     district: 3
     party: Republican
@@ -18736,7 +18736,7 @@
     url: http://www.house.gov/lucas
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OK
     district: 3
     party: Republican
@@ -18803,7 +18803,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MO
     district: 9
     party: Republican
@@ -18871,7 +18871,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NM
     district: 3
     party: Democrat
@@ -18940,7 +18940,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WY
     district: 0
     party: Republican
@@ -19010,20 +19010,20 @@
   terms:
   - type: rep
     start: '2001-10-23'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MA
     district: 9
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MA
     district: 9
     party: Democrat
     url: http://www.house.gov/lynch
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MA
     district: 9
     party: Democrat
@@ -19037,7 +19037,7 @@
     url: http://www.house.gov/lynch
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MA
     district: 9
     party: Democrat
@@ -19107,44 +19107,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 14
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 14
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 14
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 14
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 14
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 14
     party: Democrat
     url: http://www.house.gov/maloney
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 14
     party: Democrat
@@ -19158,7 +19158,7 @@
     url: http://maloney.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 14
     party: Democrat
@@ -19227,7 +19227,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 24
     party: Republican
@@ -19240,7 +19240,7 @@
     url: http://www.house.gov/marchant
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 24
     party: Republican
@@ -19373,98 +19373,98 @@
   terms:
   - type: rep
     start: '1975-01-14'
-    end: '1976-10-01'
+    end: '1977-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MA
     district: 7
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MA
     district: 7
     party: Democrat
     url: http://www.house.gov/markey
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MA
     district: 7
     party: Democrat
@@ -19478,7 +19478,7 @@
     url: http://www.house.gov/markey
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MA
     district: 7
     party: Democrat
@@ -19557,7 +19557,7 @@
   terms:
   - type: rep
     start: '2005-03-10'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 5
     party: Democrat
@@ -19570,7 +19570,7 @@
     url: http://www.house.gov/matsui
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 5
     party: Democrat
@@ -19645,38 +19645,38 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: AZ
     district: 1
     party: Republican
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: AZ
     district: 1
     party: Republican
   - type: sen
     start: '1987-01-06'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: AZ
     class: 3
     party: Republican
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: AZ
     class: 3
     party: Republican
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AZ
     class: 3
     party: Republican
     url: http://mccain.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AZ
     class: 3
     party: Republican
@@ -19743,7 +19743,7 @@
     url: http://kevinmccarthy.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 22
     party: Republican
@@ -19813,7 +19813,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 10
     party: Republican
@@ -19826,7 +19826,7 @@
     url: http://www.house.gov/mccaul
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 10
     party: Republican
@@ -19892,7 +19892,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 4
     party: Republican
@@ -19962,20 +19962,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MN
     district: 4
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MN
     district: 4
     party: Democrat
     url: http://www.house.gov/mccollum
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MN
     district: 4
     party: Democrat
@@ -19989,7 +19989,7 @@
     url: http://www.house.gov/mccollum
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MN
     district: 4
     party: Democrat
@@ -20058,56 +20058,56 @@
   terms:
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: WA
     district: 7
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: WA
     district: 7
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: WA
     district: 7
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: WA
     district: 7
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: WA
     district: 7
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: WA
     district: 7
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WA
     district: 7
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WA
     district: 7
     party: Democrat
     url: http://www.house.gov/mcdermott
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WA
     district: 7
     party: Democrat
@@ -20121,7 +20121,7 @@
     url: http://www.house.gov/mcdermott
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WA
     district: 7
     party: Democrat
@@ -20191,32 +20191,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MA
     district: 3
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MA
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MA
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MA
     district: 3
     party: Democrat
     url: http://www.house.gov/mcgovern
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MA
     district: 3
     party: Democrat
@@ -20230,7 +20230,7 @@
     url: http://www.house.gov/mcgovern
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MA
     district: 3
     party: Democrat
@@ -20299,7 +20299,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NC
     district: 10
     party: Republican
@@ -20312,7 +20312,7 @@
     url: http://www.house.gov/mchenry
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NC
     district: 10
     party: Republican
@@ -20441,7 +20441,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WA
     district: 5
     party: Republican
@@ -20454,7 +20454,7 @@
     url: http://mcmorris.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WA
     district: 5
     party: Republican
@@ -20528,7 +20528,7 @@
     url: http://mcnerney.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 11
     party: Democrat
@@ -20657,32 +20657,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 6
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 6
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 6
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 6
     party: Democrat
     url: http://www.house.gov/meeks
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 6
     party: Democrat
@@ -20696,7 +20696,7 @@
     url: http://www.house.gov/meeks
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 6
     party: Democrat
@@ -20766,44 +20766,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: FL
     district: 7
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: FL
     district: 7
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: FL
     district: 7
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: FL
     district: 7
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: FL
     district: 7
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: FL
     district: 7
     party: Republican
     url: http://www.house.gov/mica
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 7
     party: Republican
@@ -20817,7 +20817,7 @@
     url: http://www.house.gov/mica
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 7
     party: Republican
@@ -20891,56 +20891,56 @@
   terms:
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: MD
     district: 3
     party: Democrat
   - type: sen
     start: '1987-01-06'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MD
     class: 3
     party: Democrat
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MD
     class: 3
     party: Democrat
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MD
     class: 3
     party: Democrat
     url: http://mikulski.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MD
     class: 3
     party: Democrat
@@ -20986,14 +20986,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MI
     district: 10
     party: Republican
     url: http://www.house.gov/candicemiller
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MI
     district: 10
     party: Republican
@@ -21007,7 +21007,7 @@
     url: http://candicemiller.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MI
     district: 10
     party: Republican
@@ -21076,20 +21076,20 @@
   terms:
   - type: rep
     start: '2001-10-23'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: FL
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: FL
     district: 1
     party: Republican
     url: http://www.house.gov/jeffmiller
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 1
     party: Republican
@@ -21103,7 +21103,7 @@
     url: http://www.house.gov/jeffmiller
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 1
     party: Republican
@@ -21172,7 +21172,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WI
     district: 4
     party: Democrat
@@ -21185,7 +21185,7 @@
     url: http://www.house.gov/gwenmoore
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WI
     district: 4
     party: Democrat
@@ -21256,32 +21256,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: KS
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: KS
     district: 1
     party: Republican
     url: http://www.house.gov/moranks01
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: KS
     district: 1
     party: Republican
@@ -21295,7 +21295,7 @@
     url: http://www.jerrymoran.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: KS
     district: 1
     party: Republican
@@ -21402,14 +21402,14 @@
   terms:
   - type: sen
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AK
     class: 3
     party: Republican
     url: http://murkowski.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AK
     class: 3
     party: Republican
@@ -21466,7 +21466,7 @@
     url: http://chrismurphy.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CT
     district: 5
     party: Democrat
@@ -21522,14 +21522,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: PA
     district: 18
     party: Republican
     url: http://www.house.gov/murphy
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 18
     party: Republican
@@ -21543,7 +21543,7 @@
     url: http://murphy.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 18
     party: Republican
@@ -21613,20 +21613,20 @@
   terms:
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: WA
     class: 3
     party: Democrat
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WA
     class: 3
     party: Democrat
     url: http://murray.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WA
     class: 3
     party: Democrat
@@ -21671,50 +21671,50 @@
   terms:
   - type: rep
     start: '1992-11-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NY
     district: 17
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 8
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 8
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 8
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 8
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 8
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 8
     party: Democrat
     url: http://www.house.gov/nadler
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 8
     party: Democrat
@@ -21728,7 +21728,7 @@
     url: http://www.house.gov/nadler
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 8
     party: Democrat
@@ -21797,26 +21797,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 34
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 34
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 38
     party: Democrat
     url: http://www.napolitano.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 38
     party: Democrat
@@ -21830,7 +21830,7 @@
     url: http://napolitano.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 38
     party: Democrat
@@ -21899,56 +21899,56 @@
   terms:
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MA
     district: 2
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MA
     district: 2
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MA
     district: 2
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MA
     district: 2
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MA
     district: 2
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MA
     district: 2
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MA
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MA
     district: 2
     party: Democrat
     url: http://www.house.gov/neal
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MA
     district: 2
     party: Democrat
@@ -21962,7 +21962,7 @@
     url: http://www.house.gov/neal
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MA
     district: 2
     party: Democrat
@@ -22031,14 +22031,14 @@
   terms:
   - type: rep
     start: '2003-06-05'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 19
     party: Republican
     url: http://www.house.gov/neugebauer
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 19
     party: Republican
@@ -22052,7 +22052,7 @@
     url: http://randy.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 19
     party: Republican
@@ -22181,50 +22181,50 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: DC
     district: 0
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: DC
     district: 0
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: DC
     district: 0
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: DC
     district: 0
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: DC
     district: 0
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: DC
     district: 0
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: DC
     district: 0
     party: Democrat
     url: http://www.house.gov/norton
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: DC
     district: 0
     party: Democrat
@@ -22238,7 +22238,7 @@
     url: http://www.house.gov/norton
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: DC
     district: 0
     party: Democrat
@@ -22367,14 +22367,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 21
     party: Republican
     url: http://www.nunes.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 21
     party: Republican
@@ -22388,7 +22388,7 @@
     url: http://nunes.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 21
     party: Republican
@@ -22455,7 +22455,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 22
     party: Republican
@@ -22586,62 +22586,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: NJ
     district: 6
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NJ
     district: 3
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NJ
     district: 3
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NJ
     district: 6
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NJ
     district: 6
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NJ
     district: 6
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NJ
     district: 6
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NJ
     district: 6
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NJ
     district: 6
     party: Democrat
     url: http://www.house.gov/pallone
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     district: 6
     party: Democrat
@@ -22655,7 +22655,7 @@
     url: http://www.house.gov/pallone
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 6
     party: Democrat
@@ -22725,32 +22725,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NJ
     district: 8
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NJ
     district: 8
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NJ
     district: 8
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NJ
     district: 8
     party: Democrat
     url: http://www.pascrell.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     district: 8
     party: Democrat
@@ -22764,7 +22764,7 @@
     url: http://pascrell.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 8
     party: Democrat
@@ -22872,7 +22872,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MN
     district: 3
     party: Republican
@@ -22943,14 +22943,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NM
     district: 2
     party: Republican
     url: http://www.house.gov/pearce
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NM
     district: 2
     party: Republican
@@ -23034,62 +23034,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: CA
     district: 5
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: CA
     district: 5
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: CA
     district: 5
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 8
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 8
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 8
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 8
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 8
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 8
     party: Democrat
     url: http://www.house.gov/pelosi
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 8
     party: Democrat
@@ -23103,7 +23103,7 @@
     url: http://www.house.gov/pelosi
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 8
     party: Democrat
@@ -23181,7 +23181,7 @@
     url: http://perlmutter.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CO
     district: 7
     party: Democrat
@@ -23251,7 +23251,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MI
     district: 9
     party: Democrat
@@ -23319,50 +23319,50 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MN
     district: 7
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MN
     district: 7
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MN
     district: 7
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MN
     district: 7
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MN
     district: 7
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MN
     district: 7
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MN
     district: 7
     party: Democrat
     url: http://www.house.gov/collinpeterson
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MN
     district: 7
     party: Democrat
@@ -23376,7 +23376,7 @@
     url: http://collinpeterson.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MN
     district: 7
     party: Democrat
@@ -23491,7 +23491,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: ME
     district: 1
     party: Democrat
@@ -23561,32 +23561,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: PA
     district: 16
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: PA
     district: 16
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: PA
     district: 16
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: PA
     district: 16
     party: Republican
     url: http://www.house.gov/pitts
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 16
     party: Republican
@@ -23600,7 +23600,7 @@
     url: http://www.house.gov/pitts
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 16
     party: Republican
@@ -23669,7 +23669,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 2
     party: Republican
@@ -23682,7 +23682,7 @@
     url: http://www.house.gov/poe
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 2
     party: Republican
@@ -23750,7 +23750,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CO
     district: 2
     party: Democrat
@@ -23883,37 +23883,37 @@
   terms:
   - type: rep
     start: '1993-05-04'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: OH
     district: 2
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: OH
     district: 2
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OH
     district: 2
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OH
     district: 2
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OH
     district: 2
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 2
     party: Republican
@@ -23963,7 +23963,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 15
     party: Republican
@@ -24033,56 +24033,56 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: NC
     district: 4
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NC
     district: 4
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NC
     district: 4
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NC
     district: 4
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NC
     district: 4
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NC
     district: 4
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NC
     district: 4
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NC
     district: 4
     party: Democrat
     url: http://www.house.gov/price
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NC
     district: 4
     party: Democrat
@@ -24096,7 +24096,7 @@
     url: http://price.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NC
     district: 4
     party: Democrat
@@ -24164,7 +24164,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: GA
     district: 6
     party: Republican
@@ -24177,7 +24177,7 @@
     url: http://www.house.gov/tomprice
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     district: 6
     party: Republican
@@ -24245,7 +24245,7 @@
   terms:
   - type: rep
     start: '2009-04-07'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 5
     party: Democrat
@@ -24315,110 +24315,110 @@
   terms:
   - type: rep
     start: '1971-01-21'
-    end: '1972-10-18'
+    end: '1973-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '1973-01-03'
-    end: '1974-12-20'
+    end: '1975-01-03'
     state: NY
     district: 19
     party: Democrat
   - type: rep
     start: '1975-01-14'
-    end: '1976-10-01'
+    end: '1977-01-03'
     state: NY
     district: 19
     party: Democrat
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: NY
     district: 19
     party: Democrat
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: NY
     district: 19
     party: Democrat
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: NY
     district: 19
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 15
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 15
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 15
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 15
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 15
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 15
     party: Democrat
     url: http://www.house.gov/rangel
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 15
     party: Democrat
@@ -24432,7 +24432,7 @@
     url: http://rangel.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 15
     party: Democrat
@@ -24501,7 +24501,7 @@
   terms:
   - type: rep
     start: '2010-11-18'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 29
     party: Republican
@@ -24568,7 +24568,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WA
     district: 8
     party: Republican
@@ -24581,7 +24581,7 @@
     url: http://www.house.gov/reichert
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WA
     district: 8
     party: Republican
@@ -24672,38 +24672,38 @@
   terms:
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: NV
     district: 1
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: NV
     district: 1
     party: Democrat
   - type: sen
     start: '1987-01-06'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NV
     class: 3
     party: Democrat
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NV
     class: 3
     party: Democrat
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NV
     class: 3
     party: Democrat
     url: http://reid.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NV
     class: 3
     party: Democrat
@@ -25051,7 +25051,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TN
     district: 1
     party: Republican
@@ -25119,80 +25119,80 @@
   terms:
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: KY
     district: 5
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: KY
     district: 5
     party: Republican
     url: http://www.house.gov/rogers
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: KY
     district: 5
     party: Republican
@@ -25206,7 +25206,7 @@
     url: http://halrogers.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: KY
     district: 5
     party: Republican
@@ -25274,14 +25274,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AL
     district: 3
     party: Republican
     url: http://www.house.gov/mike-rogers
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: AL
     district: 3
     party: Republican
@@ -25295,7 +25295,7 @@
     url: http://www.house.gov/mike-rogers
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AL
     district: 3
     party: Republican
@@ -25364,56 +25364,56 @@
   terms:
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: CA
     district: 42
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: CA
     district: 42
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 45
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 45
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 45
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 45
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 45
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 46
     party: Republican
     url: http://www.house.gov/rohrabacher
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 46
     party: Republican
@@ -25427,7 +25427,7 @@
     url: http://www.house.gov/rohrabacher
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 46
     party: Republican
@@ -25555,7 +25555,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 16
     party: Republican
@@ -25624,56 +25624,56 @@
   terms:
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: FL
     district: 18
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: FL
     district: 18
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: FL
     district: 18
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: FL
     district: 18
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: FL
     district: 18
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: FL
     district: 18
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: FL
     district: 18
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: FL
     district: 18
     party: Republican
     url: http://www.house.gov/ros-lehtinen
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 18
     party: Republican
@@ -25687,7 +25687,7 @@
     url: http://www.house.gov/ros-lehtinen
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 18
     party: Republican
@@ -25764,7 +25764,7 @@
     url: http://roskam.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 6
     party: Republican
@@ -25893,44 +25893,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 33
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 33
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 33
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 33
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 33
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 34
     party: Democrat
     url: http://www.house.gov/roybal-allard
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 34
     party: Democrat
@@ -25944,7 +25944,7 @@
     url: http://www.house.gov/roybal-allard
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 34
     party: Democrat
@@ -26017,44 +26017,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 39
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 39
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 39
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 39
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 39
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 40
     party: Republican
     url: http://www.house.gov/royce
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 40
     party: Republican
@@ -26068,7 +26068,7 @@
     url: http://www.royce.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 40
     party: Republican
@@ -26174,14 +26174,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MD
     district: 2
     party: Democrat
     url: http://www.house.gov/ruppersberger
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MD
     district: 2
     party: Democrat
@@ -26195,7 +26195,7 @@
     url: http://www.house.gov/ruppersberger
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MD
     district: 2
     party: Democrat
@@ -26265,44 +26265,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: IL
     district: 1
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: IL
     district: 1
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: IL
     district: 1
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: IL
     district: 1
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IL
     district: 1
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IL
     district: 1
     party: Democrat
     url: http://www.house.gov/rush
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IL
     district: 1
     party: Democrat
@@ -26316,7 +26316,7 @@
     url: http://www.house.gov/rush
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 1
     party: Democrat
@@ -26386,26 +26386,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: WI
     district: 1
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WI
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WI
     district: 1
     party: Republican
     url: http://www.house.gov/ryan
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WI
     district: 1
     party: Republican
@@ -26419,7 +26419,7 @@
     url: http://www.house.gov/ryan
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WI
     district: 1
     party: Republican
@@ -26489,14 +26489,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 17
     party: Democrat
     url: http://www.house.gov/timryan
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OH
     district: 17
     party: Democrat
@@ -26510,7 +26510,7 @@
     url: http://timryan.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 17
     party: Democrat
@@ -26576,7 +26576,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MP
     district: 0
     party: Democrat
@@ -26586,7 +26586,7 @@
       end: '2009-02-23'
       party: Independent
     - start: '2009-02-23'
-      end: '2010-12-22'
+      end: '2011-01-03'
       party: Democrat
   - type: rep
     start: '2011-01-05'
@@ -26653,32 +26653,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 46
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 46
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 46
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 47
     party: Democrat
     url: http://www.house.gov/sanchez
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 47
     party: Democrat
@@ -26692,7 +26692,7 @@
     url: http://www.lorettasanchez.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 47
     party: Democrat
@@ -26770,7 +26770,7 @@
     url: http://sarbanes.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MD
     district: 3
     party: Democrat
@@ -26857,7 +26857,7 @@
     url: http://scalise.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: LA
     district: 1
     party: Republican
@@ -26928,26 +26928,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: IL
     district: 9
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IL
     district: 9
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IL
     district: 9
     party: Democrat
     url: http://www.house.gov/schakowsky
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IL
     district: 9
     party: Democrat
@@ -26961,7 +26961,7 @@
     url: http://www.house.gov/schakowsky
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 9
     party: Democrat
@@ -27030,20 +27030,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 27
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 29
     party: Democrat
     url: http://www.house.gov/schiff
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 29
     party: Democrat
@@ -27057,7 +27057,7 @@
     url: http://schiff.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 29
     party: Democrat
@@ -27125,7 +27125,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OR
     district: 5
     party: Democrat
@@ -27198,68 +27198,68 @@
   terms:
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: NY
     district: 10
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: NY
     district: 10
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: NY
     district: 10
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NY
     district: 10
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NY
     district: 10
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 9
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 9
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 9
     party: Democrat
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     class: 3
     party: Democrat
     url: http://schumer.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     class: 3
     party: Democrat
@@ -27423,14 +27423,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: GA
     district: 13
     party: Democrat
     url: http://www.house.gov/davidscott
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: GA
     district: 13
     party: Democrat
@@ -27444,7 +27444,7 @@
     url: http://davidscott.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     district: 13
     party: Democrat
@@ -27515,44 +27515,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: VA
     district: 3
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: VA
     district: 3
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: VA
     district: 3
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: VA
     district: 3
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: VA
     district: 3
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: VA
     district: 3
     party: Democrat
     url: http://www.house.gov/scott
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: VA
     district: 3
     party: Democrat
@@ -27566,7 +27566,7 @@
     url: http://www.house.gov/scott
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: VA
     district: 3
     party: Democrat
@@ -27701,86 +27701,86 @@
   terms:
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WI
     district: 9
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WI
     district: 5
     party: Republican
     url: http://www.house.gov/sensenbrenner
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WI
     district: 5
     party: Republican
@@ -27794,7 +27794,7 @@
     url: http://www.house.gov/sensenbrenner
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WI
     district: 5
     party: Republican
@@ -27863,56 +27863,56 @@
   terms:
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NY
     district: 18
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 16
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 16
     party: Democrat
     url: http://www.house.gov/serrano
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 16
     party: Democrat
@@ -27926,7 +27926,7 @@
     url: http://www.house.gov/serrano
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 16
     party: Democrat
@@ -27996,32 +27996,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 5
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 5
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 5
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 32
     party: Republican
     url: http://www.house.gov/sessions
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 32
     party: Republican
@@ -28035,7 +28035,7 @@
     url: http://www.house.gov/sessions
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 32
     party: Republican
@@ -28167,37 +28167,37 @@
   terms:
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: AL
     district: 7
     party: Democrat
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: AL
     district: 7
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: AL
     district: 7
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: AL
     district: 7
     party: Democrat
   - type: sen
     start: '1987-01-06'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: AL
     class: 3
     party: Democrat
   - type: sen
     start: '1993-01-05'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: AL
     class: 3
     party: Republican
@@ -28206,18 +28206,18 @@
       end: '1994-11-09'
       party: Democrat
     - start: '1994-11-09'
-      end: '2004-12-09'
+      end: '2005-01-03'
       party: Republican
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AL
     class: 3
     party: Republican
     url: http://shelby.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AL
     class: 3
     party: Republican
@@ -28262,32 +28262,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 24
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 24
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 24
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 27
     party: Democrat
     url: http://www.house.gov/sherman
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 27
     party: Democrat
@@ -28301,7 +28301,7 @@
     url: http://bradsherman.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 27
     party: Democrat
@@ -28371,32 +28371,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: IL
     district: 20
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: IL
     district: 20
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IL
     district: 20
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IL
     district: 19
     party: Republican
     url: http://www.house.gov/shimkus
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IL
     district: 19
     party: Republican
@@ -28410,7 +28410,7 @@
     url: http://www.house.gov/shimkus
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 19
     party: Republican
@@ -28477,20 +28477,20 @@
   terms:
   - type: rep
     start: '2001-05-17'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: PA
     district: 9
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: PA
     district: 9
     party: Republican
     url: http://www.house.gov/shuster
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: PA
     district: 9
     party: Republican
@@ -28504,7 +28504,7 @@
     url: http://www.house.gov/shuster
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 9
     party: Republican
@@ -28578,26 +28578,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: ID
     district: 2
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: ID
     district: 2
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: ID
     district: 2
     party: Republican
     url: http://www.house.gov/simpson
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: ID
     district: 2
     party: Republican
@@ -28611,7 +28611,7 @@
     url: http://www.house.gov/simpson
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: ID
     district: 2
     party: Republican
@@ -28679,7 +28679,7 @@
   terms:
   - type: rep
     start: '2006-11-13'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     district: 13
     party: Democrat
@@ -28692,7 +28692,7 @@
     url: http://www.house.gov/sires
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 13
     party: Democrat
@@ -28761,62 +28761,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: NY
     district: 30
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NY
     district: 30
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NY
     district: 30
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 28
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 28
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 28
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 28
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 28
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 28
     party: Democrat
     url: http://www.house.gov/slaughter
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 28
     party: Democrat
@@ -28830,7 +28830,7 @@
     url: http://www.louise.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 28
     party: Democrat
@@ -28899,32 +28899,32 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: WA
     district: 9
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: WA
     district: 9
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: WA
     district: 9
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: WA
     district: 9
     party: Democrat
     url: http://www.house.gov/adamsmith
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: WA
     district: 9
     party: Democrat
@@ -28938,7 +28938,7 @@
     url: http://www.house.gov/adamsmith
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: WA
     district: 9
     party: Democrat
@@ -29013,7 +29013,7 @@
     url: http://adriansmith.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NE
     district: 3
     party: Republican
@@ -29083,80 +29083,80 @@
   terms:
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NJ
     district: 4
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NJ
     district: 4
     party: Republican
     url: http://www.house.gov/chrissmith
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NJ
     district: 4
     party: Republican
@@ -29170,7 +29170,7 @@
     url: http://www.house.gov/chrissmith
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NJ
     district: 4
     party: Republican
@@ -29240,62 +29240,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 21
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 21
     party: Republican
     url: http://lamarsmith.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 21
     party: Republican
@@ -29309,7 +29309,7 @@
     url: http://lamarsmith.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 21
     party: Republican
@@ -29383,7 +29383,7 @@
     url: http://speier.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 12
     party: Democrat
@@ -29513,7 +29513,7 @@
   terms:
   - type: rep
     start: '2010-11-16'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IN
     district: 3
     party: Republican
@@ -29581,14 +29581,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 39
     party: Democrat
     url: http://www.house.gov/lindasanchez
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 39
     party: Democrat
@@ -29602,7 +29602,7 @@
     url: http://www.house.gov/lindasanchez
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 39
     party: Democrat
@@ -29674,44 +29674,44 @@
   terms:
   - type: rep
     start: '1993-04-13'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MS
     district: 2
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MS
     district: 2
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MS
     district: 2
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MS
     district: 2
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MS
     district: 2
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MS
     district: 2
     party: Democrat
     url: http://www.house.gov/thompson
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MS
     district: 2
     party: Democrat
@@ -29725,7 +29725,7 @@
     url: http://benniethompson.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MS
     district: 2
     party: Democrat
@@ -29794,26 +29794,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 1
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 1
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 1
     party: Democrat
     url: http://www.house.gov/mthompson
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 1
     party: Democrat
@@ -29827,7 +29827,7 @@
     url: http://mikethompson.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 1
     party: Democrat
@@ -29894,7 +29894,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: PA
     district: 5
     party: Republican
@@ -29964,38 +29964,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: TX
     district: 13
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: TX
     district: 13
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: TX
     district: 13
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: TX
     district: 13
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: TX
     district: 13
     party: Republican
     url: http://www.house.gov/thornberry
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: TX
     district: 13
     party: Republican
@@ -30009,7 +30009,7 @@
     url: http://www.house.gov/thornberry
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: TX
     district: 13
     party: Republican
@@ -30077,25 +30077,25 @@
   terms:
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: SD
     district: 0
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: SD
     district: 0
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: SD
     district: 0
     party: Republican
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: SD
     class: 3
     party: Republican
@@ -30142,20 +30142,20 @@
   terms:
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OH
     district: 12
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 12
     party: Republican
     url: http://www.house.gov/tiberi
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OH
     district: 12
     party: Republican
@@ -30169,7 +30169,7 @@
     url: http://tiberi.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 12
     party: Republican
@@ -30297,7 +30297,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 21
     party: Democrat
@@ -30369,19 +30369,19 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: PA
     district: 15
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: PA
     district: 15
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: PA
     district: 15
     party: Republican
@@ -30433,7 +30433,7 @@
     url: http://tsongas.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MA
     district: 5
     party: Democrat
@@ -30506,14 +30506,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OH
     district: 3
     party: Republican
     url: http://www.house.gov/miketurner
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OH
     district: 3
     party: Republican
@@ -30527,7 +30527,7 @@
     url: http://www.house.gov/miketurner
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OH
     district: 3
     party: Republican
@@ -30597,62 +30597,62 @@
   terms:
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: MI
     district: 4
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: MI
     district: 4
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: MI
     district: 4
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: MI
     district: 6
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: MI
     district: 6
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: MI
     district: 6
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: MI
     district: 6
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: MI
     district: 6
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MI
     district: 6
     party: Republican
     url: http://www.house.gov/upton
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MI
     district: 6
     party: Republican
@@ -30666,7 +30666,7 @@
     url: http://www.house.gov/upton
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MI
     district: 6
     party: Republican
@@ -30735,14 +30735,14 @@
   terms:
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: MD
     district: 8
     party: Democrat
     url: http://www.house.gov/vanhollen
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: MD
     district: 8
     party: Democrat
@@ -30756,7 +30756,7 @@
     url: http://vanhollen.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MD
     district: 8
     party: Democrat
@@ -30825,44 +30825,44 @@
   terms:
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: NY
     district: 12
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: NY
     district: 12
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: NY
     district: 12
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: NY
     district: 12
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: NY
     district: 12
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: NY
     district: 12
     party: Democrat
     url: http://www.house.gov/velazquez
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: NY
     district: 12
     party: Democrat
@@ -30876,7 +30876,7 @@
     url: http://www.house.gov/velazquez
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NY
     district: 12
     party: Democrat
@@ -30944,68 +30944,68 @@
   terms:
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: IN
     district: 1
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: IN
     district: 1
     party: Democrat
     url: http://www.house.gov/visclosky
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: IN
     district: 1
     party: Democrat
@@ -31019,7 +31019,7 @@
     url: http://www.house.gov/visclosky
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IN
     district: 1
     party: Democrat
@@ -31090,26 +31090,26 @@
   terms:
   - type: rep
     start: '1999-06-08'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: LA
     district: 1
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: LA
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: LA
     district: 1
     party: Republican
     url: http://vitter.house.gov
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: LA
     class: 3
     party: Republican
@@ -31222,26 +31222,26 @@
   terms:
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: OR
     district: 2
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: OR
     district: 2
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OR
     district: 2
     party: Republican
     url: http://walden.house.gov
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: OR
     district: 2
     party: Republican
@@ -31255,7 +31255,7 @@
     url: http://walden.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OR
     district: 2
     party: Republican
@@ -31331,7 +31331,7 @@
     url: http://walz.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: MN
     district: 1
     party: Democrat
@@ -31400,7 +31400,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: FL
     district: 20
     party: Democrat
@@ -31413,7 +31413,7 @@
     url: http://www.house.gov/schultz
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 20
     party: Democrat
@@ -31482,50 +31482,50 @@
   terms:
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: CA
     district: 29
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: CA
     district: 35
     party: Democrat
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: CA
     district: 35
     party: Democrat
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: CA
     district: 35
     party: Democrat
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: CA
     district: 35
     party: Democrat
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: CA
     district: 35
     party: Democrat
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: CA
     district: 35
     party: Democrat
     url: http://www.house.gov/waters
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: CA
     district: 35
     party: Democrat
@@ -31539,7 +31539,7 @@
     url: http://www.house.gov/waters
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: CA
     district: 35
     party: Democrat
@@ -31676,7 +31676,7 @@
     url: http://welch.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: VT
     district: 0
     party: Democrat
@@ -31745,7 +31745,7 @@
   terms:
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: GA
     district: 8
     party: Republican
@@ -31758,7 +31758,7 @@
     url: http://www.house.gov/westmoreland
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: GA
     district: 3
     party: Republican
@@ -31827,38 +31827,38 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: KY
     district: 1
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: KY
     district: 1
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: KY
     district: 1
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: KY
     district: 1
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: KY
     district: 1
     party: Republican
     url: http://www.house.gov/whitfield
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: KY
     district: 1
     party: Republican
@@ -31872,7 +31872,7 @@
     url: http://www.house.gov/whitfield
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: KY
     district: 1
     party: Republican
@@ -31942,20 +31942,20 @@
   terms:
   - type: rep
     start: '2001-12-18'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: SC
     district: 2
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: SC
     district: 2
     party: Republican
     url: http://joewilson.house.gov/
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: SC
     district: 2
     party: Republican
@@ -31969,7 +31969,7 @@
     url: http://joewilson.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: SC
     district: 2
     party: Republican
@@ -32107,7 +32107,7 @@
     url: http://www.wittman.house.gov/
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: VA
     district: 1
     party: Republican
@@ -32297,43 +32297,43 @@
   terms:
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: OR
     district: 3
     party: Democrat
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: OR
     district: 3
     party: Democrat
@@ -32345,20 +32345,20 @@
     party: Democrat
   - type: sen
     start: '1996-01-01'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: OR
     class: 3
     party: Democrat
   - type: sen
     start: '1999-01-06'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: OR
     class: 3
     party: Democrat
     url: http://wyden.senate.gov/
   - type: sen
     start: '2005-01-04'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: OR
     class: 3
     party: Democrat
@@ -32410,7 +32410,7 @@
     url: http://yarmuth.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: KY
     district: 3
     party: Democrat
@@ -32538,104 +32538,104 @@
   terms:
   - type: rep
     start: '1973-01-03'
-    end: '1974-12-20'
+    end: '1975-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1975-01-14'
-    end: '1976-10-01'
+    end: '1977-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1981-01-05'
-    end: '1982-12-23'
+    end: '1983-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1983-01-03'
-    end: '1984-10-12'
+    end: '1985-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1985-01-03'
-    end: '1986-10-18'
+    end: '1987-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1987-01-06'
-    end: '1988-10-22'
+    end: '1989-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1989-01-03'
-    end: '1990-10-28'
+    end: '1991-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1991-01-03'
-    end: '1992-10-09'
+    end: '1993-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1993-01-05'
-    end: '1994-12-01'
+    end: '1995-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '2001-01-03'
-    end: '2002-11-22'
+    end: '2003-01-03'
     state: AK
     district: 0
     party: Republican
   - type: rep
     start: '2003-01-07'
-    end: '2004-12-09'
+    end: '2005-01-03'
     state: AK
     district: 0
     party: Republican
     url: http://www.house.gov/donyoung
   - type: rep
     start: '2005-01-04'
-    end: '2006-12-09'
+    end: '2007-01-03'
     state: AK
     district: 0
     party: Republican
@@ -32649,7 +32649,7 @@
     url: http://donyoung.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AK
     district: 0
     party: Republican
@@ -32787,7 +32787,7 @@
     url: http://heller.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NV
     district: 2
     party: Republican
@@ -33265,19 +33265,19 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: AZ
     district: 1
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: AZ
     district: 1
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: AZ
     district: 1
     party: Republican
@@ -33340,7 +33340,7 @@
     url: http://foster.house.gov
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: IL
     district: 14
     party: Democrat
@@ -33396,7 +33396,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: FL
     district: 8
     party: Democrat
@@ -33452,7 +33452,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: AZ
     district: 1
     party: Democrat
@@ -33508,7 +33508,7 @@
   terms:
   - type: rep
     start: '2009-01-06'
-    end: '2010-12-22'
+    end: '2011-01-03'
     state: NV
     district: 3
     party: Democrat
@@ -35190,19 +35190,19 @@
   terms:
   - type: rep
     start: '1975-01-14'
-    end: '1976-10-01'
+    end: '1977-01-03'
     state: MN
     district: 6
     party: Democrat
   - type: rep
     start: '1977-01-04'
-    end: '1978-10-15'
+    end: '1979-01-03'
     state: MN
     district: 6
     party: Democrat
   - type: rep
     start: '1979-01-15'
-    end: '1980-12-16'
+    end: '1981-01-03'
     state: MN
     district: 6
     party: Democrat
@@ -36988,19 +36988,19 @@
   terms:
   - type: rep
     start: '1995-01-04'
-    end: '1996-10-04'
+    end: '1997-01-03'
     state: SC
     district: 1
     party: Republican
   - type: rep
     start: '1997-01-07'
-    end: '1998-12-19'
+    end: '1999-01-03'
     state: SC
     district: 1
     party: Republican
   - type: rep
     start: '1999-01-06'
-    end: '2000-12-15'
+    end: '2001-01-03'
     state: SC
     district: 1
     party: Republican


### PR DESCRIPTION
This corrects term end dates in historical terms. Per #7, we wanted to fix term end dates to be the Constitutionally-defined end of a term.

In summary, this commit does a simple string substitution to correct the following dates:

	  2nd Congress 1793-03-02 => 1793-03-03
	 22nd Congress 1833-03-02 => 1833-03-03
	 73rd Congress 1934-06-18 => 1935-01-03
	 74th Congress 1936-06-20 => 1937-01-03
	 75th Congress 1938-06-16 => 1939-01-03
	 77th Congress 1942-12-16 => 1943-01-03
	 78th Congress 1944-12-19 => 1945-01-03
	 79th Congress 1946-08-02 => 1947-01-03
	 80th Congress 1948-12-31 => 1949-01-03
	 81st Congress 1951-01-02 => 1951-01-03
	 82nd Congress 1952-07-07 => 1953-01-03
	 83rd Congress 1954-12-02 => 1955-01-03
	 84th Congress 1956-07-27 => 1957-01-03
	 85th Congress 1958-08-24 => 1959-01-03
	 86th Congress 1960-09-01 => 1961-01-03
	 87th Congress 1962-10-13 => 1963-01-03
	 88th Congress 1964-10-03 => 1965-01-03
	 89th Congress 1966-10-22 => 1967-01-03
	 90th Congress 1968-10-14 => 1969-01-03
	 91st Congress 1971-01-02 => 1971-01-03
	 92nd Congress 1972-10-18 => 1973-01-03
	 93rd Congress 1974-12-20 => 1975-01-03
	 94th Congress 1976-10-01 => 1977-01-03
	 95th Congress 1978-10-15 => 1979-01-03
	 96th Congress 1980-12-16 => 1981-01-03
	 97th Congress 1982-12-23 => 1983-01-03
	 98th Congress 1984-10-12 => 1985-01-03
	 99th Congress 1986-10-18 => 1987-01-03
	100th Congress 1988-10-22 => 1989-01-03
	101th Congress 1990-10-28 => 1991-01-03
	102th Congress 1992-10-09 => 1993-01-03
	103th Congress 1994-12-01 => 1995-01-03
	104th Congress 1996-10-04 => 1997-01-03
	105th Congress 1998-12-19 => 1999-01-03
	106th Congress 2000-12-15 => 2001-01-03
	107th Congress 2002-11-22 => 2003-01-03
	108th Congress 2004-12-09 => 2005-01-03
	109th Congress 2006-12-09 => 2007-01-03
	111th Congress 2010-12-22 => 2011-01-03

When I first created this dataset back in 2009, I used the sine die adjournment date of Congress as term end dates (as best as I could quickly identify those dates, and the later of the House or Senate). It has been a bit of a research project to figure out the actual term end dates, especially prior to 1933. Constitutional term end dates are more appropriate since a Member is a Member, and can come back into session, until the term actually ends, not when Congress last meets. In addition, I have found that historical roll call data from Voteview and historical legislative data from THOMAS/Congress.gov indicates there was legislative activity beyond the end dates that I have used --- so they may be incorrect anyway.

(Note that this doesn't address term start dates, which we've been storing as swearing-in dates, where known.)

According to the [Constitution Annotated, Amendment 20](https://www.congress.gov/content/conan/pdf/GPO-CONAN-REV-2014-10-21.pdf), quoting the Senate report on the Twentieth Amendment (1 S. Rep. No. 26, 72d Cong., 1st Sess. 2, 4, 5, 6 (1932)):

> The commencement of the terms of the first President and Vice President and of Senators and Representatives composing the First Congress was fixed by an act of [the Continental] Congress adopted September 13, 1788, and that act provided ‘that the first Wednesday in March next to be the time for commencing proceedings under the Constitution.’ It happened that the first Wednesday in March was the 4th day of March, and hence the terms of the President and Vice President and Members of Congress began on the 4th day of March.

This explains the frequency of March 3 as adjournment dates in our term end data through 1933 (72nd Congress), with only anomalies for the 2nd Congress (1793-03-02), 22nd Congress (1833-03-02), and 69th Congress (1927-03-04). I've verified that the 69th Congress did end on a March 4, and per further analysis in the Constitution Annotated (see below), it seems terms ended at some time on March 4. Nevertheless, I've left the March 3 end dates where they are (a total of 69 Congresses had that date), and I've left the 69th Congress's March 4 date alone. I've corrected the 2nd Congress and 22nd Congresses to March 3's (for consistency with the other Congresses in that time period).

The [20th Amendment](http://www.archives.gov/exhibits/charters/constitution_amendments_11-27.html) changed the start and end dates of legislative (and executive) terms. The amendment was ratified on January 23, 1933. Per section 5 of the amendment, section 1 takes effect "on the 15th day of October following the ratification of this article", i.e. October 15, 1933. Section 1 states that legislative terms start and end "at noon on the 3d day of January, of the years in which such terms would have ended if this article had not been ratified." The 73rd Congress was in session. We have its adjournment date as 1934-06-18. But its actual end date was changed by the 20th Amendment from 1935-03-03 (or -04) to 1935-01-03 at noon. So this commit changes the term end date from 1934-06-18 to 1935-01-03.

The Constitution Annotated clarifies:

> [The 20th Amendment] shortened, by the intervals between January 3 and March 4, the terms of Senators elected for terms ending March 4, 1935, 1937, and 1939 . . . It also shortened the terms of Representatives elected to the Seventy-third Congress, by the interval between January 3 and March 4, 1935.

Only a handful of Congresses since then have actually adjourned on January 3 (76th, 110th, 112th Congresses), so most of the term end dates starting with the 73rd Congress are updated by this commit to January 3.

Beginning with the 113th Congress we've been using January 3, so the last Congress updated here is the 111th Congress.

I made these changes using `sed`. Anywhere the date occurs in an `end: ` is assumed to be the end of the term at the end of a Congress. Any ends of terms on other dates not listed above are left alone because they're resignations, deaths, etc.