### PR TITLE
Move to new Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os:
   - linux
   - osx
 
+sudo: false
+
 install: pip install -r scripts/requirements.txt
 script: python test/workout.py
 


### PR DESCRIPTION
This [moves us away from Travis' legacy infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/), for faster Docker-based builds. Doing a PR to make sure it works before merging.