### PR TITLE
Adding missing Wikipedia links; adding some Wikidata links

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -37267,6 +37267,8 @@
     fec:
     - H4FL19074
     maplight: 2060
+    wikidata: Q16728087
+    wikipedia: Curt Clawson
   name:
     first: Curtis
     nickname: Curt
@@ -37518,6 +37520,8 @@
     opensecrets: N00035691
     thomas: '02221'
     maplight: 2064
+    wikidata: Q17386504
+    wikipedia: Gary Palmer (politician)
   name:
     first: Gary
     last: Palmer
@@ -37545,6 +37549,8 @@
     opensecrets: N00035792
     thomas: '02223'
     maplight: 2065
+    wikidata: Q18631366
+    wikipedia: French Hill (politician)
   name:
     first: French
     last: Hill
@@ -37572,6 +37578,8 @@
     opensecrets: N00035527
     thomas: '02224'
     maplight: 2066
+    wikidata: Q16197421
+    wikipedia: Bruce Westerman
   name:
     first: Bruce
     last: Westerman
@@ -37599,6 +37607,8 @@
     thomas: '02225'
     house_history: 15032414876
     maplight: 2067
+    wikidata: Q6774492
+    wikipedia: Martha McSally
   name:
     first: Martha
     last: McSally
@@ -37626,6 +37636,8 @@
     opensecrets: N00036097
     thomas: '02226'
     maplight: 2068
+    wikidata: Q16218474
+    wikipedia: Ruben Gallego
   name:
     first: Ruben
     last: Gallego
@@ -37652,6 +37664,8 @@
     opensecrets: N00030709
     thomas: '02227'
     maplight: 2069
+    wikidata: Q6767311
+    wikipedia: Mark DeSaulnier
   name:
     first: Mark
     last: DeSaulnier
@@ -37679,6 +37693,8 @@
     opensecrets: N00035820
     thomas: '02228'
     maplight: 2070
+    wikidata: Q7613060
+    wikipedia: Steve Knight (politician)
   name:
     first: Steve
     last: Knight
@@ -37706,6 +37722,8 @@
     opensecrets: N00033997
     thomas: '02229'
     maplight: 2071
+    wikidata: Q7171821
+    wikipedia: Pete Aguilar
   name:
     first: Pete
     last: Aguilar
@@ -37733,6 +37751,8 @@
     opensecrets: N00035825
     thomas: '02230'
     maplight: 2072
+    wikidata: Q7693450
+    wikipedia: Ted Lieu
   name:
     first: Ted
     last: Lieu
@@ -37761,6 +37781,8 @@
     thomas: '02231'
     house_history: 15032410409
     maplight: 2073
+    wikidata: Q3343727
+    wikipedia: Norma Torres
   name:
     first: Norma
     last: Torres
@@ -37789,6 +37811,8 @@
     thomas: '02232'
     house_history: 15032409970
     maplight: 2074
+    wikidata: Q6862199
+    wikipedia: Mimi Walters
   name:
     first: Mimi
     last: Walters
@@ -37817,6 +37841,8 @@
     opensecrets: N00030829
     thomas: '02233'
     maplight: 2075
+    wikidata: Q1439421
+    wikipedia: Ken Buck
   name:
     first: Ken
     last: Buck
@@ -37845,6 +37871,8 @@
     thomas: '02234'
     house_history: 15032409716
     maplight: 2076
+    wikidata: Q16195097
+    wikipedia: Gwen Graham
   name:
     first: Gwen
     last: Graham
@@ -37872,6 +37900,8 @@
     opensecrets: N00035403
     thomas: '02235'
     maplight: 2077
+    wikidata: Q18631533
+    wikipedia: Carlos Curbelo (politician)
   name:
     first: Carlos
     last: Curbelo
@@ -37898,6 +37928,8 @@
     opensecrets: N00035346
     thomas: '02236'
     maplight: 2078
+    wikidata: Q16240994
+    wikipedia: Buddy Carter
   name:
     first: Buddy
     last: Carter
@@ -37925,6 +37957,8 @@
     opensecrets: N00032243
     thomas: '02237'
     maplight: 2079
+    wikidata: Q6208081
+    wikipedia: Jody Hice
   name:
     first: Jody
     last: Hice
@@ -37952,6 +37986,8 @@
     opensecrets: N00035347
     thomas: '02238'
     maplight: 2080
+    wikidata: Q16731643
+    wikipedia: Barry Loudermilk
   name:
     first: Barry
     last: Loudermilk
@@ -37979,6 +38015,8 @@
     opensecrets: N00033720
     thomas: '02239'
     maplight: 2081
+    wikidata: Q18683976
+    wikipedia: Rick W. Allen
   name:
     first: Rick
     last: Allen
@@ -38006,6 +38044,8 @@
     opensecrets: N00035535
     thomas: '02240'
     maplight: 2082
+    wikidata: Q16197299
+    wikipedia: Mark Takai
   name:
     first: Mark
     last: Takai
@@ -38033,6 +38073,8 @@
     opensecrets: N00033744
     thomas: '02241'
     maplight: 2083
+    wikidata: Q18684853
+    wikipedia: Rod Blum
   name:
     first: Rod
     last: Blum
@@ -38060,6 +38102,8 @@
     opensecrets: N00035509
     thomas: '02242'
     maplight: 2084
+    wikidata: Q19321008
+    wikipedia: David Young (politician)
   name:
     first: David
     last: Young
@@ -38086,6 +38130,8 @@
     opensecrets: N00035420
     thomas: '02243'
     maplight: 2085
+    wikidata: Q6846090
+    wikipedia: Mike Bost
   name:
     first: Mike
     last: Bost
@@ -38113,6 +38159,8 @@
     thomas: '02244'
     opensecrets: N00036633
     maplight: 2086
+    wikidata: Q18683775
+    wikipedia: Ralph Abraham (politician)
   name:
     first: Ralph
     last: Abraham
@@ -38140,6 +38188,8 @@
     thomas: '02245'
     opensecrets: N00036135
     maplight: 2087
+    wikidata: Q18686454
+    wikipedia: Garret Graves
   name:
     first: Garret
     last: Graves
@@ -38167,6 +38217,8 @@
     opensecrets: N00035431
     thomas: '02246'
     maplight: 2088
+    wikidata: Q18045052
+    wikipedia: Seth Moulton
   name:
     first: Seth
     last: Moulton
@@ -38195,6 +38247,8 @@
     opensecrets: N00034584
     thomas: '02247'
     maplight: 2089
+    wikidata: Q4978147
+    wikipedia: Bruce Poliquin
   name:
     first: Bruce
     last: Poliquin
@@ -38222,6 +38276,8 @@
     opensecrets: N00036275
     thomas: '02248'
     maplight: 2090
+    wikidata: Q16194212
+    wikipedia: John Moolenaar
   name:
     first: John
     last: Moolenaar
@@ -38249,6 +38305,8 @@
     opensecrets: N00036449
     thomas: '02249'
     maplight: 2091
+    wikidata: Q16196834
+    wikipedia: Mike Bishop (politician)
   name:
     first: Mike
     last: Bishop
@@ -38276,6 +38334,8 @@
     opensecrets: N00035607
     thomas: '02250'
     maplight: 2092
+    wikidata: Q16982345
+    wikipedia: Dave Trott (politician)
   name:
     first: Dave
     last: Trott
@@ -38303,6 +38363,8 @@
     thomas: '02251'
     house_history: 15032409588
     maplight: 2093
+    wikidata: Q5248232
+    wikipedia: Debbie Dingell
   name:
     first: Debbie
     last: Dingell
@@ -38331,6 +38393,8 @@
     thomas: '02252'
     house_history: 15032411198
     maplight: 2094
+    wikidata: Q4960712
+    wikipedia: Brenda Lawrence
   name:
     first: Brenda
     last: Lawrence
@@ -38358,6 +38422,8 @@
     opensecrets: N00035440
     thomas: '02253'
     maplight: 2095
+    wikidata: Q7815723
+    wikipedia: Tom Emmer
   name:
     first: Tom
     last: Emmer
@@ -38385,6 +38451,8 @@
     opensecrets: N00035616
     thomas: '02254'
     maplight: 2096
+    wikidata: Q7384672
+    wikipedia: Ryan Zinke
   name:
     first: Ryan
     last: Zinke
@@ -38412,6 +38480,8 @@
     opensecrets: N00033527
     thomas: '02256'
     maplight: 2097
+    wikidata: Q5239255
+    wikipedia: David Rouzer
   name:
     first: David
     last: Rouzer
@@ -38439,6 +38509,8 @@
     opensecrets: N00005293
     thomas: '02257'
     maplight: 2098
+    wikidata: Q4953782
+    wikipedia: Brad Ashford
   name:
     first: Brad
     last: Ashford
@@ -38466,6 +38538,8 @@
     opensecrets: N00036155
     thomas: '02258'
     maplight: 2099
+    wikidata: Q18631218
+    wikipedia: Tom MacArthur
   name:
     first: Tom
     last: MacArthur
@@ -38494,6 +38568,8 @@
     thomas: '02259'
     house_history: 15032409972
     maplight: 2100
+    wikidata: Q4942457
+    wikipedia: Bonnie Watson Coleman
   name:
     first: Bonnie
     last: Watson Coleman
@@ -38521,6 +38597,8 @@
     opensecrets: N00035628
     thomas: '02260'
     maplight: 2101
+    wikidata: Q16189291
+    wikipedia: Cresent Hardy
   name:
     first: Cresent
     last: Hardy
@@ -38548,6 +38626,8 @@
     opensecrets: N00029404
     thomas: '02261'
     maplight: 2102
+    wikidata: Q16221257
+    wikipedia: Lee Zeldin
   name:
     first: Lee
     last: Zeldin
@@ -38576,6 +38656,8 @@
     thomas: '02262'
     house_history: 15032412351
     maplight: 2103
+    wikidata: Q6376887
+    wikipedia: Kathleen Rice
   name:
     first: Kathleen
     last: Rice
@@ -38604,6 +38686,8 @@
     thomas: '02263'
     house_history: 15032411587
     maplight: 2104
+    wikidata: Q18211057
+    wikipedia: Elise Stefanik
   name:
     first: Elise
     last: Stefanik
@@ -38631,6 +38715,8 @@
     opensecrets: N00035934
     thomas: '02264'
     maplight: 2105
+    wikidata: Q18619043
+    wikipedia: John Katko
   name:
     first: John
     last: Katko
@@ -38658,6 +38744,8 @@
     opensecrets: N00036175
     thomas: '02265'
     maplight: 2106
+    wikidata: Q16195304
+    wikipedia: Steve Russell (politician)
   name:
     first: Steve
     last: Russell
@@ -38685,6 +38773,8 @@
     opensecrets: N00031064
     thomas: '02266'
     maplight: 2107
+    wikidata: Q18631846
+    wikipedia: Ryan Costello
   name:
     first: Ryan
     last: Costello
@@ -38712,6 +38802,8 @@
     opensecrets: N00035307
     thomas: '02267'
     maplight: 2108
+    wikidata: Q4960876
+    wikipedia: Brendan Boyle
   name:
     first: Brendan
     last: Boyle
@@ -38739,6 +38831,8 @@
     opensecrets: N00035972
     thomas: '02268'
     maplight: 2109
+    wikidata: Q16980175
+    wikipedia: John Ratcliffe (American politician)
   name:
     first: John
     last: Ratcliffe
@@ -38766,6 +38860,8 @@
     opensecrets: N00031417
     thomas: '02269'
     maplight: 2110
+    wikidata: Q18639742
+    wikipedia: Will Hurd
   name:
     first: Will
     last: Hurd
@@ -38792,6 +38888,8 @@
     opensecrets: N00005736
     thomas: '02270'
     maplight: 2111
+    wikidata: Q16979824
+    wikipedia: Brian Babin
   name:
     first: Brian
     last: Babin
@@ -38820,6 +38918,8 @@
     thomas: '02271'
     house_history: 15032411201
     maplight: 2112
+    wikidata: Q11112119
+    wikipedia: Mia Love
   name:
     first: Mia
     last: Love
@@ -38847,6 +38947,8 @@
     opensecrets: N00036018
     thomas: '02272'
     maplight: 2113
+    wikidata: Q3036086
+    wikipedia: Don Beyer
   name:
     first: Donald
     last: Beyer
@@ -38875,6 +38977,8 @@
     thomas: '02273'
     house_history: 15032409529
     maplight: 2114
+    wikidata: Q4858820
+    wikipedia: Barbara Comstock
   name:
     first: Barbara
     last: Comstock
@@ -38902,6 +39006,8 @@
     thomas: '02274'
     house_history: 15032410230
     maplight: 2115
+    wikidata: Q18739104
+    wikipedia: Stacey Plaskett
   name:
     first: Stacey
     last: Plaskett
@@ -38929,6 +39035,8 @@
     opensecrets: N00036403
     thomas: '02275'
     maplight: 2116
+    wikidata: Q16733285
+    wikipedia: Dan Newhouse
   name:
     first: Dan
     last: Newhouse
@@ -38956,6 +39064,8 @@
     opensecrets: N00036409
     thomas: '02276'
     maplight: 2117
+    wikidata: Q5568836
+    wikipedia: Glenn Grothman
   name:
     first: Glenn
     last: Grothman
@@ -38983,6 +39093,8 @@
     opensecrets: N00033814
     thomas: '02277'
     maplight: 2118
+    wikidata: Q4718026
+    wikipedia: Alex Mooney
   name:
     first: Alex
     last: Mooney
@@ -39010,6 +39122,8 @@
     opensecrets: N00035531
     thomas: '02278'
     maplight: 2119
+    wikidata: Q5415437
+    wikipedia: Evan Jenkins (politician)
   name:
     first: Evan
     last: Jenkins
@@ -39037,6 +39151,8 @@
     thomas: '02222'
     house_history: 15032412349
     maplight: 2120
+    wikidata: Q18684027
+    wikipedia: Amata Coleman Radewagen
   name:
     first: Aumua
     last: Amata
@@ -39065,6 +39181,8 @@
     opensecrets: N00035774
     lis: S383
     maplight: 2121
+    wikidata: Q19996393
+    wikipedia: Dan Sullivan (Arkansas politician)
   name:
     first: Dan
     last: Sullivan
@@ -39093,6 +39211,8 @@
     opensecrets: N00035516
     lis: S379
     maplight: 2122
+    wikidata: Q17402717
+    wikipedia: David Perdue
   name:
     first: David
     last: Perdue
@@ -39122,6 +39242,8 @@
     lis: S376
     house_history: 15032414877
     maplight: 2123
+    wikidata: Q13475242
+    wikipedia: Joni Ernst
   name:
     first: Joni
     last: Ernst
@@ -39150,6 +39272,8 @@
     opensecrets: N00035492
     lis: S384
     maplight: 2124
+    wikidata: Q7786750
+    wikipedia: Thom Tillis
   name:
     first: Thom
     last: Tillis
@@ -39178,6 +39302,8 @@
     opensecrets: N00035187
     lis: S381
     maplight: 2125
+    wikidata: Q722503
+    wikipedia: Mike Rounds
   name:
     first: Mike
     last: Rounds
@@ -39205,6 +39331,8 @@
     opensecrets: N00035311
     thomas: '02255'
     maplight: 2126
+    wikidata: Q17388892
+    wikipedia: Mark Walker (North Carolina politician)
   name:
     first: Mark
     last: Walker
@@ -39233,6 +39361,8 @@
     opensecrets: N00035544
     lis: S382
     maplight: 2127
+    wikidata: Q16192221
+    wikipedia: Ben Sasse
   name:
     first: Benjamin
     middle: Eric


### PR DESCRIPTION
Adding missing links to Wikipedia for those entries missing Wikipedia
links.

Also, on a trial basis, including links to Wikidata as well. Wikidata
IDs are stable identifiers, meaning they will continue referring to the
member of Congress in question even if the article is renamed. The
compromise reached by myself and Konklone is to list both side by side
for the time being, with the Wikidata ID being used to occasionally
check to see that the Wikipedia page titles are up to date. I will add
Wikidata IDs for the rest of them as soon as I find an efficient way to
do so.