### PR TITLE
remove failing osx build in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 
 os:
   - linux
-  - osx
 
 sudo: false
 


### PR DESCRIPTION
It seems osx builds on travis-ci don't natively support python.  They made a change 26 days ago where these builds started failing instead of being ignored.

> Until today, the os: osx with language: python was discarded, and only Linux builds were created.

refs:
https://github.com/travis-ci/travis-ci/issues/4729
https://github.com/travis-ci/travis-ci/issues/2312
