### PR TITLE
catch pyflakes sooner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ os:
 sudo: false
 
 install: pip install -r scripts/requirements.txt
-script: python test/workout.py
-
-after_success: pyflakes scripts/*.py
+script:
+ - python test/workout.py
+ - pyflakes scripts/*.py
 
 notifications:
   email:


### PR DESCRIPTION
Helps avoid things like https://github.com/unitedstates/congress-legislators/pull/341 by failing PRs on Travis CI if there are pyflakes problems.

It does this after the main tests, so it you'll always get the results of those first.