### PR TITLE
Valid yaml for Speaker Ryan's twitter

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -1064,7 +1064,7 @@
     thomas: '01560'
     govtrack: 400351
   social:
-    twitter:SpeakerRyan
+    twitter: SpeakerRyan
     facebook: speakerryan
     youtube: reppaulryan
     instagram: SpeakerRyan


### PR DESCRIPTION
Placed a space after Speaker Ryan's twitter account name, forming valid yaml.