### PR TITLE
Add Dana Rohrabacher's YouTube account

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -5836,3 +5836,10 @@
     facebook: RepDold
     twitter: RepDold
     twitter_id: 245408102
+- id:
+    bioguide: R000409
+    govtrack: 400343
+    thomas: '00979'
+  social:
+    youtube: RepDanaRohrabacher
+    youtube_id: UCFr7qO61vGJyyBJ7B_gB1_Q

--- a/scripts/social_media.py
+++ b/scripts/social_media.py
@@ -43,13 +43,14 @@ import time
 def main():
   regexes = {
     "youtube": [
-      "https?://(?:www\\.)?youtube.com/channel/([^\\s\"/\\?#']+)",
-      "https?://(?:www\\.)?youtube.com/(?:subscribe_widget\\?p=)?(?:subscription_center\\?add_user=)?(?:user/)?([^\\s\"/\\?#']+)"
+      "(?:https?:)?//(?:www\\.)?youtube.com/embed/?\?(list=[^\\s\"/\\?#&']+)",
+      "(?:https?:)?//(?:www\\.)?youtube.com/channel/([^\\s\"/\\?#']+)",
+      "(?:https?:)?//(?:www\\.)?youtube.com/(?:subscribe_widget\\?p=)?(?:subscription_center\\?add_user=)?(?:user/)?([^\\s\"/\\?#']+)"
     ],
     "facebook": [
       "\\('facebook.com/([^']+)'\\)",
-      "https?://(?:www\\.)?facebook.com/(?:home\\.php)?(?:business/dashboard/#/)?(?:government)?(?:#!/)?(?:#%21/)?(?:#/)?pages/[^/]+/(\\d+)",
-      "https?://(?:www\\.)?facebook.com/(?:profile.php\\?id=)?(?:home\\.php)?(?:#!)?/?(?:people)?/?([^/\\s\"#\\?&']+)"
+      "(?:https?:)?//(?:www\\.)?facebook.com/(?:home\\.php)?(?:business/dashboard/#/)?(?:government)?(?:#!/)?(?:#%21/)?(?:#/)?pages/[^/]+/(\\d+)",
+      "(?:https?:)?//(?:www\\.)?facebook.com/(?:profile.php\\?id=)?(?:home\\.php)?(?:#!)?/?(?:people)?/?([^/\\s\"#\\?&']+)"
     ],
     "twitter": [
       "(?:https?:)?//(?:www\\.)?twitter.com/(?:intent/user\?screen_name=)?(?:#!/)?(?:#%21/)?@?([^\\s\"'/]+)",
@@ -187,7 +188,7 @@ def main():
 
         ytid = social['youtube']
 
-        profile_url = ("http://gdata.youtube.com/feeds/api/users/%s"
+        profile_url = ("https://gdata.youtube.com/feeds/api/users/%s"
         "?v=2&prettyprint=true&alt=json&key=%s" % (ytid, api_key))
 
         try:
@@ -200,7 +201,7 @@ def main():
             try:
               # Try to scrape the real YouTube username
               print("\Scraping YouTube username")
-              search_url = ("http://www.youtube.com/%s" % social['youtube'])
+              search_url = ("https://www.youtube.com/%s" % social['youtube'])
               csearch = requests.get(search_url).text.encode('ascii','ignore')
 
               u = re.search(r'<a[^>]*href="[^"]*/user/([^/"]*)"[.]*>',csearch)
@@ -208,7 +209,7 @@ def main():
               if u:
                 print("\t%s maps to %s" % (social['youtube'],u.group(1)))
                 social['youtube'] = u.group(1)
-                profile_url = ("http://gdata.youtube.com/feeds/api/users/%s"
+                profile_url = ("https://gdata.youtube.com/feeds/api/users/%s"
                 "?v=2&prettyprint=true&alt=json" % social['youtube'])
 
                 print("\tFetching GData profile...")


### PR DESCRIPTION
Adds Dana Rohrabacher's YouTube account, as pointed out in #308. 

This also updates the YouTube sweeper to look for YT embed widgets, even though the captured slug is not expected to be the real ID. It will drop it in the spreadsheet as a pretty obviously invalid result (starting with `list=`) and the reviewer is expected to go find the real username and replace it.

During this, I _think_ I also discovered that the YT ID resolver looks to no longer be working. I could use some verification of this.