### PR TITLE
Remove unused import

### DIFF
--- a/scripts/house_history.py
+++ b/scripts/house_history.py
@@ -4,7 +4,6 @@
 # have one, by scraping history.house.gov.
 
 import lxml.html, io
-import utils
 import requests
 from utils import load_data, save_data
 import sys


### PR DESCRIPTION
This was meant to be in PR #340 but I forgot to push the commit, so here it is!

If you wanted to catch these sooner, how about moving pyflakes from `after_success:` to the end of `script:` in .travis.yml?