### PR TITLE
added 2 OpenSecrets IDs

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -39263,6 +39263,7 @@
     wikipedia: Daniel M. Donovan, Jr.
     ballotpedia: Daniel Donovan (New York)
     maplight: 2161
+    opensecrets: N00036928
   name:
     first: Daniel
     middle: M.
@@ -39293,6 +39294,7 @@
     wikipedia: Trent Kelly (politician)
     ballotpedia: Trent Kelly
     maplight: 2163
+    opensecrets: N00037003
   name:
     first: Trent
     last: Kelly


### PR DESCRIPTION
Added OpenSecrets IDs for Daniel Donovan (N00036928) and TrentKelly
(N00037003).

Not meaning to step on anyone's toes -- I don't know how these IDs are
normally added. I got them from the urls of these pages:

http://www.opensecrets.org/politicians/summary.php?cid=N00036928&cycle=2016
http://www.opensecrets.org/politicians/summary.php?cid=N00037003&cycle=2016

after searching by name here:

http://www.opensecrets.org/politicians/summary_all.php

Cool?