### PR TITLE
Wikidata IDs and updated Wikipedia article titles for all

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -15,6 +15,7 @@
     maplight: 168
     washington_post: gIQA3O2w9O
     icpsr: 29389
+    wikidata: Q381880
   name:
     first: Sherrod
     last: Brown
@@ -111,6 +112,7 @@
     maplight: 544
     washington_post: gIQAZxKkDP
     icpsr: 39310
+    wikidata: Q22250
   name:
     first: Maria
     last: Cantwell
@@ -176,6 +178,7 @@
     ballotpedia: Ben Cardin
     maplight: 182
     washington_post: gIQAGMu99O
+    wikidata: Q723295
   name:
     first: Benjamin
     middle: L.
@@ -290,6 +293,7 @@
     ballotpedia: Tom Carper
     maplight: 545
     washington_post: gIQA3bm69O
+    wikidata: Q457432
   name:
     first: Thomas
     middle: Richard
@@ -378,6 +382,7 @@
     maplight: 727
     washington_post: gIQABeor9O
     icpsr: 40703
+    wikidata: Q887841
   name:
     first: Robert
     middle: P.
@@ -431,6 +436,7 @@
     maplight: 729
     washington_post: gIQADOuy9O
     icpsr: 40705
+    wikidata: Q331719
   name:
     first: Bob
     last: Corker
@@ -481,6 +487,7 @@
     maplight: 567
     washington_post: gIQAnrCyDP
     icpsr: 49300
+    wikidata: Q230733
   name:
     first: Dianne
     last: Feinstein
@@ -551,6 +558,7 @@
     ballotpedia: Orrin Hatch
     maplight: 574
     washington_post: gIQAzJiz9O
+    wikidata: Q381157
   name:
     first: Orrin
     middle: G.
@@ -634,6 +642,7 @@
     maplight: 724
     washington_post: gIQA5G259O
     icpsr: 40700
+    wikidata: Q22237
   name:
     first: Amy
     middle: Jean
@@ -685,6 +694,7 @@
     maplight: 725
     washington_post: gIQAiqnb9O
     icpsr: 40701
+    wikidata: Q22260
   name:
     first: Claire
     last: McCaskill
@@ -736,6 +746,7 @@
     maplight: 368
     washington_post: gIQAYgYw6O
     icpsr: 29373
+    wikidata: Q888132
   name:
     first: Robert
     last: Menéndez
@@ -841,6 +852,7 @@
     ballotpedia: Bill Nelson (Florida)
     maplight: 598
     washington_post: gIQAlLuy9O
+    wikidata: Q358437
   name:
     first: Bill
     last: Nelson
@@ -935,6 +947,7 @@
     washington_post: gIQABiDjMP
     icpsr: 29147
     house_history: 21173
+    wikidata: Q359442
   name:
     first: Bernard
     last: Sanders
@@ -1039,6 +1052,7 @@
     washington_post: gIQA5t8DAP
     icpsr: 29732
     house_history: 22090
+    wikidata: Q241092
   name:
     first: Debbie
     middle: Ann
@@ -1109,6 +1123,7 @@
     maplight: 726
     washington_post: gIQAw67AAP
     icpsr: 40702
+    wikidata: Q529351
   name:
     first: Jon
     last: Tester
@@ -1158,6 +1173,7 @@
     maplight: 728
     washington_post: gIQA7KHw9O
     icpsr: 40704
+    wikidata: Q652066
   name:
     first: Sheldon
     last: Whitehouse
@@ -1207,6 +1223,7 @@
     maplight: 732
     washington_post: gIQASOzBAP
     icpsr: 40707
+    wikidata: Q720521
   name:
     first: John
     middle: A.
@@ -1259,6 +1276,7 @@
     washington_post: gIQAC9ZCAP
     icpsr: 29534
     house_history: 23734
+    wikidata: Q390491
   name:
     first: Roger
     middle: F.
@@ -1355,6 +1373,7 @@
     maplight: 530
     washington_post: gIQAzZQL9O
     icpsr: 40304
+    wikidata: Q419976
   name:
     first: Lamar
     last: Alexander
@@ -1415,6 +1434,7 @@
     ballotpedia: Thad Cochran
     maplight: 549
     washington_post: gIQAJk599O
+    wikidata: Q723896
   name:
     first: Thad
     last: Cochran
@@ -1517,6 +1537,7 @@
     maplight: 551
     washington_post: gIQAPvDu9O
     icpsr: 49703
+    wikidata: Q22279
   name:
     first: Susan
     middle: M.
@@ -1583,6 +1604,7 @@
     maplight: 553
     washington_post: gIQAy80L9O
     icpsr: 40305
+    wikidata: Q719568
   name:
     first: John
     last: Cornyn
@@ -1658,6 +1680,7 @@
     ballotpedia: Dick Durbin
     maplight: 563
     washington_post: gIQArl8V9O
+    wikidata: Q434804
   name:
     first: Richard
     middle: J.
@@ -1790,6 +1813,7 @@
     maplight: 565
     washington_post: gIQAAWfCAP
     icpsr: 49706
+    wikidata: Q432431
   name:
     first: Michael
     middle: B.
@@ -1858,6 +1882,7 @@
     maplight: 569
     washington_post: gIQAEdOu9O
     icpsr: 29566
+    wikidata: Q22212
   name:
     first: Lindsey
     middle: O.
@@ -1944,6 +1969,7 @@
     ballotpedia: Jim Inhofe
     maplight: 576
     washington_post: gIQASu669O
+    wikidata: Q723134
   name:
     first: James
     middle: M.
@@ -2041,6 +2067,7 @@
     ballotpedia: Mitch McConnell
     maplight: 593
     washington_post: gIQAYR2b9O
+    wikidata: Q355522
   name:
     first: Mitch
     last: McConnell
@@ -2138,6 +2165,7 @@
     maplight: 807
     washington_post: gIQAosnb9O
     icpsr: 40908
+    wikidata: Q1368405
   name:
     first: Jeff
     last: Merkley
@@ -2191,6 +2219,7 @@
     maplight: 600
     washington_post: gIQAT2gt9O
     icpsr: 29142
+    wikidata: Q528979
   name:
     first: John
     middle: F.
@@ -2276,6 +2305,7 @@
     maplight: 804
     washington_post: gIQAWIdW9O
     icpsr: 40902
+    wikidata: Q721871
   name:
     first: James
     last: Risch
@@ -2327,6 +2357,7 @@
     ballotpedia: Pat Roberts
     maplight: 602
     washington_post: gIQAUECAAP
+    wikidata: Q538375
   name:
     first: Pat
     last: Roberts
@@ -2440,6 +2471,7 @@
     maplight: 607
     washington_post: gIQAHXOBAP
     icpsr: 49700
+    wikidata: Q358443
   name:
     first: Jefferson
     middle: B.
@@ -2508,6 +2540,7 @@
     washington_post: gIQAZP1b9O
     icpsr: 40906
     house_history: 22618
+    wikidata: Q270316
   name:
     first: Jeanne
     last: Shaheen
@@ -2561,6 +2594,7 @@
     maplight: 498
     washington_post: gIQAv2eM9O
     icpsr: 29924
+    wikidata: Q957690
   name:
     first: Tom
     middle: S.
@@ -2655,6 +2689,7 @@
     maplight: 803
     washington_post: gIQAUqPM9O
     icpsr: 40909
+    wikidata: Q453893
   name:
     first: Mark
     last: Warner
@@ -2708,6 +2743,7 @@
     maplight: 708
     washington_post: gIQAz4Kt9O
     icpsr: 20735
+    wikidata: Q22222
   name:
     first: Kirsten
     middle: E.
@@ -2772,6 +2808,7 @@
     maplight: 1189
     washington_post: gIQAnCqo9O
     icpsr: 40904
+    wikidata: Q319084
   name:
     first: Alan
     middle: Stuart
@@ -2824,6 +2861,7 @@
     maplight: 1371
     washington_post: gIQAaKfTKP
     icpsr: 40916
+    wikidata: Q923242
   name:
     first: Chris
     middle: Andrew
@@ -2874,6 +2912,7 @@
     maplight: 1372
     washington_post: gIQA82bVBP
     icpsr: 40915
+    wikidata: Q538868
   name:
     first: Joe
     last: Manchin
@@ -2923,6 +2962,7 @@
     maplight: 127
     washington_post: gIQAw6QSAP
     icpsr: 29701
+    wikidata: Q672671
   name:
     first: Robert
     last: Aderholt
@@ -3032,6 +3072,7 @@
     maplight: 1449
     washington_post: gIQAMkzZKP
     icpsr: 21143
+    wikidata: Q1714165
   name:
     first: Justin
     last: Amash
@@ -3093,6 +3134,7 @@
     maplight: 1498
     washington_post: gIQA6LfTKP
     icpsr: 41106
+    wikidata: Q22354
   name:
     first: Kelly
     last: Ayotte
@@ -3132,6 +3174,7 @@
     maplight: 136
     washington_post: gIQAgHwPAP
     icpsr: 29940
+    wikidata: Q40628
   name:
     first: Tammy
     last: Baldwin
@@ -3221,6 +3264,7 @@
     maplight: 1474
     washington_post: gIQA3fVUKP
     icpsr: 21171
+    wikidata: Q25568
   name:
     first: Lou
     last: Barletta
@@ -3281,6 +3325,7 @@
     house_history: 9049
     maplight: 139
     washington_post: gIQAhoxEAP
+    wikidata: Q966261
   name:
     first: Joe
     middle: Linus
@@ -3425,6 +3470,7 @@
     maplight: 1249
     washington_post: gIQA45LZKP
     icpsr: 21110
+    wikidata: Q461739
   name:
     first: Karen
     last: Bass
@@ -3485,6 +3531,7 @@
     maplight: 142
     washington_post: gIQAenAR9O
     icpsr: 29316
+    wikidata: Q1855840
   name:
     first: Xavier
     last: Becerra
@@ -3605,6 +3652,7 @@
     maplight: 1447
     washington_post: gIQAOvErKP
     icpsr: 21141
+    wikidata: Q1158992
   name:
     first: Dan
     last: Benishek
@@ -3665,6 +3713,7 @@
     maplight: 1092
     washington_post: gIQA8vao9O
     icpsr: 40910
+    wikidata: Q554792
   name:
     first: Michael
     middle: F.
@@ -3710,6 +3759,7 @@
     maplight: 731
     washington_post: gIQAjtHPAP
     icpsr: 20758
+    wikidata: Q1555314
   name:
     first: Gus
     last: Bilirakis
@@ -3789,6 +3839,7 @@
     maplight: 150
     washington_post: gIQALHQPAP
     icpsr: 20357
+    wikidata: Q433857
   name:
     first: Rob
     last: Bishop
@@ -3878,6 +3929,7 @@
     washington_post: gIQATrCOAP
     icpsr: 29339
     house_history: 7697
+    wikidata: Q983428
   name:
     first: Sanford
     middle: D.
@@ -3999,6 +4051,7 @@
     maplight: 1483
     washington_post: gIQAtZuYKP
     icpsr: 21180
+    wikidata: Q515935
   name:
     first: Diane
     last: Black
@@ -4059,6 +4112,7 @@
     maplight: 151
     washington_post: gIQALZuKAP
     icpsr: 20351
+    wikidata: Q458971
   name:
     first: Marsha
     middle: W.
@@ -4150,6 +4204,7 @@
     maplight: 152
     washington_post: gIQAqvaOAP
     icpsr: 29588
+    wikidata: Q748066
   name:
     first: Earl
     last: Blumenauer
@@ -4263,6 +4318,7 @@
     maplight: 1495
     washington_post: gIQAeNwz6O
     icpsr: 41101
+    wikidata: Q2023708
   name:
     first: Richard
     last: Blumenthal
@@ -4302,6 +4358,7 @@
     maplight: 153
     washington_post: gIQAUcQL9O
     icpsr: 29735
+    wikidata: Q1525924
   name:
     first: Roy
     last: Blunt
@@ -4386,6 +4443,7 @@
     maplight: 155
     washington_post: gIQAzRvL9O
     icpsr: 29137
+    wikidata: Q11702
   name:
     first: John
     middle: A.
@@ -4527,6 +4585,7 @@
     maplight: 159
     washington_post: gIQAxKQPAP
     icpsr: 20101
+    wikidata: Q1344707
   name:
     first: John
     last: Boozman
@@ -4595,6 +4654,7 @@
     wikipedia: Madeleine Bordallo
     house_history: 10389
     maplight: 160
+    wikidata: Q292988
   name:
     first: Madeleine
     middle: Z.
@@ -4686,6 +4746,7 @@
     maplight: 642
     washington_post: gIQAiMQPAP
     icpsr: 20514
+    wikidata: Q972735
   name:
     first: Charles
     middle: W.
@@ -4772,6 +4833,7 @@
     ballotpedia: Barbara Boxer
     maplight: 539
     washington_post: gIQArxPM9O
+    wikidata: Q237560
   name:
     first: Barbara
     last: Boxer
@@ -4858,6 +4920,7 @@
     maplight: 166
     washington_post: gIQATjbPAP
     icpsr: 29760
+    wikidata: Q472241
   name:
     first: Kevin
     middle: P.
@@ -4967,6 +5030,7 @@
     maplight: 165
     washington_post: gIQATngIAP
     icpsr: 29777
+    wikidata: Q434522
   name:
     first: Robert
     middle: Alan
@@ -5075,6 +5139,7 @@
     maplight: 1409
     washington_post: gIQAdMkz6O
     icpsr: 21193
+    wikidata: Q1941306
   name:
     first: Mo
     last: Brooks
@@ -5136,6 +5201,7 @@
     washington_post: gIQAvFwPAP
     icpsr: 29328
     house_history: 7695
+    wikidata: Q461512
   name:
     first: Corrine
     last: Brown
@@ -5256,6 +5322,7 @@
     maplight: 683
     washington_post: gIQA8OnhDP
     icpsr: 20709
+    wikidata: Q2517229
   name:
     first: Vern
     last: Buchanan
@@ -5331,6 +5398,7 @@
     maplight: 1438
     washington_post: gIQAD7JXKP
     icpsr: 21132
+    wikidata: Q944286
   name:
     first: Larry
     last: Bucshon
@@ -5390,6 +5458,7 @@
     maplight: 171
     washington_post: gIQAyRzBAP
     icpsr: 20355
+    wikidata: Q539521
   name:
     first: Michael
     middle: C.
@@ -5483,6 +5552,7 @@
     maplight: 172
     washington_post: gIQAMX709O
     icpsr: 29548
+    wikidata: Q331278
   name:
     first: Richard
     middle: M.
@@ -5560,6 +5630,7 @@
     maplight: 624
     washington_post: gIQAA20hDP
     icpsr: 20340
+    wikidata: Q983532
   name:
     first: George
     middle: Kenneth
@@ -5651,6 +5722,7 @@
     maplight: 175
     washington_post: gIQAORoVBP
     icpsr: 29323
+    wikidata: Q538978
   name:
     first: Ken
     middle: S.
@@ -5774,6 +5846,7 @@
     washington_post: gIQA3s9PAP
     icpsr: 20146
     lis: S372
+    wikidata: Q459618
   name:
     first: Shelley
     middle: Moore
@@ -5871,6 +5944,7 @@
     maplight: 180
     washington_post: gIQAarASAP
     icpsr: 29774
+    wikidata: Q459693
   name:
     first: Lois
     last: Capps
@@ -5983,6 +6057,7 @@
     maplight: 181
     washington_post: gIQAzL6PAP
     icpsr: 29919
+    wikidata: Q551578
   name:
     first: Michael
     middle: E.
@@ -6078,12 +6153,13 @@
     fec:
     - H0DE01017
     cspan: 94948
-    wikipedia: John C. Carney, Jr.
+    wikipedia: John Carney (politician)
     house_history: 11825
     ballotpedia: John C. Carney Jr.
     maplight: 1419
     washington_post: gIQABIMZKP
     icpsr: 21113
+    wikidata: Q505302
   name:
     first: John
     last: Carney
@@ -6146,6 +6222,7 @@
     maplight: 739
     washington_post: gIQAPh8PAP
     icpsr: 20757
+    wikidata: Q517649
   name:
     first: André
     last: Carson
@@ -6218,12 +6295,13 @@
     fec:
     - H2TX31044
     cspan: 1004257
-    wikipedia: John Carter (Texas)
+    wikipedia: John Carter (Texas politician)
     house_history: 11770
     ballotpedia: John Carter
     maplight: 185
     washington_post: gIQAcLQNAP
     icpsr: 20356
+    wikidata: Q369814
   name:
     first: John
     middle: R.
@@ -6316,6 +6394,7 @@
     washington_post: gIQAPBLkDP
     icpsr: 20919
     lis: S373
+    wikidata: Q861999
   name:
     first: Bill
     last: Cassidy
@@ -6383,6 +6462,7 @@
     maplight: 682
     washington_post: gIQAEoCLAP
     icpsr: 20708
+    wikidata: Q458492
   name:
     first: Kathy
     last: Castor
@@ -6458,6 +6538,7 @@
     maplight: 188
     washington_post: gIQAiE5TKP
     icpsr: 29550
+    wikidata: Q506694
   name:
     first: Steve
     middle: J.
@@ -6565,6 +6646,7 @@
     maplight: 752
     washington_post: gIQAm9WMAP
     icpsr: 20949
+    wikidata: Q1683881
   name:
     first: Jason
     last: Chaffetz
@@ -6632,6 +6714,7 @@
     maplight: 1190
     washington_post: gIQA1yiFAP
     icpsr: 20955
+    wikidata: Q460035
   name:
     first: Judy
     middle: M.
@@ -6701,6 +6784,7 @@
     maplight: 1475
     washington_post: gIQA6P5YKP
     icpsr: 21172
+    wikidata: Q938498
   name:
     first: David
     last: Cicilline
@@ -6762,6 +6846,7 @@
     maplight: 706
     washington_post: gIQAOxvIAP
     icpsr: 20733
+    wikidata: Q461679
   name:
     first: Yvette
     middle: D.
@@ -6832,11 +6917,12 @@
     fec:
     - H0MO01066
     cspan: 88332
-    wikipedia: William Lacy Clay, Jr.
+    wikipedia: Lacy Clay
     house_history: 11766
     maplight: 191
     washington_post: gIQA1BJQAP
     icpsr: 20147
+    wikidata: Q959455
   name:
     first: Wm.
     middle: Lacy
@@ -6935,6 +7021,7 @@
     maplight: 645
     washington_post: gIQANj8PAP
     icpsr: 20517
+    wikidata: Q1334654
   name:
     first: Emanuel
     last: Cleaver
@@ -7017,6 +7104,7 @@
     maplight: 192
     washington_post: gIQAv50L9O
     icpsr: 39301
+    wikidata: Q1289889
   name:
     first: James
     middle: E.
@@ -7143,6 +7231,7 @@
     ballotpedia: Dan Coats
     maplight: 1407
     washington_post: gIQAGGdaAP
+    wikidata: Q632321
   name:
     first: Daniel
     middle: Ray
@@ -7218,6 +7307,7 @@
     maplight: 753
     washington_post: gIQA5XQQAP
     icpsr: 20906
+    wikidata: Q547218
   name:
     first: Mike
     last: Coffman
@@ -7285,6 +7375,7 @@
     maplight: 721
     washington_post: gIQAxQaQAP
     icpsr: 20748
+    wikidata: Q512330
   name:
     first: Steve
     last: Cohen
@@ -7360,6 +7451,7 @@
     maplight: 194
     washington_post: gIQATSaQAP
     icpsr: 20344
+    wikidata: Q173839
   name:
     first: Tom
     last: Cole
@@ -7451,6 +7543,7 @@
     maplight: 660
     washington_post: gIQAkUaQAP
     icpsr: 20531
+    wikidata: Q538944
   name:
     first: K.
     middle: Michael
@@ -7531,6 +7624,7 @@
     maplight: 754
     washington_post: gIQA3zDRAP
     icpsr: 20952
+    wikidata: Q1514859
   name:
     first: Gerald
     middle: E.
@@ -7600,6 +7694,7 @@
     ballotpedia: John Conyers, Jr.
     maplight: 195
     washington_post: gIQA4cvo9O
+    wikidata: Q1370968
   name:
     first: John
     last: Conyers
@@ -7807,6 +7902,7 @@
     ballotpedia: Jim Cooper
     maplight: 196
     washington_post: gIQABq669O
+    wikidata: Q973737
   name:
     first: Jim
     last: Cooper
@@ -7932,6 +8028,7 @@
     maplight: 626
     washington_post: gIQAwvJSAP
     icpsr: 20501
+    wikidata: Q675869
   name:
     first: Jim
     last: Costa
@@ -8013,6 +8110,7 @@
     maplight: 680
     washington_post: gIQAQONRAP
     icpsr: 20706
+    wikidata: Q434470
   name:
     first: Joe
     last: Courtney
@@ -8090,6 +8188,7 @@
     maplight: 556
     washington_post: gIQA3hslDP
     icpsr: 29345
+    wikidata: Q734319
   name:
     first: Michael
     middle: D.
@@ -8160,6 +8259,7 @@
     maplight: 1414
     washington_post: gIQAlMfVKP
     icpsr: 21106
+    wikidata: Q2151554
   name:
     first: Eric
     middle: A.
@@ -8222,6 +8322,7 @@
     maplight: 200
     washington_post: gIQASSNRAP
     icpsr: 20111
+    wikidata: Q490511
   name:
     first: Ander
     last: Crenshaw
@@ -8316,6 +8417,7 @@
     maplight: 201
     washington_post: gIQACIr09O
     icpsr: 29925
+    wikidata: Q971318
   name:
     first: Joseph
     last: Crowley
@@ -8418,6 +8520,7 @@
     maplight: 662
     washington_post: gIQAHjjSAP
     icpsr: 20533
+    wikidata: Q539562
   name:
     first: Henry
     last: Cuellar
@@ -8500,6 +8603,7 @@
     maplight: 203
     washington_post: gIQArjZfAP
     icpsr: 20139
+    wikidata: Q671976
   name:
     first: John
     middle: Abney
@@ -8597,6 +8701,7 @@
     maplight: 204
     washington_post: gIQAKaxDAP
     icpsr: 29587
+    wikidata: Q934898
   name:
     first: Elijah
     middle: E.
@@ -8712,6 +8817,7 @@
     maplight: 209
     washington_post: gIQAgWpbKP
     icpsr: 29717
+    wikidata: Q1164657
   name:
     first: Danny
     middle: K.
@@ -8820,6 +8926,7 @@
     maplight: 207
     washington_post: gIQAumASAP
     icpsr: 20108
+    wikidata: Q460675
   name:
     first: Susan
     middle: A.
@@ -8916,6 +9023,7 @@
     ballotpedia: Peter DeFazio
     maplight: 213
     washington_post: gIQAS87AAP
+    wikidata: Q1758507
   name:
     first: Peter
     middle: A.
@@ -9053,6 +9161,7 @@
     maplight: 214
     washington_post: gIQADVSDAP
     icpsr: 29710
+    wikidata: Q437159
   name:
     first: Diana
     middle: L.
@@ -9162,6 +9271,7 @@
     maplight: 215
     washington_post: gIQAkOCT9O
     icpsr: 29109
+    wikidata: Q434952
   name:
     first: Rosa
     middle: L.
@@ -9288,6 +9398,7 @@
     maplight: 1276
     washington_post: gIQA6BMZKP
     icpsr: 21109
+    wikidata: Q1686295
   name:
     first: Jeff
     last: Denham
@@ -9348,6 +9459,7 @@
     maplight: 654
     washington_post: gIQAY7qLAP
     icpsr: 20526
+    wikidata: Q556034
   name:
     first: Charles
     middle: W.
@@ -9429,6 +9541,7 @@
     maplight: 1482
     washington_post: gIQAQg5WKP
     icpsr: 21179
+    wikidata: Q2260839
   name:
     first: Scott
     last: DesJarlais
@@ -9489,6 +9602,7 @@
     maplight: 1365
     washington_post: gIQAgpzZKP
     icpsr: 20959
+    wikidata: Q245724
   name:
     first: Theodore
     middle: E.
@@ -9552,12 +9666,13 @@
     fec:
     - H2FL25018
     cspan: 1003562
-    wikipedia: Mario Diaz-Balart
+    wikipedia: Mario Díaz-Balart
     house_history: 12575
     ballotpedia: Mario Diaz-Balart
     maplight: 221
     washington_post: gIQAvrSaAP
     icpsr: 20316
+    wikidata: Q767270
   name:
     first: Mario
     last: Diaz-Balart
@@ -9650,6 +9765,7 @@
     maplight: 224
     washington_post: gIQA0jEdKP
     icpsr: 29571
+    wikidata: Q363817
   name:
     first: Lloyd
     middle: A.
@@ -9767,6 +9883,7 @@
     maplight: 691
     washington_post: gIQAM8hOAP
     icpsr: 20717
+    wikidata: Q1691395
   name:
     first: Joe
     last: Donnelly
@@ -9830,6 +9947,7 @@
     maplight: 226
     washington_post: gIQAlqEdKP
     icpsr: 29561
+    wikidata: Q1344200
   name:
     first: Michael
     middle: F.
@@ -9947,6 +10065,7 @@
     maplight: 1493
     washington_post: gIQAx21QKP
     icpsr: 21189
+    wikidata: Q1729888
   name:
     first: Sean
     last: Duffy
@@ -10007,6 +10126,7 @@
     maplight: 1477
     washington_post: gIQAfghZKP
     icpsr: 21174
+    wikidata: Q1027026
   name:
     first: Jeff
     last: Duncan
@@ -10066,6 +10186,7 @@
     house_history: 12493
     maplight: 228
     washington_post: gIQA7YKbKP
+    wikidata: Q653994
   name:
     first: John
     middle: J.
@@ -10209,6 +10330,7 @@
     maplight: 744
     washington_post: gIQAqUKbKP
     icpsr: 20763
+    wikidata: Q461663
   name:
     first: Donna
     middle: F.
@@ -10285,6 +10407,7 @@
     maplight: 700
     washington_post: gIQA98OxDP
     icpsr: 20727
+    wikidata: Q40589
   name:
     first: Keith
     middle: Maurice
@@ -10361,6 +10484,7 @@
     maplight: 1464
     washington_post: gIQAATqZKP
     icpsr: 21159
+    wikidata: Q515971
   name:
     first: Renee
     last: Ellmers
@@ -10421,6 +10545,7 @@
     house_history: 12815
     maplight: 233
     washington_post: gIQAxS2pAP
+    wikidata: Q1329618
   name:
     first: Eliot
     middle: L.
@@ -10551,6 +10676,7 @@
     maplight: 235
     washington_post: gIQAdlYxDP
     icpsr: 29312
+    wikidata: Q291193
   name:
     first: Anna
     middle: G.
@@ -10672,6 +10798,7 @@
     maplight: 1487
     washington_post: gIQA6OqZKP
     icpsr: 21184
+    wikidata: Q881255
   name:
     first: Blake
     last: Farenthold
@@ -10731,6 +10858,7 @@
     maplight: 240
     washington_post: gIQAPPNqAP
     icpsr: 29313
+    wikidata: Q675348
   name:
     first: Sam
     last: Farr
@@ -10851,6 +10979,7 @@
     maplight: 241
     washington_post: gIQAvQNqAP
     icpsr: 29559
+    wikidata: Q1059265
   name:
     first: Chaka
     last: Fattah
@@ -10964,6 +11093,7 @@
     maplight: 1484
     washington_post: gIQAnqGVKP
     icpsr: 21181
+    wikidata: Q2344713
   name:
     first: Stephen
     last: Fincher
@@ -11024,6 +11154,7 @@
     maplight: 652
     washington_post: gIQApV5UKP
     icpsr: 20524
+    wikidata: Q45951
   name:
     first: Michael
     middle: G.
@@ -11093,6 +11224,7 @@
     maplight: 245
     washington_post: gIQAU2XIAP
     icpsr: 20100
+    wikidata: Q929581
   name:
     first: Jeff
     last: Flake
@@ -11176,6 +11308,7 @@
     maplight: 1481
     washington_post: gIQAav8tKP
     icpsr: 21178
+    wikidata: Q521959
   name:
     first: Charles
     last: Fleischmann
@@ -11238,6 +11371,7 @@
     maplight: 757
     washington_post: gIQARR2pAP
     icpsr: 20918
+    wikidata: Q1699486
   name:
     first: John
     last: Fleming
@@ -11310,6 +11444,7 @@
     maplight: 1485
     washington_post: gIQA9K9UKP
     icpsr: 21182
+    wikidata: Q862103
   name:
     first: Bill
     last: Flores
@@ -11370,6 +11505,7 @@
     maplight: 247
     washington_post: gIQAqP2pAP
     icpsr: 20143
+    wikidata: Q2130783
   name:
     first: J.
     middle: Randy
@@ -11467,6 +11603,7 @@
     maplight: 646
     washington_post: gIQAfqrHAP
     icpsr: 20518
+    wikidata: Q1397331
   name:
     first: Jeff
     middle: Lane
@@ -11549,6 +11686,7 @@
     maplight: 649
     washington_post: gIQARSNqAP
     icpsr: 20521
+    wikidata: Q458453
   name:
     first: Virginia
     last: Foxx
@@ -11631,6 +11769,7 @@
     maplight: 251
     washington_post: gIQAbTtMAP
     icpsr: 20304
+    wikidata: Q1397303
   name:
     first: Trent
     last: Franks
@@ -11720,6 +11859,7 @@
     maplight: 252
     washington_post: gIQAFP2pAP
     icpsr: 29541
+    wikidata: Q338190
   name:
     first: Rodney
     middle: P.
@@ -11842,6 +11982,7 @@
     maplight: 809
     washington_post: gIQAjN2pAP
     icpsr: 20941
+    wikidata: Q461746
   name:
     first: Marcia
     last: Fudge
@@ -11917,6 +12058,7 @@
     maplight: 1209
     washington_post: gIQAZT3s6O
     icpsr: 20958
+    wikidata: Q1340268
   name:
     first: John
     last: Garamendi
@@ -11986,6 +12128,7 @@
     washington_post: gIQAAaFWKP
     icpsr: 21112
     lis: S377
+    wikidata: Q1135774
   name:
     first: Cory
     last: Gardner
@@ -12043,6 +12186,7 @@
     maplight: 254
     washington_post: gIQAutKHAP
     icpsr: 20336
+    wikidata: Q981424
   name:
     first: Scott
     last: Garrett
@@ -12132,6 +12276,7 @@
     maplight: 1469
     washington_post: gIQAlN3VKP
     icpsr: 21165
+    wikidata: Q887945
   name:
     first: Bob
     last: Gibbs
@@ -12191,6 +12336,7 @@
     maplight: 1461
     washington_post: gIQAHlhZKP
     icpsr: 21156
+    wikidata: Q32722
   name:
     first: Christopher
     middle: P.
@@ -12252,6 +12398,7 @@
     maplight: 656
     washington_post: gIQA0GxpAP
     icpsr: 20527
+    wikidata: Q532647
   name:
     first: Louie
     middle: B.
@@ -12336,6 +12483,7 @@
     maplight: 262
     washington_post: gIQACAHpAP
     icpsr: 39308
+    wikidata: Q887952
   name:
     first: Bob
     middle: W.
@@ -12457,6 +12605,7 @@
     maplight: 1411
     washington_post: gIQAzppVKP
     icpsr: 21103
+    wikidata: Q2059832
   name:
     first: Paul
     last: Gosar
@@ -12518,6 +12667,7 @@
     maplight: 1478
     washington_post: gIQAAozZKP
     icpsr: 21175
+    wikidata: Q1822266
   name:
     first: Trey
     last: Gowdy
@@ -12577,6 +12727,7 @@
     maplight: 264
     washington_post: gIQAJGdW9O
     icpsr: 29762
+    wikidata: Q468807
   name:
     first: Kay
     last: Granger
@@ -12686,6 +12837,7 @@
     ballotpedia: Chuck Grassley
     maplight: 570
     washington_post: gIQAxsWx9O
+    wikidata: Q529294
   name:
     first: Charles
     middle: E.
@@ -12775,6 +12927,7 @@
     maplight: 265
     washington_post: gIQAEvXIAP
     icpsr: 20124
+    wikidata: Q465638
   name:
     first: Sam
     middle: B.
@@ -12872,6 +13025,7 @@
     maplight: 1369
     washington_post: gIQA82YuKP
     icpsr: 20962
+    wikidata: Q1647301
   name:
     first: Tom
     last: Graves
@@ -12940,6 +13094,7 @@
     maplight: 658
     washington_post: gIQA7bXzDP
     icpsr: 20529
+    wikidata: Q749039
   name:
     first: Al
     last: Green
@@ -13021,6 +13176,7 @@
     maplight: 266
     washington_post: gIQAYwnpAP
     icpsr: 39304
+    wikidata: Q539587
   name:
     first: Gene
     middle: Eugene
@@ -13142,6 +13298,7 @@
     maplight: 1490
     washington_post: gIQA8LqZKP
     icpsr: 21191
+    wikidata: Q1684857
   name:
     first: H.
     middle: Morgan
@@ -13203,6 +13360,7 @@
     maplight: 268
     washington_post: gIQATZnOAP
     icpsr: 20305
+    wikidata: Q946606
   name:
     first: Raúl
     middle: M.
@@ -13294,6 +13452,7 @@
     maplight: 760
     washington_post: gIQAh9rq6O
     icpsr: 20916
+    wikidata: Q910794
   name:
     first: Brett
     last: Guthrie
@@ -13362,6 +13521,7 @@
     maplight: 269
     washington_post: gIQADVuzDP
     icpsr: 29348
+    wikidata: Q718127
   name:
     first: Luis
     middle: V.
@@ -13482,6 +13642,7 @@
     maplight: 1462
     washington_post: gIQAQdiXKP
     icpsr: 21157
+    wikidata: Q32718
   name:
     first: Richard
     last: Hanna
@@ -13542,6 +13703,7 @@
     maplight: 762
     washington_post: gIQAg8GpAP
     icpsr: 20925
+    wikidata: Q1545023
   name:
     first: Gregg
     last: Harper
@@ -13604,11 +13766,12 @@
     fec:
     - H8MD01094
     cspan: 1033464
-    wikipedia: Andrew P. Harris
+    wikipedia: Andy Harris (politician)
     house_history: 15599
     maplight: 1445
     washington_post: gIQAN7ZTAP
     icpsr: 21139
+    wikidata: Q506639
   name:
     first: Andy
     last: Harris
@@ -13669,6 +13832,7 @@
     maplight: 1454
     washington_post: gIQApt5WKP
     icpsr: 21149
+    wikidata: Q375389
   name:
     first: Vicky
     last: Hartzler
@@ -13729,6 +13893,7 @@
     maplight: 276
     washington_post: gIQAz5GpAP
     icpsr: 29337
+    wikidata: Q1758631
   name:
     first: Alcee
     middle: L.
@@ -13850,6 +14015,7 @@
     maplight: 1456
     washington_post: gIQAviVUKP
     icpsr: 21151
+    wikidata: Q24243
   name:
     first: Joseph
     last: Heck
@@ -13913,6 +14079,7 @@
     maplight: 763
     washington_post: gIQAkCzTAP
     icpsr: 20930
+    wikidata: Q565374
   name:
     first: Martin
     last: Heinrich
@@ -13968,6 +14135,7 @@
     maplight: 281
     washington_post: gIQANKaU9O
     icpsr: 20352
+    wikidata: Q538785
   name:
     first: Jeb
     last: Hensarling
@@ -14057,6 +14225,7 @@
     maplight: 1491
     washington_post: gIQAHQfVKP
     icpsr: 21187
+    wikidata: Q168592
   name:
     first: Jaime
     last: Herrera Beutler
@@ -14117,6 +14286,7 @@
     maplight: 647
     washington_post: gIQAnP7UAP
     icpsr: 20519
+    wikidata: Q505581
   name:
     first: Brian
     middle: M.
@@ -14199,6 +14369,7 @@
     maplight: 764
     washington_post: gIQAtLEM9O
     icpsr: 20907
+    wikidata: Q1689111
   name:
     first: James
     middle: A.
@@ -14268,6 +14439,7 @@
     maplight: 285
     washington_post: gIQAvN7UAP
     icpsr: 29763
+    wikidata: Q256517
   name:
     first: Rubén
     middle: E.
@@ -14379,6 +14551,7 @@
     maplight: 687
     washington_post: gIQARL7UAP
     icpsr: 20713
+    wikidata: Q16476
   name:
     first: Mazie
     middle: K.
@@ -14443,6 +14616,7 @@
     maplight: 1499
     washington_post: gIQA8Pwz6O
     icpsr: 41107
+    wikidata: Q374762
   name:
     first: John
     last: Hoeven
@@ -14479,6 +14653,7 @@
     maplight: 290
     washington_post: gIQA8Id2DP
     icpsr: 20103
+    wikidata: Q399621
   name:
     first: Michael
     middle: M.
@@ -14577,6 +14752,7 @@
     ballotpedia: Steny Hoyer
     maplight: 293
     washington_post: gIQA9KQN9O
+    wikidata: Q516515
   name:
     first: Steny
     middle: H.
@@ -14754,6 +14930,7 @@
     maplight: 1440
     washington_post: gIQABtpVK
     icpsr: 21134
+    wikidata: Q2434073
   name:
     first: Tim
     last: Huelskamp
@@ -14814,6 +14991,7 @@
     maplight: 1448
     washington_post: gIQAOyHaKP
     icpsr: 21142
+    wikidata: Q862199
   name:
     first: Bill
     last: Huizenga
@@ -14874,6 +15052,7 @@
     maplight: 1434
     washington_post: gIQAHoGVKP
     icpsr: 21129
+    wikidata: Q556404
   name:
     first: Randy
     last: Hultgren
@@ -14933,6 +15112,7 @@
     maplight: 765
     washington_post: gIQAFspUAP
     icpsr: 20963
+    wikidata: Q540521
   name:
     first: Duncan
     middle: D.
@@ -15005,6 +15185,7 @@
     maplight: 1489
     washington_post: gIQAfrpVKP
     icpsr: 21186
+    wikidata: Q2157642
   name:
     first: Robert
     last: Hurt
@@ -15067,6 +15248,7 @@
     maplight: 298
     washington_post: gIQAkTA2DP
     icpsr: 29909
+    wikidata: Q130024
   name:
     first: John
     middle: H.
@@ -15133,6 +15315,7 @@
     maplight: 299
     washington_post: gIQAt0jCAP
     icpsr: 20129
+    wikidata: Q2096271
   name:
     first: Steve
     middle: J.
@@ -15231,6 +15414,7 @@
     maplight: 300
     washington_post: gIQAaSzFAP
     icpsr: 20107
+    wikidata: Q1166592
   name:
     first: Darrell
     last: Issa
@@ -15326,6 +15510,7 @@
     maplight: 338
     washington_post: gIQAenpUAP
     icpsr: 29573
+    wikidata: Q461734
   name:
     first: Sheila
     last: Jackson Lee
@@ -15440,6 +15625,7 @@
     maplight: 766
     washington_post: gIQA8hpUAP
     icpsr: 20915
+    wikidata: Q456217
   name:
     first: Lynn
     last: Jenkins
@@ -15508,6 +15694,7 @@
     maplight: 1466
     washington_post: gIQAHF5YKP
     icpsr: 21162
+    wikidata: Q862215
   name:
     first: Bill
     last: Johnson
@@ -15567,6 +15754,7 @@
     maplight: 308
     washington_post: gIQAutVSAP
     icpsr: 39305
+    wikidata: Q461526
   name:
     first: Eddie
     middle: Bernice
@@ -15688,6 +15876,7 @@
     maplight: 686
     washington_post: gIQAC8oUAP
     icpsr: 20712
+    wikidata: Q983537
   name:
     first: Henry
     middle: C.
@@ -15766,6 +15955,7 @@
     maplight: 1501
     washington_post: gIQAYIfTKP
     icpsr: 41111
+    wikidata: Q970272
   name:
     first: Ron
     last: Johnson
@@ -15802,6 +15992,7 @@
     maplight: 307
     washington_post: gIQAltpUAP
     icpsr: 29143
+    wikidata: Q539470
   name:
     first: Sam
     middle: Robert
@@ -15929,6 +16120,7 @@
     maplight: 309
     washington_post: gIQALhiUAP
     icpsr: 29546
+    wikidata: Q512537
   name:
     first: Walter
     middle: B.
@@ -16042,12 +16234,13 @@
     fec:
     - H6OH04082
     cspan: 1022879
-    wikipedia: Jim Jordan (Ohio politician)
+    wikipedia: Jim Jordan (U.S. politician)
     house_history: 16067
     ballotpedia: Jim Jordan
     maplight: 711
     washington_post: gIQAjcfUAP
     icpsr: 20738
+    wikidata: Q186215
   name:
     first: Jim
     last: Jordan
@@ -16122,6 +16315,7 @@
     house_history: 16086
     maplight: 312
     washington_post: gIQApw7AAP
+    wikidata: Q436537
   name:
     first: Marcy
     last: Kaptur
@@ -16266,11 +16460,12 @@
     fec:
     - H0MA10082
     cspan: 61856
-    wikipedia: William R. Keating
+    wikipedia: Bill Keating (politician)
     house_history: 16570
     maplight: 1446
     washington_post: gIQA23JXKP
     icpsr: 21140
+    wikidata: Q775412
   name:
     first: William
     last: Keating
@@ -16326,12 +16521,13 @@
     fec:
     - H0PA03271
     cspan: 62696
-    wikipedia: Mike Kelly (Pennsylvania)
+    wikipedia: Mike Kelly (Pennsylvania politician)
     house_history: 16572
     ballotpedia: Mike Kelly
     maplight: 1471
     washington_post: gIQAXuVWKP
     icpsr: 21167
+    wikidata: Q1431761
   name:
     first: Mike
     last: Kelly
@@ -16392,6 +16588,7 @@
     maplight: 319
     washington_post: gIQA0kXHAP
     icpsr: 29769
+    wikidata: Q505222
   name:
     first: Ron
     middle: James
@@ -16501,6 +16698,7 @@
     maplight: 321
     washington_post: gIQAr6fAAP
     icpsr: 29375
+    wikidata: Q953554
   name:
     first: Peter
     middle: T.
@@ -16623,6 +16821,7 @@
     maplight: 320
     washington_post: gIQA958MAP
     icpsr: 20325
+    wikidata: Q749710
   name:
     first: Steve
     middle: A.
@@ -16714,6 +16913,7 @@
     maplight: 1433
     washington_post: gIQARqVWKP
     icpsr: 21128
+    wikidata: Q349955
   name:
     first: Adam
     last: Kinzinger
@@ -16776,6 +16976,7 @@
     maplight: 323
     washington_post: gIQAfhXHAP
     icpsr: 20115
+    wikidata: Q339046
   name:
     first: Mark
     middle: Steven
@@ -16854,6 +17055,7 @@
     maplight: 324
     washington_post: gIQAW0U3DP
     icpsr: 20333
+    wikidata: Q465843
   name:
     first: John
     middle: Paul
@@ -16945,6 +17147,7 @@
     maplight: 1431
     washington_post: gIQAfl8vKP
     icpsr: 21125
+    wikidata: Q555393
   name:
     first: Raúl
     last: Labrador
@@ -17006,6 +17209,7 @@
     maplight: 678
     washington_post: gIQAN69TAP
     icpsr: 20704
+    wikidata: Q371106
   name:
     first: Doug
     last: Lamborn
@@ -17081,6 +17285,7 @@
     maplight: 772
     washington_post: gIQAi49TAP
     icpsr: 20929
+    wikidata: Q1819021
   name:
     first: Leonard
     last: Lance
@@ -17149,6 +17354,7 @@
     maplight: 331
     washington_post: gIQABs8MAP
     icpsr: 20136
+    wikidata: Q1397290
   name:
     first: James
     middle: R.
@@ -17247,6 +17453,7 @@
     washington_post: gIQAcjhZKP
     icpsr: 21166
     lis: S378
+    wikidata: Q45940
   name:
     first: James
     last: Lankford
@@ -17303,6 +17510,7 @@
     house_history: 17298
     maplight: 333
     icpsr: 20145
+    wikidata: Q503529
   name:
     first: Rick
     last: Larsen
@@ -17398,6 +17606,7 @@
     maplight: 334
     washington_post: gIQAmHHN9O
     icpsr: 29908
+    wikidata: Q357832
   name:
     first: John
     middle: B.
@@ -17500,6 +17709,7 @@
     maplight: 737
     washington_post: gIQAYPcwKP
     icpsr: 20755
+    wikidata: Q888061
   name:
     first: Robert
     middle: E.
@@ -17579,6 +17789,7 @@
     ballotpedia: Patrick Leahy
     maplight: 586
     washington_post: gIQAQnnb9O
+    wikidata: Q59315
   name:
     first: Patrick
     middle: J.
@@ -17655,6 +17866,7 @@
     maplight: 337
     washington_post: gIQArxTS9O
     icpsr: 29778
+    wikidata: Q289317
   name:
     first: Barbara
     last: Lee
@@ -17763,6 +17975,7 @@
     maplight: 1500
     washington_post: gIQAwTVWKP
     icpsr: 41110
+    wikidata: Q627098
   name:
     first: Mike
     last: Lee
@@ -17795,10 +18008,11 @@
     - H2MI17023
     cspan: 251
     house_history: 16921
-    wikipedia: Sander M. Levin
+    wikipedia: Sander Levin
     ballotpedia: Sander Levin
     maplight: 339
     washington_post: gIQAv24SAP
+    wikidata: Q971943
   name:
     first: Sander
     middle: M.
@@ -17948,11 +18162,12 @@
     fec:
     - H6GA05217
     cspan: 2528
-    wikipedia: John Lewis (U.S. politician)
+    wikipedia: John Lewis (Georgia politician)
     house_history: 16948
     ballotpedia: John Lewis (Georgia)
     maplight: 341
     washington_post: gIQAaw4SAP
+    wikidata: Q45380
   name:
     first: John
     middle: R.
@@ -18092,6 +18307,7 @@
     maplight: 636
     washington_post: gIQAJLoPMP
     icpsr: 20508
+    wikidata: Q518424
   name:
     first: Daniel
     middle: William
@@ -18177,6 +18393,7 @@
     maplight: 344
     washington_post: gIQA0WNqAP
     icpsr: 29539
+    wikidata: Q616850
   name:
     first: Frank
     middle: A.
@@ -18286,12 +18503,13 @@
     fec:
     - H6IA02146
     cspan: 1022883
-    wikipedia: David Loebsack
+    wikipedia: Dave Loebsack
     house_history: 17307
     ballotpedia: Dave Loebsack
     maplight: 694
     washington_post: gIQAzr4SAP
     icpsr: 20720
+    wikidata: Q771586
   name:
     first: David
     last: Loebsack
@@ -18367,6 +18585,7 @@
     maplight: 345
     washington_post: gIQAi3CLAP
     icpsr: 29504
+    wikidata: Q218217
   name:
     first: Zoe
     last: Lofgren
@@ -18480,6 +18699,7 @@
     maplight: 1455
     washington_post: gIQA4szZKP
     icpsr: 21150
+    wikidata: Q863171
   name:
     first: Billy
     last: Long
@@ -18540,6 +18760,7 @@
     ballotpedia: Nita Lowey
     maplight: 346
     washington_post: gIQAWtY09O
+    wikidata: Q460652
   name:
     first: Nita
     middle: M.
@@ -18667,12 +18888,13 @@
     fec:
     - H4OK06056
     cspan: 35692
-    wikipedia: Frank Lucas (Oklahoma)
+    wikipedia: Frank Lucas (Oklahoma legislator)
     house_history: 17205
     ballotpedia: Frank D. Lucas
     maplight: 347
     washington_post: gIQAtwMLAP
     icpsr: 29393
+    wikidata: Q246049
   name:
     first: Frank
     middle: D.
@@ -18793,6 +19015,7 @@
     maplight: 774
     washington_post: gIQAn2WgAP
     icpsr: 20926
+    wikidata: Q522181
   name:
     first: Blaine
     last: Luetkemeyer
@@ -18855,11 +19078,12 @@
     fec:
     - H8NM03196
     cspan: 1031351
-    wikipedia: Ben R. Luján
+    wikipedia: Ben Ray Luján
     house_history: 17317
     maplight: 775
     washington_post: gIQAHFzTAP
     icpsr: 20932
+    wikidata: Q324256
   name:
     first: Ben
     middle: Ray
@@ -18929,6 +19153,7 @@
     maplight: 776
     washington_post: gIQAWmVSAP
     icpsr: 20953
+    wikidata: Q456064
   name:
     first: Cynthia
     middle: M.
@@ -18993,12 +19218,13 @@
     - H2MA09072
     - S0MA00083
     cspan: 1000222
-    wikipedia: Stephen Lynch (politician)
+    wikipedia: Stephen F. Lynch
     house_history: 17301
     ballotpedia: Stephen Lynch
     maplight: 348
     washington_post: gIQAMEoVBP
     icpsr: 20119
+    wikidata: Q2344921
   name:
     first: Stephen
     middle: F.
@@ -19095,6 +19321,7 @@
     maplight: 349
     washington_post: gIQAcoKHAP
     icpsr: 29379
+    wikidata: Q455833
   name:
     first: Carolyn
     middle: B.
@@ -19215,6 +19442,7 @@
     maplight: 661
     washington_post: gIQAZ91QKP
     icpsr: 20532
+    wikidata: Q368184
   name:
     first: Kenny
     middle: Ewell
@@ -19298,6 +19526,7 @@
     maplight: 1473
     washington_post: gIQAjRiXKP
     icpsr: 21170
+    wikidata: Q2439864
   name:
     first: Tom
     last: Marino
@@ -19360,6 +19589,7 @@
     ballotpedia: Ed Markey
     maplight: 351
     washington_post: gIQAdQUz9O
+    wikidata: Q1282411
   name:
     first: Edward
     middle: J.
@@ -19546,6 +19776,7 @@
     maplight: 668
     washington_post: gIQAK2naKP
     icpsr: 20538
+    wikidata: Q399561
   name:
     first: Doris
     middle: O.
@@ -19633,6 +19864,7 @@
     ballotpedia: John McCain
     maplight: 592
     washington_post: gIQAXQHr9O
+    wikidata: Q10390
   name:
     first: John
     middle: S.
@@ -19710,6 +19942,7 @@
     maplight: 677
     washington_post: gIQA7DQW9O
     icpsr: 20703
+    wikidata: Q766866
   name:
     first: Kevin
     last: McCarthy
@@ -19801,6 +20034,7 @@
     maplight: 659
     washington_post: gIQAwuBTMP
     icpsr: 20530
+    wikidata: Q539509
   name:
     first: Michael
     middle: T.
@@ -19882,6 +20116,7 @@
     maplight: 777
     washington_post: gIQAr0cdKP
     icpsr: 20903
+    wikidata: Q535887
   name:
     first: Tom
     last: McClintock
@@ -19950,6 +20185,7 @@
     maplight: 356
     washington_post: gIQAukFTKP
     icpsr: 20122
+    wikidata: Q434893
   name:
     first: Betty
     middle: Louise
@@ -20046,6 +20282,7 @@
     house_history: 17831
     maplight: 359
     washington_post: gIQApQvNKP
+    wikidata: Q321457
   name:
     first: Jim
     middle: A.
@@ -20173,11 +20410,12 @@
     fec:
     - H4MA03022
     cspan: 45976
-    wikipedia: Jim McGovern (American politician)
+    wikipedia: Jim McGovern (U.S. politician)
     house_history: 17711
     maplight: 360
     washington_post: gIQAZRKbKP
     icpsr: 29729
+    wikidata: Q1337459
   name:
     first: James
     middle: P.
@@ -20288,6 +20526,7 @@
     maplight: 650
     washington_post: gIQA70nx9O
     icpsr: 20522
+    wikidata: Q2057809
   name:
     first: Patrick
     middle: T.
@@ -20370,6 +20609,7 @@
     maplight: 1492
     washington_post: gIQALnNUKP
     icpsr: 21188
+    wikidata: Q1175610
   name:
     first: David
     last: McKinley
@@ -20431,6 +20671,7 @@
     maplight: 664
     washington_post: gIQABLyUMP
     icpsr: 20535
+    wikidata: Q293343
   name:
     first: Cathy
     last: McMorris Rodgers
@@ -20511,6 +20752,7 @@
     maplight: 676
     washington_post: gIQAlHAVBP
     icpsr: 20702
+    wikidata: Q1344743
   name:
     first: Jerry
     last: McNerney
@@ -20586,6 +20828,7 @@
     maplight: 1472
     washington_post: gIQA2yGVKP
     icpsr: 21168
+    wikidata: Q2056533
   name:
     first: Patrick
     last: Meehan
@@ -20645,6 +20888,7 @@
     maplight: 367
     washington_post: gIQAQwSKAP
     icpsr: 29776
+    wikidata: Q1545391
   name:
     first: Gregory
     middle: W.
@@ -20754,6 +20998,7 @@
     maplight: 369
     washington_post: gIQAGSEKAP
     icpsr: 29331
+    wikidata: Q918506
   name:
     first: John
     middle: L.
@@ -20879,6 +21124,7 @@
     ballotpedia: Barbara Mikulski
     maplight: 594
     washington_post: gIQApKSAAP
+    wikidata: Q261147
   name:
     first: Barbara
     middle: A.
@@ -20974,6 +21220,7 @@
     maplight: 372
     washington_post: gIQAVsJbKP
     icpsr: 20331
+    wikidata: Q435777
   name:
     first: Candice
     last: Miller
@@ -21065,6 +21312,7 @@
     maplight: 375
     washington_post: gIQATNjVMP
     icpsr: 20110
+    wikidata: Q970478
   name:
     first: Jeff
     last: Miller
@@ -21161,6 +21409,7 @@
     maplight: 666
     washington_post: gIQArDiKAP
     icpsr: 20537
+    wikidata: Q461698
   name:
     first: Gwen
     last: Moore
@@ -21245,6 +21494,7 @@
     maplight: 379
     washington_post: gIQAdVZfAP
     icpsr: 29722
+    wikidata: Q1365787
   name:
     first: Jerry
     last: Moran
@@ -21329,6 +21579,7 @@
     maplight: 1479
     washington_post: gIQA2dVUKP
     icpsr: 21176
+    wikidata: Q1235731
   name:
     first: Mick
     last: Mulvaney
@@ -21390,6 +21641,7 @@
     maplight: 595
     washington_post: gIQA6VzBAP
     icpsr: 40300
+    wikidata: Q22360
   name:
     first: Lisa
     middle: A.
@@ -21442,12 +21694,13 @@
     - H6CT05124
     - S2CT00132
     cspan: 1021270
-    wikipedia: Chris Murphy (politician)
+    wikipedia: Chris Murphy (Connecticut politician)
     house_history: 18809
     ballotpedia: Christopher S. Murphy
     maplight: 681
     washington_post: gIQAXlFYMP
     icpsr: 20707
+    wikidata: Q1077594
   name:
     first: Christopher
     middle: S.
@@ -21511,6 +21764,7 @@
     maplight: 381
     washington_post: gIQAND0HAP
     icpsr: 20346
+    wikidata: Q2434181
   name:
     first: Tim
     last: Murphy
@@ -21602,6 +21856,7 @@
     maplight: 596
     washington_post: gIQARXaU9O
     icpsr: 49308
+    wikidata: Q258825
   name:
     first: Patty
     last: Murray
@@ -21659,6 +21914,7 @@
     maplight: 385
     washington_post: gIQALyRYMP
     icpsr: 29377
+    wikidata: Q505598
   name:
     first: Jerrold
     middle: L.
@@ -21785,6 +22041,7 @@
     maplight: 386
     washington_post: gIQAW3cdKP
     icpsr: 29903
+    wikidata: Q469139
   name:
     first: Grace
     middle: F.
@@ -21887,6 +22144,7 @@
     house_history: 18855
     maplight: 387
     washington_post: gIQA7V4aKP
+    wikidata: Q1464697
   name:
     first: Richard
     middle: E.
@@ -22020,6 +22278,7 @@
     maplight: 526
     washington_post: gIQA5hZfAP
     icpsr: 20353
+    wikidata: Q539536
   name:
     first: Randy
     last: Neugebauer
@@ -22110,6 +22369,7 @@
     maplight: 1480
     washington_post: gIQABw1QKP
     icpsr: 21177
+    wikidata: Q465749
   name:
     first: Kristi
     last: Noem
@@ -22169,6 +22429,7 @@
     house_history: 19016
     maplight: 390
     washington_post: 73c1161a-64c5-11e2-85f5-a8a9228e55e7
+    wikidata: Q461649
   name:
     first: Eleanor
     middle: Holmes
@@ -22295,6 +22556,7 @@
     maplight: 1421
     washington_post: gIQAt0HaKP
     icpsr: 21115
+    wikidata: Q2148853
   name:
     first: Richard
     last: Nugent
@@ -22355,6 +22617,7 @@
     maplight: 392
     washington_post: gIQAt1EGAP
     icpsr: 20307
+    wikidata: Q539493
   name:
     first: Devin
     middle: G.
@@ -22445,6 +22708,7 @@
     maplight: 784
     washington_post: gIQAdHcTKP
     icpsr: 20948
+    wikidata: Q2073303
   name:
     first: Pete
     last: Olson
@@ -22512,6 +22776,7 @@
     maplight: 1453
     washington_post: gIQAlE0YMP
     icpsr: 21148
+    wikidata: Q24230
   name:
     first: Steven
     last: Palazzo
@@ -22573,6 +22838,7 @@
     house_history: 19321
     maplight: 402
     washington_post: gIQAMsEdKP
+    wikidata: Q965289
   name:
     first: Frank
     middle: J.
@@ -22712,6 +22978,7 @@
     maplight: 403
     washington_post: gIQAbraOAP
     icpsr: 29741
+    wikidata: Q529090
   name:
     first: Bill
     middle: J.
@@ -22822,6 +23089,7 @@
     maplight: 1497
     washington_post: gIQA5AakAP
     icpsr: 41104
+    wikidata: Q463557
   name:
     first: Rand
     last: Paul
@@ -22862,6 +23130,7 @@
     maplight: 785
     washington_post: gIQALqDbKP
     icpsr: 20924
+    wikidata: Q466085
   name:
     first: Erik
     last: Paulsen
@@ -22931,6 +23200,7 @@
     maplight: 407
     washington_post: gIQAZbOZMP
     icpsr: 20337
+    wikidata: Q947168
   name:
     first: Stevan
     middle: E.
@@ -23011,6 +23281,7 @@
     ballotpedia: Nancy Pelosi
     maplight: 408
     washington_post: gIQAF3PM9O
+    wikidata: Q170581
   name:
     first: Nancy
     last: Pelosi
@@ -23164,6 +23435,7 @@
     maplight: 679
     washington_post: gIQAyxjSAP
     icpsr: 20705
+    wikidata: Q331507
   name:
     first: Ed
     last: Perlmutter
@@ -23233,13 +23505,14 @@
     fec:
     - H8MI09068
     cspan: 50199
-    wikipedia: Gary Peters (Michigan politician)
+    wikipedia: Gary Peters (politician)
     house_history: 20028
     ballotpedia: Gary Peters
     maplight: 787
     washington_post: gIQA36BUKP
     icpsr: 20923
     lis: S380
+    wikidata: Q1494930
   name:
     first: Gary
     middle: C.
@@ -23307,6 +23580,7 @@
     maplight: 410
     washington_post: gIQAIQ6GAP
     icpsr: 29127
+    wikidata: Q434458
   name:
     first: Collin
     middle: Clark
@@ -23431,6 +23705,7 @@
     wikipedia: Pedro Pierluisi
     house_history: 20030
     maplight: 788
+    wikidata: Q2277878
   name:
     first: Pedro
     middle: R.
@@ -23481,6 +23756,7 @@
     maplight: 789
     washington_post: gIQAr8cW9O
     icpsr: 20920
+    wikidata: Q457243
   name:
     first: Chellie
     last: Pingree
@@ -23543,12 +23819,13 @@
     fec:
     - H6PA16197
     cspan: 11706
-    wikipedia: Joseph R. Pitts
+    wikipedia: Joe Pitts
     house_history: 19742
     ballotpedia: Joseph R. Pitts
     maplight: 414
     washington_post: gIQAOAMOAP
     icpsr: 29752
+    wikidata: Q1674465
   name:
     first: Joseph
     middle: R.
@@ -23658,6 +23935,7 @@
     maplight: 657
     washington_post: gIQAqEAdKP
     icpsr: 20528
+    wikidata: Q532661
   name:
     first: Ted
     last: Poe
@@ -23740,6 +24018,7 @@
     maplight: 790
     washington_post: gIQAnqrJAP
     icpsr: 20904
+    wikidata: Q935734
   name:
     first: Jared
     last: Polis
@@ -23808,6 +24087,7 @@
     maplight: 1442
     washington_post: gIQAXNLWKP
     icpsr: 21136
+    wikidata: Q473239
   name:
     first: Mike
     last: Pompeo
@@ -23870,6 +24150,7 @@
     maplight: 419
     washington_post: gIQAGuioAP
     icpsr: 29386
+    wikidata: Q926069
   name:
     first: Robert
     middle: J.
@@ -23953,6 +24234,7 @@
     maplight: 791
     washington_post: gIQAx8mRAP
     icpsr: 20909
+    wikidata: Q862373
   name:
     first: Bill
     last: Posey
@@ -24021,6 +24303,7 @@
     ballotpedia: David Price
     maplight: 420
     washington_post: gIQAd3ZCAP
+    wikidata: Q984010
   name:
     first: David
     middle: E.
@@ -24154,6 +24437,7 @@
     maplight: 632
     washington_post: gIQAaTFu9O
     icpsr: 20505
+    wikidata: Q1415243
   name:
     first: Tom
     last: Price
@@ -24235,6 +24519,7 @@
     maplight: 1186
     washington_post: gIQAMV709O
     icpsr: 20954
+    wikidata: Q465767
   name:
     first: Mike
     last: Quigley
@@ -24298,10 +24583,11 @@
     fec:
     - H6NY19029
     cspan: 1745
-    wikipedia: Charles B. Rangel
+    wikipedia: Charles Rangel
     house_history: 20144
     maplight: 426
     washington_post: gIQACn7y9O
+    wikidata: Q368091
   name:
     first: Charles
     nickname: Charlie
@@ -24489,6 +24775,7 @@
     maplight: 1374
     washington_post: gIQAVOXZKP
     icpsr: 21101
+    wikidata: Q2440035
   name:
     first: Tom
     middle: W.
@@ -24557,6 +24844,7 @@
     maplight: 665
     washington_post: gIQAemFTKP
     icpsr: 20536
+    wikidata: Q456464
   name:
     first: David
     middle: G.
@@ -24640,6 +24928,7 @@
     ballotpedia: Harry Reid
     maplight: 601
     washington_post: gIQA8MlN9O
+    wikidata: Q314459
   name:
     first: Harry
     middle: M.
@@ -24736,6 +25025,7 @@
     maplight: 1468
     washington_post: gIQARWEUKP
     icpsr: 21164
+    wikidata: Q976676
   name:
     first: James
     last: Renacci
@@ -24797,6 +25087,7 @@
     maplight: 1494
     washington_post: gIQAYpZVKP
     icpsr: 21190
+    wikidata: Q2139894
   name:
     first: Reid
     last: Ribble
@@ -24858,6 +25149,7 @@
     maplight: 1443
     washington_post: gIQAUvGVKP
     icpsr: 21137
+    wikidata: Q561284
   name:
     first: Cedric
     last: Richmond
@@ -24918,6 +25210,7 @@
     maplight: 1488
     washington_post: gIQA7lZVKP
     icpsr: 21185
+    wikidata: Q2800221
   name:
     first: Edward
     middle: Scott
@@ -24980,6 +25273,7 @@
     maplight: 1408
     washington_post: gIQAGcVUKP
     icpsr: 21192
+    wikidata: Q439117
   name:
     first: Martha
     last: Roby
@@ -25039,6 +25333,7 @@
     maplight: 792
     washington_post: gIQArh0q6O
     icpsr: 20947
+    wikidata: Q1665842
   name:
     first: David
     middle: P.
@@ -25107,6 +25402,7 @@
     ballotpedia: Harold Rogers
     maplight: 434
     washington_post: gIQAovNCAP
+    wikidata: Q547153
   name:
     first: Harold
     last: Rogers
@@ -25258,12 +25554,13 @@
     fec:
     - H2AL03032
     cspan: 1014740
-    wikipedia: Mike D. Rogers
+    wikipedia: Mike_Rogers_(Alabama_politician)
     house_history: 20795
     ballotpedia: Mike Rogers (Alabama)
     maplight: 433
     washington_post: gIQAkR2cKP
     icpsr: 20301
+    wikidata: Q693238
   name:
     first: Mike
     last: Rogers
@@ -25352,6 +25649,7 @@
     wikipedia: Dana Rohrabacher
     maplight: 436
     washington_post: gIQAWYNqAP
+    wikidata: Q983055
   name:
     first: Dana
     middle: T.
@@ -25485,6 +25783,7 @@
     maplight: 1437
     washington_post: gIQAJQXZKP
     icpsr: 21131
+    wikidata: Q1521384
   name:
     first: Todd
     last: Rokita
@@ -25544,6 +25843,7 @@
     maplight: 793
     washington_post: gIQADjiUAP
     icpsr: 20910
+    wikidata: Q506110
   name:
     first: Thomas
     middle: J.
@@ -25613,6 +25913,7 @@
     ballotpedia: Ileana Ros-Lehtinen
     maplight: 437
     washington_post: gIQAVGfJAP
+    wikidata: Q265791
   name:
     first: Ileana
     last: Ros-Lehtinen
@@ -25746,6 +26047,7 @@
     maplight: 689
     washington_post: gIQAN1SKAP
     icpsr: 20715
+    wikidata: Q968214
   name:
     first: Peter
     middle: J.
@@ -25822,6 +26124,7 @@
     maplight: 1423
     washington_post: gIQAP9JXKP
     icpsr: 21117
+    wikidata: Q1188940
   name:
     first: Dennis
     last: Ross
@@ -25882,6 +26185,7 @@
     maplight: 440
     washington_post: gIQAozxLAP
     icpsr: 29317
+    wikidata: Q469115
   name:
     first: Lucille
     last: Roybal-Allard
@@ -26004,6 +26308,7 @@
     maplight: 441
     washington_post: gIQACovbKP
     icpsr: 29321
+    wikidata: Q1282477
   name:
     first: Edward
     middle: R.
@@ -26126,6 +26431,7 @@
     maplight: 1496
     washington_post: gIQA5xxt6O
     icpsr: 41102
+    wikidata: Q324546
   name:
     first: Marco
     last: Rubio
@@ -26162,6 +26468,7 @@
     maplight: 442
     washington_post: gIQAUKkDAP
     icpsr: 20329
+    wikidata: Q981559
   name:
     first: C.
     middle: A. Dutch
@@ -26253,6 +26560,7 @@
     maplight: 443
     washington_post: gIQAPjFgAP
     icpsr: 29346
+    wikidata: Q888599
   name:
     first: Bobby
     middle: L.
@@ -26374,6 +26682,7 @@
     maplight: 445
     washington_post: gIQAUWiV9O
     icpsr: 29939
+    wikidata: Q203966
   name:
     first: Paul
     middle: D.
@@ -26477,6 +26786,7 @@
     maplight: 444
     washington_post: gIQAQAddKP
     icpsr: 20343
+    wikidata: Q513960
   name:
     first: Tim
     middle: J.
@@ -26565,6 +26875,7 @@
     wikipedia: Gregorio Sablan
     maplight: 794
     house_history: 22610
+    wikidata: Q3116336
   name:
     first: Gregorio
     last: Sablan
@@ -26641,6 +26952,7 @@
     washington_post: gIQAaQoGAP
     icpsr: 29709
     house_history: 21168
+    wikidata: Q469094
   name:
     first: Loretta
     middle: B.
@@ -26752,6 +27064,7 @@
     washington_post: gIQA5SKbKP
     icpsr: 20724
     house_history: 22592
+    wikidata: Q984509
   name:
     first: John
     middle: P.
@@ -26831,6 +27144,7 @@
     washington_post: gIQAxgVSKP
     icpsr: 20759
     house_history: 22608
+    wikidata: Q1857141
   name:
     first: Steve
     middle: Joseph
@@ -26915,6 +27229,7 @@
     washington_post: gIQAOWtJAP
     icpsr: 29911
     house_history: 22550
+    wikidata: Q440885
   name:
     first: Janice
     middle: D.
@@ -27019,6 +27334,7 @@
     washington_post: gIQAdNd69O
     icpsr: 20104
     house_history: 22560
+    wikidata: Q350843
   name:
     first: Adam
     middle: B.
@@ -27115,6 +27431,7 @@
     washington_post: gIQA4NoVBP
     icpsr: 20944
     house_history: 22616
+    wikidata: Q1387868
   name:
     first: Kurt
     last: Schrader
@@ -27185,6 +27502,7 @@
     maplight: 606
     washington_post: gIQAOSQN9O
     house_history: 21322
+    wikidata: Q380900
   name:
     first: Charles
     middle: E.
@@ -27293,6 +27611,7 @@
     washington_post: gIQAdnZVKP
     icpsr: 21105
     house_history: 22621
+    wikidata: Q1176561
   name:
     first: David
     last: Schweikert
@@ -27352,6 +27671,7 @@
     washington_post: gIQADLfVKP
     icpsr: 21123
     house_history: 22631
+    wikidata: Q781167
   name:
     first: Austin
     last: Scott
@@ -27412,6 +27732,7 @@
     washington_post: gIQAoN2QAP
     icpsr: 20321
     house_history: 22574
+    wikidata: Q132071
   name:
     first: David
     last: Scott
@@ -27502,6 +27823,7 @@
     washington_post: gIQAf8WlMP
     icpsr: 39307
     house_history: 21368
+    wikidata: Q888668
   name:
     first: Robert
     middle: C.
@@ -27626,6 +27948,7 @@
     washington_post: gIQAKxVWKP
     icpsr: 21173
     house_history: 22623
+    wikidata: Q561315
   name:
     first: Tim
     last: Scott
@@ -27688,6 +28011,7 @@
     maplight: 456
     washington_post: gIQAk3QFAP
     house_history: 21438
+    wikidata: Q952268
   name:
     first: F.
     middle: James
@@ -27851,6 +28175,7 @@
     maplight: 457
     washington_post: gIQAsIfJAP
     house_history: 21443
+    wikidata: Q460267
   name:
     first: José
     middle: E.
@@ -27984,6 +28309,7 @@
     washington_post: gIQAabpX9O
     icpsr: 29759
     house_history: 21446
+    wikidata: Q437852
   name:
     first: Pete
     middle: A.
@@ -28093,6 +28419,7 @@
     washington_post: gIQAsFMZKP
     icpsr: 21102
     house_history: 22624
+    wikidata: Q461621
   name:
     first: Terri
     last: Sewell
@@ -28155,6 +28482,7 @@
     maplight: 608
     washington_post: gIQARAfM9O
     house_history: 21534
+    wikidata: Q472254
   name:
     first: Richard
     middle: C.
@@ -28250,6 +28578,7 @@
     washington_post: gIQAxbtdKP
     icpsr: 29707
     house_history: 21565
+    wikidata: Q672919
   name:
     first: Brad
     middle: J.
@@ -28359,6 +28688,7 @@
     washington_post: gIQApUPnMP
     icpsr: 29718
     house_history: 21589
+    wikidata: Q1701747
   name:
     first: John
     middle: M.
@@ -28467,6 +28797,7 @@
     washington_post: gIQAcujSAP
     icpsr: 20134
     house_history: 22568
+    wikidata: Q862455
   name:
     first: Bill
     last: Shuster
@@ -28565,6 +28896,7 @@
     washington_post: gIQARxVLAP
     icpsr: 29910
     house_history: 22556
+    wikidata: Q549521
   name:
     first: Michael
     middle: K.
@@ -28669,6 +29001,7 @@
     washington_post: gIQADYaQAP
     icpsr: 20542
     house_history: 22587
+    wikidata: Q527509
   name:
     first: Albio
     last: Sires
@@ -28749,6 +29082,7 @@
     maplight: 468
     washington_post: gIQA2WJY9O
     house_history: 21738
+    wikidata: Q299833
   name:
     first: Louise
     middle: McIntosh
@@ -28888,6 +29222,7 @@
     washington_post: gIQAiu9RKP
     icpsr: 29768
     house_history: 21774
+    wikidata: Q350916
   name:
     first: Adam
     last: Smith
@@ -28996,6 +29331,7 @@
     washington_post: gIQAJnjSAP
     icpsr: 20729
     house_history: 22600
+    wikidata: Q373443
   name:
     first: Adrian
     last: Smith
@@ -29070,6 +29406,7 @@
     maplight: 469
     washington_post: gIQA3TasAP
     house_history: 21787
+    wikidata: Q981167
   name:
     first: Christopher
     middle: H.
@@ -29228,6 +29565,7 @@
     maplight: 470
     washington_post: gIQA2CjGAP
     house_history: 21856
+    wikidata: Q685149
   name:
     first: Lamar
     middle: S.
@@ -29366,6 +29704,7 @@
     washington_post: gIQAvManMP
     icpsr: 20762
     house_history: 22606
+    wikidata: Q218544
   name:
     first: Jackie
     last: Speier
@@ -29441,6 +29780,7 @@
     washington_post: gIQA88sTKP
     icpsr: 21163
     house_history: 22627
+    wikidata: Q324099
   name:
     first: Steve
     last: Stivers
@@ -29502,6 +29842,7 @@
     washington_post: gIQANwHaKP
     icpsr: 21100
     house_history: 22629
+    wikidata: Q1902106
   name:
     first: Marlin
     middle: A.
@@ -29569,6 +29910,7 @@
     washington_post: gIQAqylHAP
     icpsr: 20310
     house_history: 22572
+    wikidata: Q291143
   name:
     first: Linda
     middle: T.
@@ -29662,6 +30004,7 @@
     washington_post: gIQAfwiAAP
     icpsr: 29368
     house_history: 22870
+    wikidata: Q817877
   name:
     first: Bennie
     middle: G.
@@ -29782,6 +30125,7 @@
     washington_post: gIQAxsgIAP
     icpsr: 29901
     house_history: 23200
+    wikidata: Q1323196
   name:
     first: Mike
     middle: Michael
@@ -29884,6 +30228,7 @@
     washington_post: gIQAzSQNAP
     icpsr: 20946
     house_history: 23213
+    wikidata: Q1531120
   name:
     first: Glenn
     last: Thompson
@@ -29952,6 +30297,7 @@
     washington_post: gIQAQXkDAP
     icpsr: 29572
     house_history: 22922
+    wikidata: Q539444
   name:
     first: Mac
     middle: M.
@@ -30067,6 +30413,7 @@
     washington_post: gIQAtDPp9O
     icpsr: 29754
     house_history: 22937
+    wikidata: Q462981
   name:
     first: John
     last: Thune
@@ -30129,6 +30476,7 @@
     washington_post: gIQAL5YWBP
     icpsr: 20130
     house_history: 23204
+    wikidata: Q603467
   name:
     first: Patrick
     middle: J.
@@ -30227,6 +30575,7 @@
     washington_post: gIQAxnpVKP
     icpsr: 21111
     house_history: 23219
+    wikidata: Q782994
   name:
     first: Scott
     last: Tipton
@@ -30282,11 +30631,12 @@
     fec:
     - H8NY21203
     cspan: 1031353
-    wikipedia: Paul Tonko
+    wikipedia: Paul D. Tonko
     maplight: 801
     washington_post: gIQA3w8MAP
     icpsr: 20934
     house_history: 23217
+    wikidata: Q1373548
   name:
     first: Paul
     last: Tonko
@@ -30357,6 +30707,7 @@
     washington_post: gIQARUpBAP
     icpsr: 29935
     house_history: 23202
+    wikidata: Q971308
   name:
     first: Patrick
     middle: J.
@@ -30415,6 +30766,7 @@
     washington_post: gIQA3UrNAP
     icpsr: 20754
     house_history: 23209
+    wikidata: Q440246
   name:
     first: Niki
     middle: S.
@@ -30495,6 +30847,7 @@
     washington_post: gIQAA2beKP
     icpsr: 20342
     house_history: 23206
+    wikidata: Q505722
   name:
     first: Michael
     middle: R.
@@ -30585,6 +30938,7 @@
     ballotpedia: Fred Upton
     maplight: 499
     washington_post: gIQATEgtAP
+    wikidata: Q505236
   name:
     first: Fred
     middle: Stephen
@@ -30723,6 +31077,7 @@
     maplight: 500
     washington_post: gIQAPhsc9O
     icpsr: 20330
+    wikidata: Q1077819
   name:
     first: Chris
     last: Van Hollen
@@ -30813,6 +31168,7 @@
     maplight: 501
     washington_post: gIQAHvY09O
     icpsr: 29378
+    wikidata: Q434890
   name:
     first: Nydia
     middle: M.
@@ -30932,6 +31288,7 @@
     ballotpedia: Peter J. Visclosky
     maplight: 502
     washington_post: gIQA8WtdKP
+    wikidata: Q514660
   name:
     first: Peter
     middle: J.
@@ -31079,6 +31436,7 @@
     maplight: 503
     washington_post: gIQAHam69O
     icpsr: 29918
+    wikidata: Q519780
   name:
     first: David
     last: Vitter
@@ -31143,6 +31501,7 @@
     washington_post: gIQA0wGVKP
     icpsr: 20725
     house_history: 24179
+    wikidata: Q978618
   name:
     first: Tim
     last: Walberg
@@ -31210,6 +31569,7 @@
     washington_post: gIQAYvzZKP
     icpsr: 29932
     house_history: 24165
+    wikidata: Q1397359
   name:
     first: Greg
     middle: P.
@@ -31313,6 +31673,7 @@
     washington_post: gIQA69DYKP
     icpsr: 20726
     house_history: 24181
+    wikidata: Q2434360
   name:
     first: Timothy
     middle: James
@@ -31389,6 +31750,7 @@
     washington_post: gIQA8aOBAP
     icpsr: 20504
     house_history: 24177
+    wikidata: Q50104
   name:
     first: Debbie
     last: Wasserman Schultz
@@ -31471,6 +31833,7 @@
     washington_post: gIQA6Nu99O
     icpsr: 29106
     house_history: 23438
+    wikidata: Q461727
   name:
     first: Maxine
     last: Waters
@@ -31598,6 +31961,7 @@
     washington_post: gIQAzVVUKP
     icpsr: 21116
     house_history: 24192
+    wikidata: Q1163099
   name:
     first: Daniel
     last: Webster
@@ -31659,6 +32023,7 @@
     washington_post: gIQAwdWwMP
     icpsr: 20750
     house_history: 24183
+    wikidata: Q1112656
   name:
     first: Peter
     last: Welch
@@ -31734,6 +32099,7 @@
     washington_post: gIQAWE0KAP
     icpsr: 20506
     house_history: 24175
+    wikidata: Q505730
   name:
     first: Lynn
     middle: A.
@@ -31816,6 +32182,7 @@
     washington_post: gIQAhbJcKP
     icpsr: 29525
     house_history: 23704
+    wikidata: Q544795
   name:
     first: Ed
     last: Whitfield
@@ -31930,6 +32297,7 @@
     washington_post: gIQA3RwLAP
     icpsr: 20138
     house_history: 24173
+    wikidata: Q928855
   name:
     first: Joe
     middle: G.
@@ -32027,6 +32395,7 @@
     washington_post: gIQA8EKXKP
     icpsr: 21118
     house_history: 24196
+    wikidata: Q461504
   name:
     first: Frederica
     last: Wilson
@@ -32088,6 +32457,7 @@
     washington_post: gIQAtNhSKP
     icpsr: 20756
     house_history: 24189
+    wikidata: Q541251
   name:
     first: Robert
     middle: J.
@@ -32165,6 +32535,7 @@
     washington_post: gIQAHcFWKP
     icpsr: 21108
     house_history: 24197
+    wikidata: Q1029527
   name:
     first: Steve
     last: Womack
@@ -32224,6 +32595,7 @@
     washington_post: gIQArSXZKP
     icpsr: 21122
     house_history: 24199
+    wikidata: Q2156128
   name:
     first: Rob
     last: Woodall
@@ -32286,6 +32658,7 @@
     maplight: 619
     washington_post: gIQAfn599O
     house_history: 24150
+    wikidata: Q529344
   name:
     first: Ron
     last: Wyden
@@ -32392,6 +32765,7 @@
     maplight: 696
     washington_post: gIQAIuVYBP
     icpsr: 20723
+    wikidata: Q699970
   name:
     first: John
     middle: A.
@@ -32466,6 +32840,7 @@
     maplight: 1441
     washington_post: gIQAJsGVKP
     icpsr: 21135
+    wikidata: Q187037
   name:
     first: Kevin
     last: Yoder
@@ -32526,6 +32901,7 @@
     ballotpedia: Don Young
     maplight: 525
     washington_post: gIQAsCfJAP
+    wikidata: Q1239590
   name:
     first: Don
     middle: E.
@@ -32707,6 +33083,7 @@
     maplight: 1439
     washington_post: gIQA1LLWKP
     icpsr: 21133
+    wikidata: Q25483
   name:
     first: Todd
     last: Young
@@ -32770,6 +33147,7 @@
     maplight: 703
     washington_post: gIQAljK0DP
     icpsr: 20730
+    wikidata: Q251763
   name:
     first: Dean
     last: Heller
@@ -32840,6 +33218,7 @@
     maplight: 1676
     washington_post: gIQAVGFB9S
     icpsr: 21195
+    wikidata: Q512071
   name:
     first: Janice
     last: Hahn
@@ -32903,6 +33282,7 @@
     maplight: 1680
     washington_post: gJQAwGAWBW
     icpsr: 21196
+    wikidata: Q23944
   name:
     first: Mark
     middle: E.
@@ -32965,6 +33345,7 @@
     maplight: 1682
     washington_post: 02f1e8a6-747e-11e2-95e4-6148e45d7adb
     icpsr: 21198
+    wikidata: Q45946
   name:
     first: Suzanne
     last: Bonamici
@@ -33025,6 +33406,7 @@
     washington_post: b05148de-4bbb-11e2-8758-b64a2997a921
     icpsr: 31101
     house_history: 15032387032
+    wikidata: Q2091892
   name:
     first: Suzan
     middle: K.
@@ -33084,6 +33466,7 @@
     maplight: 1684
     washington_post: 841a4814-4bbc-11e2-8758-b64a2997a921
     icpsr: 31102
+    wikidata: Q2426031
   name:
     first: Thomas
     last: Massie
@@ -33141,6 +33524,7 @@
     maplight: 1687
     washington_post: gIQA5yLeKP
     icpsr: 31103
+    wikidata: Q1240224
   name:
     first: Donald
     middle: M.
@@ -33204,6 +33588,7 @@
     maplight: 1728
     washington_post: a91363f0-5047-11e2-950a-7863a013264b
     icpsr: 41112
+    wikidata: Q1827902
   name:
     first: Brian
     middle: Emanuel
@@ -33255,6 +33640,7 @@
     washington_post: 21c60a8a-4bbd-11e2-8758-b64a2997a921
     icpsr: 29500
     house_history: 21154
+    wikidata: Q1909268
   name:
     first: Matt
     last: Salmon
@@ -33317,12 +33703,13 @@
     - H8IL14067
     - H2IL11124
     cspan: 1027346
-    wikipedia: Bill Foster (Illinois politician)
+    wikipedia: Bill Foster (politician)
     house_history: 13555
     ballotpedia: Bill Foster
     maplight: 738
     washington_post: gIQAnjxyDP
     icpsr: 20749
+    wikidata: Q2903389
   name:
     first: Bill
     last: Foster
@@ -33386,6 +33773,7 @@
     maplight: 758
     washington_post: gIQAp6qMAP
     icpsr: 20908
+    wikidata: Q1281084
   name:
     first: Alan
     last: Grayson
@@ -33442,6 +33830,7 @@
     maplight: 768
     washington_post: gIQAeTvs6O
     icpsr: 20902
+    wikidata: Q558460
   name:
     first: Ann
     last: Kirkpatrick
@@ -33498,6 +33887,7 @@
     washington_post: gIQAsdNqAP
     icpsr: 20927
     house_history: 23215
+    wikidata: Q524440
   name:
     first: Dina
     last: Titus
@@ -33552,6 +33942,7 @@
     washington_post: 8803d7f2-4bbb-11e2-8758-b64a2997a921
     icpsr: 21301
     lis: S374
+    wikidata: Q3090307
   name:
     first: Tom
     last: Cotton
@@ -33598,6 +33989,7 @@
     washington_post: f9d0a3fa-4bbc-11e2-8758-b64a2997a921
     icpsr: 21300
     house_history: 15032387755
+    wikidata: Q1556541
   name:
     first: Kyrsten
     last: Sinema
@@ -33647,6 +34039,7 @@
     maplight: 1734
     washington_post: 3ca0c2b0-4bb7-11e2-8758-b64a2997a921
     icpsr: 21302
+    wikidata: Q1703840
   name:
     first: Doug
     last: LaMalfa
@@ -33695,6 +34088,7 @@
     maplight: 1735
     washington_post: 1fca09ea-4bbb-11e2-8758-b64a2997a921
     icpsr: 21303
+    wikidata: Q3276717
   name:
     first: Jared
     last: Huffman
@@ -33743,6 +34137,7 @@
     maplight: 1736
     washington_post: gIQAaC5TKP
     icpsr: 21304
+    wikidata: Q3389105
   name:
     first: Ami
     last: Bera
@@ -33791,6 +34186,7 @@
     maplight: 1737
     washington_post: 7b7f60a0-4bbb-11e2-8758-b64a2997a921
     icpsr: 21305
+    wikidata: Q3408766
   name:
     first: Paul
     last: Cook
@@ -33837,6 +34233,7 @@
     maplight: 1738
     washington_post: df3311a4-4bbc-11e2-8758-b64a2997a921
     icpsr: 21306
+    wikidata: Q3466996
   name:
     first: Eric
     last: Swalwell
@@ -33881,6 +34278,7 @@
     maplight: 1739
     washington_post: 648810a8-4bb7-11e2-8758-b64a2997a921
     icpsr: 21307
+    wikidata: Q3528567
   name:
     first: David
     last: Valadao
@@ -33931,6 +34329,7 @@
     washington_post: 31764ab4-4bbb-11e2-8758-b64a2997a921
     icpsr: 21308
     house_history: 15032386871
+    wikidata: Q3577073
   name:
     first: Julia
     last: Brownley
@@ -33971,7 +34370,7 @@
     thomas: '02107'
     cspan: 63934
     votesmart: 9754
-    wikipedia: Tony Cardenas
+    wikipedia: Tony Cárdenas
     fec:
     - H2CA28113
     opensecrets: N00033373
@@ -33979,6 +34378,7 @@
     maplight: 1741
     washington_post: 56b232a2-4bbb-11e2-8758-b64a2997a921
     icpsr: 21309
+    wikidata: Q3620422
   name:
     first: Tony
     last: Cárdenas
@@ -34027,6 +34427,7 @@
     maplight: 1743
     washington_post: e540f502-4bbc-11e2-8758-b64a2997a921
     icpsr: 21311
+    wikidata: Q3701994
   name:
     first: Raul
     last: Ruiz
@@ -34074,6 +34475,7 @@
     maplight: 1744
     washington_post: 1234320e-4bbd-11e2-8758-b64a2997a921
     icpsr: 21312
+    wikidata: Q399593
   name:
     first: Mark
     last: Takano
@@ -34121,6 +34523,7 @@
     maplight: 1745
     washington_post: e40cda5c-4bb2-11e2-8758-b64a2997a921
     icpsr: 21313
+    wikidata: Q3740782
   name:
     first: Alan
     last: Lowenthal
@@ -34170,6 +34573,7 @@
     maplight: 1746
     washington_post: ec1c449e-4bbc-11e2-8758-b64a2997a921
     icpsr: 21314
+    wikidata: Q3791701
   name:
     first: Juan
     last: Vargas
@@ -34218,6 +34622,7 @@
     maplight: 1747
     washington_post: a73993a4-4bbc-11e2-8758-b64a2997a921
     icpsr: 21315
+    wikidata: Q3791514
   name:
     first: Scott
     last: Peters
@@ -34268,6 +34673,7 @@
     washington_post: 13c60a22-4bbb-11e2-8758-b64a2997a921
     icpsr: 21316
     house_history: 15032387067
+    wikidata: Q3090454
   name:
     first: Elizabeth
     last: Esty
@@ -34317,6 +34723,7 @@
     maplight: 1749
     washington_post: 5b1d8114-4bbd-11e2-8758-b64a2997a921
     icpsr: 21317
+    wikidata: Q3090476
   name:
     first: Ted
     last: Yoho
@@ -34364,6 +34771,7 @@
     maplight: 1750
     washington_post: 9f576f4a-4bbb-11e2-8758-b64a2997a921
     icpsr: 21318
+    wikidata: Q3105215
   name:
     first: Ron
     last: DeSantis
@@ -34412,6 +34820,7 @@
     maplight: 1751
     washington_post: 6b2c5c48-4bbc-11e2-8758-b64a2997a921
     icpsr: 21319
+    wikidata: Q3182011
   name:
     first: Patrick
     last: Murphy
@@ -34462,6 +34871,7 @@
     washington_post: be839182-4bbb-11e2-8758-b64a2997a921
     icpsr: 21321
     house_history: 15032387115
+    wikidata: Q3182451
   name:
     first: Lois
     last: Frankel
@@ -34510,6 +34920,7 @@
     maplight: 1755
     washington_post: 1d0e1ae2-4bb7-11e2-8758-b64a2997a921
     icpsr: 21323
+    wikidata: Q3162841
   name:
     first: Doug
     last: Collins
@@ -34559,6 +34970,7 @@
     washington_post: d9703ac2-4bbb-11e2-8758-b64a2997a921
     icpsr: 21324
     house_history: 15032387167
+    wikidata: Q32620
   name:
     first: Tulsi
     last: Gabbard
@@ -34608,6 +35020,7 @@
     washington_post: gIQAc3A69O
     icpsr: 21325
     house_history: 15032387037
+    wikidata: Q3036410
   name:
     first: Tammy
     last: Duckworth
@@ -34647,13 +35060,14 @@
     cspan: 68337
     opensecrets: N00034784
     votesmart: 9622
-    wikipedia: Rodney L. Davis
+    wikipedia: Rodney Davis (politician)
     fec:
     - H2IL13120
     ballotpedia: Rodney Davis (Illinois)
     maplight: 1760
     washington_post: 96fa7cca-4bbb-11e2-8758-b64a2997a921
     icpsr: 21328
+    wikidata: Q134035
   name:
     first: Rodney
     last: Davis
@@ -34702,6 +35116,7 @@
     washington_post: e8b15fa2-4bb6-11e2-8758-b64a2997a921
     icpsr: 21329
     house_history: 15032386872
+    wikidata: Q723148
   name:
     first: Cheri
     last: Bustos
@@ -34751,6 +35166,7 @@
     washington_post: gIQApl2vMP
     icpsr: 21330
     house_history: 15032387909
+    wikidata: Q3157413
   name:
     first: Jackie
     last: Walorski
@@ -34800,6 +35216,7 @@
     washington_post: 4a86e324-4bbb-11e2-8758-b64a2997a921
     icpsr: 21331
     house_history: 15032386870
+    wikidata: Q3225324
   name:
     first: Susan
     last: Brooks
@@ -34849,6 +35266,7 @@
     maplight: 1764
     washington_post: 458bd608-4bbc-11e2-8758-b64a2997a921
     icpsr: 21332
+    wikidata: Q3225316
   name:
     first: Luke
     last: Messer
@@ -34897,6 +35315,7 @@
     maplight: 1765
     washington_post: gIQAwh5WKP
     icpsr: 21333
+    wikidata: Q3828645
   name:
     first: Garland
     last: Barr
@@ -34946,6 +35365,7 @@
     washington_post: gIQAZHDx9O
     icpsr: 41301
     house_history: 15032390639
+    wikidata: Q434706
   name:
     first: Elizabeth
     last: Warren
@@ -34981,6 +35401,7 @@
     maplight: 1767
     washington_post: e7a2a990-4bbb-11e2-8758-b64a2997a921
     icpsr: 21335
+    wikidata: Q1707784
   name:
     first: Joseph
     last: Kennedy
@@ -35042,6 +35463,7 @@
     maplight: 1768
     washington_post: 8e7e3d34-4bbb-11e2-8758-b64a2997a921
     icpsr: 21334
+    wikidata: Q2688821
   name:
     first: John
     last: Delaney
@@ -35091,6 +35513,7 @@
     maplight: 1769
     washington_post: f79ee714-4bb6-11e2-8758-b64a2997a921
     icpsr: 41300
+    wikidata: Q544464
   name:
     first: Angus
     last: King
@@ -35128,6 +35551,7 @@
     maplight: 1770
     washington_post: 2ef59d70-4bb7-11e2-8758-b64a2997a921
     icpsr: 21372
+    wikidata: Q3880272
   name:
     first: Daniel
     last: Kildee
@@ -35179,6 +35603,7 @@
     opensecrets: N00021207
     ballotpedia: Rick Nolan
     maplight: 1730
+    wikidata: Q2151594
   name:
     first: Richard
     middle: M.
@@ -35246,6 +35671,7 @@
     washington_post: 4ffdd49c-4bb7-11e2-8758-b64a2997a921
     icpsr: 21337
     house_history: 15032387908
+    wikidata: Q3917251
   name:
     first: Ann
     last: Wagner
@@ -35294,6 +35720,7 @@
     washington_post: a8a98402-4bbb-11e2-8758-b64a2997a921
     icpsr: 21338
     lis: S375
+    wikidata: Q3200900
   name:
     first: Steve
     last: Daines
@@ -35340,6 +35767,7 @@
     maplight: 1774
     washington_post: 22ad1ec6-4bbc-11e2-8758-b64a2997a921
     icpsr: 21346
+    wikidata: Q3956999
   name:
     first: Richard
     last: Hudson
@@ -35388,6 +35816,7 @@
     maplight: 1775
     washington_post: 99d73b26-4bbc-11e2-8758-b64a2997a921
     icpsr: 21347
+    wikidata: Q3956848
   name:
     first: Robert
     last: Pittenger
@@ -35436,6 +35865,7 @@
     maplight: 1776
     washington_post: 4e4cac9a-4bbc-11e2-8758-b64a2997a921
     icpsr: 21348
+    wikidata: Q3956796
   name:
     first: Mark
     last: Meadows
@@ -35483,6 +35913,7 @@
     maplight: 1777
     washington_post: f31bb79e-4bbb-11e2-8758-b64a2997a921
     icpsr: 21349
+    wikidata: Q3956828
   name:
     first: George
     last: Holding
@@ -35533,6 +35964,7 @@
     washington_post: 135fbac8-4bbc-11e2-8758-b64a2997a921
     icpsr: 41303
     house_history: 15032390641
+    wikidata: Q50597
   name:
     first: Heidi
     last: Heitkamp
@@ -35570,6 +36002,7 @@
     maplight: 1779
     washington_post: 6a855e58-4bbb-11e2-8758-b64a2997a921
     icpsr: 21350
+    wikidata: Q3957020
   name:
     first: Kevin
     last: Cramer
@@ -35620,6 +36053,7 @@
     washington_post: 15a67e5c-4bb7-11e2-8758-b64a2997a921
     icpsr: 41302
     house_history: 15032390640
+    wikidata: Q2580649
   name:
     first: Deb
     last: Fischer
@@ -35657,6 +36091,7 @@
     washington_post: 2487b9f4-4bb7-11e2-8758-b64a2997a921
     icpsr: 21340
     house_history: 15032387341
+    wikidata: Q3917208
   name:
     first: Ann
     last: Kuster
@@ -35707,6 +36142,7 @@
     washington_post: 5c69cf42-4bbc-11e2-8758-b64a2997a921
     icpsr: 21341
     house_history: 15032387385
+    wikidata: Q3917203
   name:
     first: Michelle
     last: Lujan Grisham
@@ -35756,6 +36192,7 @@
     washington_post: caf57010-4bbc-11e2-8758-b64a2997a921
     icpsr: 21342
     house_history: 15032387500
+    wikidata: Q5591303
   name:
     first: Grace
     last: Meng
@@ -35803,6 +36240,7 @@
     maplight: 1785
     washington_post: 08cb2674-4bbc-11e2-8758-b64a2997a921
     icpsr: 21343
+    wikidata: Q5640425
   name:
     first: Hakeem
     last: Jeffries
@@ -35850,6 +36288,7 @@
     maplight: 1786
     washington_post: 7935c716-4bbc-11e2-8758-b64a2997a921
     icpsr: 21344
+    wikidata: Q2262244
   name:
     first: Sean
     last: Maloney
@@ -35892,12 +36331,13 @@
     fec:
     - H8NY29032
     votesmart: 139770
-    wikipedia: Chris Collins (American politician)
+    wikipedia: Chris Collins (U.S. politician)
     opensecrets: N00001285
     ballotpedia: Chris Collins
     maplight: 1787
     washington_post: f06054ec-4bb6-11e2-8758-b64a2997a921
     icpsr: 21345
+    wikidata: Q5106218
   name:
     first: Chris
     last: Collins
@@ -35945,6 +36385,7 @@
     maplight: 1788
     washington_post: 738c1fea-4bb7-11e2-8758-b64a2997a921
     icpsr: 21351
+    wikidata: Q892413
   name:
     first: Brad
     last: Wenstrup
@@ -35992,6 +36433,7 @@
     washington_post: 2548b43e-4bbb-11e2-8758-b64a2997a921
     icpsr: 21352
     house_history: 15032386867
+    wikidata: Q976417
   name:
     first: Joyce
     last: Beatty
@@ -36039,6 +36481,7 @@
     maplight: 1790
     washington_post: 6d3ab89a-4bb7-11e2-8758-b64a2997a921
     icpsr: 21353
+    wikidata: Q976778
   name:
     first: David
     last: Joyce
@@ -36088,6 +36531,7 @@
     maplight: 1791
     washington_post: 1ba9a374-4bbc-11e2-8758-b64a2997a921
     icpsr: 21354
+    wikidata: Q3601035
   name:
     first: Jim
     last: Bridenstine
@@ -36136,6 +36580,7 @@
     maplight: 1792
     washington_post: 55872562-4bbc-11e2-8758-b64a2997a921
     icpsr: 21355
+    wikidata: Q3448772
   name:
     first: Markwayne
     last: Mullin
@@ -36184,6 +36629,7 @@
     maplight: 1793
     washington_post: a05aac8a-4bbc-11e2-8758-b64a2997a921
     icpsr: 21356
+    wikidata: Q7437040
   name:
     first: Scott
     last: Perry
@@ -36232,6 +36678,7 @@
     maplight: 1794
     washington_post: f31f081c-4bbc-11e2-8758-b64a2997a921
     icpsr: 21357
+    wikidata: Q5978897
   name:
     first: Keith
     last: Rothfus
@@ -36280,6 +36727,7 @@
     maplight: 1795
     washington_post: 3a43408e-4bbb-11e2-8758-b64a2997a921
     icpsr: 21358
+    wikidata: Q4111531
   name:
     first: Matthew
     last: Cartwright
@@ -36329,6 +36777,7 @@
     maplight: 1796
     washington_post: 33a9ef8c-4bbd-11e2-8758-b64a2997a921
     icpsr: 21359
+    wikidata: Q3956858
   name:
     first: Tom
     last: Rice
@@ -36377,6 +36826,7 @@
     maplight: 1797
     washington_post: b8d4a00a-4bbb-11e2-8758-b64a2997a921
     icpsr: 41304
+    wikidata: Q2036942
   name:
     first: Ted
     last: Cruz
@@ -36412,6 +36862,7 @@
     maplight: 1798
     washington_post: 407de97a-4bbd-11e2-8758-b64a2997a921
     icpsr: 21360
+    wikidata: Q4014569
   name:
     first: Randy
     last: Weber
@@ -36461,6 +36912,7 @@
     maplight: 1799
     washington_post: 4308607c-4bb7-11e2-8758-b64a2997a921
     icpsr: 21361
+    wikidata: Q4014532
   name:
     first: Beto
     last: O'Rourke
@@ -36507,6 +36959,7 @@
     maplight: 1800
     washington_post: 625d409c-4bbb-11e2-8758-b64a2997a921
     icpsr: 21362
+    wikidata: Q1167934
   name:
     first: Joaquin
     last: Castro
@@ -36556,6 +37009,7 @@
     maplight: 1802
     washington_post: 46eb6828-4bbd-11e2-8758-b64a2997a921
     icpsr: 21364
+    wikidata: Q4014560
   name:
     first: Roger
     last: Williams
@@ -36604,6 +37058,7 @@
     maplight: 1803
     washington_post: 01e1bbba-4bbd-11e2-8758-b64a2997a921
     icpsr: 21365
+    wikidata: Q4068811
   name:
     first: Marc
     last: Veasey
@@ -36652,6 +37107,7 @@
     maplight: 1804
     washington_post: 9636abe4-5505-11e2-bf3e-76c0a789346f
     icpsr: 21366
+    wikidata: Q4069225
   name:
     first: Filemon
     last: Vela
@@ -36700,6 +37156,7 @@
     maplight: 1805
     washington_post: 57b0efa8-4bb7-11e2-8758-b64a2997a921
     icpsr: 21367
+    wikidata: Q4068880
   name:
     first: Chris
     last: Stewart
@@ -36749,6 +37206,7 @@
     maplight: 1806
     washington_post: gIQAem3o9O
     icpsr: 41305
+    wikidata: Q359888
   name:
     first: Timothy
     last: Kaine
@@ -36785,6 +37243,7 @@
     maplight: 1807
     washington_post: 3518ebbc-4bb7-11e2-8758-b64a2997a921
     icpsr: 21368
+    wikidata: Q4068828
   name:
     first: Derek
     last: Kilmer
@@ -36831,6 +37290,7 @@
     maplight: 1808
     washington_post: 07bb54a2-4bb7-11e2-8758-b64a2997a921
     icpsr: 21369
+    wikidata: Q4068793
   name:
     first: Denny
     last: Heck
@@ -36879,6 +37339,7 @@
     maplight: 1809
     washington_post: 933d8a40-4bbc-11e2-8758-b64a2997a921
     icpsr: 21370
+    wikidata: Q1900355
   name:
     first: Mark
     last: Pocan
@@ -36928,6 +37389,7 @@
     icpsr: 21371
     house_history: 15032393262
     maplight: 2045
+    wikidata: Q3437091
   name:
     first: Robin
     last: Kelly
@@ -36977,6 +37439,7 @@
     washington_post: gIQAd8Ty9O
     icpsr: 29565
     house_history: 21195
+    wikidata: Q11669
   name:
     first: Marshall
     last: Sanford
@@ -37043,6 +37506,7 @@
     ballotpedia: Jason Smith (Missouri representative)
     cspan: 71083
     icpsr: 21373
+    wikidata: Q6163589
   name:
     first: Jason
     middle: T.
@@ -37091,6 +37555,7 @@
     - S4NJ00185
     cspan: 84679
     maplight: 2051
+    wikidata: Q1135767
   name:
     first: Cory
     middle: Anthony
@@ -37138,6 +37603,7 @@
     cspan: 73178
     house_history: 15032398493
     maplight: 2053
+    wikidata: Q6376330
   name:
     first: Katherine
     middle: M.
@@ -37182,6 +37648,7 @@
     - H4AL01123
     cspan: 73486
     maplight: 2054
+    wikidata: Q4954892
   name:
     first: Bradley
     last: Byrne
@@ -37225,6 +37692,7 @@
     fec:
     - H4FL13101
     maplight: 2056
+    wikidata: Q15963996
   name:
     first: David
     middle: W.
@@ -37309,6 +37777,7 @@
     ballotpedia: David Brat
     house_history: 15032409257
     maplight: 2061
+    wikidata: Q17160419
   name:
     first: David
     middle: Alan
@@ -37354,6 +37823,7 @@
     ballotpedia: Donald Norcross
     house_history: 15032409258
     maplight: 2062
+    wikidata: Q5294942
   name:
     first: Donald
     middle: W.
@@ -37398,6 +37868,7 @@
     ballotpedia: Alma Adams
     house_history: 15032409256
     maplight: 2063
+    wikidata: Q4733597
   name:
     first: Alma
     last: Adams
@@ -37441,6 +37912,7 @@
     house_history: 12599
     icpsr: 21127
     maplight: 1432
+    wikidata: Q2156912
   name:
     first: Bob
     last: Dold
@@ -37482,6 +37954,7 @@
     house_history: 14291
     icpsr: 21152
     maplight: 1457
+    wikidata: Q24250
   name:
     first: Frank
     last: Guinta
@@ -39390,10 +39863,11 @@
     - H6NY11174
     govtrack: 412672
     votesmart: 127760
-    wikipedia: Daniel M. Donovan, Jr.
+    wikipedia: Dan Donovan (politician)
     ballotpedia: Daniel Donovan (New York)
     maplight: 2161
     opensecrets: N00036928
+    wikidata: Q5217998
   name:
     first: Daniel
     middle: M.
@@ -39425,6 +39899,7 @@
     ballotpedia: Trent Kelly
     maplight: 2163
     opensecrets: N00037003
+    wikidata: Q20204915
   name:
     first: Trent
     last: Kelly
@@ -39455,6 +39930,7 @@
     ballotpedia: Darin LaHood
     house_history: 15032425053
     maplight: 2164
+    wikidata: Q5222780
   name:
     first: Darin
     last: LaHood


### PR DESCRIPTION
Got Wikidata IDs for the rest of them by starting with the Wikipedia
titles, auditing them to make sure they were referring to the right
person, and then adding the ID in. I updated page titles for articles
that were renamed; in the future, a script will be able to do this
automatically based on the Wikidata ID. The question is to how to do
this automatically in the long term.