### PR TITLE
Add district office data

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains data about legislators...:
 * `legislators-current.yaml`: Currently serving Members of Congress (as of last update).
 * `legislators-historical.yaml`: Historical Members of Congress (i.e. all Members of Congress except those in the current file).
 * `legislators-social-media.yaml`: Current social media accounts for Members of Congress. Official accounts only (no campaign or personal accounts).
+* `legislators-district-offices.yaml`: District offices for current Members of Congress.
 
 ...and about committees:
 
@@ -101,6 +102,8 @@ Terms correspond to elections and are listed in chronological order. If a legisl
 The split between `legislators-current.yaml` and `legislators-historical.yaml` is somewhat arbitrary because these files may not be updated immediately when a legislator leaves office. If it matters to you, just load both files.
 
 A separate file `legislators-social-media.yaml` stores social media account information. Its structure is similar but includes different fields.
+
+The file `legislators-district-offices.yaml` contains the address and contact information for local (district, or home-state) offices for current Members of Congress.
 
 Legislators Data Dictionary
 ---------------------------
@@ -244,6 +247,12 @@ Options used with the above tasks:
 * `--bioguide`: Limit activity to a single member, by bioguide ID.
 * `--email`: In conjunction with `--sweep`, send an email if there are any new leads, using settings in scripts/email/config.yml (if it was created and filled out).
 
+District Offices Data Dictionary
+----------------------------
+
+The file `legislators-district-offices.yaml` stores current district office informaiton.
+
+Each record has two sections: `id` and `offices`. The `id` section identifies the legislator using bioguide, thomas, and govtrack IDs (where available). The `offices` section has a list of offices, each with address, phone, and fax information (if available).
 
 Committees Data Dictionary
 --------------------------

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -39720,6 +39720,7 @@
   name:
     first: Warren
     last: Davidson
+    official_full: Warren Davidson
   bio:
     gender: M
     birthday: '1970-03-01'
@@ -39730,3 +39731,6 @@
     state: OH
     district: 8
     party: Republican
+    address: 1011 Longworth HOB; Washington DC 20515-3508
+    office: 1011 Longworth House Office Building
+    phone: 202-225-6205

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -1,0 +1,13911 @@
+- id:
+    bioguide: Y000033
+    govtrack: 400440
+    thomas: '01256'
+  offices:
+  - address: 612 West Willoughby Avenue, Suite B
+    building: ''
+    city: Juneau
+    fax: 907-271-5950
+    phone: 907-586-7400
+    state: AK
+    suite: PO Box 21247
+    zip: 99802-1247
+  - address: 100 Cushman Street
+    building: Key Bank Building
+    city: Fairbanks
+    fax: 907-456-0279
+    phone: 907-456-0210
+    state: AK
+    suite: Suite 307
+    zip: '99707'
+  - address: 4241 B Street
+    building: ''
+    city: Anchorage
+    fax: 907-271-5950
+    phone: 907-271-5978
+    state: AK
+    suite: Suite 203
+    zip: '99503'
+- id:
+    bioguide: B001289
+    govtrack: 412601
+    thomas: 02197
+  offices:
+  - address: 1302 North McKenzie Street
+    building: ''
+    city: Foley
+    fax: 251-943-2093
+    phone: 251-943-2073
+    state: AL
+    suite: ''
+    zip: '36535'
+  - address: 11 North Water Street
+    building: ''
+    city: Mobile
+    fax: 251-690-2815
+    phone: 251-690-2811
+    state: AL
+    suite: Suite 15290
+    zip: '36609'
+- id:
+    bioguide: R000591
+    govtrack: 412394
+    thomas: 01986
+  offices:
+  - address: 505 East Three Notch Street
+    building: City Hall
+    city: Andalusia
+    fax: 334-222-3342
+    phone: 334-428-1129
+    state: AL
+    suite: '#322'
+    zip: '36420'
+  - address: 401 Adams Avenue
+    building: ''
+    city: Montgomery
+    fax: 334-277-8534
+    phone: 334-277-9113
+    state: AL
+    suite: Suite 160
+    zip: '36104'
+  - address: 217 Graceland Drive
+    building: ''
+    city: Dothan
+    fax: 334-671-1480
+    phone: 334-794-9680
+    state: AL
+    suite: Suite 5
+    zip: '36305'
+- id:
+    bioguide: R000575
+    govtrack: 400341
+    thomas: '01704'
+  offices:
+  - address: 1129 Noble Street
+    building: ''
+    city: Anniston
+    fax: 256-237-9203
+    phone: 256-236-5655
+    state: AL
+    suite: Suite 104
+    zip: '36201'
+  - address: 701 Avenue A
+    building: G.W. Andrews Federal Building
+    city: Opelika
+    fax: 334-742-0109
+    phone: 334-745-6221
+    state: AL
+    suite: Suite 300
+    zip: '36801'
+- id:
+    bioguide: A000055
+    govtrack: 400004
+    thomas: '01460'
+  offices:
+  - address: 1710 Alabama Avenue
+    building: Carl Elliott Federal Building
+    city: Jasper
+    fax: 205-221-9035
+    phone: 205-221-2310
+    state: AL
+    suite: Room 247
+    zip: 35501-5400
+  - address: 205 Fourth Avenue, Northeast
+    building: ''
+    city: Cullman
+    fax: 256-737-0885
+    phone: 256-734-6043
+    state: AL
+    suite: Suite 104
+    zip: '35055'
+  - address: 600 Broad Street
+    building: Federal Building
+    city: Gadsden
+    fax: 256-546-8778
+    phone: 256-546-0201
+    state: AL
+    suite: Suite 107
+    zip: 35901-3745
+  - address: 1011 George Wallace Boulevard
+    building: ''
+    city: Tuscumbia
+    fax: 256-381-7659
+    phone: 256-381-3450
+    state: AL
+    suite: Suite 146
+    zip: '35674'
+- id:
+    bioguide: B001274
+    govtrack: 412395
+    thomas: 01987
+  offices:
+  - address: 302 Lee Street
+    building: ''
+    city: Decatur
+    fax: 256-355-9406
+    phone: 256-355-9400
+    state: AL
+    suite: Room 86
+    zip: '35601'
+  - address: 2101West Clinton Avenue
+    building: ''
+    city: Huntsville
+    fax: 256-551-0194
+    phone: 256-551-0190
+    state: AL
+    suite: Suite 302
+    zip: '35805'
+  - address: 102 South Court Street
+    building: ''
+    city: Florence
+    fax: 256-718-5156
+    phone: 256-718-5155
+    state: AL
+    suite: Suite 310
+    zip: '35630'
+- id:
+    bioguide: P000609
+    govtrack: 412608
+    thomas: '02221'
+  offices:
+  - address: 703 2nd Avenue North
+    building: ''
+    city: Clanton
+    fax: ''
+    phone: 205-280-6846
+    state: AL
+    suite: PO Box 502
+    zip: '35243'
+  - address: 3535 Grandview Parkway
+    building: ''
+    city: Birmingham
+    fax: 205-968-1294
+    phone: 205-968-1290
+    state: AL
+    suite: Suite 525
+    zip: '35243'
+  - address: 202 East 3rd Avenue
+    building: ''
+    city: East Oneonta
+    fax: ''
+    phone: ''
+    state: AL
+    suite: ''
+    zip: '35121'
+- id:
+    bioguide: S001185
+    govtrack: 412396
+    thomas: 01988
+  offices:
+  - address: 101 South Lawrence Street
+    building: ''
+    city: Montgomery
+    fax: 334-262-1921
+    phone: 334-262-1919
+    state: AL
+    suite: ''
+    zip: '36104'
+  - address: 908 Alabama Avenue
+    building: Federal Building
+    city: Selma
+    fax: 334-877-4489
+    phone: 334-877-4414
+    state: AL
+    suite: Suite 112
+    zip: '36701'
+  - address: 2 20 Street North
+    building: ''
+    city: Birmingham
+    fax: 205-254-1974
+    phone: 205-254-1960
+    state: AL
+    suite: Suite 1130
+    zip: '35203'
+  - address: 186 Field of Dreams Drive
+    building: ''
+    city: Demopolis
+    fax: 334-877-4489
+    phone: 334-287-0860
+    state: AL
+    suite: ''
+    zip: '36732'
+  - address: 2501 7th Street
+    building: ''
+    city: Tuscaloosa
+    fax: 205-752-5899
+    phone: 205-752-5380
+    state: AL
+    suite: Suite 300
+    zip: '35401'
+- id:
+    bioguide: C001087
+    govtrack: 412400
+    thomas: 01989
+  offices:
+  - address: 112 South 1st
+    building: ''
+    city: Cabot
+    fax: 501-843-4955
+    phone: 501-843-3043
+    state: AR
+    suite: ''
+    zip: '72023'
+  - address: 2400 Highland Drive
+    building: ''
+    city: Jonesboro
+    fax: 870-203-0542
+    phone: 870-203-0540
+    state: AR
+    suite: Suite 300
+    zip: '72401'
+  - address: 1001 Highway 62 East
+    building: ''
+    city: Mountain Home
+    fax: 870-424-3149
+    phone: 870-424-2075
+    state: AR
+    suite: Suite 9
+    zip: '72653'
+- id:
+    bioguide: H001072
+    govtrack: 412609
+    thomas: '02223'
+  offices:
+  - address: 1501 North University
+    building: ''
+    city: Little Rock
+    fax: 501-324-6029
+    phone: 501-324-5941
+    state: AR
+    suite: Suite 150
+    zip: '72207'
+  - address: 1105 Deer Street
+    building: ''
+    city: Conway
+    fax: 501-358-3494
+    phone: 501-358-3481
+    state: AR
+    suite: Suite 12
+    zip: '72032'
+- id:
+    bioguide: W000809
+    govtrack: 412402
+    thomas: 01991
+  offices:
+  - address: 3333 Pinnacle Hills
+    building: ''
+    city: Rogers
+    fax: 479-464-0063
+    phone: 479-464-0446
+    state: AR
+    suite: Suite 120
+    zip: '72758'
+  - address: 303 North Main Street
+    building: ''
+    city: Harrison
+    fax: 870-741-7741
+    phone: 870-741-6900
+    state: AR
+    suite: Suite 102
+    zip: '72601'
+  - address: 423 North 6th Street
+    building: ''
+    city: Fort Smith
+    fax: 479-424-2737
+    phone: 479-424-1146
+    state: AR
+    suite: ''
+    zip: '72902'
+- id:
+    bioguide: W000821
+    govtrack: 412610
+    thomas: '02224'
+  offices:
+  - address: 101 North Washington Avenue
+    building: Union County Courthouse
+    city: El Dorado
+    fax: 870- 864-8958
+    phone: 870-864-8946
+    state: AR
+    suite: Suite 406
+    zip: '71730'
+  - address: 101 Reserve Street
+    building: Hot Springs Federal Building
+    city: Hot Springs
+    fax: 501-609-9887
+    phone: 501-609-9796
+    state: AR
+    suite: Suite 200
+    zip: '71901'
+  - address: 100 East 8th Avenue
+    building: ''
+    city: Pine Bluff
+    fax: 870-536-8364
+    phone: 870-536-8178
+    state: AR
+    suite: Room 2521
+    zip: '71601'
+  - address: 211 West Commercial Street
+    building: ''
+    city: Ozark
+    fax: 501-295-9752
+    phone: ' 479-667-0075'
+    state: AR
+    suite: ''
+    zip: '72949'
+- id:
+    bioguide: R000600
+    govtrack: 412664
+    thomas: '02222'
+  offices:
+  - address: 1 Fagatogo Square
+    building: ''
+    city: Fagatogo
+    fax: 684-633-3607
+    phone: 684-633-3601
+    state: AS
+    suite: ''
+    zip: '96799'
+- id:
+    bioguide: K000368
+    govtrack: 412286
+    thomas: 01907
+  offices:
+  - address: 211 North Florence Street
+    building: ''
+    city: Casa Grande
+    fax: 520-316-0842
+    phone: 520-316-0839
+    state: AZ
+    suite: Suite 1
+    zip: '85122'
+  - address: 405 North Beaver Street
+    building: ''
+    city: Flagstaff
+    fax: 928-213-9981
+    phone: 928-213-9977
+    state: AZ
+    suite: Suite 6
+    zip: '86001'
+  - address: 11555 West Civic Center Drive
+    building: ''
+    city: Marana
+    fax: 520-382-2664
+    phone: 520-382-2663
+    state: AZ
+    suite: ''
+    zip: '85653'
+- id:
+    bioguide: M001197
+    govtrack: 412611
+    thomas: '02225'
+  offices:
+  - address: 3945 East Fort Lowell Road
+    building: ''
+    city: Tucson
+    fax: 520-322-9490
+    phone: 520-881-3588
+    state: AZ
+    suite: Suite 211
+    zip: '85712'
+- id:
+    bioguide: G000551
+    govtrack: 400162
+    thomas: 01708
+  offices:
+  - address: 146 North State Avenue
+    building: ''
+    city: Somerton
+    fax: 928-343-7949
+    phone: 928-343-7933
+    state: AZ
+    suite: ''
+    zip: '85350'
+  - address: 738 North 5th Avenue
+    building: ''
+    city: Tucson
+    fax: 520-622-0198
+    phone: 520-622-6788
+    state: AZ
+    suite: Suite 110
+    zip: '85705'
+  - address: 13065 West McDowell Road
+    building: Rancho Santa Fe Center
+    city: Avondale
+    fax: 623-535-7479
+    phone: 623-536-3388
+    state: AZ
+    suite: Suite C-113
+    zip: '85392'
+- id:
+    bioguide: G000565
+    govtrack: 412397
+    thomas: 01992
+  offices:
+  - address: 122 North Cortez Street
+    building: ''
+    city: Prescott
+    fax: ''
+    phone: 928-445-1683
+    state: AZ
+    suite: Suite 104
+    zip: '86301'
+  - address: 6499 South Kings Ranch Road
+    building: ''
+    city: Gold Canyon
+    fax: ''
+    phone: 480-882-2697
+    state: AZ
+    suite: '#4'
+    zip: '85118'
+- id:
+    bioguide: S000018
+    govtrack: 400606
+    thomas: 01009
+  offices:
+  - address: 207 North Gilbert Road
+    building: ''
+    city: Gilbert
+    fax: 480-699-4730
+    phone: 480-699-8239
+    state: AZ
+    suite: Suite 209
+    zip: '85234'
+- id:
+    bioguide: S001183
+    govtrack: 412399
+    thomas: 01994
+  offices:
+  - address: 10603 North Hayden Road
+    building: ''
+    city: Scottsdale
+    fax: 480-946-2446
+    phone: 480-946-2411
+    state: AZ
+    suite: Suite 108
+    zip: '85260'
+- id:
+    bioguide: G000574
+    govtrack: 412612
+    thomas: '02226'
+  offices:
+  - address: 411 North Central Avenue
+    building: ''
+    city: Phoenix
+    fax: 602-257-9103
+    phone: 602-256-0551
+    state: AZ
+    suite: Suite 150
+    zip: '85004'
+- id:
+    bioguide: F000448
+    govtrack: 400141
+    thomas: '01707'
+  offices:
+  - address: 7121 West Bell Road
+    building: ''
+    city: Glendale
+    fax: 623-776-7832
+    phone: 623-776-7911
+    state: AZ
+    suite: Suite 200
+    zip: '85308'
+- id:
+    bioguide: S001191
+    govtrack: 412509
+    thomas: 02099
+  offices:
+  - address: 2944 North 44th Street
+    building: ''
+    city: Phoenix
+    fax: ''
+    phone: 602-956-2285
+    state: AZ
+    suite: Suite 150
+    zip: '85018'
+- id:
+    bioguide: L000578
+    govtrack: 412510
+    thomas: '02100'
+  offices:
+  - address: 2862 Olive Highway
+    building: ''
+    city: Oroville
+    fax: 530-534-7800
+    phone: 530-534-7100
+    state: CA
+    suite: Suite D
+    zip: '95966'
+  - address: 2885 Chum Creek Road
+    building: ''
+    city: Redding
+    fax: 530-223-5897
+    phone: 530-223-5898
+    state: CA
+    suite: Suite C
+    zip: '96002'
+  - address: 2399 Rickenbacker Way
+    building: ''
+    city: Auburn
+    fax: 530-878-5037
+    phone: 530-878-5035
+    state: CA
+    suite: Suite 106
+    zip: 95602-9537
+- id:
+    bioguide: H001068
+    govtrack: 412511
+    thomas: '02101'
+  offices:
+  - address: 317 Third Street
+    building: ''
+    city: Eureka
+    fax: 707-407-3559
+    phone: 707-407-3585
+    state: CA
+    suite: Suite 1
+    zip: '95501'
+  - address: 430 North Franklin Street
+    building: ''
+    city: Fort Bragg
+    fax: 707-962-0905
+    phone: 707-962-0933
+    state: CA
+    suite: PO Box 2208
+    zip: '95437'
+  - address: 999 Fifth Avenue
+    building: ''
+    city: San Rafael
+    fax: 415-258-9913
+    phone: 415-258-9657
+    state: CA
+    suite: Suite 290
+    zip: '94901'
+  - address: 206 G Street
+    building: ''
+    city: Petaluma
+    fax: ''
+    phone: 707-981-8967
+    state: CA
+    suite: Unit 3
+    zip: '94952'
+  - address: 559 Low Gap Road
+    building: ''
+    city: Ukiah
+    fax: 707-671-7449
+    phone: 707-671-7449
+    state: CA
+    suite: ''
+    zip: '95482'
+- id:
+    bioguide: G000559
+    govtrack: 412382
+    thomas: 01973
+  offices:
+  - address: 412 G Street
+    building: ''
+    city: Davis
+    fax: 530-753-5614
+    phone: 530-753-5301
+    state: CA
+    suite: ''
+    zip: '95616'
+  - address: 1261 Travis Boulevard
+    building: ''
+    city: Fairfield
+    fax: 707-438-0523
+    phone: 707-438-1822
+    state: CA
+    suite: ''
+    zip: '94533'
+  - address: 795 Plumas Street
+    building: ''
+    city: Yuba City
+    fax: 530-763-4248
+    phone: 530-329-8865
+    state: CA
+    suite: ''
+    zip: '95991'
+- id:
+    bioguide: M001177
+    govtrack: 412295
+    thomas: 01908
+  offices:
+  - address: 2200A Douglas Boulevard
+    building: ''
+    city: Roseville
+    fax: 916-786-6364
+    phone: 916-786-5560
+    state: CA
+    suite: Suite 240
+    zip: '95661'
+- id:
+    bioguide: T000460
+    govtrack: 400403
+    thomas: 01593
+  offices:
+  - address: 1040 Main Street
+    building: ''
+    city: Napa
+    fax: 707-251-9800
+    phone: 707-226-9898
+    state: CA
+    suite: Suite 101
+    zip: 94559-2605
+  - address: 985 Walnut Avenue
+    building: ''
+    city: Vallejo
+    fax: 707-645-1870
+    phone: 707-645-1888
+    state: CA
+    suite: ''
+    zip: '94592'
+  - address: 2300 Country Center Drive
+    building: ''
+    city: Santa Rosa
+    fax: 707-542-2745
+    phone: 707-542-7182
+    state: CA
+    suite: Suite A100
+    zip: '95403'
+  - address: 2721 Napa Valley Corporate Drive
+    building: ''
+    city: Napa
+    fax: 707-251-9800
+    phone: 707-226-9898
+    state: CA
+    suite: Building 2
+    zip: 94559-2605
+- id:
+    bioguide: M001163
+    govtrack: 400663
+    thomas: 01814
+  offices:
+  - address: 501 I Street
+    building: Robert T. Matsui Federal Courthouse
+    city: Sacramento
+    fax: 916-444-6117
+    phone: 916-498-5600
+    state: CA
+    suite: Suite 12-600
+    zip: 95814-7305
+- id:
+    bioguide: B001287
+    govtrack: 412512
+    thomas: '02102'
+  offices:
+  - address: 11060 White Rock Road
+    building: ''
+    city: Rancho Cordova
+    fax: 916-635-0514
+    phone: 916-635-0505
+    state: CA
+    suite: Suite 180
+    zip: '95670'
+- id:
+    bioguide: C001094
+    govtrack: 412513
+    thomas: '02103'
+  offices:
+  - address: 14955 Dale Evans Parkway
+    building: Apple Valley Town Hall
+    city: Apple Valley
+    fax: ''
+    phone: 760-247-1815
+    state: CA
+    suite: ''
+    zip: '92307'
+  - address: 34932 Yucaipa Boulevard
+    building: ''
+    city: Yucaipa
+    fax: 909-797-4997
+    phone: 909-797-4900
+    state: CA
+    suite: ''
+    zip: '92399'
+- id:
+    bioguide: M001166
+    govtrack: 412189
+    thomas: 01832
+  offices:
+  - address: 2222 Grand Canal Boulevard
+    building: ''
+    city: Stockton
+    fax: 209-476-8587
+    phone: 209-476-8552
+    state: CA
+    suite: Suite 7
+    zip: '95207'
+  - address: 4703 Lone Tree Way
+    building: Antioch Community Center
+    city: Antioch
+    fax: 925-754-0728
+    phone: 925-754-0716
+    state: CA
+    suite: ''
+    zip: '94531'
+- id:
+    bioguide: D000612
+    govtrack: 412403
+    thomas: 01995
+  offices:
+  - address: 4701 Sisk Road
+    building: ''
+    city: Modesto
+    fax: 209-579-5028
+    phone: 209-579-5458
+    state: CA
+    suite: Suite 202
+    zip: '95356'
+- id:
+    bioguide: D000623
+    govtrack: 412613
+    thomas: '02227'
+  offices:
+  - address: 440 Civic Center Plaza
+    building: ''
+    city: Richmond
+    fax: 510-620-1005
+    phone: 510- 620-1000
+    state: CA
+    suite: 2nd Floor
+    zip: '94804'
+  - address: 101 Ygnacio Valley Road
+    building: ''
+    city: Walnut Creek
+    fax: 925-933-2677
+    phone: 925-933-2660
+    state: CA
+    suite: 'Suite #210'
+    zip: '94596'
+- id:
+    bioguide: P000197
+    govtrack: 400314
+    thomas: 00905
+  offices:
+  - address: 90 7th Street
+    building: ''
+    city: San Francisco
+    fax: 415-861-1670
+    phone: 415-556-4862
+    state: CA
+    suite: Suite 2-800
+    zip: '94103'
+- id:
+    bioguide: L000551
+    govtrack: 400237
+    thomas: '01501'
+  offices:
+  - address: 1301 Clay Street
+    building: ''
+    city: Oakland
+    fax: 510-763-6538
+    phone: 510-763-0370
+    state: CA
+    suite: Suite 1000 North
+    zip: '94612'
+- id:
+    bioguide: S001175
+    govtrack: 412259
+    thomas: 01890
+  offices:
+  - address: 155 Bovet Road
+    building: ''
+    city: San Mateo
+    fax: 650-375-8270
+    phone: 650-342-0300
+    state: CA
+    suite: Suite 780
+    zip: 94402-1704
+- id:
+    bioguide: S001193
+    govtrack: 412514
+    thomas: '02104'
+  offices:
+  - address: 5075 Hopyard Road
+    building: ''
+    city: Pleasanton
+    fax: ''
+    phone: 925-460-5100
+    state: CA
+    suite: Suite 220
+    zip: '94588'
+  - address: 1260 B Street
+    building: ''
+    city: Hayward
+    fax: ''
+    phone: 510-370-3322
+    state: CA
+    suite: Suite 150
+    zip: '94541'
+- id:
+    bioguide: C001059
+    govtrack: 400618
+    thomas: '01774'
+  offices:
+  - address: 855 M Street
+    building: ''
+    city: Fresno
+    fax: 559-495-1027
+    phone: 559-495-1620
+    state: CA
+    suite: Suite 940
+    zip: '93721'
+  - address: 2222 M Street
+    building: ''
+    city: Merced
+    fax: ''
+    phone: 209-384-1620
+    state: CA
+    suite: Suite 305
+    zip: '95340'
+- id:
+    bioguide: H001034
+    govtrack: 400185
+    thomas: '01634'
+  offices:
+  - address: 2001 Gateway Place
+    building: ''
+    city: San Jose
+    fax: 408-436-2721
+    phone: 408-436-2720
+    state: CA
+    suite: Suite 670W
+    zip: '95110'
+  - address: 900 Lafayette Street
+    building: ''
+    city: Santa Clara
+    fax: 408-436-2721
+    phone: 408-436-2720
+    state: CA
+    suite: Suite 206
+    zip: '95050'
+- id:
+    bioguide: E000215
+    govtrack: 400124
+    thomas: '00355'
+  offices:
+  - address: 698 Emerson Street
+    building: ''
+    city: Palo Alto
+    fax: 650-323-3498
+    phone: 650-323-2984
+    state: CA
+    suite: ''
+    zip: '94301'
+- id:
+    bioguide: L000397
+    govtrack: 400245
+    thomas: '00701'
+  offices:
+  - address: 635 North First Street
+    building: ''
+    city: San Jose
+    fax: ''
+    phone: 408-271-8700
+    state: CA
+    suite: Suite B
+    zip: '95112'
+- id:
+    bioguide: F000030
+    govtrack: 400129
+    thomas: 00368
+  offices:
+  - address: 701 Ocean Avenue
+    building: ''
+    city: Santa Cruz
+    fax: 831-429-1458
+    phone: 831-429-1976
+    state: CA
+    suite: Room 318C
+    zip: 95060-4002
+  - address: 100 West Alisal Street
+    building: ''
+    city: Salinas
+    fax: 831-424-7099
+    phone: 831-424-2229
+    state: CA
+    suite: ''
+    zip: '93901'
+- id:
+    bioguide: V000129
+    govtrack: 412515
+    thomas: '02105'
+  offices:
+  - address: 101 North Irwin Street
+    building: ''
+    city: Hanford
+    fax: 559-582-5527
+    phone: 559-582-5526
+    state: CA
+    suite: Suite 110B
+    zip: '93230'
+  - address: 2700 M Street
+    building: ''
+    city: Bakersfield
+    fax: ''
+    phone: 661-864-7736
+    state: CA
+    suite: Suite 250B
+    zip: '93301'
+- id:
+    bioguide: N000181
+    govtrack: 400297
+    thomas: '01710'
+  offices:
+  - address: 113 North Church Street
+    building: ''
+    city: Visalia
+    fax: 559-733-3865
+    phone: 559-733-3861
+    state: CA
+    suite: Suite 208
+    zip: '93291'
+  - address: 264 Clovis Avenue
+    building: ''
+    city: Clovis
+    fax: 559-323-5528
+    phone: 559-323-5235
+    state: CA
+    suite: Suite 206
+    zip: '93612'
+- id:
+    bioguide: M001165
+    govtrack: 412190
+    thomas: 01833
+  offices:
+  - address: 4100 Empire Drive
+    building: ''
+    city: Bakersfield
+    fax: 661-637-0867
+    phone: 661-327-3611
+    state: CA
+    suite: Suite 150
+    zip: '93309'
+- id:
+    bioguide: C001036
+    govtrack: 400062
+    thomas: '01471'
+  offices:
+  - address: 1101 South Broadway
+    building: ''
+    city: Santa Maria
+    fax: ''
+    phone: 805-349-3832
+    state: CA
+    suite: Suite A
+    zip: '93454'
+  - address: 1411 Marsh Street
+    building: ''
+    city: San Luis Obispo
+    fax: 805-546-8368
+    phone: 805-546-8348
+    state: CA
+    suite: Suite 205
+    zip: 93401-2957
+  - address: 301 East Carrillo Street
+    building: ''
+    city: Santa Barbara
+    fax: 805-730-9153
+    phone: 805-730-1710
+    state: CA
+    suite: Suite A
+    zip: '93101'
+- id:
+    bioguide: K000387
+    govtrack: 412614
+    thomas: 02228
+  offices:
+  - address: 1008 West Avenue M-14
+    building: ''
+    city: Palmdale
+    fax: ''
+    phone: 661-441-0320
+    state: CA
+    suite: Suite E
+    zip: '93551'
+  - address: 26415 Carl Boyer Drive
+    building: ''
+    city: Santa Clarita
+    fax: 661-255-5630
+    phone: 805-581-7130
+    state: CA
+    suite: Suite 220
+    zip: '91350'
+  - address: 1445 East Los Angeles Avenue
+    building: ''
+    city: Simi Valley
+    fax: ''
+    phone: 805-581-7130
+    state: CA
+    suite: '#206'
+    zip: '93065'
+- id:
+    bioguide: B001285
+    govtrack: 412516
+    thomas: '02106'
+  offices:
+  - address: 223 East Thousand Oaks Boulevard
+    building: ''
+    city: Thousand Oaks
+    fax: 805-379-1779
+    phone: 805-379-1779
+    state: CA
+    suite: Suite 411
+    zip: '91360'
+  - address: 300 East Esplanade Drive
+    building: ''
+    city: Oxnard
+    fax: 805-379-1799
+    phone: 805-379-1779
+    state: CA
+    suite: Suite 470
+    zip: '93036'
+- id:
+    bioguide: C001080
+    govtrack: 412379
+    thomas: 01970
+  offices:
+  - address: 527 South Lake Avenue
+    building: ''
+    city: Pasadena
+    fax: 626-304-0132
+    phone: 626-304-0110
+    state: CA
+    suite: Suite 106
+    zip: '91101'
+  - address: 415 West Foothill Boulevard
+    building: ''
+    city: Claremont
+    fax: 909-399-0198
+    phone: 909-625-5394
+    state: CA
+    suite: Suite 122
+    zip: '91711'
+- id:
+    bioguide: S001150
+    govtrack: 400361
+    thomas: '01635'
+  offices:
+  - address: 245 East Olive Avenue
+    building: ''
+    city: Burbank
+    fax: 818-450-2928
+    phone: 818-450-2900
+    state: CA
+    suite: Suite 200
+    zip: '91502'
+- id:
+    bioguide: C001097
+    govtrack: 412517
+    thomas: '02107'
+  offices:
+  - address: 8134 Van Nuys Boulevard
+    building: ''
+    city: Panorama City
+    fax: 818-781-7462
+    phone: 818-781-7407
+    state: CA
+    suite: Suite 206
+    zip: '91402'
+- id:
+    bioguide: S000344
+    govtrack: 400371
+    thomas: '01526'
+  offices:
+  - address: 5000 Van Nuys Boulevard
+    building: ''
+    city: Sherman Oaks
+    fax: 818-501-1554
+    phone: 818-501-9200
+    state: CA
+    suite: Suite 420
+    zip: '91403'
+- id:
+    bioguide: A000371
+    govtrack: 412615
+    thomas: 02229
+  offices:
+  - address: 685 East  Carnegie Drive
+    building: ''
+    city: San Bernardino
+    fax: 909-890-9643
+    phone: 909-890-4445
+    state: CA
+    suite: Suite 100
+    zip: '92408'
+- id:
+    bioguide: N000179
+    govtrack: 400290
+    thomas: '01602'
+  offices:
+  - address: 4401 Santa Anita Avenue
+    building: ''
+    city: El Monte
+    fax: 626-350-0450
+    phone: 626-350-0150
+    state: CA
+    suite: Suite 201
+    zip: '91731'
+- id:
+    bioguide: L000582
+    govtrack: 412616
+    thomas: '02230'
+  offices:
+  - address: 5055 Wilshire Boulevard
+    building: ''
+    city: Los Angeles
+    fax: 323-655-0502
+    phone: 323-651-1040
+    state: CA
+    suite: Suite 310
+    zip: '90036'
+  - address: 1600 Rosecrans Avenue
+    building: ''
+    city: Manhattan Beach
+    fax: 323-655-0502
+    phone: 310-321-7664
+    state: CA
+    suite: 4th Floor
+    zip: '90266'
+- id:
+    bioguide: B000287
+    govtrack: 400021
+    thomas: '00070'
+  offices:
+  - address: 350 South Bixel Street
+    building: ''
+    city: Los Angeles
+    fax: ''
+    phone: 213-481-1425
+    state: CA
+    suite: Suite 120
+    zip: '90017'
+- id:
+    bioguide: T000474
+    govtrack: 412617
+    thomas: '02231'
+  offices:
+  - address: 3200 Inland Empire Boulevard
+    building: ''
+    city: Ontario
+    fax: ''
+    phone: 909-481-6474
+    state: CA
+    suite: Suite 200B
+    zip: '91764'
+- id:
+    bioguide: R000599
+    govtrack: 412519
+    thomas: 02109
+  offices:
+  - address: 445 East Florida Avenue
+    building: ''
+    city: Hemet
+    fax: 951-765-3784
+    phone: 351-765-2304
+    state: CA
+    suite: 2nd Floor
+    zip: '92543'
+  - address: 43875 Washington Street
+    building: ''
+    city: Palm Desert
+    fax: 760-424-8993
+    phone: 760-424-8888
+    state: CA
+    suite: Suite F
+    zip: '92211'
+- id:
+    bioguide: B001270
+    govtrack: 412404
+    thomas: 01996
+  offices:
+  - address: 4929 Wilshire Boulevard
+    building: ''
+    city: Los Angeles
+    fax: 323-965-1113
+    phone: 323-965-1422
+    state: CA
+    suite: Suite 650
+    zip: '90010'
+- id:
+    bioguide: S001156
+    govtrack: 400355
+    thomas: '01757'
+  offices:
+  - address: 12440 Imperial Highway
+    building: ''
+    city: Norwalk
+    fax: 562-924-2914
+    phone: 562-860-5050
+    state: CA
+    suite: Suite 140
+    zip: '90650'
+- id:
+    bioguide: R000487
+    govtrack: 400348
+    thomas: 00998
+  offices:
+  - address: 210 West Birch Street
+    building: ''
+    city: Brea
+    fax: 909-225-0109
+    phone: 909-420-0010
+    state: CA
+    suite: Suite 201
+    zip: '92821'
+  - address: 1380 South Fullerton Road
+    building: ''
+    city: Rowland Heights
+    fax: 626-810-3891
+    phone: 626-964-5123
+    state: CA
+    suite: '#205'
+    zip: '91748'
+- id:
+    bioguide: R000486
+    govtrack: 400347
+    thomas: 00997
+  offices:
+  - address: 500 Citadel Drive
+    building: ''
+    city: Commerce
+    fax: 323-721-8789
+    phone: 323-721-8790
+    state: CA
+    suite: Suite 320
+    zip: '90040'
+- id:
+    bioguide: T000472
+    govtrack: 412520
+    thomas: '02110'
+  offices:
+  - address: 3403 10th Street
+    building: ''
+    city: Riverside
+    fax: 951- 222-0217
+    phone: 951-222-0203
+    state: CA
+    suite: Suite 610
+    zip: '92501'
+- id:
+    bioguide: C000059
+    govtrack: 400057
+    thomas: '00165'
+  offices:
+  - address: 4160 Temescal Canyon Road
+    building: ''
+    city: Corona
+    fax: 951-277-0420
+    phone: 951-277-0042
+    state: CA
+    suite: Suite 214
+    zip: '92883'
+- id:
+    bioguide: W000187
+    govtrack: 400422
+    thomas: '01205'
+  offices:
+  - address: 10124 South Broadway
+    building: ''
+    city: Los Angeles
+    fax: 323-757-9506
+    phone: 323-757-8900
+    state: CA
+    suite: Suite 1
+    zip: '90003'
+- id:
+    bioguide: H001063
+    govtrack: 412498
+    thomas: 02089
+  offices:
+  - address: 140 West 6th Street
+    building: ''
+    city: San Pedro
+    fax: 310-831-1885
+    phone: 310-831-1799
+    state: CA
+    suite: ''
+    zip: '90731'
+- id:
+    bioguide: W000820
+    govtrack: 412618
+    thomas: '02232'
+  offices:
+  - address: 3333 Michelson Drive
+    building: ''
+    city: Irvine
+    fax: 949-263-8704
+    phone: 949-263-8703
+    state: CA
+    suite: Suite 230
+    zip: '92612'
+- id:
+    bioguide: S000030
+    govtrack: 400356
+    thomas: '01522'
+  offices:
+  - address: 12397 Lewis Street
+    building: ''
+    city: Garden Grove
+    fax: 714-621-0401
+    phone: 714-621-0102
+    state: CA
+    suite: Suite 101
+    zip: '92840'
+- id:
+    bioguide: L000579
+    govtrack: 412521
+    thomas: '02111'
+  offices:
+  - address: 100 West Broadway
+    building: ''
+    city: Long Beach
+    fax: 562-437-6434
+    phone: 562-436-3828
+    state: CA
+    suite: West Tower Suite 600
+    zip: '90802'
+- id:
+    bioguide: R000409
+    govtrack: 400343
+    thomas: 00979
+  offices:
+  - address: 101 Main Street
+    building: ''
+    city: Huntington Beach
+    fax: ''
+    phone: 714-960-6483
+    state: CA
+    suite: Suite 380
+    zip: '92648'
+- id:
+    bioguide: I000056
+    govtrack: 400196
+    thomas: '01640'
+  offices:
+  - address: 1800 Thibodo Road
+    building: ''
+    city: Vista
+    fax: 760-599-1178
+    phone: 760-599-5000
+    state: CA
+    suite: Suite 310
+    zip: 92081-7515
+  - address: 33282 Golden Latern Street
+    building: ''
+    city: Dana Point
+    fax: ''
+    phone: 949-281-2449
+    state: CA
+    suite: Suite 102
+    zip: '92629'
+- id:
+    bioguide: H001048
+    govtrack: 412283
+    thomas: 01909
+  offices:
+  - address: 1611 North Magnolia Avenue
+    building: ''
+    city: El Cajon
+    fax: 619-449-2251
+    phone: 619-448-5201
+    state: CA
+    suite: Suite 310
+    zip: '92020'
+  - address: 333 South Juniper Street
+    building: ''
+    city: Escondido
+    fax: ''
+    phone: 760-743-3260
+    state: CA
+    suite: Suite 110
+    zip: '92025'
+- id:
+    bioguide: V000130
+    govtrack: 412522
+    thomas: '02112'
+  offices:
+  - address: 333 F Street
+    building: ''
+    city: Chula Vista
+    fax: 619-422-7290
+    phone: 619-422-5963
+    state: CA
+    suite: Suite A
+    zip: '91910'
+  - address: 380 North 8th Street
+    building: ''
+    city: El Centro
+    fax: 760-321-9664
+    phone: 760-312-9900
+    state: CA
+    suite: '#14'
+    zip: '92243'
+- id:
+    bioguide: P000608
+    govtrack: 412523
+    thomas: '02113'
+  offices:
+  - address: 4350 Executive Drive
+    building: ''
+    city: San Diego
+    fax: 858-455-5516
+    phone: 858-455-5550
+    state: CA
+    suite: Suite 105
+    zip: '92121'
+- id:
+    bioguide: D000598
+    govtrack: 400097
+    thomas: '01641'
+  offices:
+  - address: 2700 Adams Avenue
+    building: ''
+    city: San Diego
+    fax: 619-280-5311
+    phone: 619-280-5353
+    state: CA
+    suite: Suite 102
+    zip: '92116'
+- id:
+    bioguide: D000197
+    govtrack: 400101
+    thomas: 01479
+  offices:
+  - address: 600 Grant Street
+    building: ''
+    city: Denver
+    fax: 303-844-4996
+    phone: 303-844-4988
+    state: CO
+    suite: Suite 202
+    zip: '80203'
+- id:
+    bioguide: P000598
+    govtrack: 412308
+    thomas: 01910
+  offices:
+  - address: ''
+    building: ''
+    city: Frisco
+    fax: ''
+    phone: 970-668-3240
+    state: CO
+    suite: PO Box 1453
+    zip: '80443'
+  - address: 1644 Walnut Street
+    building: ''
+    city: Boulder
+    fax: 303-568-9007
+    phone: 303-484-9596
+    state: CO
+    suite: Suite 220
+    zip: '80302'
+  - address: 1220 South College Avenue
+    building: ''
+    city: Fort Collins
+    fax: ''
+    phone: 970-226-1239
+    state: CO
+    suite: ''
+    zip: '80525'
+- id:
+    bioguide: T000470
+    govtrack: 412405
+    thomas: 01997
+  offices:
+  - address: 225 North 5th Street
+    building: ''
+    city: Grand Junction
+    fax: 970-241-3053
+    phone: 970-241-2499
+    state: CO
+    suite: Suite 702
+    zip: '81501'
+  - address: 609 Main Street
+    building: ''
+    city: Alamosa
+    fax: 719-587-5137
+    phone: 719-587-5105
+    state: CO
+    suite: '#105 Box 11'
+    zip: '81101'
+  - address: 503 North Main Street
+    building: ''
+    city: Pueblo
+    fax: 719-542-1127
+    phone: 719-542-1073
+    state: CO
+    suite: Suite 658
+    zip: '81003'
+  - address: 835 East Second Avenue
+    building: ''
+    city: Durango
+    fax: 970-259-1563
+    phone: 970-259-1490
+    state: CO
+    suite: Suite 230
+    zip: '81301'
+- id:
+    bioguide: B001297
+    govtrack: 412619
+    thomas: '02233'
+  offices:
+  - address: 900 Castleton Road
+    building: ''
+    city: Castle Rock
+    fax: ''
+    phone: 720-639-9165
+    state: CO
+    suite: Suite 112
+    zip: '80109'
+  - address: 1122 9th Street
+    building: ''
+    city: Greeley
+    fax: 970-702-2951
+    phone: 970-702-2136
+    state: CO
+    suite: Suite 204
+    zip: '80631'
+  - address: 302 North 3rd Street
+    building: ''
+    city: Sterling
+    fax: 970-522-0915
+    phone: 970-762-0109
+    state: CO
+    suite: ''
+    zip: '80751'
+- id:
+    bioguide: L000564
+    govtrack: 412191
+    thomas: 01834
+  offices:
+  - address: 1125 Kelly Johnson Boulevard
+    building: ''
+    city: Colorado Springs
+    fax: 719-520-0840
+    phone: 719-520-0055
+    state: CO
+    suite: Suite 330
+    zip: '80920'
+- id:
+    bioguide: C001077
+    govtrack: 412271
+    thomas: 01912
+  offices:
+  - address: 3300 South Parker Road
+    building: Cherry Creek Place IV
+    city: Aurora
+    fax: 720-748-7680
+    phone: 720-748-7514
+    state: CO
+    suite: Suite 305
+    zip: '80014'
+- id:
+    bioguide: P000593
+    govtrack: 412192
+    thomas: 01835
+  offices:
+  - address: 12600 West Colfax Avenue
+    building: ''
+    city: Lakewood
+    fax: 303-274-6455
+    phone: 303-274-7944
+    state: CO
+    suite: Suite B-400
+    zip: '80215'
+- id:
+    bioguide: L000557
+    govtrack: 400233
+    thomas: 01583
+  offices:
+  - address: 221 Main Street
+    building: ''
+    city: Hartford
+    fax: 860-278-2111
+    phone: 860-278-8888
+    state: CT
+    suite: 2nd Floor
+    zip: 06106-1890
+- id:
+    bioguide: C001069
+    govtrack: 412193
+    thomas: 01836
+  offices:
+  - address: 77 Hazard Avenue
+    building: ''
+    city: Enfield
+    fax: 860-741-6036
+    phone: 860-741-6011
+    state: CT
+    suite: Unit J
+    zip: 06082
+  - address: 55 Main Street
+    building: ''
+    city: Norwich
+    fax: 860-886-2974
+    phone: 860-886-0139
+    state: CT
+    suite: Suite 250
+    zip: '06360'
+- id:
+    bioguide: D000216
+    govtrack: 400103
+    thomas: 00281
+  offices:
+  - address: 59 Elm Street
+    building: ''
+    city: New Haven
+    fax: 203-772-2260
+    phone: 203-562-3718
+    state: CT
+    suite: ''
+    zip: 06510-2047
+- id:
+    bioguide: H001047
+    govtrack: 412282
+    thomas: 01913
+  offices:
+  - address: 211 State Street
+    building: ''
+    city: Bridgeport
+    fax: 203-333-6655
+    phone: 203-333-6600
+    state: CT
+    suite: 2nd Floor
+    zip: '06604'
+  - address: 888 Washington Boulevard
+    building: ''
+    city: Stamford
+    fax: 203-323-1793
+    phone: 203-353-9400
+    state: CT
+    suite: 10th Floor
+    zip: 06901
+- id:
+    bioguide: E000293
+    govtrack: 412524
+    thomas: '02114'
+  offices:
+  - address: 114 West Main Street
+    building: Old Post Office Plaza, LLC
+    city: New Britain
+    fax: 860-225-7289
+    phone: 860-223-8412
+    state: CT
+    suite: Suite 206
+    zip: '06051'
+- id:
+    bioguide: N000147
+    govtrack: 400295
+    thomas: 00868
+  offices:
+  - address: 90 K Street, NE
+    building: ''
+    city: Washington
+    fax: 202-408-9048
+    phone: 202-408-9041
+    state: DC
+    suite: Suite 100
+    zip: '20001'
+  - address: 2041 Martin Luther King Jr. Ave., S.E.,
+    building: ''
+    city: Washington
+    fax: 202-678-8844
+    phone: 202-678-8900
+    state: DC
+    suite: Suite 238
+    zip: '20020'
+- id:
+    bioguide: C001083
+    govtrack: 412407
+    thomas: 01999
+  offices:
+  - address: 233 North King Street
+    building: ''
+    city: Wilmington
+    fax: 302-428-1950
+    phone: 302-691-7333
+    state: DE
+    suite: Suite 200
+    zip: '19801'
+  - address: 33 The Circle
+    building: ''
+    city: Georgetown
+    fax: 302-854-0669
+    phone: 302-854-0667
+    state: DE
+    suite: ''
+    zip: '19947'
+- id:
+    bioguide: M001144
+    govtrack: 400279
+    thomas: 01685
+  offices:
+  - address: 348 SW Miracle Strip Parkway
+    building: ''
+    city: Fort Walton Beach
+    fax: 850-664-0851
+    phone: 850-664-1266
+    state: FL
+    suite: Suite 24
+    zip: '32548'
+  - address: 4300 Bayou Boulevard
+    building: ''
+    city: Pensacola
+    fax: 850-479-9394
+    phone: 850-479-1183
+    state: FL
+    suite: Suite 13
+    zip: '32503'
+- id:
+    bioguide: G000575
+    govtrack: 412620
+    thomas: '02234'
+  offices:
+  - address: 840 West 11th Street
+    building: ''
+    city: Panama City
+    fax: 850-763-3764
+    phone: 850-785-0812
+    state: FL
+    suite: Suite 2250
+    zip: '32401'
+  - address: 300 South Adams Street
+    building: ''
+    city: Tallahassee
+    fax: 850-891-8620
+    phone: 850-891-8610
+    state: FL
+    suite: A-3
+    zip: '32301'
+- id:
+    bioguide: Y000065
+    govtrack: 412525
+    thomas: '02115'
+  offices:
+  - address: 5000 NW 27th Court
+    building: ''
+    city: Gainesville
+    fax: ''
+    phone: 352-505-0838
+    state: FL
+    suite: Suite E
+    zip: '32606'
+  - address: 1213 Blanding Boulevard
+    building: ''
+    city: Orange Park
+    fax: ''
+    phone: 904-276-9626
+    state: FL
+    suite: ''
+    zip: '32065'
+- id:
+    bioguide: C001045
+    govtrack: 400086
+    thomas: '01643'
+  offices:
+  - address: 1061 Riverside Avenue
+    building: ''
+    city: Jacksonville
+    fax: 904-598-0486
+    phone: 904-598-0481
+    state: FL
+    suite: Suite 100
+    zip: '32204'
+- id:
+    bioguide: B000911
+    govtrack: 400048
+    thomas: '00132'
+  offices:
+  - address: 101 East Union Street
+    building: ''
+    city: Jacksonville
+    fax: 904-354-2721
+    phone: 904-354-1652
+    state: FL
+    suite: Suite 202
+    zip: 32202-3060
+  - address: 455 North Garland Avenue
+    building: ''
+    city: Orlando
+    fax: 407-872-5763
+    phone: 407-872-2208
+    state: FL
+    suite: ''
+    zip: '32801'
+- id:
+    bioguide: D000621
+    govtrack: 412526
+    thomas: '02116'
+  offices:
+  - address: 1000 City Centrer Circle
+    building: ''
+    city: Port Orange
+    fax: 386-756-9903
+    phone: 386-756-9798
+    state: FL
+    suite: ''
+    zip: '32129'
+  - address: 3940 Lewis Speedway
+    building: ''
+    city: St. Augustine
+    fax: 904-827-1114
+    phone: 904-827-1101
+    state: FL
+    suite: Suite 2104
+    zip: '32084'
+  - address: 2000 PGA Boulevard
+    building: ''
+    city: Palm Beach Gardens
+    fax: 561-253-8436
+    phone: 561-253-8433
+    state: FL
+    suite: Suite A3220
+    zip: '33408'
+- id:
+    bioguide: M000689
+    govtrack: 400273
+    thomas: 00800
+  offices:
+  - address: 100 East Sybelia Avenue
+    building: ''
+    city: Maitland
+    fax: 407-657-5353
+    phone: 407-657-8080
+    state: FL
+    suite: Suite 340
+    zip: 32751-4495
+  - address: 840 Deltona Boulevard
+    building: ''
+    city: Deltona
+    fax: 386-860-5730
+    phone: 386-860-1499
+    state: FL
+    suite: Suite G
+    zip: 32725-7162
+  - address: 95 East Mitchell Hammock Road
+    building: ''
+    city: Oviedo
+    fax: 407-366-0839
+    phone: 407-366-0833
+    state: FL
+    suite: Suite 202
+    zip: '32765'
+- id:
+    bioguide: P000599
+    govtrack: 412309
+    thomas: 01915
+  offices:
+  - address: 2725 Judge Fran Jamieson Way
+    building: ''
+    city: Melbourne
+    fax: 321-639-8595
+    phone: 321-632-1776
+    state: FL
+    suite: Building C
+    zip: '32940'
+- id:
+    bioguide: G000556
+    govtrack: 412276
+    thomas: 01914
+  offices:
+  - address: 5842 South Semoran Boulevard
+    building: ''
+    city: Orlando
+    fax: 407-615-8890
+    phone: 407-615-8889
+    state: FL
+    suite: ''
+    zip: '32822'
+  - address: 101 North Church Street
+    building: ''
+    city: Kissimmee
+    fax: 407-846-2087
+    phone: 407-518-4983
+    state: FL
+    suite: Suite 550
+    zip: '34741'
+- id:
+    bioguide: W000806
+    govtrack: 412410
+    thomas: '02002'
+  offices:
+  - address: 300 West Plant Street
+    building: ''
+    city: Winter Garden
+    fax: 407-654-5814
+    phone: 407-654-5705
+    state: FL
+    suite: ''
+    zip: '34787'
+  - address: 315 West Main Street
+    building: ''
+    city: Tavares
+    fax: 407-654-5814
+    phone: 352-383-3552
+    state: FL
+    suite: ''
+    zip: '32778'
+  - address: 685 West Montrose Street
+    building: ''
+    city: Clermont
+    fax: 407-654-5814
+    phone: 352-383-3552
+    state: FL
+    suite: ''
+    zip: '34711'
+  - address: 451 Third Street NW
+    building: ''
+    city: Winter Haven
+    fax: 407-654-5814
+    phone: 863-453-0273
+    state: FL
+    suite: ''
+    zip: '33881'
+- id:
+    bioguide: N000185
+    govtrack: 412409
+    thomas: '02001'
+  offices:
+  - address: 11035 Spring Hill Drive
+    building: ''
+    city: Spring Hill
+    fax: 352-341-2316
+    phone: 352-684-4446
+    state: FL
+    suite: ''
+    zip: '36408'
+  - address: 212 West Main Street
+    building: ''
+    city: Inverness
+    fax: 352-341-2316
+    phone: 352-341-2354
+    state: FL
+    suite: Suite 204
+    zip: '34450'
+  - address: 8015 East CR-466
+    building: ''
+    city: The Villages
+    fax: 352-689-4621
+    phone: 352-689-4684
+    state: FL
+    suite: ''
+    zip: '32162'
+  - address: 115 SE 25th Avenue
+    building: ''
+    city: Ocala
+    fax: 352-351-1674
+    phone: 352-351-1670
+    state: FL
+    suite: ''
+    zip: '34471'
+- id:
+    bioguide: B001257
+    govtrack: 412250
+    thomas: 01838
+  offices:
+  - address: 600 Klosterman Road
+    building: ''
+    city: Tarpon Springs
+    fax: 727-940-5861
+    phone: 727-940-5860
+    state: FL
+    suite: Room BB-038
+    zip: 34689-1229
+  - address: 5901 Argerian Drive
+    building: ''
+    city: Wesley Chapel
+    fax: 813-501-4944
+    phone: 813-501-4942
+    state: FL
+    suite: Suite 102
+    zip: 33545-4220
+  - address: 7132 Little Road
+    building: ''
+    city: New Port Richey
+    fax: 727-232-2923
+    phone: 727-232-2921
+    state: FL
+    suite: ''
+    zip: '34654'
+- id:
+    bioguide: J000296
+    govtrack: 412603
+    thomas: 02199
+  offices:
+  - address: 9210 113th Street
+    building: ''
+    city: Seminole
+    fax: 727-392-4989
+    phone: 727-392-4100
+    state: FL
+    suite: ''
+    zip: '33772'
+  - address: 425 22nd Avenue North
+    building: ''
+    city: St. Petersburg
+    fax: 727-821-0484
+    phone: 727-823-8900
+    state: FL
+    suite: Suite C
+    zip: '33704'
+  - address: 29275 U.S. Highway 19 North
+    building: ''
+    city: Clearwater
+    fax: 727-781-4409
+    phone: 727-781-4400
+    state: FL
+    suite: ''
+    zip: '33761'
+- id:
+    bioguide: C001066
+    govtrack: 412195
+    thomas: 01839
+  offices:
+  - address: 4144 North Armenia Avenue
+    building: ''
+    city: Tampa
+    fax: 813-871-2864
+    phone: 813-871-2817
+    state: FL
+    suite: Suite 300
+    zip: '33609'
+- id:
+    bioguide: R000593
+    govtrack: 412411
+    thomas: '02003'
+  offices:
+  - address: 170 Fitzgerald Road
+    building: ''
+    city: Lakeland
+    fax: 863-648-0749
+    phone: 863-644-8215
+    state: FL
+    suite: Suite 1
+    zip: '33813'
+  - address: 110 West Reynolds Street
+    building: ''
+    city: Plant City
+    fax: 863-648-0749
+    phone: 813-752-4790
+    state: FL
+    suite: Suite 101
+    zip: '33563'
+- id:
+    bioguide: B001260
+    govtrack: 412196
+    thomas: 01840
+  offices:
+  - address: 1051 Manatee Avenue West
+    building: ''
+    city: Bradenton
+    fax: 941-748-1564
+    phone: 941-747-9081
+    state: FL
+    suite: Suite 305
+    zip: '34205'
+  - address: 111 South Orange Avenue
+    building: ''
+    city: Sarasota
+    fax: 941-951-2972
+    phone: 941-951-6643
+    state: FL
+    suite: Floor 2R, Suite 202W
+    zip: '34236'
+- id:
+    bioguide: R000583
+    govtrack: 412311
+    thomas: 01916
+  offices:
+  - address: 10008 Park Place Avenue
+    building: ''
+    city: Riverview
+    fax: 941-575-9103
+    phone: 813-677-8646
+    state: FL
+    suite: ''
+    zip: '33578'
+  - address: 226 Taylor Street
+    building: ''
+    city: Punta Gorda
+    fax: 941-575-9103
+    phone: 941-575-9101
+    state: FL
+    suite: Suite 230
+    zip: '33950'
+  - address: 4507 George Boulevard
+    building: ''
+    city: Sebring
+    fax: 941-575-9103
+    phone: 863-402-9082
+    state: FL
+    suite: ''
+    zip: '33875'
+- id:
+    bioguide: M001191
+    govtrack: 412527
+    thomas: '02117'
+  offices:
+  - address: 2000 PGA Boulevard
+    building: ''
+    city: Palm Beach Gardens
+    fax: 561-253-8830
+    phone: 561-253-8433
+    state: FL
+    suite: Suite A3220
+    zip: '33408'
+  - address: 121 SW Port Street Boulevard
+    building: ''
+    city: Port St. Lucie
+    fax: 772-336-2899
+    phone: 772-336-2877
+    state: FL
+    suite: Room 187
+    zip: '34984'
+  - address: 171 SW Flagler Avenue
+    building: ''
+    city: Stuart
+    fax: 772-781-3267
+    phone: 772-781-3266
+    state: FL
+    suite: ''
+    zip: '34994'
+  - address: 2300 Virginia Avenue
+    building: ''
+    city: Fort Pierce
+    fax: 772-464-8392
+    phone: 772-489-0736
+    state: FL
+    suite: Room 200A
+    zip: '34982'
+- id:
+    bioguide: C001102
+    govtrack: 412604
+    thomas: '02200'
+  offices:
+  - address: 3299 Tamiami Trail
+    building: ''
+    city: Naples
+    fax: ''
+    phone: 239-252-6225
+    state: FL
+    suite: Suite 105
+    zip: '34112'
+  - address: 804 Nicholas Parkway East
+    building: ''
+    city: Cape Coral
+    fax: ''
+    phone: 239-573-5837
+    state: FL
+    suite: Suite 1
+    zip: '33990'
+- id:
+    bioguide: H000324
+    govtrack: 400170
+    thomas: '00511'
+  offices:
+  - address: 2701 West Oakland Park Boulevard
+    building: ''
+    city: Fort Lauderdale
+    fax: 954-735-9444
+    phone: 954-733-2800
+    state: FL
+    suite: Suite 200
+    zip: '33311'
+  - address: 1755 East Tiffany Drive
+    building: Town of Mangonia Park Municipal Center
+    city: Mangonia Park
+    fax: ''
+    phone: 561-469-7048
+    state: FL
+    suite: ''
+    zip: '33407'
+- id:
+    bioguide: D000610
+    govtrack: 412385
+    thomas: 01976
+  offices:
+  - address: 8177 Glades Road
+    building: ''
+    city: Boca Raton
+    fax: ''
+    phone: 561-470-5440
+    state: FL
+    suite: Suite 211
+    zip: '33434'
+  - address: 1300 Coral Springs Drive
+    building: ''
+    city: Coral Springs
+    fax: ''
+    phone: 954-255-8336
+    state: FL
+    suite: ''
+    zip: '33071'
+  - address: 5790 Margate Boulevard
+    building: ''
+    city: Margate
+    fax: ''
+    phone: 954-972-6454
+    state: FL
+    suite: ''
+    zip: '33063'
+- id:
+    bioguide: F000462
+    govtrack: 412529
+    thomas: 02119
+  offices:
+  - address: 2500 North Military Trail
+    building: ''
+    city: Boca Raton
+    fax: 561-998-9048
+    phone: 561-998-9045
+    state: FL
+    suite: Suite 490
+    zip: '33431'
+- id:
+    bioguide: W000797
+    govtrack: 400623
+    thomas: '01777'
+  offices:
+  - address: 19200 West Country Club Drive
+    building: ''
+    city: Aventura
+    fax: 305-932-9664
+    phone: 305-936-5724
+    state: FL
+    suite: ''
+    zip: '33180'
+  - address: 10100 Pines Boulevard
+    building: ''
+    city: Pembroke Pines
+    fax: 954-437-4776
+    phone: 954-437-3936
+    state: FL
+    suite: ''
+    zip: '33026'
+- id:
+    bioguide: W000808
+    govtrack: 412412
+    thomas: '02004'
+  offices:
+  - address: 18425 NW 2nd Avenue
+    building: ''
+    city: Miami Gardens
+    fax: 305-690-5951
+    phone: 305-690-5905
+    state: FL
+    suite: Suite 355
+    zip: '33169'
+  - address: 10100 Pines Boulevard
+    building: Pembroke Pines City Hal
+    city: Pembroke Pines
+    fax: ''
+    phone: 954-450-6767
+    state: FL
+    suite: Building B Third Floor
+    zip: '33026'
+  - address: 1965 South State Road 7
+    building: West Park City Hall
+    city: West Park
+    fax: ''
+    phone: 954-989-2688
+    state: FL
+    suite: ''
+    zip: '33023'
+- id:
+    bioguide: D000600
+    govtrack: 400108
+    thomas: '01717'
+  offices:
+  - address: 4715 Golden Gate Parkway
+    building: ''
+    city: Naples
+    fax: 239-348-3569
+    phone: 239-348-1620
+    state: FL
+    suite: Suite 1
+    zip: '34116'
+  - address: 8669 NW 36th Street
+    building: ''
+    city: Doral
+    fax: 305-470-8575
+    phone: 305-470-8555
+    state: FL
+    suite: Suite 100
+    zip: '33166'
+- id:
+    bioguide: C001107
+    govtrack: 412621
+    thomas: '02235'
+  offices:
+  - address: 12851 SW 42nd Street
+    building: ''
+    city: Miami
+    fax: 305-228-9397
+    phone: 305-222-0160
+    state: FL
+    suite: Suite 131
+    zip: '33175'
+  - address: 1100 Simonton Street
+    building: ''
+    city: Key West
+    fax: 305-292-4486
+    phone: 305-222-0160
+    state: FL
+    suite: Suite 1-213
+    zip: '33010'
+  - address: 404 West Palm Drive
+    building: ''
+    city: Florida City
+    fax: ''
+    phone: 305-247-1234
+    state: FL
+    suite: ''
+    zip: '33034'
+- id:
+    bioguide: R000435
+    govtrack: 400344
+    thomas: 00985
+  offices:
+  - address: 4960 SW 72 Avenue
+    building: ''
+    city: Miami
+    fax: 305-668-5970
+    phone: 305-668-2285
+    state: FL
+    suite: Suite 208
+    zip: '33144'
+- id:
+    bioguide: C001103
+    govtrack: 412622
+    thomas: '02236'
+  offices:
+  - address: 1510 Newcastle Street
+    building: ''
+    city: Brunswick
+    fax: 912-265-9013
+    phone: 912-265-9010
+    state: GA
+    suite: Suite 200
+    zip: '31520'
+  - address: 6602 Abercorn Street
+    building: ''
+    city: Savannah
+    fax: 912-352-0105
+    phone: 912-352-0101
+    state: GA
+    suite: Suite 105B
+    zip: '31405'
+- id:
+    bioguide: B000490
+    govtrack: 400030
+    thomas: 00091
+  offices:
+  - address: 18 Ninth Street
+    building: ''
+    city: Columbus
+    fax: 706-320-9479
+    phone: 706-320-9477
+    state: GA
+    suite: Suite 201
+    zip: '31901'
+  - address: 235 Roosevelt Avenue
+    building: Albany Towers
+    city: Albany
+    fax: 229-436-2099
+    phone: 229-439-8067
+    state: GA
+    suite: Suite 114
+    zip: 31701-2640
+  - address: 682 Cherry Street
+    building: City Hall Annex
+    city: Macon
+    fax: 478-803-2637
+    phone: 478-803-2631
+    state: GA
+    suite: Suite 302
+    zip: '31201'
+- id:
+    bioguide: W000796
+    govtrack: 400627
+    thomas: 01779
+  offices:
+  - address: 1601-B East Highway 34
+    building: ''
+    city: Newnan
+    fax: 770-683-2042
+    phone: 770-683-2033
+    state: GA
+    suite: Suite 3
+    zip: '30265'
+- id:
+    bioguide: J000288
+    govtrack: 412199
+    thomas: 01843
+  offices:
+  - address: 5700 Hillandale Drive
+    building: ''
+    city: Lithonia
+    fax: 770-987-8721
+    phone: 770-987-2291
+    state: GA
+    suite: Suite 120
+    zip: '30058'
+- id:
+    bioguide: L000287
+    govtrack: 400240
+    thomas: 00688
+  offices:
+  - address: 100 Peachtree Street NW
+    building: The Equitable Building
+    city: Atlanta
+    fax: 404-331-0947
+    phone: 404-659-0116
+    state: GA
+    suite: Suite 1920
+    zip: '30303'
+- id:
+    bioguide: P000591
+    govtrack: 400626
+    thomas: 01778
+  offices:
+  - address: 85-C Mill Street
+    building: ''
+    city: Roswell
+    fax: 770-998-0050
+    phone: 770-998-0049
+    state: GA
+    suite: Suite 300
+    zip: '30075'
+- id:
+    bioguide: W000810
+    govtrack: 412416
+    thomas: 02008
+  offices:
+  - address: 75 Langley Drive
+    building: ''
+    city: Lawrenceville
+    fax: 770-232-2909
+    phone: 770-232-3005
+    state: GA
+    suite: ''
+    zip: '30046'
+- id:
+    bioguide: S001189
+    govtrack: 412417
+    thomas: 02009
+  offices:
+  - address: 127-B North Central Avenue
+    building: ''
+    city: Tifton
+    fax: 229-396-5179
+    phone: 229-396-5175
+    state: GA
+    suite: ''
+    zip: '31974'
+  - address: 230 Margie Drive
+    building: ''
+    city: Warner Robins
+    fax: 478-971-1778
+    phone: 478-971-1776
+    state: GA
+    suite: Suite 500
+    zip: '31088'
+- id:
+    bioguide: C001093
+    govtrack: 412531
+    thomas: '02121'
+  offices:
+  - address: 210 Washington Street NW
+    building: ''
+    city: Gainesville
+    fax: 770-297-3390
+    phone: 770-297-3388
+    state: GA
+    suite: Suite 202
+    zip: '30501'
+- id:
+    bioguide: H001071
+    govtrack: 412623
+    thomas: '02237'
+  offices:
+  - address: 100 Court Street
+    building: ''
+    city: Monroe
+    fax: 770-226-6751
+    phone: 770- 266-6751
+    state: GA
+    suite: PO Box 728
+    zip: '36055'
+  - address: 210 Railroad Street
+    building: City-County Administration Building
+    city: Thomson
+    fax: ''
+    phone: 770- 207-1776
+    state: GA
+    suite: Room 2401
+    zip: '30824'
+  - address: 3015 Heritage Road
+    building: ''
+    city: Milledgeville
+    fax: 478-451-2911
+    phone: 478- 457-0007
+    state: GA
+    suite: Suite 6
+    zip: '31061'
+- id:
+    bioguide: L000583
+    govtrack: 412624
+    thomas: 02238
+  offices:
+  - address: 219 Roswell Street
+    building: ''
+    city: Marietta
+    fax: 770-795-9551
+    phone: 770-429-1776
+    state: GA
+    suite: ''
+    zip: '30060'
+  - address: 9898 Highway 92
+    building: ''
+    city: Woodstock
+    fax: 770-517-7427
+    phone: 770-429-1776
+    state: GA
+    suite: Suite 100
+    zip: '30188'
+  - address: 135 West Cherokee Avenue
+    building: ''
+    city: Cartersville
+    fax: ''
+    phone: 770-429-1776
+    state: GA
+    suite: ''
+    zip: '30120'
+  - address: 600 Galleria Parkway
+    building: ''
+    city: Atlanta
+    fax: 678-556-5184
+    phone: 770-429-1776
+    state: GA
+    suite: Suite 120
+    zip: '30339'
+- id:
+    bioguide: A000372
+    govtrack: 412625
+    thomas: 02239
+  offices:
+  - address: 2743 Perimeter Parkway
+    building: ''
+    city: Augusta
+    fax: 706-228-1954
+    phone: 706-228-1980
+    state: GA
+    suite: Bldg. 200, Suite 225
+    zip: '30909'
+  - address: 101 North Jefferson Street
+    building: ''
+    city: Dublin
+    fax: 478-243-9452
+    phone: 478-272-4030
+    state: GA
+    suite: ''
+    zip: '31021'
+  - address: 50 East Main Street
+    building: ''
+    city: Statesboro
+    fax: 912-243-9453
+    phone: 912-243-9452
+    state: GA
+    suite: ''
+    zip: '30458'
+  - address: 107 Old Airport Road
+    building: ''
+    city: Vidalia
+    fax: 912-403-3317
+    phone: 912-403-3311
+    state: GA
+    suite: Suite A
+    zip: '30475'
+- id:
+    bioguide: S001157
+    govtrack: 400363
+    thomas: '01722'
+  offices:
+  - address: 888 Concord Road
+    building: ''
+    city: Smyrna
+    fax: 770-432-5813
+    phone: 770-432-5405
+    state: GA
+    suite: Suite 100
+    zip: '30080'
+  - address: 173 North Main Street
+    building: ''
+    city: Jonesboro
+    fax: 770-210-5673
+    phone: 770-210-5073
+    state: GA
+    suite: ''
+    zip: '30236'
+- id:
+    bioguide: G000560
+    govtrack: 412388
+    thomas: 01979
+  offices:
+  - address: 600 East Frist Street
+    building: ''
+    city: Rome
+    fax: 706-232-7864
+    phone: 706-290-1776
+    state: GA
+    suite: Suite 301
+    zip: '30161'
+  - address: 702 South Thornton Avenue
+    building: ''
+    city: Dalton
+    fax: 706-278-0840
+    phone: 706-226-5320
+    state: GA
+    suite: ''
+    zip: '30720'
+- id:
+    bioguide: B001245
+    govtrack: 400041
+    thomas: '01723'
+  offices:
+  - address: 120 Father Duenas Avenue
+    building: ''
+    city: Hagatna
+    fax: 671-477-2587
+    phone: 671-477-4272
+    state: GU
+    suite: Suite 107
+    zip: '96910'
+- id:
+    bioguide: T000473
+    govtrack: 412626
+    thomas: '02240'
+  offices:
+  - address: 300 Ala Moana Boulevard
+    building: ''
+    city: Honolulu
+    fax: 808-533-0133
+    phone: 808-541-2570
+    state: HI
+    suite: Room 4-104
+    zip: '96850'
+- id:
+    bioguide: G000571
+    govtrack: 412532
+    thomas: '02122'
+  offices:
+  - address: 300 Ala Moana Boulevard
+    building: 5-104 Prince Kuhio Building
+    city: Honolulu
+    fax: ''
+    phone: ''
+    state: HI
+    suite: ''
+    zip: '96850'
+- id:
+    bioguide: B001294
+    govtrack: 412627
+    thomas: '02241'
+  offices:
+  - address: 1050 Main Street
+    building: ''
+    city: Dubuque
+    fax: ''
+    phone: 563-557-7789
+    state: IA
+    suite: ''
+    zip: '52001'
+  - address: 310 3rd Street SE
+    building: ''
+    city: Cedar Rapids
+    fax: 319-364-2994
+    phone: 319-364-2288
+    state: IA
+    suite: ''
+    zip: '52401'
+  - address: 515 Main Street
+    building: ''
+    city: Cedar Falls
+    fax: ''
+    phone: 319-266-6925
+    state: IA
+    suite: Suite D
+    zip: '50613'
+- id:
+    bioguide: L000565
+    govtrack: 412209
+    thomas: 01846
+  offices:
+  - address: 125 South Dubuque Street
+    building: ''
+    city: Iowa City
+    fax: 319-351-5789
+    phone: 319-351-0789
+    state: IA
+    suite: ''
+    zip: 52240-4003
+  - address: 209 West 4th Street
+    building: ''
+    city: Davenport
+    fax: 563-323-5231
+    phone: 563-323-5988
+    state: IA
+    suite: '#104'
+    zip: '52801'
+- id:
+    bioguide: Y000066
+    govtrack: 412628
+    thomas: '02242'
+  offices:
+  - address: 208 West Taylor Street
+    building: ''
+    city: Creston
+    fax: ''
+    phone: 641-782-2495
+    state: IA
+    suite: ''
+    zip: '50801'
+  - address: 601 East Locust Street
+    building: ''
+    city: Des Moines
+    fax: ''
+    phone: 515-282-1909
+    state: IA
+    suite: Suite 204
+    zip: '50309'
+  - address: 208 West Taylor Street
+    building: ''
+    city: Creston
+    fax: ''
+    phone: 641-782-2495
+    state: IA
+    suite: ''
+    zip: '50801'
+  - address: 501 5th Avenue
+    building: ''
+    city: Council Bluffs
+    fax: ''
+    phone: 712-325-1404
+    state: IA
+    suite: ''
+    zip: '51503'
+- id:
+    bioguide: K000362
+    govtrack: 400220
+    thomas: '01724'
+  offices:
+  - address: 306 Grand Avenue
+    building: ''
+    city: Spencer
+    fax: 712-580-3354
+    phone: 712-580-7754
+    state: IA
+    suite: PO Box 650
+    zip: '51301'
+  - address: 526 Nebraska Street
+    building: ''
+    city: Sioux City
+    fax: 712-224-4693
+    phone: 712-224-4692
+    state: IA
+    suite: ''
+    zip: '51101'
+  - address: 1421 South Bell Avenue
+    building: ''
+    city: Ames
+    fax: 515-232-2844
+    phone: 515-232-2885
+    state: IA
+    suite: Suite 102
+    zip: '50010'
+  - address: 723 Central Avenue
+    building: ''
+    city: Fort Dodge
+    fax: 515-576-7141
+    phone: 515-573-2738
+    state: IA
+    suite: ''
+    zip: '50501'
+  - address: 202 1st Street SE
+    building: ''
+    city: Mason City
+    fax: 641-201-1523
+    phone: 641-201-1624
+    state: IA
+    suite: Suite 126
+    zip: '50401'
+- id:
+    bioguide: L000573
+    govtrack: 412419
+    thomas: '02011'
+  offices:
+  - address: 33 East Broadway Avenue
+    building: ''
+    city: Meridian
+    fax: 208-888-0894
+    phone: 208-888-3188
+    state: ID
+    suite: Suite 251
+    zip: '83642'
+  - address: 313 D Street
+    building: ''
+    city: Lewiston
+    fax: ''
+    phone: 208-743-1388
+    state: ID
+    suite: Suite 107
+    zip: '83501'
+  - address: 1250 Ironwood Drive
+    building: ''
+    city: Coeur d'Alene
+    fax: 208-667-0310
+    phone: 208-667-0127
+    state: ID
+    suite: '#241'
+    zip: '83814'
+- id:
+    bioguide: S001148
+    govtrack: 400376
+    thomas: 01590
+  offices:
+  - address: 410 Memorial Drive
+    building: ''
+    city: Idaho Falls
+    fax: 208-523-2384
+    phone: 208-523-6701
+    state: ID
+    suite: Suite 203
+    zip: '83402'
+  - address: 275 South 5th Avenue
+    building: ''
+    city: Pocatello
+    fax: 208-233-2095
+    phone: 208-233-2222
+    state: ID
+    suite: '#275'
+    zip: 83201-5730
+  - address: 1341 Fillmore Street
+    building: ''
+    city: Twin Falls
+    fax: 208-734-7244
+    phone: 208-734-7219
+    state: ID
+    suite: '#202'
+    zip: '83301'
+  - address: 802 West Bannock
+    building: ''
+    city: Boise
+    fax: 208-334-9533
+    phone: 208-334-1953
+    state: ID
+    suite: Suite 600
+    zip: 83702-5820
+- id:
+    bioguide: R000515
+    govtrack: 400350
+    thomas: '01003'
+  offices:
+  - address: 3235 West 147th Street
+    building: ''
+    city: Midlothian
+    fax: 708-385-3860
+    phone: 708-385-9550
+    state: IL
+    suite: ''
+    zip: 60445-3656
+  - address: 700 East 79th Street
+    building: ''
+    city: Chicago
+    fax: 773-224-9624
+    phone: 773-224-6500
+    state: IL
+    suite: ''
+    zip: 60619-3102
+- id:
+    bioguide: K000385
+    govtrack: 412595
+    thomas: 02190
+  offices:
+  - address: 600 Holiday Plaza Drive
+    building: ''
+    city: Matteson
+    fax: 708-679-0216
+    phone: 708-679-0078
+    state: IL
+    suite: Suite 505
+    zip: '60443'
+- id:
+    bioguide: L000563
+    govtrack: 400630
+    thomas: 01781
+  offices:
+  - address: 5309 West 95th Street
+    building: ''
+    city: Oak Lawn
+    fax: 708-424-1855
+    phone: 708-424-0853
+    state: IL
+    suite: ''
+    zip: '60453'
+  - address: 6245 South Archer Avenue
+    building: ''
+    city: Chicago
+    fax: 773-767-9395
+    phone: 773-948-6223
+    state: IL
+    suite: ''
+    zip: '60638'
+  - address: 222 East 9th Street
+    building: Central Square Building
+    city: Lockport
+    fax: 815-838-1993
+    phone: 815-838-1990
+    state: IL
+    suite: '#109'
+    zip: '60441'
+  - address: 14700 South Ravinia Avenue
+    building: Orland Park Village Hall
+    city: Orland Park
+    fax: 815-403-5963
+    phone: 708-403-4379
+    state: IL
+    suite: ''
+    zip: '60462'
+- id:
+    bioguide: G000535
+    govtrack: 400163
+    thomas: 00478
+  offices:
+  - address: 5531 West Cermak Road
+    building: ''
+    city: Cicero
+    fax: 708-652-5118
+    phone: 708-652-5180
+    state: IL
+    suite: ''
+    zip: '60804'
+  - address: 3240 West Fullerton Avenue
+    building: ''
+    city: Chicago
+    fax: 773-342-0776
+    phone: 773-342-0774
+    state: IL
+    suite: ''
+    zip: '60647'
+- id:
+    bioguide: Q000023
+    govtrack: 412331
+    thomas: 01967
+  offices:
+  - address: 3742 West Irving Park Road
+    building: ''
+    city: Chicago
+    fax: 773-267-6583
+    phone: 773-267-5926
+    state: IL
+    suite: ''
+    zip: '60618'
+- id:
+    bioguide: R000580
+    govtrack: 412202
+    thomas: 01848
+  offices:
+  - address: 2700 International Drive
+    building: ''
+    city: West Chicago
+    fax: 630-232-7393
+    phone: 630-232-0006
+    state: IL
+    suite: Suite 304
+    zip: '60185'
+- id:
+    bioguide: D000096
+    govtrack: 400093
+    thomas: '01477'
+  offices:
+  - address: 2746 West Madison Street
+    building: ''
+    city: Chicago
+    fax: 773-533-7530
+    phone: 773-533-7520
+    state: IL
+    suite: ''
+    zip: '60612'
+- id:
+    bioguide: D000622
+    govtrack: 412533
+    thomas: '02123'
+  offices:
+  - address: 1701 East Woodfield Road
+    building: ''
+    city: Schaumburg
+    fax: ''
+    phone: ''
+    state: IL
+    suite: Suite 704
+    zip: '60173'
+- id:
+    bioguide: S001145
+    govtrack: 400360
+    thomas: 01588
+  offices:
+  - address: 5533 North Broadway Street
+    building: ''
+    city: Chicago
+    fax: 773-506-9202
+    phone: 773-506-7100
+    state: IL
+    suite: Suite 2
+    zip: 60640-1405
+  - address: 820 Davis Street
+    building: ''
+    city: Evanston
+    fax: 847-328-3425
+    phone: 847-328-3409
+    state: IL
+    suite: Suite 105
+    zip: '60201'
+  - address: 1852 Johns Drive
+    building: ''
+    city: Glenview
+    fax: 847-328-3425
+    phone: 847-328-3409
+    state: IL
+    suite: ''
+    zip: '60025'
+- id:
+    bioguide: D000613
+    govtrack: 412420
+    thomas: '02013'
+  offices:
+  - address: 300 Village Green
+    building: ''
+    city: Lincolnshire
+    fax: 847-793-8499
+    phone: 847-793-8400
+    state: IL
+    suite: Suite 235
+    zip: '60069'
+  - address: 442 North Cedar Lake Road
+    building: ''
+    city: Round Lake
+    fax: 847-793-8499
+    phone: 847-309-6627
+    state: IL
+    suite: ''
+    zip: '60073'
+- id:
+    bioguide: F000454
+    govtrack: 412257
+    thomas: 01888
+  offices:
+  - address: 2711 East New York Street
+    building: ''
+    city: Aurora
+    fax: ''
+    phone: 630-585-7672
+    state: IL
+    suite: Suite 204
+    zip: '60502'
+  - address: 195 Springfield Avenue
+    building: ''
+    city: Joliet
+    fax: ''
+    phone: 815-280-5876
+    state: IL
+    suite: Suite 102
+    zip: '60435'
+- id:
+    bioguide: B001295
+    govtrack: 412629
+    thomas: '02243'
+  offices:
+  - address: 23 Public Square
+    building: ''
+    city: Belleville
+    fax: 618-233-8765
+    phone: 618-233-8026
+    state: IL
+    suite: Suite 404
+    zip: '62220'
+  - address: 2000 Edison Avenue
+    building: City Hall
+    city: Granite City
+    fax: 618-451-2126
+    phone: 618-451-7065
+    state: IL
+    suite: ''
+    zip: '62040'
+  - address: 300 East Main Street
+    building: ''
+    city: Carbondale
+    fax: 618-457-2990
+    phone: 618-457-5787
+    state: IL
+    suite: Hunter Building - Suite 4
+    zip: '62901'
+  - address: 1330 Swanwick Street
+    building: ''
+    city: Chester
+    fax: 618-826-1923
+    phone: 618-826-3043
+    state: IL
+    suite: ''
+    zip: '62233'
+  - address: 201 East Nolen Street
+    building: ''
+    city: West Frankfort
+    fax: 618-937-3307
+    phone: 618-937-6402
+    state: IL
+    suite: ''
+    zip: '62896'
+  - address: 1100 Main Street
+    building: Mt. Vernon City Hall
+    city: Mount Vernon
+    fax: ''
+    phone: 618-513-5294
+    state: IL
+    suite: ''
+    zip: '62864'
+  - address: 101 East Third Street
+    building: ''
+    city: Alton
+    fax: 618- 233-8765
+    phone: 618-233-8026
+    state: IL
+    suite: ''
+    zip: '62002'
+- id:
+    bioguide: D000619
+    govtrack: 412536
+    thomas: '02126'
+  offices:
+  - address: 2004 Fox Drive
+    building: ''
+    city: Champaign
+    fax: 217-403-4691
+    phone: 217-403-4690
+    state: IL
+    suite: ''
+    zip: '61820'
+  - address: 243 South Water Street
+    building: ''
+    city: Decatur
+    fax: 217-791-6168
+    phone: 217-791-6224
+    state: IL
+    suite: Suite 100
+    zip: '62523'
+  - address: 108 East Market Street
+    building: ''
+    city: Taylorville
+    fax: 217-824-5121
+    phone: 217-824-5117
+    state: IL
+    suite: ''
+    zip: '62568'
+  - address: 104 West North Street
+    building: ''
+    city: Normal
+    fax: ''
+    phone: 309-252-8834
+    state: IL
+    suite: ''
+    zip: '61761'
+  - address: 9 Junction Drive
+    building: ''
+    city: Glen Carbon
+    fax: 618-205-8662
+    phone: 618-205-8660
+    state: IL
+    suite: Suite 9
+    zip: '62034'
+- id:
+    bioguide: H001059
+    govtrack: 412422
+    thomas: '02015'
+  offices:
+  - address: 1797 West State Street
+    building: ''
+    city: Geneva
+    fax: 630-232-7174
+    phone: 630-232-7104
+    state: IL
+    suite: Suite A
+    zip: '60134'
+  - address: 40W310 Lafox Road
+    building: ''
+    city: Campton Hills
+    fax: 630-584-2746
+    phone: 630-584-2734
+    state: IL
+    suite: Suite F2
+    zip: '60175'
+- id:
+    bioguide: S000364
+    govtrack: 400373
+    thomas: '01527'
+  offices:
+  - address: 110 East Locust Street
+    building: ''
+    city: Harrisburg
+    fax: 618-252-8317
+    phone: 618-252-8271
+    state: IL
+    suite: Room 12
+    zip: '62946'
+  - address: 15 Professional Park Drive
+    building: ''
+    city: Maryville
+    fax: 618-288-7219
+    phone: 618-288-7190
+    state: IL
+    suite: ''
+    zip: '62062'
+  - address: 101 North 4th Street
+    building: ''
+    city: Effingham
+    fax: 217-342-1219
+    phone: 217-347-7947
+    state: IL
+    suite: Suite 303
+    zip: '62401'
+  - address: 201 North Vermilion Street
+    building: ''
+    city: Danville
+    fax: 217-446-0670
+    phone: 217-446-0664
+    state: IL
+    suite: Suite 218
+    zip: '61832'
+- id:
+    bioguide: K000378
+    govtrack: 412421
+    thomas: '02014'
+  offices:
+  - address: 628 Columbus Street
+    building: ''
+    city: Ottawa
+    fax: 815-431-9383
+    phone: 815-431-9271
+    state: IL
+    suite: Suite 507
+    zip: '61350'
+- id:
+    bioguide: B001286
+    govtrack: 412537
+    thomas: '02127'
+  offices:
+  - address: 2401 4th Avenue
+    building: ''
+    city: Rock Island
+    fax: 309-786-3720
+    phone: 309-786-3406
+    state: IL
+    suite: ''
+    zip: '61201'
+  - address: 3100 North Knoxville Avenue
+    building: ''
+    city: Peoria
+    fax: ''
+    phone: 309-966-1813
+    state: IL
+    suite: Suite 205
+    zip: '61603'
+  - address: 119 North Church Street
+    building: ''
+    city: Rockford
+    fax: ''
+    phone: 815-968-8011
+    state: IL
+    suite: Suite 207 and 208
+    zip: '61101'
+- id:
+    bioguide: V000108
+    govtrack: 400417
+    thomas: 01188
+  offices:
+  - address: 7895 Broadway
+    building: ''
+    city: Merrillville
+    fax: 219-795-1850
+    phone: 219-795-1844
+    state: IN
+    suite: Suite A
+    zip: '46410'
+- id:
+    bioguide: W000813
+    govtrack: 412538
+    thomas: 02128
+  offices:
+  - address: 202 Lincolnway East
+    building: ''
+    city: Mishawaka
+    fax: 574-217-8735
+    phone: 574-204-2645
+    state: IN
+    suite: Suite 101
+    zip: '46544'
+  - address: 709 Main Street
+    building: ''
+    city: Rochester
+    fax: ''
+    phone: 574-223-4373
+    state: IN
+    suite: ''
+    zip: '46975'
+- id:
+    bioguide: S001188
+    govtrack: 412392
+    thomas: 01981
+  offices:
+  - address: 1300 South Harrison
+    building: ''
+    city: Fort Wayne
+    fax: 260-424-4042
+    phone: 260-424-3041
+    state: IN
+    suite: Suite 3105
+    zip: '46802'
+  - address: 700 Park Avenue
+    building: ''
+    city: Winona Lake
+    fax: 574-269-3112
+    phone: 574-269-1940
+    state: IN
+    suite: ''
+    zip: '46590'
+- id:
+    bioguide: R000592
+    govtrack: 412426
+    thomas: '02017'
+  offices:
+  - address: 355 South Washington Street
+    building: ''
+    city: Danville
+    fax: 317-718-0405
+    phone: 317-718-0404
+    state: IN
+    suite: ''
+    zip: '46122'
+  - address: 337 Columbia Street
+    building: ''
+    city: Lafayette
+    fax: 765-838-3931
+    phone: 765-838-3930
+    state: IN
+    suite: ''
+    zip: '47901'
+- id:
+    bioguide: B001284
+    govtrack: 412539
+    thomas: 02129
+  offices:
+  - address: 11611 North Meridian Street
+    building: ''
+    city: Carmel
+    fax: 317-846-7306
+    phone: 317-848-0201
+    state: IN
+    suite: Suite 415
+    zip: '46032'
+  - address: 120 East 8th Street
+    building: ''
+    city: Anderson
+    fax: 765-640-5116
+    phone: 765-640-5115
+    state: IN
+    suite: Suite 101
+    zip: '46016'
+- id:
+    bioguide: M001189
+    govtrack: 412540
+    thomas: '02130'
+  offices:
+  - address: 107 West Charles Street
+    building: ''
+    city: Muncie
+    fax: 765-747-5586
+    phone: 765-747-5566
+    state: IN
+    suite: ''
+    zip: '47305'
+  - address: 2 Public Square
+    building: ''
+    city: Shelbyville
+    fax: 317-421-0739
+    phone: 317-421-0704
+    state: IN
+    suite: ''
+    zip: '46176'
+- id:
+    bioguide: C001072
+    govtrack: 412258
+    thomas: 01889
+  offices:
+  - address: 300 East Fall Creek Parkway North Drive
+    building: ''
+    city: Indianapolis
+    fax: 317-283-6567
+    phone: 317-283-6516
+    state: IN
+    suite: Suite 300
+    zip: 46205-4258
+- id:
+    bioguide: B001275
+    govtrack: 412427
+    thomas: 02018
+  offices:
+  - address: 420 Main Street
+    building: ''
+    city: Evansville
+    fax: 812-422-4761
+    phone: 812-465-6484
+    state: IN
+    suite: Suite 1403
+    zip: '47708'
+  - address: 901 Wabash Avenue
+    building: ''
+    city: Terre Haute
+    fax: 812-232-0526
+    phone: 812-232-0523
+    state: IN
+    suite: Suite 140
+    zip: '47807'
+  - address: 1500 North Chestnut Street
+    building: ''
+    city: Vincennes
+    fax: ''
+    phone: 855-519-1629
+    state: IN
+    suite: ''
+    zip: '47591'
+  - address: 610 Main Street
+    building: ''
+    city: Jasper
+    fax: 812-422-4761
+    phone: 812-482-4255
+    state: IN
+    suite: 2nd Floor
+    zip: '47547'
+- id:
+    bioguide: Y000064
+    govtrack: 412428
+    thomas: 02019
+  offices:
+  - address: 320 West 8th Street
+    building: ''
+    city: Bloomington
+    fax: 812-336-3355
+    phone: 812-336-3000
+    state: IN
+    suite: Suite 114
+    zip: '47404'
+  - address: 279 Quartermaster Court
+    building: ''
+    city: Jeffersonville
+    fax: 812-288-3873
+    phone: 812-288-3999
+    state: IN
+    suite: ''
+    zip: '47130'
+- id:
+    bioguide: H001057
+    govtrack: 412429
+    thomas: '02020'
+  offices:
+  - address: 200 South Santa Fe
+    building: ''
+    city: Salina
+    fax: 785-827-6957
+    phone: 785-309-0572
+    state: KS
+    suite: Suite 6
+    zip: '67402'
+  - address: 100 Mililtary Avenue
+    building: ''
+    city: Dodge City
+    fax: 620-225-0297
+    phone: 620-225-0172
+    state: KS
+    suite: Suite 205
+    zip: '67801'
+  - address: 1 North Main
+    building: ''
+    city: Hutchinson
+    fax: 620-665-6360
+    phone: 620-665-6138
+    state: KS
+    suite: Suite 525
+    zip: '67501'
+  - address: 727 Poyntz Avenue
+    building: ''
+    city: Manhattan
+    fax: 785-827-6957
+    phone: 785-309-0572
+    state: KS
+    suite: Suite 10
+    zip: '66502'
+- id:
+    bioguide: J000290
+    govtrack: 412284
+    thomas: 01921
+  offices:
+  - address: 1001 North Broadway Street
+    building: ''
+    city: Pittsburgh
+    fax: 620-231-5972
+    phone: 620-231-5966
+    state: KS
+    suite: Suite C
+    zip: '66762'
+  - address: 3550 SW 5th Street
+    building: ''
+    city: Topeka
+    fax: 785-234-5967
+    phone: 785-234-5966
+    state: KS
+    suite: ''
+    zip: '66606'
+  - address: 120 North 6th Street
+    building: ''
+    city: Independence
+    fax: 620-231-5972
+    phone: 620-231-5966
+    state: KS
+    suite: ''
+    zip: '67301'
+- id:
+    bioguide: Y000063
+    govtrack: 412430
+    thomas: '02021'
+  offices:
+  - address: 7325 West 79th Street
+    building: ''
+    city: Overland Park
+    fax: 913-621-1533
+    phone: 913-621-0832
+    state: KS
+    suite: ''
+    zip: '66204'
+- id:
+    bioguide: P000602
+    govtrack: 412431
+    thomas: '02022'
+  offices:
+  - address: 7701 East Kellogg
+    building: ''
+    city: Wichita
+    fax: 316-262-5309
+    phone: 316-262-8992
+    state: KS
+    suite: Suite 510
+    zip: '67207'
+- id:
+    bioguide: W000413
+    govtrack: 400431
+    thomas: '01222'
+  offices:
+  - address: 100 Fountain Avenue
+    building: ''
+    city: Paducah
+    fax: 270-442-6805
+    phone: 270-442-6901
+    state: KY
+    suite: Room 104
+    zip: '42001'
+  - address: 222 First Street
+    building: ''
+    city: Henderson
+    fax: 270-826-6783
+    phone: 270-826-4180
+    state: KY
+    suite: Suite 224
+    zip: '42420'
+  - address: 200 North Main Street
+    building: ''
+    city: Thompkinsville
+    fax: 270-487-0019
+    phone: 270-487-9509
+    state: KY
+    suite: Suite F
+    zip: '42167'
+  - address: 1403 South Main Street
+    building: ''
+    city: Hopkinsville
+    fax: 270-885-8598
+    phone: 270-885-8079
+    state: KY
+    suite: ''
+    zip: '42240'
+- id:
+    bioguide: G000558
+    govtrack: 412278
+    thomas: 01922
+  offices:
+  - address: 2200 Airport Road
+    building: ''
+    city: Owensboro
+    fax: ''
+    phone: ''
+    state: KY
+    suite: ''
+    zip: '42301'
+  - address: 996 Wilkinson Trace
+    building: ''
+    city: Bowling Green
+    fax: 270-842-9081
+    phone: 270-842-9896
+    state: KY
+    suite: Suite B2
+    zip: '42103'
+  - address: 411 West Lincoln Trail Road
+    building: ''
+    city: Radcliff
+    fax: ''
+    phone: ''
+    state: KY
+    suite: ''
+    zip: '40160'
+- id:
+    bioguide: Y000062
+    govtrack: 412211
+    thomas: 01853
+  offices:
+  - address: 600 Martin Luther King Jr. Place
+    building: Romano Mazzoli Federal Building
+    city: Louisville
+    fax: 502-582-5897
+    phone: 502-582-5129
+    state: KY
+    suite: Suite 216
+    zip: '40202'
+  - address: 7219 Dixie Highway
+    building: Southwest Government Center
+    city: Louisville
+    fax: 502-935-6934
+    phone: 502-933-5863
+    state: KY
+    suite: ''
+    zip: '40258'
+- id:
+    bioguide: M001184
+    govtrack: 412503
+    thomas: 02094
+  offices:
+  - address: 1700 Greenup Avenue R-505
+    building: ''
+    city: Ashland
+    fax: ''
+    phone: 606-324-9898
+    state: KY
+    suite: ''
+    zip: '41101'
+  - address: 541 Buttermilk Pike
+    building: ''
+    city: Cresent Springs
+    fax: 859-426-0061
+    phone: 859-426-0080
+    state: KY
+    suite: Suite 208
+    zip: '41017'
+- id:
+    bioguide: R000395
+    govtrack: 400340
+    thomas: 00977
+  offices:
+  - address: 48 South Kentucky Highway 15
+    building: ''
+    city: Hazard
+    fax: 606-439-4647
+    phone: 606-439-0794
+    state: KY
+    suite: ''
+    zip: '41701'
+  - address: 551 Clifty Street
+    building: ''
+    city: Somerest
+    fax: 606-678-4856
+    phone: 606-679-8346
+    state: KY
+    suite: ''
+    zip: '42503'
+  - address: 110 Resource Court
+    building: ''
+    city: Prestonsburg
+    fax: 606-889-0371
+    phone: 606-886-0844
+    state: KY
+    suite: Suite A
+    zip: 41653-1842
+- id:
+    bioguide: B001282
+    govtrack: 412541
+    thomas: '02131'
+  offices:
+  - address: 2709 Old Rosebud Road
+    building: ''
+    city: Lexington
+    fax: ''
+    phone: 859-219-1366
+    state: KY
+    suite: ''
+    zip: '40509'
+- id:
+    bioguide: S001176
+    govtrack: 412261
+    thomas: 01892
+  offices:
+  - address: 21454 Koop Drive
+    building: ''
+    city: Mandeville
+    fax: 985-893-9707
+    phone: 985-893-9064
+    state: LA
+    suite: Suite 2C
+    zip: '70471'
+  - address: 8026 Main Street
+    building: ''
+    city: Houma
+    fax: ''
+    phone: 985-879-2300
+    state: LA
+    suite: Suite 700
+    zip: '70360'
+  - address: 110 Veterans Boulevard
+    building: ''
+    city: Metairie
+    fax: 504-837-4239
+    phone: 504-837-1259
+    state: LA
+    suite: Suite 500
+    zip: '70005'
+  - address: 1514 Martens Drive
+    building: ''
+    city: Hammond
+    fax: 985-340-3122
+    phone: 985-340-2185
+    state: LA
+    suite: Suite10
+    zip: '70401'
+- id:
+    bioguide: R000588
+    govtrack: 412432
+    thomas: '02023'
+  offices:
+  - address: 200 Derbigny Street
+    building: ''
+    city: Gretna
+    fax: ''
+    phone: 504-365-0390
+    state: LA
+    suite: Suite 3200
+    zip: '70053'
+  - address: 2021 Lakeshore Drive
+    building: ''
+    city: New Orleans
+    fax: 504-288-4090
+    phone: 504-288-3777
+    state: LA
+    suite: Suite 309
+    zip: '70122'
+  - address: 1520 Thomas H. Delpit Drive
+    building: ''
+    city: Baton Rouge
+    fax: 202-636-5680
+    phone: 225-636-5600
+    state: LA
+    suite: Suite 126
+    zip: '70802'
+- id:
+    bioguide: B001255
+    govtrack: 400636
+    thomas: 01787
+  offices:
+  - address: One Lakeshore Drive
+    building: Capital One Tower
+    city: Lake Charles
+    fax: 337-433-0974
+    phone: 337-433-1747
+    state: LA
+    suite: Suite 1775
+    zip: '70629'
+  - address: 800 LaFayette Street
+    building: ''
+    city: Lafayette
+    fax: 337-235-6072
+    phone: 337-235-6322
+    state: LA
+    suite: Suite 1400
+    zip: '70501'
+- id:
+    bioguide: F000456
+    govtrack: 412275
+    thomas: 01924
+  offices:
+  - address: 700 Benton Road
+    building: ''
+    city: Bossier City
+    fax: ''
+    phone: 318-549-1712
+    state: LA
+    suite: ''
+    zip: '71111'
+  - address: 103 North Third Street
+    building: ''
+    city: Leesville
+    fax: 337-238-0566
+    phone: 337-238-0778
+    state: LA
+    suite: ''
+    zip: '71446'
+  - address: 6425 Youree Drive
+    building: ''
+    city: Shreveport
+    fax: 318-798-2063
+    phone: 318-798-2254
+    state: LA
+    suite: Suite 350
+    zip: '71105'
+- id:
+    bioguide: A000374
+    govtrack: 412630
+    thomas: '02244'
+  offices:
+  - address: 426 DeSiard Street
+    building: ''
+    city: Monroe
+    fax: 318-322-3577
+    phone: 318-322-3500
+    state: LA
+    suite: ''
+    zip: '71201'
+  - address: 1434 Dorchester Drive
+    building: ''
+    city: Alexandria
+    fax: 318-445-3776
+    phone: 318-445-0818
+    state: LA
+    suite: Suite E
+    zip: '71301'
+- id:
+    bioguide: G000577
+    govtrack: 412631
+    thomas: '02245'
+  offices:
+  - address: 2351 Energy Drive
+    building: ''
+    city: Baton Rouge
+    fax: 225-442-1736
+    phone: 225-442-1731
+    state: LA
+    suite: Suite 1200
+    zip: '70808'
+  - address: 29261 Frost Road
+    building: ''
+    city: Livingston
+    fax: 225-929-7688
+    phone: 225-686-4413
+    state: LA
+    suite: 2nd Floor
+    zip: '70754'
+  - address: 908 East First Street
+    building: NSU Campus, Candies Hall
+    city: Thibodaux
+    fax: 225-442-1736
+    phone: 985-448-4103
+    state: LA
+    suite: Suite 405
+    zip: '70301'
+- id:
+    bioguide: N000015
+    govtrack: 400291
+    thomas: 00854
+  offices:
+  - address: 300 State Street
+    building: ''
+    city: Springfield
+    fax: 413-747-0604
+    phone: 413-785-0325
+    state: MA
+    suite: Suite 200
+    zip: '01105'
+  - address: 78 Center Street
+    building: ''
+    city: Pittsfield
+    fax: 413-443-2792
+    phone: 413-442-0946
+    state: MA
+    suite: ''
+    zip: '01201'
+- id:
+    bioguide: M000312
+    govtrack: 400263
+    thomas: '01504'
+  offices:
+  - address: 94 Pleasant Street
+    building: ''
+    city: Northampton
+    fax: 413-584-1216
+    phone: 413-341-8700
+    state: MA
+    suite: ''
+    zip: '01060'
+  - address: 12 East Worcester Street
+    building: ''
+    city: Worcester
+    fax: 508-754-0982
+    phone: 508-831-7356
+    state: MA
+    suite: Suite 1
+    zip: 01608
+  - address: 24 Church Street
+    building: ''
+    city: Leominster
+    fax: 978-466-3973
+    phone: 978-466-3552
+    state: MA
+    suite: Room 29
+    zip: '01453'
+- id:
+    bioguide: T000465
+    govtrack: 412254
+    thomas: 01884
+  offices:
+  - address: 126 John Street
+    building: ''
+    city: Lowell
+    fax: 978-459-1907
+    phone: 978-459-0101
+    state: MA
+    suite: Suite 12
+    zip: 01852-1940
+- id:
+    bioguide: K000379
+    govtrack: 412543
+    thomas: '02172'
+  offices:
+  - address: 8 North Main Street
+    building: ''
+    city: Attleboro
+    fax: 508-431-1101
+    phone: 508-431-1110
+    state: MA
+    suite: Suite 200
+    zip: '02703'
+  - address: 29 Crafts Street
+    building: ''
+    city: Newton
+    fax: 617-332-3308
+    phone: 617-332-3333
+    state: MA
+    suite: Suite 375
+    zip: 02458
+- id:
+    bioguide: C001101
+    govtrack: 412600
+    thomas: 02196
+  offices:
+  - address: 5 High Street
+    building: ''
+    city: Medford
+    fax: ''
+    phone: 781-396-2900
+    state: MA
+    suite: Suite 101
+    zip: '02155'
+  - address: 116 Concord Street
+    building: ''
+    city: Framingham
+    fax: ''
+    phone: 508-319-9757
+    state: MA
+    suite: Suite 1
+    zip: '01702'
+- id:
+    bioguide: M001196
+    govtrack: 412632
+    thomas: '02246'
+  offices:
+  - address: 17 Peabody Square
+    building: ''
+    city: Peabody
+    fax: 978-717-5463
+    phone: 978-531-1669
+    state: MA
+    suite: ''
+    zip: 01960
+  - address: 21 Front Street
+    building: ''
+    city: Salem
+    fax: ''
+    phone: ''
+    state: MA
+    suite: ''
+    zip: 01970
+- id:
+    bioguide: C001037
+    govtrack: 400063
+    thomas: '01564'
+  offices:
+  - address: 110 First Street
+    building: ''
+    city: Cambridge
+    fax: 617-621-8628
+    phone: 617-621-6208
+    state: MA
+    suite: ''
+    zip: '02141'
+- id:
+    bioguide: L000562
+    govtrack: 400249
+    thomas: 01686
+  offices:
+  - address: One Harbor Street
+    building: ''
+    city: Boston
+    fax: 617-428-2011
+    phone: 617-428-2000
+    state: MA
+    suite: Suite 304
+    zip: '02210'
+  - address: 155 West Elm Street
+    building: ''
+    city: Brockton
+    fax: 508-580-4692
+    phone: 508-586-5555
+    state: MA
+    suite: Suite 200
+    zip: '02301'
+  - address: 1245 Hancock Street
+    building: ''
+    city: Quincy
+    fax: 617-773-0955
+    phone: 617-657-6305
+    state: MA
+    suite: Suite 16
+    zip: '32169'
+- id:
+    bioguide: K000375
+    govtrack: 412435
+    thomas: '02025'
+  offices:
+  - address: 297 North Street
+    building: ''
+    city: Hyannis
+    fax: 508-790-1959
+    phone: 508-771-0666
+    state: MA
+    suite: Suite 312
+    zip: '02601'
+  - address: 2 Court Street
+    building: ''
+    city: Plymouth
+    fax: 508-732-0072
+    phone: 508-746-9000
+    state: MA
+    suite: ''
+    zip: '02360'
+  - address: 558 Pleasant Street
+    building: ''
+    city: New Bedford
+    fax: 508-999-6468
+    phone: 508-999-6462
+    state: MA
+    suite: Suite 309
+    zip: '02740'
+- id:
+    bioguide: H001052
+    govtrack: 412434
+    thomas: '02026'
+  offices:
+  - address: 15 East Churchville Road
+    building: ''
+    city: Bel Air
+    fax: 410-588-5673
+    phone: 410-588-5670
+    state: MD
+    suite: Suite 102B
+    zip: '21014'
+  - address: 100 Olde Point Village
+    building: ''
+    city: Chester
+    fax: 410-643-5429
+    phone: 410-643-5425
+    state: MD
+    suite: Suite 101
+    zip: '21619'
+  - address: 212 West Main Streetd
+    building: ''
+    city: Salisbury
+    fax: 443-944-8625
+    phone: 443-944-8624
+    state: MD
+    suite: Suite 204B
+    zip: '21801'
+- id:
+    bioguide: R000576
+    govtrack: 400349
+    thomas: 01728
+  offices:
+  - address: 375 West Padonia Road
+    building: The Atrium
+    city: Timonium
+    fax: 410-628-2708
+    phone: 410-628-2701
+    state: MD
+    suite: Suite 200
+    zip: '21093'
+- id:
+    bioguide: S001168
+    govtrack: 412212
+    thomas: 01854
+  offices:
+  - address: 600 Baltimore Avenue
+    building: ''
+    city: Towson
+    fax: 410-832-8898
+    phone: 410-832-8890
+    state: MD
+    suite: Suite 303
+    zip: '21204'
+- id:
+    bioguide: E000290
+    govtrack: 412263
+    thomas: 01894
+  offices:
+  - address: 5001 Silver Hill Road
+    building: ''
+    city: Suitland
+    fax: 301-516-7608
+    phone: 301-516-7601
+    state: MD
+    suite: Suite 106
+    zip: '20746'
+  - address: 877 Baltimore Annapolis Boulevard
+    building: Ritchie Court Office Building
+    city: Severna Park
+    fax: 301-516-7608
+    phone: 410-421-8061
+    state: MD
+    suite: Suite 101
+    zip: '21146'
+- id:
+    bioguide: H000874
+    govtrack: 400189
+    thomas: '00566'
+  offices:
+  - address: 6500 Cherrywood Lane
+    building: U.S. District Courthouse
+    city: Greenbelt
+    fax: 301-474-4697
+    phone: 301-474-0119
+    state: MD
+    suite: Suite 310
+    zip: '20770'
+  - address: 401 Post Office Road
+    building: ''
+    city: Waldorf
+    fax: 301-843-1331
+    phone: 301-843-1577
+    state: MD
+    suite: Suite 202
+    zip: '20602'
+- id:
+    bioguide: D000620
+    govtrack: 412544
+    thomas: '02133'
+  offices:
+  - address: 9801 Washingtonian Boulevard
+    building: ''
+    city: Gaithersburg
+    fax: 301-926-0324
+    phone: 301-926-0300
+    state: MD
+    suite: Suite 330
+    zip: '20878'
+  - address: 38 South Potomac Street
+    building: ''
+    city: Hagerstown
+    fax: ''
+    phone: 301-733-2900
+    state: MD
+    suite: Suite 205
+    zip: '21740'
+- id:
+    bioguide: C000984
+    govtrack: 400090
+    thomas: '00256'
+  offices:
+  - address: 8267 Main Street
+    building: Ellicott Mills Post Office
+    city: Ellicott City
+    fax: 410-465-8740
+    phone: 410-465-8259
+    state: MD
+    suite: Room 102
+    zip: 21043-8267
+  - address: 1010 Park Avenue
+    building: ''
+    city: Baltimore
+    fax: 410-685-9399
+    phone: 410-685-9199
+    state: MD
+    suite: Suite 105
+    zip: '21201'
+  - address: 754 Frederick Road
+    building: ''
+    city: Catonsville
+    fax: 410-455-0110
+    phone: 410-719-8777
+    state: MD
+    suite: ''
+    zip: 21228-4504
+- id:
+    bioguide: V000128
+    govtrack: 400415
+    thomas: 01729
+  offices:
+  - address: 51 Monroe Street
+    building: ''
+    city: Rockville
+    fax: 301-424-5992
+    phone: 301-424-3501
+    state: MD
+    suite: Suite 507
+    zip: '20850'
+- id:
+    bioguide: P000597
+    govtrack: 412307
+    thomas: 01927
+  offices:
+  - address: 2 Portland Fish Pier
+    building: ''
+    city: Portland
+    fax: 207-871-0720
+    phone: 207-774-5019
+    state: ME
+    suite: Suite 304
+    zip: '04101'
+  - address: 1 Silver Street
+    building: ''
+    city: Waterville
+    fax: 207-873-5717
+    phone: 207-873-5713
+    state: ME
+    suite: ''
+    zip: 04901
+- id:
+    bioguide: P000611
+    govtrack: 412633
+    thomas: '02247'
+  offices:
+  - address: 631 Main Street
+    building: ''
+    city: Presque Isle
+    fax: 207-764-2822
+    phone: 207-764-1968
+    state: ME
+    suite: Suite 2
+    zip: 04769
+  - address: 179 Libson Street
+    building: ''
+    city: Lewiston
+    fax: 207-784-5672
+    phone: 207-784-0768
+    state: ME
+    suite: ''
+    zip: '04240'
+  - address: 6 State Street
+    building: ''
+    city: Bangor
+    fax: 207- 942-7101
+    phone: 207-942-0583
+    state: ME
+    suite: Suite 101
+    zip: '04401'
+- id:
+    bioguide: B001271
+    govtrack: 412436
+    thomas: '02027'
+  offices:
+  - address: 3301 Veterans Drive
+    building: ''
+    city: Traverse City
+    fax: 877-504-0291
+    phone: 877-376-5613
+    state: MI
+    suite: Suite 106
+    zip: '49684'
+  - address: 500 South Stephenson Avenue
+    building: ''
+    city: Iron Mountain
+    fax: 906-828-1583
+    phone: 906-828-1581
+    state: MI
+    suite: Suite 500
+    zip: '49801'
+  - address: 1349 South Otsego Avenue
+    building: ''
+    city: Gaylord
+    fax: 989-448-8858
+    phone: 989-448-8811
+    state: MI
+    suite: Suite 7A
+    zip: '49735'
+  - address: 307 South Front Street
+    building: ''
+    city: Marquette
+    fax: 906-273-1663
+    phone: 906-273-1661
+    state: MI
+    suite: Suite 120
+    zip: '49855'
+  - address: 454 West Baldwin Street
+    building: ''
+    city: Alpena
+    fax: 989-340-1636
+    phone: 989-340-1634
+    state: MI
+    suite: ''
+    zip: '49707'
+- id:
+    bioguide: H001058
+    govtrack: 412437
+    thomas: 02028
+  offices:
+  - address: 1 South Harbor Avenue
+    building: ''
+    city: Grand Haven
+    fax: 616-570-0934
+    phone: 616-414-5516
+    state: MI
+    suite: Suite 6B
+    zip: '49417'
+  - address: 4555 Wilson Avenue SW
+    building: ''
+    city: Grandville
+    fax: 616-570-0934
+    phone: 616-570-0917
+    state: MI
+    suite: Suite 3
+    zip: '49418'
+- id:
+    bioguide: A000367
+    govtrack: 412438
+    thomas: 02029
+  offices:
+  - address: 110 Michigan Street NW
+    building: ''
+    city: Grand Rapids
+    fax: 616-454-5630
+    phone: 616-451-8383
+    state: MI
+    suite: Suite 460
+    zip: '49503'
+  - address: 70 West Michigan Avenue
+    building: ''
+    city: Battle Creek
+    fax: ''
+    phone: 269-205-3823
+    state: MI
+    suite: Suite 212
+    zip: '49017'
+- id:
+    bioguide: M001194
+    govtrack: 412634
+    thomas: 02248
+  offices:
+  - address: 200 East Main Street
+    building: ''
+    city: Midland
+    fax: 989-631-6271
+    phone: 989-631-2552
+    state: MI
+    suite: Suite 230
+    zip: 48640-5103
+- id:
+    bioguide: K000380
+    govtrack: 412546
+    thomas: '02134'
+  offices:
+  - address: 801 South Saginaw Street
+    building: ''
+    city: Flint
+    fax: ''
+    phone: 810-238-8627
+    state: MI
+    suite: Plaza Level
+    zip: '48502'
+- id:
+    bioguide: U000031
+    govtrack: 400414
+    thomas: '01177'
+  offices:
+  - address: 720 Main Street
+    building: ''
+    city: St. Joseph
+    fax: 269-982-0237
+    phone: 269-982-1986
+    state: MI
+    suite: ''
+    zip: 49085-1124
+  - address: 157 South Kalamazoo Mall
+    building: ''
+    city: Kalamazoo
+    fax: 269-385-2888
+    phone: 269-385-0039
+    state: MI
+    suite: Suite 180
+    zip: 49007-4827
+- id:
+    bioguide: W000798
+    govtrack: 412213
+    thomas: 01855
+  offices:
+  - address: 110 1st Street
+    building: ''
+    city: Jackson
+    fax: 517-780-9081
+    phone: 517-780-9075
+    state: MI
+    suite: Suite 2
+    zip: '49201'
+- id:
+    bioguide: B001293
+    govtrack: 412635
+    thomas: 02249
+  offices:
+  - address: 711 East Grand River Avenue
+    building: ''
+    city: Brighton
+    fax: 810-227-8628
+    phone: 810-227-8600
+    state: MI
+    suite: Suite A
+    zip: '48116'
+- id:
+    bioguide: L000263
+    govtrack: 400238
+    thomas: 00683
+  offices:
+  - address: 27085 Gratiot Avenue
+    building: ''
+    city: Roseville
+    fax: 586-498-7123
+    phone: 586-498-7122
+    state: MI
+    suite: Suite C
+    zip: '48066'
+- id:
+    bioguide: M001150
+    govtrack: 400276
+    thomas: '01731'
+  offices:
+  - address: 48701 Van Dyke Ave.
+    building: ''
+    city: Shelby Township
+    fax: 586-997-5013
+    phone: 586-997-5010
+    state: MI
+    suite: ''
+    zip: '48317'
+- id:
+    bioguide: T000475
+    govtrack: 412636
+    thomas: '02250'
+  offices:
+  - address: 625 East Big Beaver Road
+    building: ''
+    city: Troy
+    fax: 248-528-0714
+    phone: 248-528-0711
+    state: MI
+    suite: Suite 204
+    zip: '48083'
+- id:
+    bioguide: D000624
+    govtrack: 412637
+    thomas: '02251'
+  offices:
+  - address: 301 West Michigan Avenue
+    building: ''
+    city: Ypsilanti
+    fax: ''
+    phone: 734-481-1100
+    state: MI
+    suite: Suite 400
+    zip: '48197'
+  - address: 19855 West Outer Drive
+    building: ''
+    city: Dearborn
+    fax: ''
+    phone: 313-278-2936
+    state: MI
+    suite: Suite 103-E
+    zip: '48124'
+- id:
+    bioguide: C000714
+    govtrack: 400080
+    thomas: 00229
+  offices:
+  - address: 33300 Warren Road
+    building: ''
+    city: Westland
+    fax: 734-675-4218
+    phone: 734-675-4084
+    state: MI
+    suite: Suite 13
+    zip: '48185'
+  - address: 231 West Lafayette
+    building: Federal Building
+    city: Detroit
+    fax: 313-226-2085
+    phone: 313-961-5670
+    state: MI
+    suite: Room 669
+    zip: 48226-2776
+- id:
+    bioguide: L000581
+    govtrack: 412638
+    thomas: '02252'
+  offices:
+  - address: 5555 Conner Avenue
+    building: ''
+    city: Detroit
+    fax: 313-499-1633
+    phone: 313-423-6183
+    state: MI
+    suite: Suite 3015
+    zip: '49213'
+  - address: 26700 Lahser Road
+    building: ''
+    city: Southfield
+    fax: 248-356-4532
+    phone: 248-356-2052
+    state: MI
+    suite: Suite 330
+    zip: '48033'
+- id:
+    bioguide: W000799
+    govtrack: 412214
+    thomas: 01856
+  offices:
+  - address: 527 1/2 South Front Street
+    building: ''
+    city: Mankato
+    fax: 507-388-6181
+    phone: 507-388-2149
+    state: MN
+    suite: ''
+    zip: '56001'
+- id:
+    bioguide: K000363
+    govtrack: 400224
+    thomas: '01733'
+  offices:
+  - address: 350 West Burnsville Parkway
+    building: ''
+    city: Burnsville
+    fax: 952-808-1261
+    phone: 952-808-1213
+    state: MN
+    suite: Suite 135
+    zip: '55337'
+- id:
+    bioguide: P000594
+    govtrack: 412303
+    thomas: 01930
+  offices:
+  - address: 250 Prairie Center Drive
+    building: ''
+    city: Eden Prairie
+    fax: 952-405-8514
+    phone: 952-405-8510
+    state: MN
+    suite: Suite 230
+    zip: '55344'
+- id:
+    bioguide: M001143
+    govtrack: 400259
+    thomas: '01653'
+  offices:
+  - address: 165 Western Avenue North
+    building: ''
+    city: St. Paul
+    fax: 651-224-3056
+    phone: 651-224-9191
+    state: MN
+    suite: Suite 17
+    zip: '55102'
+- id:
+    bioguide: E000288
+    govtrack: 412215
+    thomas: 01857
+  offices:
+  - address: 2100 Plymouth Avenue North
+    building: ''
+    city: Minneapolis
+    fax: 612-522-9915
+    phone: 612-522-1212
+    state: MN
+    suite: ''
+    zip: '55411'
+- id:
+    bioguide: E000294
+    govtrack: 412639
+    thomas: '02253'
+  offices:
+  - address: 9201 Quaday Avenue, NE
+    building: ''
+    city: Otsego
+    fax: 763-241-7955
+    phone: 763-241-6848
+    state: MN
+    suite: Suite 206
+    zip: '55330'
+- id:
+    bioguide: P000258
+    govtrack: 400316
+    thomas: 00910
+  offices:
+  - address: 324 3rd Street SW
+    building: ''
+    city: Willmar
+    fax: 320-235-2651
+    phone: 320-235-1061
+    state: MN
+    suite: Suite 4
+    zip: '56201'
+  - address: 1420 East College Drive
+    building: ''
+    city: Marshall
+    fax: 507-537-2298
+    phone: 507-537-2299
+    state: MN
+    suite: SW/SC
+    zip: '56258'
+  - address: 714 Lake Avenue
+    building: ''
+    city: Detroit Lakes
+    fax: 218-847-5109
+    phone: 218-847-5056
+    state: MN
+    suite: Suite 107
+    zip: '56501'
+  - address: 2603 Wheat Drive
+    building: ''
+    city: Red Lake Falls
+    fax: 218-253-4373
+    phone: 218-253-4356
+    state: MN
+    suite: ''
+    zip: '56750'
+- id:
+    bioguide: N000127
+    govtrack: 408211
+    thomas: 00867
+  offices:
+  - address: 11 East Superior Street
+    building: Duluth Technology Village
+    city: Duluth
+    fax: 218-464-5098
+    phone: 218-464-5095
+    state: MN
+    suite: '#125'
+    zip: '55802'
+  - address: 313 North Main Street
+    building: Chisago County Government Center
+    city: Center City
+    fax: ''
+    phone: 218-491-3131
+    state: MN
+    suite: Room 103
+    zip: '55012'
+- id:
+    bioguide: C001049
+    govtrack: 400074
+    thomas: '01654'
+  offices:
+  - address: 111 South 10th Street
+    building: Thomas F. Eagleton Courthouse
+    city: St. Louis
+    fax: 314-367-1341
+    phone: 314-367-1970
+    state: MO
+    suite: Suite 24.344
+    zip: '63102'
+  - address: 6830 Gravois Avenue
+    building: ''
+    city: St. Louis
+    fax: 314-669-9398
+    phone: 314-669-9393
+    state: MO
+    suite: ''
+    zip: 63116-1137
+  - address: 1281 Graham Road
+    building: ''
+    city: Florissant
+    fax: 314-383-8020
+    phone: 314-383-5240
+    state: MO
+    suite: Suite 202
+    zip: '63031'
+- id:
+    bioguide: W000812
+    govtrack: 412548
+    thomas: '02137'
+  offices:
+  - address: 301 Soverign Court
+    building: ''
+    city: Ballwin
+    fax: ''
+    phone: 636-779-5449
+    state: MO
+    suite: Suite 201
+    zip: '63011'
+- id:
+    bioguide: L000569
+    govtrack: 412292
+    thomas: 01931
+  offices:
+  - address: 2117 Missouri Boulevard
+    building: ''
+    city: Jefferson City
+    fax: 573-635-8347
+    phone: 573-635-7232
+    state: MO
+    suite: ''
+    zip: '65109'
+  - address: 113 East Pearce Boulevard
+    building: ''
+    city: Wentzville
+    fax: ''
+    phone: 636-327-7055
+    state: MO
+    suite: ''
+    zip: '63385'
+  - address: 516 Jefferson Street
+    building: ''
+    city: Washington
+    fax: 636-239-0478
+    phone: 636-239-2276
+    state: MO
+    suite: ''
+    zip: '63090'
+- id:
+    bioguide: H001053
+    govtrack: 412444
+    thomas: '02032'
+  offices:
+  - address: 2415 Carter Lane
+    building: ''
+    city: Columbia
+    fax: 573-442-9309
+    phone: 573-442-9311
+    state: MO
+    suite: ''
+    zip: '65201'
+  - address: 219 North Adams Street
+    building: ''
+    city: Lebanon
+    fax: 417-532-3886
+    phone: 417-532-5582
+    state: MO
+    suite: ''
+    zip: '65536'
+- id:
+    bioguide: C001061
+    govtrack: 400639
+    thomas: 01790
+  offices:
+  - address: 211 West Maple Avenue
+    building: ''
+    city: Independence
+    fax: 816-833-2991
+    phone: 816-833-4545
+    state: MO
+    suite: ''
+    zip: '64050'
+  - address: 101 West 31st Street
+    building: ''
+    city: Kansas City
+    fax: 816-471-5215
+    phone: 816-842-4545
+    state: MO
+    suite: ''
+    zip: '64108'
+  - address: 1923 Main Street
+    building: ''
+    city: Higginsville
+    fax: 660-584-7227
+    phone: 660-584-7373
+    state: MO
+    suite: ''
+    zip: '64037'
+- id:
+    bioguide: G000546
+    govtrack: 400158
+    thomas: '01656'
+  offices:
+  - address: 11724 NW Plaza Circle
+    building: ''
+    city: Kansas City
+    fax: 816-792-0694
+    phone: 816-792-3976
+    state: MO
+    suite: Suite 900
+    zip: '64153'
+  - address: 411 Jules Street
+    building: ''
+    city: St. Joseph
+    fax: 816-749-0801
+    phone: 816-749-0800
+    state: MO
+    suite: Room 111
+    zip: '64501'
+- id:
+    bioguide: L000576
+    govtrack: 412445
+    thomas: '02033'
+  offices:
+  - address: 2727 East 32nd Street
+    building: ''
+    city: Joplin
+    fax: 471-781-2832
+    phone: 471-781-1041
+    state: MO
+    suite: Suite 2
+    zip: '64804'
+  - address: 3232 East Ridgeview Street
+    building: ''
+    city: Springfield
+    fax: 417-889-4915
+    phone: 417-889-1800
+    state: MO
+    suite: ''
+    zip: '65804'
+- id:
+    bioguide: S001195
+    govtrack: 412596
+    thomas: 02191
+  offices:
+  - address: 830 South Bishop Avenue
+    building: ''
+    city: Rolla
+    fax: 573-364-1053
+    phone: 573-364-2455
+    state: MO
+    suite: Suite A
+    zip: 65401-4340
+  - address: 2502 Tanner Drive
+    building: ''
+    city: Cape Girardeau
+    fax: 573-335-1931
+    phone: 573-335-0101
+    state: MO
+    suite: Suite 205
+    zip: '63701'
+  - address: 22 East Columbia
+    building: ''
+    city: Farmington
+    fax: 573-756-9762
+    phone: 573-756-9755
+    state: MO
+    suite: PO Box 1165
+    zip: '63640'
+  - address: 35 Court Square
+    building: ''
+    city: West Plains
+    fax: 417-255-2009
+    phone: 417-255-1515
+    state: MO
+    suite: Suite 300
+    zip: '65775'
+  - address: 2911 North Westwood Boulevard
+    building: ''
+    city: Poplar Bluff
+    fax: ''
+    phone: ''
+    state: MO
+    suite: Suite C
+    zip: '63901'
+- id:
+    bioguide: S001177
+    govtrack: 412312
+    thomas: 01962
+  offices:
+  - address: P.O. Box 504879
+    building: ''
+    city: Saipan
+    fax: 670-323-2649
+    phone: 670-323-2647
+    state: MP
+    suite: ''
+    zip: '96950'
+  - address: PO Box 520394
+    building: ''
+    city: Tinian
+    fax: 670-433-2648
+    phone: 670-433-2647
+    state: MP
+    suite: ''
+    zip: '96952'
+  - address: PO Box 1361
+    building: ''
+    city: Rota
+    fax: 670-532-2649
+    phone: 670-532-2647
+    state: MP
+    suite: ''
+    zip: '96951'
+- id:
+    bioguide: K000388
+    govtrack: 412673
+    thomas: 02294
+  offices:
+  - address: 318 North 7th Street
+    building: ''
+    city: Columbus
+    fax: 662-328-5982
+    phone: 662-327-0748
+    state: MS
+    suite: Suite D
+    zip: '39701'
+  - address: 2565 Caffey Stree
+    building: ''
+    city: Hernando
+    fax: 662-449- 4836
+    phone: 662-449-3090
+    state: MS
+    suite: Suite 200
+    zip: '38632'
+  - address: 431 West Main Street
+    building: ''
+    city: Tupelo
+    fax: 662-841-8845
+    phone: 662-841-8808
+    state: MS
+    suite: ''
+    zip: '38804'
+- id:
+    bioguide: T000193
+    govtrack: 400402
+    thomas: '01151'
+  offices:
+  - address: 910 Courthouse Lane
+    building: ''
+    city: Greenville
+    fax: 662-334-1304
+    phone: 662-335-9003
+    state: MS
+    suite: ''
+    zip: '38701'
+  - address: 3607 Medgar Evers Boulevard
+    building: ''
+    city: Jackson
+    fax: 601-982-5337
+    phone: 601-946-9003
+    state: MS
+    suite: ''
+    zip: '39213'
+  - address: 263 East Main Street
+    building: ''
+    city: Marks
+    fax: ''
+    phone: 662-326-9003
+    state: MS
+    suite: PO Box 356
+    zip: '38646'
+  - address: 509 Highway 82 West
+    building: ''
+    city: Greenwood
+    fax: 662-453-0118
+    phone: 662-455-9003
+    state: MS
+    suite: Suite F
+    zip: '38930'
+  - address: 106 West Green Street
+    building: ''
+    city: Mound Bayou
+    fax: 662-453-0118
+    phone: 662-455-9003
+    state: MS
+    suite: Suite 106
+    zip: '38762'
+  - address: 107 West Madison Street
+    building: ''
+    city: Bolton
+    fax: 601-866-9036
+    phone: 601-866-9003
+    state: MS
+    suite: ''
+    zip: '39041'
+- id:
+    bioguide: H001045
+    govtrack: 412280
+    thomas: 01933
+  offices:
+  - address: 1901 Front Street
+    building: ''
+    city: Meridan
+    fax: 601-693-1801
+    phone: 601-693-6681
+    state: MS
+    suite: Suite A
+    zip: '39301'
+  - address: 1 Research Boulevard
+    building: ''
+    city: Starkville
+    fax: 662-324-0033
+    phone: 662-324-0007
+    state: MS
+    suite: Suite 206
+    zip: '39759'
+  - address: 230 South Whitworth Street
+    building: ''
+    city: Brookhaven
+    fax: 601-823-5512
+    phone: 601-823-3400
+    state: MS
+    suite: ''
+    zip: '39601'
+  - address: 2507-A Old Brandon Road
+    building: ''
+    city: Pearl
+    fax: 601-932-4647
+    phone: 601-932 2410
+    state: MS
+    suite: ''
+    zip: '39208'
+- id:
+    bioguide: P000601
+    govtrack: 412443
+    thomas: '02035'
+  offices:
+  - address: 641 Main Street
+    building: ''
+    city: Hattiesburg
+    fax: ''
+    phone: 601-582-3246
+    state: MS
+    suite: Suite 142
+    zip: '39403'
+  - address: 3118 Pascagoula Street
+    building: ''
+    city: Pascagoula
+    fax: 228-202-8105
+    phone: 228-202-8104
+    state: MS
+    suite: Suite 181
+    zip: '39567'
+  - address: 970 Tommy Munro Drive
+    building: ''
+    city: Biloxi
+    fax: 228-864-3099
+    phone: 228-864-7670
+    state: MS
+    suite: Suite D
+    zip: '39532'
+- id:
+    bioguide: Z000018
+    govtrack: 412640
+    thomas: '02254'
+  offices:
+  - address: 222 North 32nd Street
+    building: ''
+    city: Billings
+    fax: 406-702-1182
+    phone: 406-969-1736
+    state: MT
+    suite: Suite 900
+    zip: '59101'
+  - address: 910 North Last Chance Gulch
+    building: ''
+    city: Helena
+    fax: 406-502-1436
+    phone: 406-502-1435
+    state: MT
+    suite: Suite B
+    zip: '59601'
+  - address: 1008 South Avenue
+    building: ''
+    city: Missoula
+    fax: 406-540-4371
+    phone: ' 406- 540-4370'
+    state: MT
+    suite: Suite 2
+    zip: '59801'
+  - address: 710 Central Avenue
+    building: ''
+    city: Great Falls
+    fax: 406-315-3862
+    phone: 406-315-3860
+    state: MT
+    suite: ''
+    zip: '59401'
+- id:
+    bioguide: B001251
+    govtrack: 400616
+    thomas: '01761'
+  offices:
+  - address: 216 NE Nash Street
+    building: ''
+    city: Wilson
+    fax: 252-291-0356
+    phone: 252-237-9816
+    state: NC
+    suite: Suite B
+    zip: '27893'
+  - address: 309 West 3nd Street
+    building: ''
+    city: Weldon
+    fax: ''
+    phone: 252-538-4123
+    state: NC
+    suite: ''
+    zip: '27890'
+  - address: 411 West Chapel Hill Street
+    building: NC Mutual Building
+    city: Durham
+    fax: ''
+    phone: 888-874-9063
+    state: NC
+    suite: Suite 905
+    zip: '27701'
+- id:
+    bioguide: E000291
+    govtrack: 412457
+    thomas: '02036'
+  offices:
+  - address: 406 West Broad Street
+    building: ''
+    city: Dunn
+    fax: 910-230-1940
+    phone: 910-230-1910
+    state: NC
+    suite: ''
+    zip: '28334'
+  - address: 222 Sunset Avenue
+    building: ''
+    city: Asheboro
+    fax: 336-629-7819
+    phone: 336-626-3060
+    state: NC
+    suite: Suite 101
+    zip: '27203'
+- id:
+    bioguide: J000255
+    govtrack: 400209
+    thomas: '00612'
+  offices:
+  - address: 1105-C Corporate Drive
+    building: ''
+    city: Greenville
+    fax: 252-931-1002
+    phone: 800-351-1697
+    state: NC
+    suite: ''
+    zip: 27858-4211
+- id:
+    bioguide: P000523
+    govtrack: 400326
+    thomas: 00930
+  offices:
+  - address: 301 Green Street
+    building: ''
+    city: Fayetteville
+    fax: 910-339-0159
+    phone: 910-323-0260
+    state: NC
+    suite: Suite 315
+    zip: '28301'
+  - address: 436 North Harrington Street
+    building: ''
+    city: Raleigh
+    fax: 919-859-5998
+    phone: 919-859-5999
+    state: NC
+    suite: Suite 100
+    zip: '27603'
+  - address: 1777 Fordham Boulevard
+    building: ''
+    city: Chapel Hill
+    fax: 919-967-8324
+    phone: 919-967-7924
+    state: NC
+    suite: Suite 204
+    zip: '27514'
+- id:
+    bioguide: F000450
+    govtrack: 400643
+    thomas: 01791
+  offices:
+  - address: 3540 Clemmons Road
+    building: ''
+    city: Clemmons
+    fax: 336-778-2290
+    phone: 336-778-0211
+    state: NC
+    suite: Suite 125
+    zip: '27012'
+  - address: 240 Highway 105 Extension
+    building: ''
+    city: Boone
+    fax: 828-265-0390
+    phone: 828-265-0240
+    state: NC
+    suite: Suite 200
+    zip: '28607'
+- id:
+    bioguide: W000819
+    govtrack: 412670
+    thomas: '02255'
+  offices:
+  - address: 809 Green Valley Road
+    building: ''
+    city: Greensboro
+    fax: ''
+    phone: 336-333-5005
+    state: NC
+    suite: Suite 104
+    zip: '27408'
+  - address: 107 Midtown Commons
+    building: ''
+    city: Madison
+    fax: 336-427-0480
+    phone: 336-427-0044
+    state: NC
+    suite: ''
+    zip: '27025'
+  - address: 219 B West Elm Street
+    building: ''
+    city: Graham
+    fax: 336-350-9514
+    phone: 336-229-0159
+    state: NC
+    suite: PO Box 812
+    zip: 27253-0812
+  - address: 1634 North Main Street
+    building: ''
+    city: High Point
+    fax: 336-886-8740
+    phone: 336-886-5106
+    state: NC
+    suite: Suite 101
+    zip: 27262-2644
+- id:
+    bioguide: R000603
+    govtrack: 412641
+    thomas: '02256'
+  offices:
+  - address: 310 Government Center Drive
+    building: ''
+    city: Bolivia
+    fax: 910-253-6114
+    phone: 910-253-6111
+    state: NC
+    suite: Unit 1
+    zip: '28422'
+  - address: 2736 NC Hwy 210
+    building: Johnston County Agriculture Center
+    city: Smithfield
+    fax: 910-938-3540
+    phone: 910-938-3040
+    state: NC
+    suite: ''
+    zip: '27577'
+  - address: 230 Government Center Drive
+    building: ''
+    city: Wilmington
+    fax: 910-395-0209
+    phone: 910-395-0202
+    state: NC
+    suite: Suite 113
+    zip: '28403'
+- id:
+    bioguide: H001067
+    govtrack: 412550
+    thomas: '02140'
+  offices:
+  - address: 325 McGill Avenue, NW
+    building: ''
+    city: Concord
+    fax: 704-782-1004
+    phone: 704-786-1612
+    state: NC
+    suite: Suite 500
+    zip: '28027'
+  - address: 1015 Fayetteville Road
+    building: ''
+    city: Rockingham
+    fax: ''
+    phone: 910-997-2070
+    state: NC
+    suite: ''
+    zip: '28379'
+- id:
+    bioguide: P000606
+    govtrack: 412551
+    thomas: '02141'
+  offices:
+  - address: 2701 Coltsgate Road
+    building: ''
+    city: Charlotte
+    fax: 704-365-6384
+    phone: 704-362-1060
+    state: NC
+    suite: Suite 105
+    zip: '28211'
+  - address: 116 Morlake Drive
+    building: ''
+    city: Mooresville
+    fax: 704-696-8190
+    phone: 704-696-8188
+    state: NC
+    suite: Suite 101A
+    zip: '28117'
+- id:
+    bioguide: M001156
+    govtrack: 400644
+    thomas: 01792
+  offices:
+  - address: 87 4th Street NW, Suite A
+    building: ''
+    city: Hickory
+    fax: 828-327-8311
+    phone: 828-327-6100
+    state: NC
+    suite: PO Box 1830
+    zip: '28603'
+  - address: 160 Midland Avenue
+    building: ''
+    city: Black Mountain
+    fax: ''
+    phone: 828-669-0600
+    state: NC
+    suite: ''
+    zip: '28711'
+  - address: 128 West Main Avenue
+    building: Gaston County Administrative Building
+    city: Gastonia
+    fax: 828-327-8311
+    phone: 704-833-0096
+    state: NC
+    suite: PO Box 2394
+    zip: '28052'
+- id:
+    bioguide: M001187
+    govtrack: 412552
+    thomas: '02142'
+  offices:
+  - address: 200 North Grove Street
+    building: Henderson County Court House
+    city: Hendersonville
+    fax: 828-693-5603
+    phone: 828-693-5660
+    state: NC
+    suite: Suite 90
+    zip: '28792'
+  - address: 2345 Morganton Boulevard
+    building: ''
+    city: Lenoir
+    fax: ''
+    phone: 828-426-8701
+    state: NC
+    suite: ''
+    zip: '28645'
+  - address: 11 Crystal Street
+    building: ''
+    city: Spruce Pine
+    fax: ''
+    phone: 828-765-0573
+    state: NC
+    suite: ''
+    zip: '28777'
+  - address: 100 Spaulding Road
+    building: ''
+    city: Marion
+    fax: ''
+    phone: 828-765-0573
+    state: NC
+    suite: ''
+    zip: '28752'
+- id:
+    bioguide: A000370
+    govtrack: 412607
+    thomas: '02201'
+  offices:
+  - address: 321 West 11th Street
+    building: ''
+    city: Charlotte
+    fax: 704-344-9971
+    phone: 704-344-9950
+    state: NC
+    suite: Suites 100 & 200
+    zip: '28202'
+  - address: 1600 East Wendover Avenue
+    building: ''
+    city: Greensboro
+    fax: 336-379-9951
+    phone: 336-275-9950
+    state: NC
+    suite: Suite 1
+    zip: '27405'
+- id:
+    bioguide: H001065
+    govtrack: 412553
+    thomas: '02143'
+  offices:
+  - address: 3725 National Drive
+    building: ''
+    city: Raleigh
+    fax: 919-782-4490
+    phone: 919-782-4400
+    state: NC
+    suite: Suite 101
+    zip: '27612'
+- id:
+    bioguide: C001096
+    govtrack: 412555
+    thomas: '02144'
+  offices:
+  - address: 220 East Rosser Avenue
+    building: ''
+    city: Bismarck
+    fax: 701-224-0431
+    phone: 701-224-0355
+    state: ND
+    suite: 328 Federal Building
+    zip: '58501'
+  - address: 3217 Fiechtner Drive
+    building: ''
+    city: Fargo
+    fax: 701-356-2217
+    phone: 701-356-2216
+    state: ND
+    suite: Suite D
+    zip: '58103'
+  - address: 4200 James Ray Drive
+    building: ''
+    city: Grand Forks
+    fax: ''
+    phone: 701-738-4880
+    state: ND
+    suite: Office 600
+    zip: '58202'
+  - address: 315 Main Street
+    building: ''
+    city: Minot
+    fax: ''
+    phone: 701-839-0255
+    state: ND
+    suite: Suite 203
+    zip: '58701'
+- id:
+    bioguide: F000449
+    govtrack: 400640
+    thomas: 01793
+  offices:
+  - address: 629 Broad Street
+    building: ''
+    city: Fremont
+    fax: 402-727-9130
+    phone: 402-727-0888
+    state: NE
+    suite: PO Box 377
+    zip: '68025'
+  - address: 301 South 13th Street
+    building: ''
+    city: Lincoln
+    fax: 402-438-1604
+    phone: 402-438-1598
+    state: NE
+    suite: Suite 100
+    zip: '68508'
+  - address: 125 South 4th Street
+    building: ''
+    city: Norfolk
+    fax: 402-379-2101
+    phone: 402-379-2064
+    state: NE
+    suite: Suite 101
+    zip: '68701'
+- id:
+    bioguide: A000373
+    govtrack: 412642
+    thomas: '02257'
+  offices:
+  - address: 7126 Pacific Street
+    building: ''
+    city: Omaha
+    fax: 402-502-7092
+    phone: 402-916-5678
+    state: NE
+    suite: ''
+    zip: '68106'
+- id:
+    bioguide: S001172
+    govtrack: 412217
+    thomas: 01860
+  offices:
+  - address: 1811 West Second Street
+    building: ''
+    city: Grand Island
+    fax: 308-384-3902
+    phone: 308-384-3900
+    state: NE
+    suite: Suite 275
+    zip: '68803'
+  - address: 416 Valley View Drive
+    building: ''
+    city: Scottsbluff
+    fax: 308-633-6335
+    phone: 308-633-6333
+    state: NE
+    suite: Suite 600
+    zip: '69361'
+- id:
+    bioguide: G000570
+    govtrack: 412447
+    thomas: 02038
+  offices:
+  - address: 33 Lowell Street
+    building: ''
+    city: Manchester
+    fax: 603-641-9561
+    phone: 603-641-9536
+    state: NH
+    suite: ''
+    zip: '03101'
+  - address: 20 North Main Street
+    building: ''
+    city: Rochester
+    fax: 603-335-7702
+    phone: 603-335-7700
+    state: NH
+    suite: ''
+    zip: 03867
+- id:
+    bioguide: K000382
+    govtrack: 412557
+    thomas: '02145'
+  offices:
+  - address: 18 North Main Street
+    building: ''
+    city: Concord
+    fax: 603-226-1010
+    phone: 603-226-1002
+    state: NH
+    suite: Fourth Floor
+    zip: '03301'
+  - address: 70 East Pearl Street
+    building: ''
+    city: Nashua
+    fax: 603-595-2016
+    phone: 603-595-2006
+    state: NH
+    suite: ''
+    zip: '03060'
+  - address: 107 Glessner Road
+    building: ''
+    city: Bethlehem
+    fax: ''
+    phone: 603-444-7700
+    state: NH
+    suite: ''
+    zip: '03574'
+- id:
+    bioguide: N000188
+    govtrack: 412606
+    thomas: '02202'
+  offices:
+  - address: 515 Grove Street
+    building: ''
+    city: Haddon Heights
+    fax: 856-546-9529
+    phone: 856-546-5100
+    state: NJ
+    suite: Suite 3C
+    zip: 08035-1709
+  - address: 10 Melrose Avenue
+    building: ''
+    city: Cherry Hill
+    fax: 856-427-4109
+    phone: 856-427-7000
+    state: NJ
+    suite: Suite 210
+    zip: 08003
+- id:
+    bioguide: L000554
+    govtrack: 400244
+    thomas: 00699
+  offices:
+  - address: 5914 Main Street
+    building: ''
+    city: Mays Landing
+    fax: 609-625-5071
+    phone: 800-471-4450
+    state: NJ
+    suite: Suite 103
+    zip: 08330-1751
+- id:
+    bioguide: M001193
+    govtrack: 412643
+    thomas: 02258
+  offices:
+  - address: 4167 Church Road
+    building: ''
+    city: Mount Laurel
+    fax: 856-780-6440
+    phone: 856-780-6436
+    state: NJ
+    suite: ''
+    zip: 08054
+  - address: 600 Mule Road
+    building: Township of Toms River Town Hall
+    city: Toms River
+    fax: 732-279-6062
+    phone: 732-279-6013
+    state: NJ
+    suite: Unit 6
+    zip: 08757
+  - address: 535 East Main Street
+    building: Gibson House Community Center
+    city: Marlton
+    fax: 856-574-4697
+    phone: 856-267-5182
+    state: NJ
+    suite: ''
+    zip: 08053
+- id:
+    bioguide: S000522
+    govtrack: 400380
+    thomas: '01071'
+  offices:
+  - address: 4573 South Broad Street
+    building: ''
+    city: Hamilton
+    fax: 609-585-9155
+    phone: 609-585-7878
+    state: NJ
+    suite: ''
+    zip: 08620
+  - address: 405 Route 539
+    building: ''
+    city: Cream Ridge
+    fax: 609-286-2630
+    phone: 609-286-2571
+    state: NJ
+    suite: ''
+    zip: 08514-2303
+  - address: 112 Village Center Drive
+    building: Raintree Shopping Center
+    city: Freehold
+    fax: 732-380-3079
+    phone: 732-780-3035
+    state: NJ
+    suite: 2nd Floor
+    zip: 07728
+- id:
+    bioguide: G000548
+    govtrack: 400145
+    thomas: '01737'
+  offices:
+  - address: 266 Harristown Road
+    building: ''
+    city: Glen Rock
+    fax: 201-444-5488
+    phone: 201-444-5454
+    state: NJ
+    suite: Suite 104
+    zip: '07452'
+  - address: 83 Spring Street
+    building: ''
+    city: Newton
+    fax: 973-300-1051
+    phone: 973-300-2000
+    state: NJ
+    suite: Suite 302A
+    zip: 07860
+- id:
+    bioguide: P000034
+    govtrack: 400308
+    thomas: 00887
+  offices:
+  - address: 67/69 Church Street
+    building: Kilmer Square
+    city: New Brunswick
+    fax: 732-249-1335
+    phone: 732-249-8892
+    state: NJ
+    suite: ''
+    zip: 08901-1242
+  - address: 504 Broadway
+    building: ''
+    city: Long Branch
+    fax: 732-870-3890
+    phone: 732-571-1140
+    state: NJ
+    suite: ''
+    zip: '07740'
+- id:
+    bioguide: L000567
+    govtrack: 412290
+    thomas: 01936
+  offices:
+  - address: 361 Route 31
+    building: ''
+    city: Flemington
+    fax: 908-788-2869
+    phone: 908-788-6900
+    state: NJ
+    suite: Unit 1400
+    zip: 08822
+  - address: 425 North Avenue
+    building: ''
+    city: Westfield
+    fax: 908-518-7751
+    phone: 908-518-7733
+    state: NJ
+    suite: ''
+    zip: 07090
+- id:
+    bioguide: S001165
+    govtrack: 412186
+    thomas: 01818
+  offices:
+  - address: 5500 Palisade Avenue
+    building: ''
+    city: West New York
+    fax: 201-617-2809
+    phone: 201-558-0800
+    state: NJ
+    suite: Suite A
+    zip: 07093
+  - address: 121 Newark Avenue
+    building: ''
+    city: Jersey City
+    fax: 201-309-0384
+    phone: 201-309-0301
+    state: NJ
+    suite: Suite 200
+    zip: '07302'
+  - address: 800 Anna Street
+    building: ''
+    city: Elizabeth
+    fax: 908-820-0694
+    phone: 908-820-0692
+    state: NJ
+    suite: ''
+    zip: '07201'
+  - address: 630 Avenue C
+    building: Bayonne City Hall
+    city: Bayonne
+    fax: 201-858-7139
+    phone: 201-823-2900
+    state: NJ
+    suite: Room 9
+    zip: '07002'
+- id:
+    bioguide: P000096
+    govtrack: 400309
+    thomas: '01510'
+  offices:
+  - address: 200 Federal Plaza
+    building: Robert A. Roe Building
+    city: Paterson
+    fax: 973-523-0637
+    phone: 973-523-5152
+    state: NJ
+    suite: Suite 500
+    zip: 07505-1953
+- id:
+    bioguide: P000604
+    govtrack: 412506
+    thomas: 02097
+  offices:
+  - address: 333 North Broad Street
+    building: ''
+    city: Elizabeth
+    fax: 908-629-0221
+    phone: 908-629-0222
+    state: NJ
+    suite: ''
+    zip: 07208
+  - address: 60 Nelson Place
+    building: LeRoy F. Smith Public Safety Building
+    city: Newark
+    fax: 973-645-5902
+    phone: 973-645-3213
+    state: NJ
+    suite: 14th Floor
+    zip: 07102-3506
+  - address: 253 Martin Luther King Drive
+    building: ''
+    city: Jersey City
+    fax: 201-369-0395
+    phone: 201-369-0392
+    state: NJ
+    suite: ''
+    zip: '07305'
+- id:
+    bioguide: F000372
+    govtrack: 400142
+    thomas: '00414'
+  offices:
+  - address: 30 Schuyler Place
+    building: ''
+    city: Morristown
+    fax: ''
+    phone: 973-984-0711
+    state: NJ
+    suite: Second Floor
+    zip: 07960
+- id:
+    bioguide: W000822
+    govtrack: 412644
+    thomas: 02259
+  offices:
+  - address: 50 Washington Road
+    building: ''
+    city: West Windsor
+    fax: 609-750-0618
+    phone: 609-750-9365
+    state: NJ
+    suite: ''
+    zip: 08550-1012
+  - address: 850 Bear Tavern Road
+    building: ''
+    city: Ewing
+    fax: 609-883-2093
+    phone: 609-883-0026
+    state: NJ
+    suite: Suite 201
+    zip: 08628
+- id:
+    bioguide: L000580
+    govtrack: 412558
+    thomas: '02146'
+  offices:
+  - address: 400 Gold Avenue SW
+    building: ''
+    city: Albuquerque
+    fax: 505-346-6723
+    phone: 505-346-6781
+    state: NM
+    suite: Suite 680
+    zip: '87102'
+- id:
+    bioguide: P000588
+    govtrack: 400313
+    thomas: 01738
+  offices:
+  - address: 1717 West 2nd Street
+    building: ''
+    city: Roswell
+    fax: ''
+    phone: 855-473-2723
+    state: NM
+    suite: Suite 110
+    zip: '88201'
+  - address: 570 North Telshor Boulevard
+    building: ''
+    city: Las Cruces
+    fax: ''
+    phone: 855-473-2723
+    state: NM
+    suite: ''
+    zip: '88011'
+- id:
+    bioguide: L000570
+    govtrack: 412293
+    thomas: 01939
+  offices:
+  - address: 110 West Aztec Avenue
+    building: ''
+    city: Gallup
+    fax: 505-863-0678
+    phone: 505-863-0582
+    state: NM
+    suite: ''
+    zip: '87301'
+  - address: 903 University Avenue
+    building: ''
+    city: Las Vegas
+    fax: 505-454-3265
+    phone: 505-454-3038
+    state: NM
+    suite: PO Box 1368
+    zip: '87701'
+  - address: 1611 Calle Lorca
+    building: ''
+    city: Santa Fe
+    fax: 505-986-5047
+    phone: 505-984-8950
+    state: NM
+    suite: Suite A
+    zip: '87505'
+  - address: 800 Municipal Drive
+    building: ''
+    city: Farmington
+    fax: 505-324-1026
+    phone: 505-324-1005
+    state: NM
+    suite: ''
+    zip: '87401'
+  - address: 404 West Route 66 Boulevard
+    building: ''
+    city: Tucumcari
+    fax: 575-461-3192
+    phone: 575-461-3029
+    state: NM
+    suite: ''
+    zip: '88401'
+  - address: 3200 Civic Center NE
+    building: ''
+    city: Rio Rancho
+    fax: 505-994-0550
+    phone: 505-994-0499
+    state: NM
+    suite: Suite 330
+    zip: '87144'
+- id:
+    bioguide: T000468
+    govtrack: 412318
+    thomas: 01940
+  offices:
+  - address: 550 East Charleston Boulevard
+    building: ''
+    city: Las Vegas
+    fax: ''
+    phone: 702-220-9823
+    state: NV
+    suite: Suite B
+    zip: '89104'
+- id:
+    bioguide: A000369
+    govtrack: 412500
+    thomas: 02090
+  offices:
+  - address: 5310 Kietzke Lane
+    building: ''
+    city: Reno
+    fax: 775-686-5711
+    phone: 775-686-5760
+    state: NV
+    suite: Suite 103
+    zip: '89511'
+  - address: 905 Railroad Street
+    building: ''
+    city: Elko
+    fax: ''
+    phone: 775-777-7705
+    state: NV
+    suite: Suite 104D
+    zip: '89801'
+- id:
+    bioguide: H001055
+    govtrack: 412446
+    thomas: '02040'
+  offices:
+  - address: 8872 South Eastern Avenue
+    building: ''
+    city: Las Vegas
+    fax: 702-837-0728
+    phone: 702-387-4941
+    state: NV
+    suite: Suite 220
+    zip: '89123'
+- id:
+    bioguide: H001070
+    govtrack: 412645
+    thomas: '02260'
+  offices:
+  - address: 2250 Las Vegas Boulevard, North
+    building: ''
+    city: North Las Vegas
+    fax: 702-476-0911
+    phone: 702-912-1634
+    state: NV
+    suite: Suite 500
+    zip: '89030'
+- id:
+    bioguide: Z000017
+    govtrack: 412646
+    thomas: '02261'
+  offices:
+  - address: 31 Oak Street
+    building: ''
+    city: Patchogue
+    fax: 631-289-3181
+    phone: 631-289-6500
+    state: NY
+    suite: Suite 20
+    zip: '11772'
+  - address: 137 Hampton Road
+    building: ''
+    city: Southampton
+    fax: 631-259-8451
+    phone: 631-259-8450
+    state: NY
+    suite: ''
+    zip: '11968'
+- id:
+    bioguide: K000210
+    govtrack: 400219
+    thomas: '00635'
+  offices:
+  - address: 1003 Park Boulevard
+    building: ''
+    city: Massapequa Park
+    fax: 516-541-6602
+    phone: 516-541-4225
+    state: NY
+    suite: ''
+    zip: 11762-2741
+- id:
+    bioguide: I000057
+    govtrack: 400195
+    thomas: '01663'
+  offices:
+  - address: 534 Broad Hollow Road
+    building: ''
+    city: Melville
+    fax: 631-777-7610
+    phone: 631-777-7391
+    state: NY
+    suite: Suite 302
+    zip: '11747'
+  - address: 1 Barstow Road
+    building: ''
+    city: Great Neck
+    fax: ''
+    phone: 516-304-5651
+    state: NY
+    suite: Suite P-22
+    zip: '11021'
+- id:
+    bioguide: R000602
+    govtrack: 412647
+    thomas: '02262'
+  offices:
+  - address: 300 Garden City Plaza
+    building: ''
+    city: Garden City
+    fax: 516-739-2973
+    phone: 516-739-3008
+    state: NY
+    suite: Suite 200
+    zip: '11530'
+- id:
+    bioguide: M001137
+    govtrack: 400271
+    thomas: '01506'
+  offices:
+  - address: 67-12 Rockaway Beach Boulevard
+    building: ''
+    city: Arverne
+    fax: 347-230-4045
+    phone: 347-230-4032
+    state: NY
+    suite: ''
+    zip: '11692'
+  - address: 153-01 Jamaica Avenue
+    building: ''
+    city: Jamaica
+    fax: 718-725-9868
+    phone: 718-725-6000
+    state: NY
+    suite: 2nd Floor
+    zip: '11432'
+- id:
+    bioguide: M001188
+    govtrack: 412560
+    thomas: 02148
+  offices:
+  - address: 40-13 159th Street
+    building: ''
+    city: Flushing
+    fax: 718-445-7868
+    phone: 718-445-6364
+    state: NY
+    suite: ''
+    zip: '11358'
+  - address: 118-35 Queens Boulevard
+    building: ''
+    city: Forest Hills
+    fax: ''
+    phone: 718-455-7861
+    state: NY
+    suite: 17th Floor
+    zip: '11375'
+- id:
+    bioguide: V000081
+    govtrack: 400416
+    thomas: 01184
+  offices:
+  - address: 266 Broadway
+    building: ''
+    city: Brooklyn
+    fax: ''
+    phone: 718-599-3658
+    state: NY
+    suite: Suite 201
+    zip: '11211'
+  - address: 500 Pearl Street
+    building: ''
+    city: New York
+    fax: ''
+    phone: 212-619-2606
+    state: NY
+    suite: Suite 973
+    zip: '10007'
+  - address: 16 Court Street
+    building: ''
+    city: Brooklyn
+    fax: ''
+    phone: 718-222-5819
+    state: NY
+    suite: Suite 1006
+    zip: '11241'
+- id:
+    bioguide: J000294
+    govtrack: 412561
+    thomas: 02149
+  offices:
+  - address: 445 Neptune Avenue, 1st Floor
+    building: ''
+    city: Brooklyn
+    fax: ''
+    phone: 718-373-0033
+    state: NY
+    suite: Community Room 2C
+    zip: '11224'
+  - address: 55 Hanson Place
+    building: ''
+    city: Brooklyn
+    fax: ''
+    phone: 718-237-2211
+    state: NY
+    suite: Suite 603
+    zip: '11217'
+- id:
+    bioguide: C001067
+    govtrack: 412221
+    thomas: 01864
+  offices:
+  - address: 123 Linden Boulevard
+    building: ''
+    city: Brooklyn
+    fax: 718-287-1223
+    phone: 718-287-1142
+    state: NY
+    suite: Fourth Floor
+    zip: '11226'
+- id:
+    bioguide: N000002
+    govtrack: 400289
+    thomas: 00850
+  offices:
+  - address: 201 Varick Street
+    building: ''
+    city: New York
+    fax: 212-367-7356
+    phone: 212-367-7350
+    state: NY
+    suite: Suite 669
+    zip: '10014'
+  - address: 6605 Fort Hamilton Parkway
+    building: ''
+    city: Brooklyn
+    fax: ''
+    phone: 718-373-3198
+    state: NY
+    suite: ''
+    zip: '11219'
+- id:
+    bioguide: D000625
+    govtrack: 412672
+    thomas: 02293
+  offices:
+  - address: 7308 13th Avenue
+    building: ''
+    city: Brooklyn
+    fax: 718-630-5388
+    phone: 718-630-5277
+    state: NY
+    suite: ''
+    zip: '11228'
+  - address: 265 New Dorp Lane
+    building: ''
+    city: Staten Island
+    fax: 718-980-0768
+    phone: 718-351-1062
+    state: NY
+    suite: 2nd Floor
+    zip: '10306'
+- id:
+    bioguide: M000087
+    govtrack: 400251
+    thomas: 00729
+  offices:
+  - address: 1651 3rd Avenue
+    building: ''
+    city: New York
+    fax: 212-860-0704
+    phone: 212-860-0606
+    state: NY
+    suite: Suite 311
+    zip: 10128-3679
+  - address: 31-19 Newtown Avenue
+    building: ''
+    city: Astoria
+    fax: 718-932-1805
+    phone: 718-932-1804
+    state: NY
+    suite: ''
+    zip: '11102'
+- id:
+    bioguide: R000053
+    govtrack: 400333
+    thomas: 00944
+  offices:
+  - address: 163 West 125th Street
+    building: ''
+    city: New York
+    fax: 212-663-4277
+    phone: 212-663-3900
+    state: NY
+    suite: Suite 737
+    zip: 10027-4404
+- id:
+    bioguide: C001038
+    govtrack: 400087
+    thomas: '01604'
+  offices:
+  - address: 82-11 37th Avenue
+    building: ''
+    city: Queens
+    fax: ''
+    phone: 718-779-1400
+    state: NY
+    suite: Suite 402
+    zip: '11372'
+  - address: 2800 Bruckner Boulevard
+    building: ''
+    city: Bronx
+    fax: ''
+    phone: 718-931-1400
+    state: NY
+    suite: Suite 301
+    zip: '10465'
+- id:
+    bioguide: S000248
+    govtrack: 400366
+    thomas: '01042'
+  offices:
+  - address: 1231 Lafayette Avenue
+    building: ''
+    city: Bronx
+    fax: 718-620-0658
+    phone: 718-620-0084
+    state: NY
+    suite: 4th Floor
+    zip: '10474'
+- id:
+    bioguide: E000179
+    govtrack: 400122
+    thomas: '00344'
+  offices:
+  - address: 3655 Johnson Avenue
+    building: ''
+    city: Bronx
+    fax: 718-796-5134
+    phone: 718-796-9700
+    state: NY
+    suite: ''
+    zip: 10463-1671
+  - address: 6 Gramatan Avenue
+    building: ''
+    city: Mount Vernon
+    fax: 914-699-3646
+    phone: 914-699-4100
+    state: NY
+    suite: Suite 205
+    zip: '10550'
+  - address: 177 Dreiser Loop
+    building: ''
+    city: Bronx
+    fax: 718-320-2047
+    phone: 718-320-2314
+    state: NY
+    suite: Room 3
+    zip: '10475'
+- id:
+    bioguide: L000480
+    govtrack: 400246
+    thomas: 00709
+  offices:
+  - address: 222 Mamaroneck Avenue
+    building: ''
+    city: White Plains
+    fax: 914-328-1505
+    phone: 914-428-1707
+    state: NY
+    suite: '#312'
+    zip: 10605-1303
+  - address: 67 North Main Street
+    building: ''
+    city: New City
+    fax: 845-634-4079
+    phone: 845-639-3485
+    state: NY
+    suite: '#101'
+    zip: '10956'
+- id:
+    bioguide: M001185
+    govtrack: 412562
+    thomas: '02150'
+  offices:
+  - address: 123 Grand Street
+    building: ''
+    city: Newburgh
+    fax: 845-561-2890
+    phone: 845-561-1259
+    state: NY
+    suite: 2nd Floor
+    zip: '12550'
+- id:
+    bioguide: G000564
+    govtrack: 412453
+    thomas: '02043'
+  offices:
+  - address: 721 Broadway
+    building: ''
+    city: Kingston
+    fax: ''
+    phone: 845-514-2322
+    state: NY
+    suite: ''
+    zip: '12401'
+  - address: 92 Sullivan Avenue
+    building: ''
+    city: Liberty
+    fax: ''
+    phone: 845-747-9261
+    state: NY
+    suite: PO Box 578
+    zip: '12754'
+  - address: 2 Hudson Street
+    building: ''
+    city: Kinderhook
+    fax: ''
+    phone: 518-610-8133
+    state: NY
+    suite: PO Box 775
+    zip: '12106'
+  - address: 25 Chestnut Street
+    building: ''
+    city: Cooperstown
+    fax: ''
+    phone: 607-282-4002
+    state: NY
+    suite: ''
+    zip: '13326'
+  - address: 4254  Albany Post Road
+    building: ''
+    city: Hyde Park
+    fax: ''
+    phone: 845-698-0132
+    state: NY
+    suite: ''
+    zip: '12538'
+  - address: 111 Main Street
+    building: ''
+    city: Delhi
+    fax: ''
+    phone: ''
+    state: NY
+    suite: ''
+    zip: '13753'
+- id:
+    bioguide: T000469
+    govtrack: 412319
+    thomas: 01942
+  offices:
+  - address: 105 Jay Street
+    building: ''
+    city: Schenectady
+    fax: 518-374-7908
+    phone: 518-374-4547
+    state: NY
+    suite: Room 15
+    zip: '12305'
+  - address: 61 Columbia Street
+    building: ''
+    city: Albany
+    fax: 518-427-5107
+    phone: 518-465-0700
+    state: NY
+    suite: 4th Floor
+    zip: '12210'
+  - address: 61 Church Street
+    building: ''
+    city: Amsterdam
+    fax: 518-843-8874
+    phone: 518-843-3400
+    state: NY
+    suite: Room 309
+    zip: '12010'
+- id:
+    bioguide: S001196
+    govtrack: 412648
+    thomas: '02263'
+  offices:
+  - address: 23 Durkee Street
+    building: ''
+    city: Plattsburgh
+    fax: 518-561-2408
+    phone: 518-561-2324
+    state: NY
+    suite: Suite C
+    zip: '12901'
+  - address: 120 Washington Street
+    building: ''
+    city: Watertown
+    fax: 315-782-1291
+    phone: 315-782-3150
+    state: NY
+    suite: Suite 200
+    zip: 13601-3370
+  - address: 136 Glen Street
+    building: ''
+    city: Glens Falls
+    fax: 518-743-1391
+    phone: 518-743-0964
+    state: NY
+    suite: ''
+    zip: '12801'
+- id:
+    bioguide: H001051
+    govtrack: 412454
+    thomas: '02044'
+  offices:
+  - address: 49 Court Street
+    building: ''
+    city: Binghamton
+    fax: 607-723-0215
+    phone: 607-723-0212
+    state: NY
+    suite: Suite 230
+    zip: '13901'
+  - address: 258 Genesee Street
+    building: ''
+    city: Utica
+    fax: 315-724-9746
+    phone: 315-724-9740
+    state: NY
+    suite: ''
+    zip: '13502'
+- id:
+    bioguide: R000585
+    govtrack: 412393
+    thomas: 01982
+  offices:
+  - address: 433 Exchange Street
+    building: ''
+    city: Geneva
+    fax: 315-325-4045
+    phone: 315-759-5229
+    state: NY
+    suite: ''
+    zip: '14456'
+  - address: 89 West Market Street
+    building: ''
+    city: Corning
+    fax: 607-654-7568
+    phone: 607-654-7566
+    state: NY
+    suite: ''
+    zip: '14830'
+  - address: 2 East 2nd Street
+    building: ''
+    city: Jamestown
+    fax: 716-708-6058
+    phone: 716-708-6369
+    state: NY
+    suite: Suite 300
+    zip: '14701'
+  - address: One Bluebird Square
+    building: ''
+    city: Olean
+    fax: 716-806-1069
+    phone: 716-379-8434
+    state: NY
+    suite: ''
+    zip: '14760'
+  - address: 401 East State Street
+    building: ''
+    city: Ithaca
+    fax: ''
+    phone: 607-222-2027
+    state: NY
+    suite: Suite 400-10
+    zip: '14850'
+- id:
+    bioguide: K000386
+    govtrack: 412649
+    thomas: '02264'
+  offices:
+  - address: 71 Genesee Street
+    building: ''
+    city: Auburn
+    fax: 315-253-2435
+    phone: 315-253-4068
+    state: NY
+    suite: ''
+    zip: '13021'
+  - address: 440 South Warren Street
+    building: ''
+    city: Syracuse
+    fax: 315-423-5604
+    phone: 315-423-5657
+    state: NY
+    suite: 7th Floor Suite 711
+    zip: '13202'
+- id:
+    bioguide: S000480
+    govtrack: 400378
+    thomas: 01069
+  offices:
+  - address: 100 State Street
+    building: 3120 Federal Building,
+    city: Rochester
+    fax: 585-232-1954
+    phone: 585-232-4850
+    state: NY
+    suite: ''
+    zip: 14614-1350
+- id:
+    bioguide: H001038
+    govtrack: 400641
+    thomas: 01794
+  offices:
+  - address: 726 Exchange Street
+    building: ''
+    city: Buffalo
+    fax: 716-852-3929
+    phone: 716-852-3501
+    state: NY
+    suite: Suite 601
+    zip: '14210'
+  - address: 640 Park Place
+    building: ''
+    city: Niagara Falls
+    fax: 716-282-2479
+    phone: 716-282-1274
+    state: NY
+    suite: ''
+    zip: '14301'
+- id:
+    bioguide: C001092
+    govtrack: 412563
+    thomas: '02151'
+  offices:
+  - address: 2813 Wehrle Drive
+    building: ''
+    city: Williamsville
+    fax: 716-631-7610
+    phone: 716-634-2324
+    state: NY
+    suite: Suite 13
+    zip: '14221'
+  - address: 128 Main Street
+    building: ''
+    city: Geneseo
+    fax: 585-519-4009
+    phone: 585-519-4002
+    state: NY
+    suite: Unit 2
+    zip: '14454'
+- id:
+    bioguide: C000266
+    govtrack: 400071
+    thomas: 00186
+  offices:
+  - address: 441 Vine Street
+    building: ''
+    city: Cincinnati
+    fax: 513-421-8722
+    phone: 513-684-2723
+    state: OH
+    suite: Suite 3003
+    zip: '45202'
+  - address: 11 South Broadway
+    building: ''
+    city: Lebanon
+    fax: 513-421-8722
+    phone: 513-421-8704
+    state: OH
+    suite: ''
+    zip: '45036'
+- id:
+    bioguide: W000815
+    govtrack: 412564
+    thomas: '02152'
+  offices:
+  - address: 7954 Beechmont Avenue
+    building: ''
+    city: Cincinnati
+    fax: 513-605-1377
+    phone: 513-474-7777
+    state: OH
+    suite: Suite 200
+    zip: '45245'
+  - address: 170 North Main Street
+    building: ''
+    city: Peebles
+    fax: ''
+    phone: 513-605-1380
+    state: OH
+    suite: ''
+    zip: '45660'
+- id:
+    bioguide: B001281
+    govtrack: 412565
+    thomas: '02153'
+  offices:
+  - address: 471 East Broad Street
+    building: ''
+    city: Columbus
+    fax: 614-220-5640
+    phone: 614-220-0003
+    state: OH
+    suite: Suite 1100
+    zip: '43215'
+- id:
+    bioguide: J000289
+    govtrack: 412226
+    thomas: 01868
+  offices:
+  - address: 3121 West Elm Plaza
+    building: ''
+    city: Lima
+    fax: 419-999-4238
+    phone: 419-999-6455
+    state: OH
+    suite: ''
+    zip: '45805'
+  - address: 13B East Main Street
+    building: ''
+    city: Norwalk
+    fax: 419-668-3015
+    phone: 419-663-1426
+    state: OH
+    suite: ''
+    zip: '44857'
+- id:
+    bioguide: L000566
+    govtrack: 412256
+    thomas: 01885
+  offices:
+  - address: 1045 North Main Street
+    building: ''
+    city: Bowling Green
+    fax: ''
+    phone: 419-354-8700
+    state: OH
+    suite: Suite 6
+    zip: '43402'
+  - address: 101 Clinton Street
+    building: ''
+    city: Defiance
+    fax: ''
+    phone: 419-782-1996
+    state: OH
+    suite: Suite 1200
+    zip: '43512'
+  - address: 318 Dorney Plaza
+    building: ''
+    city: Findlay
+    fax: ''
+    phone: 419-422-7791
+    state: OH
+    suite: Room 302
+    zip: '45840'
+- id:
+    bioguide: J000292
+    govtrack: 412460
+    thomas: '02046'
+  offices:
+  - address: 246 Front Street
+    building: ''
+    city: Marietta
+    fax: 740-376-0886
+    phone: 740-376-0868
+    state: OH
+    suite: ''
+    zip: '45750'
+  - address: 192 East State Street
+    building: ''
+    city: Salem
+    fax: 330-337-7125
+    phone: 330-337-6951
+    state: OH
+    suite: ''
+    zip: '44460'
+  - address: 202 Park Avenue
+    building: ''
+    city: Ironton
+    fax: 740-594-9482
+    phone: 740-534-9431
+    state: OH
+    suite: Suite C
+    zip: '45638'
+  - address: 116 Southgate Parkway
+    building: ''
+    city: Cambridge
+    fax: 740-432-2587
+    phone: 740-432-2366
+    state: OH
+    suite: ''
+    zip: '43725'
+- id:
+    bioguide: G000563
+    govtrack: 412463
+    thomas: 02049
+  offices:
+  - address: 110 Cottage Street
+    building: ''
+    city: Ashland
+    fax: 419-207-0655
+    phone: 419-207-0650
+    state: OH
+    suite: ''
+    zip: '44805'
+  - address: 110 Central Plaza South
+    building: ''
+    city: Canton
+    fax: ''
+    phone: 330-737-1631
+    state: OH
+    suite: ''
+    zip: '44702'
+- id:
+    bioguide: K000009
+    govtrack: 400211
+    thomas: '00616'
+  offices:
+  - address: 1 Maritime Plaza
+    building: ''
+    city: Toledo
+    fax: 419-255-9623
+    phone: 419-259-7500
+    state: OH
+    suite: Room 600
+    zip: 43604-1853
+  - address: 200 West Erie
+    building: ''
+    city: Lorain
+    fax: ''
+    phone: 440-288-1500
+    state: OH
+    suite: Room 310
+    zip: '44052'
+  - address: 17021 Lorain Avenue
+    building: ''
+    city: Cleveland
+    fax: 440-799-8499
+    phone: 216-767-5933
+    state: ' OH'
+    suite: ''
+    zip: '44111'
+- id:
+    bioguide: T000463
+    govtrack: 400411
+    thomas: '01741'
+  offices:
+  - address: 120 West Third Street
+    building: ''
+    city: Dayton
+    fax: 937-225-2752
+    phone: 937-225-2843
+    state: OH
+    suite: Suite 305
+    zip: '45402'
+- id:
+    bioguide: F000455
+    govtrack: 412327
+    thomas: 01895
+  offices:
+  - address: 4834 Richmond Road
+    building: ''
+    city: Warrensville
+    fax: 216-522-4908
+    phone: 216-522-4900
+    state: OH
+    suite: Suite 150
+    zip: '44128'
+  - address: 1225 Lawton Street
+    building: ''
+    city: Akron
+    fax: 330-835-4863
+    phone: 330-835-4578
+    state: OH
+    suite: ''
+    zip: '44320'
+- id:
+    bioguide: T000462
+    govtrack: 400406
+    thomas: '01664'
+  offices:
+  - address: 250 East Wilson Bridge Road
+    building: ''
+    city: Worthington
+    fax: 614-818-0887
+    phone: 614-523-2555
+    state: OH
+    suite: Suite 100
+    zip: '43085'
+- id:
+    bioguide: R000577
+    govtrack: 400352
+    thomas: '01756'
+  offices:
+  - address: 241 West Federal Street
+    building: ''
+    city: Youngstown
+    fax: 330-740-0182
+    phone: 330-740-0193
+    state: OH
+    suite: ''
+    zip: '44503'
+  - address: 1030 Tallmadge Avenue
+    building: ''
+    city: Akron
+    fax: 330-630-7314
+    phone: 330-630-7311
+    state: OH
+    suite: ''
+    zip: '44310'
+  - address: 197 West Market Street
+    building: ''
+    city: Warren
+    fax: 330-373-0098
+    phone: 330-373-0074
+    state: OH
+    suite: ''
+    zip: 44481-0074
+- id:
+    bioguide: J000295
+    govtrack: 412566
+    thomas: '02154'
+  offices:
+  - address: 1 Victoria Place
+    building: ''
+    city: Painesville
+    fax: 440-352-3622
+    phone: 440-352-3939
+    state: OH
+    suite: Room 320
+    zip: '44077'
+  - address: 10075 Ravenna Road
+    building: Twinsburg Government Center
+    city: Twinsburg
+    fax: 330-425-7071
+    phone: 330-425-9291
+    state: OH
+    suite: ''
+    zip: '44087'
+- id:
+    bioguide: S001187
+    govtrack: 412461
+    thomas: '02047'
+  offices:
+  - address: 3790 Municipal Way
+    building: ''
+    city: Hilliard
+    fax: 614-771-3990
+    phone: 614-771-4968
+    state: OH
+    suite: ''
+    zip: '43026'
+  - address: 123 south Broad Street
+    building: ''
+    city: Lancaster
+    fax: 740-654-2482
+    phone: 740-654-2654
+    state: OH
+    suite: Suite 235
+    zip: '43130'
+  - address: 69 North South Street
+    building: ''
+    city: Wilimington
+    fax: 937-283-7052
+    phone: 937-283-7049
+    state: OH
+    suite: ''
+    zip: '45177'
+- id:
+    bioguide: R000586
+    govtrack: 412462
+    thomas: 02048
+  offices:
+  - address: 1 Park Center Drive
+    building: ''
+    city: Wadsworth
+    fax: 330-334-0061
+    phone: 330-334-0040
+    state: OH
+    suite: Suite 302
+    zip: '44281'
+  - address: 7335 Ridge Road
+    building: ''
+    city: Parma
+    fax: 440-882-6560
+    phone: 440-882-6779
+    state: OH
+    suite: Suite 2
+    zip: '44129'
+- id:
+    bioguide: B001283
+    govtrack: 412567
+    thomas: '02155'
+  offices:
+  - address: 2448 East 81st Street
+    building: ''
+    city: Tulsa
+    fax: 918-935-2716
+    phone: 918-935-3222
+    state: OK
+    suite: Suite 5150
+    zip: '74137'
+- id:
+    bioguide: M001190
+    govtrack: 412568
+    thomas: '02156'
+  offices:
+  - address: 1 East Choctaw
+    building: ''
+    city: McAlester
+    fax: 918-423-1940
+    phone: 918-423-5951
+    state: OK
+    suite: Suite 175
+    zip: '74501'
+  - address: 3109 Azalea Park Drive
+    building: ''
+    city: Muskogee
+    fax: 918-686-0128
+    phone: 918-687-2533
+    state: OK
+    suite: ''
+    zip: '74401'
+- id:
+    bioguide: L000491
+    govtrack: 400247
+    thomas: '00711'
+  offices:
+  - address: 10952 NW Expressway
+    building: ''
+    city: Yukon
+    fax: 405-373-2046
+    phone: 405-373-1958
+    state: OK
+    suite: Suite B
+    zip: '73099'
+- id:
+    bioguide: C001053
+    govtrack: 400077
+    thomas: '01742'
+  offices:
+  - address: 100 East 13th Street
+    building: Sugg Clinic Office Building
+    city: Ada
+    fax: 580-436-5451
+    phone: 580-436-5375
+    state: OK
+    suite: Suite 213
+    zip: 74820-6548
+  - address: 711 SW D Avenue
+    building: ''
+    city: Lawton
+    fax: 580-357-7477
+    phone: 580-357-2131
+    state: OK
+    suite: Suite 201
+    zip: '73501'
+  - address: 2424 Springer Drive
+    building: ''
+    city: Norman
+    fax: 405-321-7369
+    phone: 405-329-6500
+    state: OK
+    suite: Suite 201
+    zip: '73069'
+- id:
+    bioguide: R000604
+    govtrack: 412650
+    thomas: '02265'
+  offices:
+  - address: 1015 North Broadway
+    building: ''
+    city: Oklahoma City
+    fax: 405-234-9909
+    phone: 405-234-9900
+    state: OK
+    suite: Suite 310
+    zip: '73102'
+- id:
+    bioguide: B001278
+    govtrack: 412501
+    thomas: 02092
+  offices:
+  - address: 12725 SW Millikan Way
+    building: ''
+    city: Beaverton
+    fax: 503-469-6018
+    phone: 503-469-6010
+    state: OR
+    suite: Suite 220
+    zip: '97005'
+- id:
+    bioguide: W000791
+    govtrack: 400419
+    thomas: 01596
+  offices:
+  - address: 14 North Central Avenue
+    building: ''
+    city: Medford
+    fax: 541-779-0204
+    phone: 800-533-3303
+    state: OR
+    suite: Suite 112
+    zip: '97501'
+  - address: 1211 Washington Avenue
+    building: ''
+    city: La Grande
+    fax: 541-624-2402
+    phone: 541-624-2400
+    state: OR
+    suite: ''
+    zip: '97850'
+  - address: 1051 NW Bond Street
+    building: ''
+    city: Bend
+    fax: 541-389-4452
+    phone: 541-389-4408
+    state: OR
+    suite: Suite 400
+    zip: '97701'
+- id:
+    bioguide: B000574
+    govtrack: 400033
+    thomas: 00099
+  offices:
+  - address: 911 North East 11th Avenue
+    building: ''
+    city: Portland
+    fax: 503-230-5413
+    phone: 503-231-2300
+    state: OR
+    suite: Suite 200
+    zip: '97232'
+- id:
+    bioguide: D000191
+    govtrack: 400100
+    thomas: 00279
+  offices:
+  - address: 612 Southeast Jackson St.
+    building: ''
+    city: Roseburg
+    fax: 541-440-3525
+    phone: 541-440-3523
+    state: OR
+    suite: Suite 9
+    zip: 97470-4956
+  - address: 125 Central Avenue
+    building: ''
+    city: Coos Bay
+    fax: 541-269-5760
+    phone: 541-269-2609
+    state: OR
+    suite: Suite 350
+    zip: 97420-2301
+  - address: 405 East 8th Avenue
+    building: ''
+    city: Eugene
+    fax: 541-465-6458
+    phone: 541-465-6732
+    state: OR
+    suite: '#2030'
+    zip: '97401'
+- id:
+    bioguide: S001180
+    govtrack: 412315
+    thomas: 01950
+  offices:
+  - address: 621 High Street
+    building: ''
+    city: Oregon City
+    fax: 503-557-1981
+    phone: 503-557-1324
+    state: OR
+    suite: ''
+    zip: '97045'
+  - address: 544 Ferry Street
+    building: ''
+    city: Salem
+    fax: 503-588-5517
+    phone: 503-588-9100
+    state: OR
+    suite: Suite 2
+    zip: '97301'
+- id:
+    bioguide: B001227
+    govtrack: 400047
+    thomas: 01469
+  offices:
+  - address: 1350 Edgmont Avenue
+    building: ''
+    city: Chester
+    fax: 484-816-0029
+    phone: 610-874-7094
+    state: PA
+    suite: Suite 2575
+    zip: 19013-4403
+  - address: 1907-09 South Broad Street
+    building: ''
+    city: Philadelphia
+    fax: 215-398-4636
+    phone: 215-389-4627
+    state: PA
+    suite: ''
+    zip: 19148-2216
+  - address: 2630 Memphis Street
+    building: ''
+    city: Philadelphia
+    fax: 215-426-7741
+    phone: 215-426-4616
+    state: PA
+    suite: ''
+    zip: 19125-2344
+  - address: 2637 East Clearfield Street
+    building: ''
+    city: Philadelphia
+    fax: 267-519-2262
+    phone: 267-519-2252
+    state: PA
+    suite: ''
+    zip: '19134'
+- id:
+    bioguide: F000043
+    govtrack: 400130
+    thomas: '00371'
+  offices:
+  - address: 2401 North 54th Street
+    building: ''
+    city: Philadelphia
+    fax: 215-871-4456
+    phone: 215-871-4455
+    state: PA
+    suite: ''
+    zip: '19131'
+- id:
+    bioguide: K000376
+    govtrack: 412465
+    thomas: '02051'
+  offices:
+  - address: 208 East Bayfront Parkway
+    building: ''
+    city: Erie
+    fax: 814-454-8197
+    phone: 814-454-8190
+    state: PA
+    suite: Suite 102
+    zip: '16507'
+  - address: 101 East Diamond Street
+    building: ''
+    city: Butler
+    fax: 724-282-3682
+    phone: 724-282-2557
+    state: PA
+    suite: Suite 218
+    zip: '16001'
+  - address: 33 Chestnut Avenue
+    building: ''
+    city: Sharon
+    fax: 724-342-7242
+    phone: 724-342-7170
+    state: PA
+    suite: ''
+    zip: '16146'
+- id:
+    bioguide: P000605
+    govtrack: 412569
+    thomas: '02157'
+  offices:
+  - address: 22 Chambersburg Street
+    building: ''
+    city: Gettysburg
+    fax: 717-334-6314
+    phone: 717-338-1919
+    state: PA
+    suite: ''
+    zip: '17325'
+  - address: 2209 East Market Street
+    building: ''
+    city: York
+    fax: 717-757-5001
+    phone: 717-600-1919
+    state: PA
+    suite: ''
+    zip: '17402'
+  - address: 730 North Front Street
+    building: ''
+    city: Wormleysburg
+    fax: 717-635-9861
+    phone: 717-635-9504
+    state: PA
+    suite: ''
+    zip: '17043'
+- id:
+    bioguide: T000467
+    govtrack: 412317
+    thomas: 01952
+  offices:
+  - address: 127 West Spring Street
+    building: ''
+    city: Titusville
+    fax: 814-827-7307
+    phone: 814-827-3985
+    state: PA
+    suite: Suite C
+    zip: '16354'
+  - address: 3555 Benner Pike
+    building: ''
+    city: Bellefonte
+    fax: 814-353-0218
+    phone: 814-353-0215
+    state: PA
+    suite: Suite 101
+    zip: '16823'
+- id:
+    bioguide: C001106
+    govtrack: 412651
+    thomas: '02266'
+  offices:
+  - address: 840 North Park Road
+    building: ''
+    city: Wyomissing
+    fax: 610-376-7633
+    phone: 610-376-7630
+    state: PA
+    suite: ''
+    zip: '19610'
+  - address: 111 East Uwchlan Avenue
+    building: ''
+    city: Exton
+    fax: 610-594-1419
+    phone: 610-594-1415
+    state: PA
+    suite: ''
+    zip: '19341'
+  - address: 21 West Market Street
+    building: ''
+    city: West Chester
+    fax: 610-696-2985
+    phone: 610- 696-2982
+    state: PA
+    suite: Suite 105
+    zip: '19382'
+- id:
+    bioguide: M001181
+    govtrack: 412466
+    thomas: '02052'
+  offices:
+  - address: 940 West Sproul Road
+    building: ''
+    city: Springfield
+    fax: 610-690-7329
+    phone: 610-690-7323
+    state: PA
+    suite: ''
+    zip: '19064'
+- id:
+    bioguide: F000451
+    govtrack: 400646
+    thomas: 01797
+  offices:
+  - address: 1717Langhorne Newtown Road
+    building: ''
+    city: Langhorne
+    fax: 215-579-8109
+    phone: 215-579-8102
+    state: PA
+    suite: Suite 400
+    zip: '19047'
+- id:
+    bioguide: S001154
+    govtrack: 409888
+    thomas: 01681
+  offices:
+  - address: 310 Penn Street
+    building: ''
+    city: Hollidaysburg
+    fax: 814-696-6726
+    phone: 814-696-6318
+    state: PA
+    suite: Suite 200
+    zip: '16648'
+  - address: 827 Water Street
+    building: ''
+    city: Indiana
+    fax: 724-463-0518
+    phone: 724-463-0516
+    state: PA
+    suite: '#3'
+    zip: '15701'
+  - address: 100 Lincoln Way East
+    building: ''
+    city: Chambersburg
+    fax: 717-264-0269
+    phone: 717-264-8308
+    state: PA
+    suite: Suite B
+    zip: '17201'
+- id:
+    bioguide: M001179
+    govtrack: 412468
+    thomas: '02053'
+  offices:
+  - address: 1020 Commerce Park Drive
+    building: ''
+    city: Williamsport
+    fax: 570-322-3965
+    phone: 570-322-3961
+    state: PA
+    suite: Suite 1A
+    zip: '17701'
+  - address: 713 Bridge Street
+    building: ''
+    city: Selinsgrove
+    fax: 570-374-3598
+    phone: 570-374-9469
+    state: PA
+    suite: Room 29
+    zip: '17870'
+  - address: 543 Easton Turnpike
+    building: ''
+    city: Lake Ariel
+    fax: 570-689-6028
+    phone: 570-689-6024
+    state: PA
+    suite: Suite 101
+    zip: '18436'
+- id:
+    bioguide: B001269
+    govtrack: 412469
+    thomas: '02054'
+  offices:
+  - address: 1 South Church Street
+    building: ''
+    city: Hazleton
+    fax: 570-751-0054
+    phone: 570-751-0050
+    state: PA
+    suite: Suite 100
+    zip: '18201'
+  - address: 59 West Louther Street
+    building: ''
+    city: Carlisle
+    fax: 717-218-0190
+    phone: 717-249-0190
+    state: PA
+    suite: ''
+    zip: '17013'
+  - address: 4813 Jonestown Road
+    building: ''
+    city: Harrisburg
+    fax: 717-695-6794
+    phone: 717-525-7002
+    state: PA
+    suite: Suite 101
+    zip: '17109'
+  - address: 106 Arch Street
+    building: ''
+    city: Sunbury
+    fax: 570-988-7805
+    phone: 570-988-7801
+    state: PA
+    suite: ''
+    zip: '17801'
+- id:
+    bioguide: R000598
+    govtrack: 412570
+    thomas: 02158
+  offices:
+  - address: 6000 Babcock Boulevard
+    building: ''
+    city: Pittsburgh
+    fax: 412-593-2022
+    phone: 412-837-1361
+    state: PA
+    suite: Suite 104
+    zip: '15237'
+  - address: 110 Franklin Street
+    building: ''
+    city: Johnstown
+    fax: 412-593-2022
+    phone: 814-619-3659
+    state: PA
+    suite: Suite 150
+    zip: '15901'
+  - address: 650 Corporation Street
+    building: ''
+    city: Beaver
+    fax: 412-593-2022
+    phone: 724-359-1626
+    state: PA
+    suite: Suite 304
+    zip: '15009'
+- id:
+    bioguide: B001296
+    govtrack: 412652
+    thomas: '02267'
+  offices:
+  - address: 801 Old York Road
+    building: ''
+    city: Jenkintown
+    fax: 215-517-6575
+    phone: 215-517-6572
+    state: PA
+    suite: Suite 212
+    zip: '19046'
+  - address: 5675 North Front Street
+    building: ''
+    city: Philadelphia
+    fax: 267-437-3886
+    phone: 267-335-5643
+    state: PA
+    suite: Suite 180
+    zip: '19120'
+  - address: 2375 Woodward Street
+    building: ''
+    city: Philadelphia
+    fax: 215-856-3734
+    phone: 215-335-3355
+    state: PA
+    suite: Suite 105
+    zip: '19155'
+  - address: 115 East Glenside Avenue
+    building: ''
+    city: Glenside
+    fax: 215-277-7225
+    phone: 215-517-6572
+    state: PA
+    suite: Suite 1
+    zip: '19038'
+- id:
+    bioguide: D000482
+    govtrack: 400114
+    thomas: '00316'
+  offices:
+  - address: 11 Duff Road
+    building: ''
+    city: Penn Hills
+    fax: 412-241-6820
+    phone: 412-241-6055
+    state: PA
+    suite: ''
+    zip: 15235-3263
+  - address: 627 Lysle Boulevard
+    building: ''
+    city: McKeesport
+    fax: 412-664-4053
+    phone: 412-664-4049
+    state: PA
+    suite: ''
+    zip: '15132'
+  - address: 2637 East Carson Street
+    building: ''
+    city: Pittsburgh
+    fax: 412-390-2118
+    phone: 412-390-1499
+    state: PA
+    suite: ''
+    zip: '15203'
+- id:
+    bioguide: D000604
+    govtrack: 400648
+    thomas: 01799
+  offices:
+  - address: 3900 Hamilton Boulevard
+    building: ''
+    city: Allentown
+    fax: 610-770-3498
+    phone: 610-770-3490
+    state: PA
+    suite: Suite 207
+    zip: '18103'
+  - address: 61 North 3rd Street
+    building: ''
+    city: Hamburg
+    fax: 610-562-4352
+    phone: 610-562-4281
+    state: PA
+    suite: ''
+    zip: '19526'
+  - address: 250 West Chocolate Avenue
+    building: ''
+    city: Hershey
+    fax: 717-533-3979
+    phone: 717-533-3959
+    state: PA
+    suite: Suite 2
+    zip: '17033'
+  - address: 342 West Main Street
+    building: ''
+    city: Annville
+    fax: 717-867-1540
+    phone: 717-867-1026
+    state: PA
+    suite: ''
+    zip: '17003'
+- id:
+    bioguide: P000373
+    govtrack: 400320
+    thomas: '01514'
+  offices:
+  - address: 150 North Queen Street
+    building: ''
+    city: Lancaster
+    fax: 717-393-0924
+    phone: 717-393-0667
+    state: PA
+    suite: Suite 716
+    zip: '17602'
+  - address: Routes 82 and 926
+    building: ''
+    city: Unionville
+    fax: 610-444-5750
+    phone: 610-444-4581
+    state: PA
+    suite: PO Box 837
+    zip: '19375'
+- id:
+    bioguide: C001090
+    govtrack: 412571
+    thomas: 02159
+  offices:
+  - address: 226 Wyoming Avenue
+    building: ''
+    city: Scranton
+    fax: 570-341-1055
+    phone: 570-341-1050
+    state: PA
+    suite: ''
+    zip: '18503'
+  - address: 121 Progress Avenue
+    building: ''
+    city: Pottsville
+    fax: 570-622-2902
+    phone: 570-624-0140
+    state: PA
+    suite: Suite 310
+    zip: '17901'
+  - address: 400 Northampton
+    building: ''
+    city: Easton
+    fax: 610-252-3257
+    phone: 484-546-0776
+    state: PA
+    suite: Suite 307
+    zip: '18042'
+- id:
+    bioguide: M001151
+    govtrack: 400285
+    thomas: '01744'
+  offices:
+  - address: 2040 Frederickson Place
+    building: ''
+    city: Greensburg
+    fax: 724-850-7315
+    phone: 724-850-7312
+    state: PA
+    suite: ''
+    zip: '15601'
+  - address: 504 Washington Road
+    building: ''
+    city: Pittsburgh
+    fax: 412-429-5092
+    phone: 412-344-5583
+    state: PA
+    suite: ''
+    zip: '15228'
+- id:
+    bioguide: P000596
+    govtrack: 412306
+    thomas: 01953
+  offices:
+  - address: Ant. Edif. Medicina Tropical
+    building: 157 Ave. de la Constitución
+    city: San Juan
+    fax: 787-729-7738
+    phone: 787-723-6333
+    state: PR
+    suite: ''
+    zip: 00901
+- id:
+    bioguide: C001084
+    govtrack: 412470
+    thomas: '02055'
+  offices:
+  - address: 1070 Main Street
+    building: ''
+    city: Pawtucket
+    fax: 401-729-5608
+    phone: 401-729-5600
+    state: RI
+    suite: Suite 300
+    zip: 02860
+- id:
+    bioguide: L000559
+    govtrack: 400230
+    thomas: 01668
+  offices:
+  - address: 300 Centerville Road
+    building: ''
+    city: Warwick
+    fax: 401-737-2982
+    phone: 401-732-9400
+    state: RI
+    suite: Suite 200 South
+    zip: 02886
+- id:
+    bioguide: S000051
+    govtrack: 400607
+    thomas: '01012'
+  offices:
+  - address: 530 Johnnie Dobbs Boulevard
+    building: ''
+    city: Mount Pleasant
+    fax: 843-352-7620
+    phone: 843-352-7572
+    state: SC
+    suite: Suite 201
+    zip: '29464'
+  - address: 710 Boundary Street, Suite 1D
+    building: ''
+    city: Beaufort
+    fax: 843-521-2535
+    phone: 843-521-2530
+    state: SC
+    suite: PO Box 1538
+    zip: '29902'
+- id:
+    bioguide: W000795
+    govtrack: 400433
+    thomas: 01688
+  offices:
+  - address: 1700 Sunset Boulevard
+    building: ''
+    city: West Columbia
+    fax: 803-939-0078
+    phone: 803-939-0041
+    state: SC
+    suite: Suite 1
+    zip: '29169'
+  - address: 1930 University Parkway, Suite 1600
+    building: ''
+    city: Aiken
+    fax: 803-642-6418
+    phone: 803-642-6416
+    state: SC
+    suite: PO Box 104
+    zip: '29801'
+- id:
+    bioguide: D000615
+    govtrack: 412472
+    thomas: '02057'
+  offices:
+  - address: 1028 Hayne Avenue, SW
+    building: ''
+    city: Aiken
+    fax: 803-648-9038
+    phone: 803-649-5571
+    state: SC
+    suite: ''
+    zip: 29801-3730
+  - address: 303 West Beltline Boulevard
+    building: ''
+    city: Anderson
+    fax: 864-225-7049
+    phone: 864-224-7401
+    state: SC
+    suite: ''
+    zip: 29625-1505
+  - address: 200 Courthouse Public Square
+    building: ''
+    city: Laurens
+    fax: 864-681-1030
+    phone: 864-681-1028
+    state: SC
+    suite: PO Box 471
+    zip: '29360'
+  - address: 401 Adams Avenue
+    building: ''
+    city: Montgomery
+    fax: 334-262-8758
+    phone: 334-262-7718
+    state: AL
+    suite: Suite 160
+    zip: '36104'
+- id:
+    bioguide: G000566
+    govtrack: 412473
+    thomas: 02058
+  offices:
+  - address: 104 South Main Street
+    building: ''
+    city: Greenville
+    fax: 864-241-0982
+    phone: 864-241-0175
+    state: SC
+    suite: Suite 801
+    zip: '29601'
+  - address: 101 West St. John Street
+    building: ''
+    city: Spartanburg
+    fax: 864-583-3926
+    phone: 864-583-3264
+    state: SC
+    suite: ''
+    zip: '29308'
+- id:
+    bioguide: M001182
+    govtrack: 412474
+    thomas: 02059
+  offices:
+  - address: 1456 Ebenezer Road
+    building: ''
+    city: Rock Hill
+    fax: 803-327-4330
+    phone: 803-327-1114
+    state: SC
+    suite: ''
+    zip: '29732'
+  - address: 531-A Oxford Drive
+    building: ''
+    city: Sumter
+    fax: 803-774-0188
+    phone: 803-774-0186
+    state: SC
+    suite: ''
+    zip: '29150'
+  - address: 110 Railroad Avenue
+    building: ''
+    city: Gaffney
+    fax: 864-206-6005
+    phone: 864-206-6004
+    state: SC
+    suite: ''
+    zip: '29340'
+- id:
+    bioguide: C000537
+    govtrack: 400075
+    thomas: 00208
+  offices:
+  - address: 176 Brooks Boulevard
+    building: ''
+    city: Santee
+    fax: 803-854-4900
+    phone: 803-854-4700
+    state: SC
+    suite: ''
+    zip: '29142'
+  - address: 130 West Main Street
+    building: ''
+    city: Kingstree
+    fax: 843-355-1232
+    phone: 843-355-1211
+    state: SC
+    suite: ''
+    zip: '29556'
+  - address: 1225 Lady Street
+    building: ''
+    city: Columbia
+    fax: 803-799-9060
+    phone: 803-799-1100
+    state: SC
+    suite: Suite 200
+    zip: 29201-3415
+- id:
+    bioguide: R000597
+    govtrack: 412572
+    thomas: '02160'
+  offices:
+  - address: 2411 North Oak Street
+    building: ''
+    city: Myrtle Beach
+    fax: 843-445-6418
+    phone: 843-445-6459
+    state: SC
+    suite: Suite 405
+    zip: '29577'
+  - address: 1831 West Evans Street
+    building: ''
+    city: Florence
+    fax: 843-679-9783
+    phone: 843-679-9781
+    state: SC
+    suite: Suite 300
+    zip: '29501'
+- id:
+    bioguide: N000184
+    govtrack: 412475
+    thomas: '02060'
+  offices:
+  - address: 300 North Dakota Avenue
+    building: ''
+    city: Sioux Falls
+    fax: 605-275-2875
+    phone: 605-275-2868
+    state: SD
+    suite: Suite 314
+    zip: '57105'
+  - address: 343 Quincy Street
+    building: ''
+    city: Rapid City
+    fax: 605-791-4679
+    phone: 605-791-4673
+    state: SD
+    suite: ''
+    zip: '57701'
+  - address: 818 South Broadway
+    building: ''
+    city: Watertown
+    fax: 605-878-2871
+    phone: 605-878-2868
+    state: SD
+    suite: Suite 113
+    zip: '57201'
+  - address: 415 South Main Street
+    building: ''
+    city: Aberdeen
+    fax: 605-262-2869
+    phone: 605-262-2862
+    state: SD
+    suite: Suite 203
+    zip: '57401'
+- id:
+    bioguide: R000582
+    govtrack: 412310
+    thomas: 01954
+  offices:
+  - address: 1609 Walters State CC Drive
+    building: ''
+    city: Morristown
+    fax: 423-254-1403
+    phone: 423-254-1400
+    state: TN
+    suite: Unit 4
+    zip: '37813'
+  - address: 205 Revere Street
+    building: ''
+    city: Kingsport
+    fax: 423-247-0119
+    phone: 423-247-8161
+    state: TN
+    suite: ''
+    zip: '37660'
+- id:
+    bioguide: D000533
+    govtrack: 400116
+    thomas: '00322'
+  offices:
+  - address: 800 Market Street
+    building: ''
+    city: Knoxville
+    fax: 865-544-0728
+    phone: 865-523-3772
+    state: TN
+    suite: Suite 110
+    zip: 37902-2312
+  - address: 331 Court Street
+    building: ''
+    city: Maryville
+    fax: 865-984-0521
+    phone: 865-984-5464
+    state: TN
+    suite: ''
+    zip: '37804'
+- id:
+    bioguide: F000459
+    govtrack: 412476
+    thomas: '02061'
+  offices:
+  - address: 900 Georgia Avenue
+    building: ''
+    city: Chattanooga
+    fax: 423-756-6613
+    phone: 423-756-2342
+    state: TN
+    suite: Suite 126
+    zip: '37402'
+  - address: 200 Administration Road
+    building: ''
+    city: Oak Ridge
+    fax: 865-576-3221
+    phone: 865-576-1976
+    state: TN
+    suite: Suite 100
+    zip: '37830'
+  - address: 6 East Madison Avenue
+    building: ''
+    city: Athens
+    fax: 423-745-6025
+    phone: 423-745-4671
+    state: TN
+    suite: ''
+    zip: '37303'
+  - address: 6 East Madison Avenue
+    building: ''
+    city: Athens
+    fax: 423-745-6025
+    phone: 423-745-4671
+    state: TN
+    suite: ''
+    zip: '37303'
+- id:
+    bioguide: D000616
+    govtrack: 412477
+    thomas: '02062'
+  offices:
+  - address: 200 South Jefferson Street
+    building: Federal Building
+    city: Winchester
+    fax: 931-962-3435
+    phone: 931-962-3180
+    state: TN
+    suite: Suite 311
+    zip: '37398'
+  - address: 305 West Main Street
+    building: ''
+    city: Murfreesboro
+    fax: 615-896-8218
+    phone: 615-896-1986
+    state: TN
+    suite: ''
+    zip: '37130'
+  - address: 301 Keith Street
+    building: ''
+    city: Cleveland
+    fax: 423-472-7800
+    phone: 423-472-7500
+    state: TN
+    suite: Suite 212
+    zip: '37311'
+  - address: 711 North Garden Street
+    building: ''
+    city: Columbia
+    fax: 931-381-9945
+    phone: 931-381-9920
+    state: TN
+    suite: ''
+    zip: '38401'
+- id:
+    bioguide: C000754
+    govtrack: 400081
+    thomas: '00231'
+  offices:
+  - address: 605 Church Street
+    building: ''
+    city: Nashville
+    fax: 615-736-7479
+    phone: 615-736-5295
+    state: TN
+    suite: ''
+    zip: '32719'
+- id:
+    bioguide: B001273
+    govtrack: 412478
+    thomas: '02063'
+  offices:
+  - address: 29 Taylor Avenue
+    building: ''
+    city: Crossville
+    fax: 931-206-8980
+    phone: 931-854-0069
+    state: TN
+    suite: Suite 201
+    zip: '38555'
+  - address: 321 East Spring Street
+    building: ''
+    city: Cookeville
+    fax: 615-206-8980
+    phone: 931-854-0069
+    state: TN
+    suite: Suite 301
+    zip: '38501'
+  - address: 355 North Belvedere Drive
+    building: ''
+    city: Gallatin
+    fax: 615-206-8980
+    phone: 615-206-8204
+    state: TN
+    suite: Suite 308
+    zip: '37066'
+- id:
+    bioguide: B001243
+    govtrack: 400032
+    thomas: 01748
+  offices:
+  - address: 305 Public Square
+    building: ''
+    city: Franklin
+    fax: 615-599-2916
+    phone: 615-591-5161
+    state: TN
+    suite: Suite 212
+    zip: '37064'
+  - address: 7975 Stage Hills Boulevard
+    building: ''
+    city: Memphis
+    fax: 901-373-8215
+    phone: 901-382-5811
+    state: TN
+    suite: Suite 1
+    zip: '38133'
+  - address: 128 North 2nd Street
+    building: ''
+    city: Clarksville
+    fax: 931-503-0393
+    phone: 931-503-0391
+    state: TN
+    suite: Suite 202
+    zip: '37040'
+- id:
+    bioguide: F000458
+    govtrack: 412479
+    thomas: '02064'
+  offices:
+  - address: 117 North Liberty Street
+    building: ''
+    city: Jackson
+    fax: 731-427-1537
+    phone: 731-423-4848
+    state: TN
+    suite: ''
+    zip: '38301'
+  - address: 100 South Main Street
+    building: ''
+    city: Dyersburg
+    fax: 731-285-5008
+    phone: 731-285-0910
+    state: TN
+    suite: Suite 1
+    zip: '38024'
+  - address: 406 Lindell Street South
+    building: ''
+    city: Martin
+    fax: ''
+    phone: 731-588-5190
+    state: TN
+    suite: Suite C
+    zip: '38237'
+  - address: 5384 Poplar Avenue
+    building: ''
+    city: Memphis
+    fax: ''
+    phone: 901-682-4422
+    state: TN
+    suite: Suite 410
+    zip: '38119'
+  - address: 12015 Walker Street
+    building: ''
+    city: Arlington
+    fax: ''
+    phone: 901-581-4718
+    state: TN
+    suite: ''
+    zip: '38002'
+- id:
+    bioguide: C001068
+    govtrack: 412236
+    thomas: 01878
+  offices:
+  - address: 167 North Main Street
+    building: Clifford Davis/Odell Horton Federal Building
+    city: Memphis
+    fax: 901-544-4329
+    phone: 901-544-4131
+    state: TN
+    suite: Suite 369
+    zip: '38103'
+- id:
+    bioguide: G000552
+    govtrack: 400651
+    thomas: 01801
+  offices:
+  - address: 101 East Methvin
+    building: ''
+    city: Longview
+    fax: ''
+    phone: 903-236-8597
+    state: TX
+    suite: Suite 302
+    zip: '75601'
+  - address: 300 East Shepherd
+    building: ''
+    city: Lufkin
+    fax: ''
+    phone: 936-632-3180
+    state: TX
+    suite: ''
+    zip: '75901'
+  - address: 1121 ESE Loop 323
+    building: ''
+    city: Tyler
+    fax: 903-561-7110
+    phone: 903-561-6349
+    state: TX
+    suite: Suite 206
+    zip: '75701'
+  - address: 102 West Houston Street
+    building: ''
+    city: Marshall
+    fax: ''
+    phone: 903-938-8386
+    state: TX
+    suite: ''
+    zip: '75670'
+  - address: 101 West Main
+    building: ''
+    city: Nacogdoches
+    fax: ''
+    phone: 936-715-9514
+    state: TX
+    suite: Suite 160
+    zip: '75961'
+- id:
+    bioguide: P000592
+    govtrack: 400652
+    thomas: 01802
+  offices:
+  - address: 710 North Post Oak Road
+    building: ''
+    city: Houston
+    fax: 281-446-0252
+    phone: 281-446-0242
+    state: TX
+    suite: Suite 510
+    zip: '77024'
+  - address: 1801 Kingwood Drive
+    building: ''
+    city: Kingwood
+    fax: 281-446-0252
+    phone: 281-446-0242
+    state: TX
+    suite: Suite 240
+    zip: '77339'
+- id:
+    bioguide: J000174
+    govtrack: 400206
+    thomas: '00603'
+  offices:
+  - address: 1255 West 15th Street
+    building: ''
+    city: Plano
+    fax: 469-304-0392
+    phone: 469-304-0382
+    state: TX
+    suite: Suite 170
+    zip: '75075'
+- id:
+    bioguide: R000601
+    govtrack: 412653
+    thomas: 02268
+  offices:
+  - address: 2600 North Robinson Road
+    building: ''
+    city: Texarkana
+    fax: 903- 832-3232
+    phone: 903- 823-3173
+    state: TX
+    suite: Suite 190
+    zip: '75599'
+  - address: 6531 Horizon Road
+    building: ''
+    city: Rockwall
+    fax: 972-771-1222
+    phone: 972-771-0001
+    state: TX
+    suite: Suite A
+    zip: '75032'
+  - address: 100 West Houston Street
+    building: ''
+    city: Sherman
+    fax: 903-868-8613
+    phone: 903-813-5270
+    state: TX
+    suite: 2nd Floor
+    zip: 75090-0041
+- id:
+    bioguide: H001036
+    govtrack: 400175
+    thomas: 01749
+  offices:
+  - address: 6510 Abrams Road
+    building: ''
+    city: Dallas
+    fax: 214-349-0738
+    phone: 214-349-9996
+    state: TX
+    suite: Suite 243
+    zip: '75231'
+  - address: 810 East Corsicana Street
+    building: ''
+    city: Athens
+    fax: 903-675-8351
+    phone: 903-675-8288
+    state: TX
+    suite: Suite C
+    zip: '75751'
+- id:
+    bioguide: B000213
+    govtrack: 400018
+    thomas: '00062'
+  offices:
+  - address: 6001 West Ronald Reagan Memorial Highway
+    building: ''
+    city: Arlington
+    fax: 817-548-7029
+    phone: 817-543-1000
+    state: TX
+    suite: Suite 200
+    zip: '76017'
+  - address: 2106 A West Ennis Avenue
+    building: ''
+    city: Ennis
+    fax: 972-875-1907
+    phone: 972-875-8488
+    state: TX
+    suite: ''
+    zip: '75119'
+- id:
+    bioguide: C001048
+    govtrack: 400089
+    thomas: '01670'
+  offices:
+  - address: 10000 Memorial Drive
+    building: ''
+    city: Houston
+    fax: 713-680-8070
+    phone: 713-682-8828
+    state: TX
+    suite: Suite 620
+    zip: 77024-3490
+- id:
+    bioguide: B000755
+    govtrack: 400046
+    thomas: 01468
+  offices:
+  - address: 1300 11th Street
+    building: ''
+    city: Huntsville
+    fax: 936-439-9546
+    phone: 936-439-9532
+    state: TX
+    suite: Suite 400
+    zip: '77340'
+  - address: 200 River Pointe
+    building: ''
+    city: Conroe
+    fax: 936-441-5757
+    phone: 936-441-5700
+    state: TX
+    suite: Suite 304
+    zip: 77304-2817
+- id:
+    bioguide: G000553
+    govtrack: 400653
+    thomas: 01803
+  offices:
+  - address: 3003 South Loop West
+    building: ''
+    city: Houston
+    fax: 713-383-9202
+    phone: 713-383-9234
+    state: TX
+    suite: Suite 460
+    zip: '77054'
+- id:
+    bioguide: M001157
+    govtrack: 400654
+    thomas: 01804
+  offices:
+  - address: 990 Village Square
+    building: Rosewood Professional Building
+    city: Tomball
+    fax: 281-255-0034
+    phone: 281-255-8372
+    state: TX
+    suite: Suite B
+    zip: '77375'
+  - address: 2000 South Market Street
+    building: ''
+    city: Brenham
+    fax: 979-830-1984
+    phone: 979-830-8497
+    state: TX
+    suite: Suite 303
+    zip: '77833'
+  - address: 9009 Mountain Ridge Drive
+    building: Austin Building
+    city: Austin
+    fax: 512-473-0514
+    phone: 512-473-2357
+    state: TX
+    suite: Suite 230
+    zip: '78759'
+- id:
+    bioguide: C001062
+    govtrack: 400655
+    thomas: 01805
+  offices:
+  - address: 6 Desta Drive
+    building: ''
+    city: Midland
+    fax: 432-687-0277
+    phone: 432-687-2390
+    state: TX
+    suite: Suite 2000
+    zip: '79705'
+  - address: 104 West Sandstone
+    building: County Annex
+    city: Llano
+    fax: 325-247-2676
+    phone: 325-247-2826
+    state: TX
+    suite: ''
+    zip: '78643'
+  - address: 411 West 8th Street
+    building: City Hall
+    city: Odessa
+    fax: 432-332-6538
+    phone: 432-331-9667
+    state: TX
+    suite: 5th Floor
+    zip: '79761'
+  - address: 33 East Twohig
+    building: ''
+    city: San Angelo
+    fax: 325-659-4014
+    phone: 325-659-4010
+    state: TX
+    suite: Suite 307
+    zip: '76903'
+  - address: 501 Center Avenue
+    building: Brownwood City Hall
+    city: Brownwood
+    fax: 325-646-2979
+    phone: 325-646-1950
+    state: TX
+    suite: ''
+    zip: '76801'
+  - address: 132 Houston Street
+    building: ''
+    city: Granbury
+    fax: 682-936-2567
+    phone: 682-936-2577
+    state: TX
+    suite: ''
+    zip: '76048'
+- id:
+    bioguide: G000377
+    govtrack: 400157
+    thomas: 01487
+  offices:
+  - address: 1701 River Run Road
+    building: ''
+    city: Fort Worth
+    fax: 817-335-5852
+    phone: 817-338-0909
+    state: TX
+    suite: Suite 407
+    zip: '76107'
+- id:
+    bioguide: T000238
+    govtrack: 400404
+    thomas: '01155'
+  offices:
+  - address: 905 South Fillmore Street
+    building: ''
+    city: Amarillo
+    fax: 806-371-7044
+    phone: 806-371-8844
+    state: TX
+    suite: Suite 520
+    zip: '79101'
+  - address: 2525 Kell Boulevard
+    building: ''
+    city: Wichita Falls
+    fax: 940-692-0539
+    phone: 940-692-1700
+    state: TX
+    suite: Suite 406
+    zip: '76308'
+- id:
+    bioguide: W000814
+    govtrack: 412574
+    thomas: '02161'
+  offices:
+  - address: 505 Orleans Street
+    building: ''
+    city: Beaumont
+    fax: 409-835-0578
+    phone: 409-835-0108
+    state: TX
+    suite: Suite 103
+    zip: '77701'
+  - address: 122 West Way
+    building: ''
+    city: Lake Jackson
+    fax: 979-285-0271
+    phone: 979-285-0231
+    state: TX
+    suite: Suite 301
+    zip: '77566'
+  - address: 174 Calder Road
+    building: ''
+    city: League City
+    fax: 281-316-0271
+    phone: 281-316-0231
+    state: TX
+    suite: Suite 150
+    zip: '77573'
+- id:
+    bioguide: H000636
+    govtrack: 400179
+    thomas: 01490
+  offices:
+  - address: 2864 West Trenton Road
+    building: ''
+    city: Edinburg
+    fax: 956-682-0141
+    phone: 956-682-5545
+    state: TX
+    suite: ''
+    zip: '78539'
+  - address: 100 South Austin Street
+    building: ''
+    city: Seguin
+    fax: 830-379-0984
+    phone: 830-401-0457
+    state: TX
+    suite: Suite 1
+    zip: '78155'
+- id:
+    bioguide: O000170
+    govtrack: 412575
+    thomas: '02162'
+  offices:
+  - address: 303 North Oregon Street
+    building: ''
+    city: El Paso
+    fax: ''
+    phone: 915-541-1400
+    state: TX
+    suite: Suite 210
+    zip: '79901'
+- id:
+    bioguide: F000461
+    govtrack: 412480
+    thomas: '02065'
+  offices:
+  - address: 3000 Briarcrest Drive
+    building: ''
+    city: Bryan
+    fax: 979-703-8845
+    phone: 979-703-4037
+    state: TX
+    suite: Suite 406
+    zip: '77802'
+  - address: 400 Austin Avenue
+    building: ''
+    city: Waco
+    fax: 254-732-1755
+    phone: 254-732-0748
+    state: TX
+    suite: Suite 302
+    zip: '76701'
+  - address: 14205 Burnet Road
+    building: ''
+    city: Austin
+    fax: 512-373-3511
+    phone: 512-373-3378
+    state: TX
+    suite: Suite 230
+    zip: '78728'
+- id:
+    bioguide: J000032
+    govtrack: 400199
+    thomas: 00588
+  offices:
+  - address: 1919 Smith Street
+    building: ''
+    city: Houston
+    fax: 713-655-1612
+    phone: 713-655-0050
+    state: TX
+    suite: Suite 1180
+    zip: 77002-8049
+  - address: 6719 West Montgomery
+    building: ''
+    city: Houston
+    fax: ''
+    phone: 713-691-4882
+    state: TX
+    suite: Suite 204
+    zip: 77091-3105
+  - address: 420 West 19th Street
+    building: ''
+    city: Houston
+    fax: ''
+    phone: 713-861-4070
+    state: TX
+    suite: ''
+    zip: 77008-3914
+  - address: 4300 Lyons Avenue
+    building: ''
+    city: Houston
+    fax: 713-227-7707
+    phone: 713-227-7740
+    state: TX
+    suite: ''
+    zip: '77020'
+- id:
+    bioguide: N000182
+    govtrack: 400441
+    thomas: 01758
+  offices:
+  - address: 1510 Scurry Street
+    building: ''
+    city: Big Spring
+    fax: 432-264-1838
+    phone: 432-264-0722
+    state: TX
+    suite: Suite B
+    zip: '79720'
+  - address: 500 Chestnut Street
+    building: ''
+    city: Abilene
+    fax: 325-675-5038
+    phone: 325-675-9779
+    state: TX
+    suite: Room 819
+    zip: '79602'
+  - address: 611 University Avenue
+    building: ''
+    city: Lubbock
+    fax: 806-767-9168
+    phone: 806-763-1611
+    state: TX
+    suite: Suite 220
+    zip: '79401'
+- id:
+    bioguide: C001091
+    govtrack: 412576
+    thomas: '02163'
+  offices:
+  - address: 727 E. Cesar E. Chavez Boulevard
+    building: ''
+    city: San Antonio
+    fax: 210-979-0737
+    phone: 210-348-8216
+    state: TX
+    suite: Suite B-128
+    zip: '78206'
+- id:
+    bioguide: S000583
+    govtrack: 400381
+    thomas: '01075'
+  offices:
+  - address: 1100 NE Loop 410
+    building: Guaranty Bank Building
+    city: San Antonio
+    fax: 210-821-5947
+    phone: 210-821-5024
+    state: TX
+    suite: Suite 640
+    zip: '78209'
+  - address: 301 Junction Highway
+    building: ''
+    city: Kerrville
+    fax: 830-896-0168
+    phone: 830-896-0154
+    state: TX
+    suite: Suite 346C
+    zip: '78028'
+- id:
+    bioguide: O000168
+    govtrack: 412302
+    thomas: 01955
+  offices:
+  - address: 1650 Highway 6
+    building: ''
+    city: Sugar Land
+    fax: 281-494-2649
+    phone: 281-494-2690
+    state: TX
+    suite: Suite 150
+    zip: '77477'
+  - address: 6302 West Broadway Street
+    building: ''
+    city: Pearland
+    fax: 281-485-4850
+    phone: 281-485-4855
+    state: TX
+    suite: Suite 220
+    zip: '77581'
+  - address: 22333 Grand Corner Drive
+    building: ''
+    city: Katy
+    fax: ''
+    phone: 281-889-7134
+    state: TX
+    suite: Suite 151
+    zip: '77494'
+- id:
+    bioguide: H001073
+    govtrack: 412654
+    thomas: 02269
+  offices:
+  - address: 17721 Rogers Branch Parkway
+    building: Texas A&M San Antonio Patriots' Casa
+    city: San Antonio
+    fax: 210-927-4903
+    phone: 210-921-3130
+    state: TX
+    suite: Suite 120
+    zip: '78258'
+  - address: One University Way
+    building: ''
+    city: San Antonio
+    fax: ''
+    phone: 210-784-5023
+    state: TX
+    suite: Suite 212E & 212F
+    zip: '78224'
+  - address: 1104 West 10th Street
+    building: ''
+    city: Del Rio
+    fax: ''
+    phone: 830-422-2040
+    state: TX
+    suite: ''
+    zip: 78840-8503
+  - address: 100 Monroe Street
+    building: ''
+    city: Eagle Pass
+    fax: ''
+    phone: 210-238-4296
+    state: TX
+    suite: ''
+    zip: 78852-4830
+  - address: 124 South Horizon Boulevard
+    building: ''
+    city: Sorocco
+    fax: ''
+    phone: 915-235-6421
+    state: TX
+    suite: ''
+    zip: 79927-2620
+- id:
+    bioguide: M001158
+    govtrack: 400656
+    thomas: 01806
+  offices:
+  - address: 9901 East Valley Ranch Parkway
+    building: ''
+    city: Irving
+    fax: 972-409-9704
+    phone: 972-556-0162
+    state: TX
+    suite: Suite 2060
+    zip: '75063'
+- id:
+    bioguide: W000816
+    govtrack: 412578
+    thomas: '02165'
+  offices:
+  - address: 1005 Congress Avenue
+    building: ''
+    city: Austin
+    fax: 512-473-8946
+    phone: 512-473-8910
+    state: TX
+    suite: Suite 925
+    zip: '78701'
+  - address: 1 Walnut Street
+    building: ''
+    city: Cleburne
+    fax: 817-774-2576
+    phone: 817-774-2575
+    state: TX
+    suite: Suite 145
+    zip: '76033'
+- id:
+    bioguide: B001248
+    govtrack: 400052
+    thomas: '01751'
+  offices:
+  - address: 2000 South Stemmons Freeway
+    building: ''
+    city: Lake Dallas
+    fax: 940-497-5067
+    phone: 940-497-5031
+    state: TX
+    suite: Suite 200
+    zip: '75065'
+- id:
+    bioguide: F000460
+    govtrack: 412482
+    thomas: '02067'
+  offices:
+  - address: 5606 North Navarro Street
+    building: ''
+    city: Victoria
+    fax: 361-894-6460
+    phone: 361-894-6446
+    state: TX
+    suite: Suite 203
+    zip: '77904'
+  - address: 101 North Shoreline Boulevard
+    building: ''
+    city: Corpus Christi
+    fax: 361-884-2223
+    phone: 361-884-2222
+    state: TX
+    suite: Suite 300
+    zip: '78401'
+- id:
+    bioguide: C001063
+    govtrack: 400657
+    thomas: 01807
+  offices:
+  - address: 100 North F.M. 3167
+    building: ''
+    city: Rio Grande City
+    fax: 956-488-0952
+    phone: 956-487-5603
+    state: TX
+    suite: ''
+    zip: '78582'
+  - address: 117 East Tom Landry
+    building: ''
+    city: Mission
+    fax: 956-424-3936
+    phone: 956-424-3942
+    state: TX
+    suite: ''
+    zip: '78572'
+  - address: 615 East Houston Street
+    building: ''
+    city: San Antonio
+    fax: 210-277-6671
+    phone: 210-271-2851
+    state: TX
+    suite: Suite 563
+    zip: '78205'
+  - address: 602 East Calton Road
+    building: ''
+    city: Laredo
+    fax: 956-725-2647
+    phone: 956-725-0639
+    state: TX
+    suite: Suite 2
+    zip: '78041'
+- id:
+    bioguide: G000410
+    govtrack: 400160
+    thomas: '00462'
+  offices:
+  - address: 11811 I-10 East
+    building: ''
+    city: Houston
+    fax: 713-330-0807
+    phone: 713-330-0761
+    state: TX
+    suite: Suite 430
+    zip: '77029'
+  - address: 256 North Sam Houston Parkway East
+    building: ''
+    city: Houston
+    fax: 281-999-5716
+    phone: 281-999-5879
+    state: TX
+    suite: Suite 29
+    zip: '77060'
+- id:
+    bioguide: J000126
+    govtrack: 400204
+    thomas: 00599
+  offices:
+  - address: 3102 Maple Avenue
+    building: ''
+    city: Dallas
+    fax: 214-922-7028
+    phone: 214-922-8885
+    state: TX
+    suite: Suite 600
+    zip: '75201'
+- id:
+    bioguide: C001051
+    govtrack: 400068
+    thomas: '01752'
+  offices:
+  - address: 1717 North IH 35
+    building: One Financial Center
+    city: Round Rock
+    fax: ''
+    phone: 512-246-1600
+    state: TX
+    suite: Suite 303
+    zip: '78664'
+  - address: 6544B South General Bruce Drive
+    building: ''
+    city: Temple
+    fax: ''
+    phone: 254-933-1392
+    state: TX
+    suite: ''
+    zip: '76502'
+- id:
+    bioguide: S000250
+    govtrack: 400367
+    thomas: '01525'
+  offices:
+  - address: 12750 Merit Drive
+    building: Park Central VII
+    city: Dallas
+    fax: 972-392-0615
+    phone: 972-392-0505
+    state: TX
+    suite: Suite 1434
+    zip: 75251-1229
+- id:
+    bioguide: V000131
+    govtrack: 412579
+    thomas: '02166'
+  offices:
+  - address: 1881 Sylvan Avenue
+    building: JP Morgan Chase Building
+    city: Dallas
+    fax: 214-741-2026
+    phone: 214-741-1387
+    state: TX
+    suite: Suite 108
+    zip: '75208'
+  - address: 4200 South Freeway
+    building: ''
+    city: Fort Worth
+    fax: 817-920-9324
+    phone: 817-920-9086
+    state: TX
+    suite: Suite 412
+    zip: '76115'
+- id:
+    bioguide: V000132
+    govtrack: 412580
+    thomas: '02167'
+  offices:
+  - address: 333 Ebony Avenue
+    building: ''
+    city: Brownsville
+    fax: ''
+    phone: 956-544-8352
+    state: TX
+    suite: ''
+    zip: '78520'
+  - address: 500 East Main
+    building: ''
+    city: Alice
+    fax: ''
+    phone: 956-544-8352
+    state: TX
+    suite: ''
+    zip: '78332'
+  - address: 1390 West Expressway 83
+    building: ''
+    city: San Benito
+    fax: 956-276-4603
+    phone: 956-544-8352
+    state: TX
+    suite: ''
+    zip: '78586'
+  - address: 500 South Kansas Avenue
+    building: ''
+    city: Weslaco
+    fax: 956-520-8277
+    phone: 956-520-8273
+    state: TX
+    suite: ''
+    zip: '78596'
+- id:
+    bioguide: D000399
+    govtrack: 400111
+    thomas: '00303'
+  offices:
+  - address: 300 East 8th Street
+    building: ''
+    city: Austin
+    fax: ''
+    phone: 512-916-5921
+    state: TX
+    suite: '#763'
+    zip: 78701-3275
+  - address: 217 West Travis Street
+    building: ''
+    city: San Antonio
+    fax: ''
+    phone: 210-704-1080
+    state: TX
+    suite: ''
+    zip: '78205'
+- id:
+    bioguide: B001291
+    govtrack: 412655
+    thomas: '02270'
+  offices:
+  - address: 420 Green Avenue
+    building: ''
+    city: Orange
+    fax: 409-886-9918
+    phone: 409-883-8075
+    state: TX
+    suite: ''
+    zip: 77630-5803
+  - address: 203 Ivy Avenue
+    building: ''
+    city: Deer Park
+    fax: 832-780-0964
+    phone: 832-780-0966
+    state: TX
+    suite: Suite 600
+    zip: '77536'
+  - address: 100 West Bluff Drive
+    building: Tyler County Courthouse
+    city: Woodville
+    fax: ''
+    phone: 844-303-8934
+    state: TX
+    suite: ''
+    zip: '75979'
+- id:
+    bioguide: B001250
+    govtrack: 400029
+    thomas: '01753'
+  offices:
+  - address: 324 25th Street
+    building: Federal Building
+    city: Ogden
+    fax: 801-625-0124
+    phone: 801-625-0107
+    state: UT
+    suite: Suite 1017
+    zip: '84401'
+- id:
+    bioguide: S001192
+    govtrack: 412581
+    thomas: 02168
+  offices:
+  - address: 420 East South Temple
+    building: ''
+    city: Salt Lake City
+    fax: 801-364-5551
+    phone: 801-364-5550
+    state: UT
+    suite: '#390'
+    zip: '84111'
+  - address: 253 West St. George Boulevard
+    building: ''
+    city: St. George
+    fax: 435-627-1911
+    phone: 435-627-1500
+    state: UT
+    suite: Suite 100
+    zip: '84770'
+- id:
+    bioguide: C001076
+    govtrack: 412270
+    thomas: 01956
+  offices:
+  - address: 51 South University Avenue
+    building: ''
+    city: Provo
+    fax: 801-851-2509
+    phone: 801-851-2500
+    state: UT
+    suite: Suite 318
+    zip: '84601'
+- id:
+    bioguide: L000584
+    govtrack: 412656
+    thomas: '02271'
+  offices:
+  - address: 9067 South 1300 West
+    building: ''
+    city: West Jordan
+    fax: 801-987-8631
+    phone: 801-486-1236
+    state: UT
+    suite: Suite 101
+    zip: '84088'
+- id:
+    bioguide: W000804
+    govtrack: 412255
+    thomas: 01886
+  offices:
+  - address: 401 Main Street
+    building: ''
+    city: Yorktown
+    fax: 757-874-7164
+    phone: 757-874-6687
+    state: VA
+    suite: PO Box 494
+    zip: '23690'
+  - address: 508 Church Lane
+    building: ''
+    city: Tappahannock
+    fax: 804-443-0671
+    phone: 804-443-0668
+    state: VA
+    suite: PO Box 3106
+    zip: '22560'
+  - address: 95 Dunn Drive
+    building: ''
+    city: Stafford
+    fax: 540-659-2737
+    phone: 540-659-2734
+    state: VA
+    suite: Suite 201
+    zip: '22556'
+- id:
+    bioguide: R000589
+    govtrack: 412483
+    thomas: 02068
+  offices:
+  - address: 4772 Euclid Road
+    building: ''
+    city: Virginia Beach
+    fax: 757-687-8298
+    phone: 757-687-8290
+    state: VA
+    suite: Suite E
+    zip: '23462'
+  - address: 36312 Lankford Highway
+    building: ''
+    city: Belle Haven
+    fax: 757-422-4793
+    phone: 757-442-4790
+    state: VA
+    suite: Suite 5
+    zip: '23306'
+  - address: 1100 Exploration Way
+    building: ''
+    city: Hampton
+    fax: 757- 687-8298
+    phone: 757-687-8290
+    state: VA
+    suite: Suite 302
+    zip: '23666'
+- id:
+    bioguide: S000185
+    govtrack: 400364
+    thomas: '01037'
+  offices:
+  - address: 2600 Washington Avenue
+    building: ''
+    city: Newport News
+    fax: 757-928-6694
+    phone: 757-380-1000
+    state: VA
+    suite: Suite 1010
+    zip: 23607-4317
+  - address: 400 North 8th Street
+    building: ''
+    city: Richmond
+    fax: 804-648-6026
+    phone: 804-644-4845
+    state: VA
+    suite: Suite 430
+    zip: 23219-4805
+- id:
+    bioguide: F000445
+    govtrack: 400137
+    thomas: 01683
+  offices:
+  - address: 505 Independence Parkway
+    building: ''
+    city: Chesapeake
+    fax: 757-382-0780
+    phone: 757-382-0080
+    state: VA
+    suite: Suite 104
+    zip: '23320'
+  - address: 9401 Courthouse Road
+    building: ''
+    city: Chesterfield
+    fax: 804-318-1013
+    phone: 804-318-1363
+    state: VA
+    suite: Suite 202
+    zip: '23832'
+- id:
+    bioguide: H001060
+    govtrack: 412484
+    thomas: 02069
+  offices:
+  - address: 308 Craghead Street
+    building: ''
+    city: Danville
+    fax: 434-791-4619
+    phone: 434-791-2596
+    state: VA
+    suite: Suite 102-D
+    zip: '24541'
+  - address: 686 Berkmar Circle
+    building: ''
+    city: Charlottesville
+    fax: 434-973-9635
+    phone: 434-973-9631
+    state: VA
+    suite: ''
+    zip: '22901'
+  - address: 515 South Main Street
+    building: ''
+    city: Farmville
+    fax: 434-395-1248
+    phone: 434-395-0120
+    state: VA
+    suite: PO Box O
+    zip: '23901'
+- id:
+    bioguide: G000289
+    govtrack: 400154
+    thomas: '00446'
+  offices:
+  - address: 117 South Lewis Street
+    building: ''
+    city: Staunton
+    fax: 540-885-3930
+    phone: 540-885-3861
+    state: VA
+    suite: Suite 215
+    zip: '24401'
+  - address: 70 North Mason Street
+    building: ''
+    city: Harrisonburg
+    fax: 540-432-6593
+    phone: 540-432-2391
+    state: VA
+    suite: ''
+    zip: '22802'
+  - address: 916 Main Street
+    building: ''
+    city: Lynchburg
+    fax: 434-845-8245
+    phone: 434-845-8306
+    state: VA
+    suite: Suite 300
+    zip: '24504'
+  - address: 10 Franklin Road, SE
+    building: ''
+    city: Roanoke
+    fax: 540-857-2675
+    phone: 540-857-2672
+    state: VA
+    suite: Suite 540
+    zip: '24011'
+- id:
+    bioguide: B001290
+    govtrack: 412605
+    thomas: '02203'
+  offices:
+  - address: 4201 Dominion Boulevard
+    building: ''
+    city: Glen Allen
+    fax: 804-747-5308
+    phone: 804-747-4073
+    state: VA
+    suite: Suite 110
+    zip: '23060'
+  - address: 9104 Courthouse Road
+    building: ''
+    city: Spotsylvania
+    fax: 504-507-7019
+    phone: 540-507-7216
+    state: VA
+    suite: PO Box 99
+    zip: '22553'
+- id:
+    bioguide: B001292
+    govtrack: 412657
+    thomas: '02272'
+  offices:
+  - address: 5285 Shawnee Road
+    building: ''
+    city: Alexandria
+    fax: 703-658-5408
+    phone: 703-658-5403
+    state: VA
+    suite: Suite 250
+    zip: '22312'
+- id:
+    bioguide: G000568
+    govtrack: 412485
+    thomas: '02070'
+  offices:
+  - address: 323 West Main Street
+    building: ''
+    city: Abingdon
+    fax: 276-525-1444
+    phone: 276-525-1405
+    state: VA
+    suite: ''
+    zip: '24210'
+  - address: 17 West Main Street
+    building: ''
+    city: Christiansburg
+    fax: 540-381-5675
+    phone: 540-381-5671
+    state: VA
+    suite: ''
+    zip: '24073'
+- id:
+    bioguide: C001105
+    govtrack: 412658
+    thomas: '02273'
+  offices:
+  - address: 21430 Cedar Drive
+    building: ''
+    city: Sterling
+    fax: 703- 404-6906
+    phone: 703-404-6903
+    state: VA
+    suite: Suite 218
+    zip: '20164'
+  - address: 117 East Picadlilly Street
+    building: ''
+    city: Winchester
+    fax: ''
+    phone: 540-773-3600
+    state: VA
+    suite: Suite 100D
+    zip: '22601'
+- id:
+    bioguide: C001078
+    govtrack: 412272
+    thomas: 01959
+  offices:
+  - address: 2241-D Tacketts Mill Drive
+    building: ''
+    city: Woodbridge
+    fax: 571-670-6042
+    phone: 571-408-4407
+    state: VA
+    suite: ''
+    zip: '22192'
+  - address: 4115 Annandale Road
+    building: ''
+    city: Annandale
+    fax: 703-354-1284
+    phone: 703-256-3071
+    state: VA
+    suite: Suite 103
+    zip: '22003'
+- id:
+    bioguide: P000610
+    govtrack: 412659
+    thomas: '02274'
+  offices:
+  - address: 60 King Street
+    building: ''
+    city: Frederiksted
+    fax: 340-778-5111
+    phone: 340- 778-5900
+    state: VI
+    suite: ''
+    zip: 00840
+  - address: 9100 Port of Sale Mall
+    building: ''
+    city: St. Thomas
+    fax: 340-774-8033
+    phone: 340-774-4408
+    state: VI
+    suite: Suite 23
+    zip: 00803
+- id:
+    bioguide: W000800
+    govtrack: 412239
+    thomas: 01879
+  offices:
+  - address: 128 Lakeside Avenue
+    building: ''
+    city: Burlington
+    fax: ''
+    phone: 802-652-2450
+    state: VT
+    suite: Suite 235
+    zip: '05401'
+- id:
+    bioguide: D000617
+    govtrack: 412505
+    thomas: 02096
+  offices:
+  - address: 22121 17th Avenue SE
+    building: Canyon Park Business Center
+    city: Bothell
+    fax: 425-485-0083
+    phone: 425-485-0085
+    state: WA
+    suite: Building E, Suite 220
+    zip: '98021'
+  - address: 204 West Montgomery Street
+    building: ''
+    city: Mount Vernon
+    fax: 425-485-0083
+    phone: 360-416-7879
+    state: WA
+    suite: ''
+    zip: '98273'
+- id:
+    bioguide: L000560
+    govtrack: 400232
+    thomas: '01675'
+  offices:
+  - address: 119 North Commercial Street
+    building: ''
+    city: Bellingham
+    fax: 360-733-5144
+    phone: 360-733-4500
+    state: WA
+    suite: Suite 1350
+    zip: '98225'
+  - address: 2930 Wetmore Avenue
+    building: Wall Street Building
+    city: Everett
+    fax: 425-252-6606
+    phone: 425-252-3188
+    state: WA
+    suite: Suite 9F
+    zip: '98201'
+- id:
+    bioguide: H001056
+    govtrack: 412486
+    thomas: '02071'
+  offices:
+  - address: 750 Anderson Street
+    building: Howard House on Officer's Row
+    city: Vancouver
+    fax: 360-695-6197
+    phone: 360-695-6292
+    state: WA
+    suite: Suite B
+    zip: '98661'
+- id:
+    bioguide: N000189
+    govtrack: 412660
+    thomas: '02275'
+  offices:
+  - address: 402 East Yakima Avenue
+    building: ''
+    city: Yakima
+    fax: 509-452-3438
+    phone: 509-452-3243
+    state: WA
+    suite: Suite 445
+    zip: '98901'
+  - address: 3100 George Washington Way
+    building: ''
+    city: Richland
+    fax: 509- 713-7377
+    phone: 509-713-7374
+    state: WA
+    suite: '#135'
+    zip: '99354'
+- id:
+    bioguide: M001159
+    govtrack: 400659
+    thomas: 01809
+  offices:
+  - address: 555 South Main Street
+    building: ''
+    city: Colville
+    fax: 202-225-3392
+    phone: 509-684-3481
+    state: WA
+    suite: ''
+    zip: '99114'
+  - address: 26 East Main Street
+    building: ''
+    city: Walla Walla
+    fax: 509-353-2412
+    phone: 509-529-9358
+    state: WA
+    suite: Suite 2
+    zip: '99362'
+  - address: 10 North Post
+    building: ''
+    city: Spokane
+    fax: 202-225-3392
+    phone: 509-353-2374
+    state: WA
+    suite: Suite 625
+    zip: '99201'
+- id:
+    bioguide: K000381
+    govtrack: 412583
+    thomas: 02169
+  offices:
+  - address: 950 Pacific Avenue
+    building: ''
+    city: Tacoma
+    fax: ''
+    phone: 253-272-3515
+    state: WA
+    suite: Suite 1230
+    zip: '98402'
+  - address: 345 6th Street
+    building: ''
+    city: Bremerton
+    fax: ''
+    phone: 360-373-9725
+    state: WA
+    suite: Suite 500
+    zip: '98337'
+- id:
+    bioguide: M000404
+    govtrack: 400262
+    thomas: '00766'
+  offices:
+  - address: 1809 7th Avenue
+    building: ''
+    city: Seattle
+    fax: 206-553-7175
+    phone: 206-553-7170
+    state: WA
+    suite: Suite 1212
+    zip: 98101-1399
+- id:
+    bioguide: R000578
+    govtrack: 400660
+    thomas: 01810
+  offices:
+  - address: 22605 SE 56th Street
+    building: ''
+    city: Issaquah
+    fax: 425-270-3589
+    phone: 425-677-7414
+    state: WA
+    suite: Suite 130
+    zip: '98029'
+  - address: 2 1st Street SE
+    building: ''
+    city: Auburn
+    fax: ''
+    phone: 206-498-8103
+    state: WA
+    suite: ''
+    zip: '98001'
+  - address: 5 South Wenatchee Avenue
+    building: ''
+    city: Wenatchee
+    fax: ''
+    phone: 509-885-6615
+    state: WA
+    suite: Suite 315
+    zip: '98801'
+- id:
+    bioguide: S000510
+    govtrack: 400379
+    thomas: 01528
+  offices:
+  - address: 15 South Grady Way
+    building: 101 Evergreen Building
+    city: Renton
+    fax: 425-793-5181
+    phone: 425-793-5180
+    state: WA
+    suite: ''
+    zip: '98057'
+- id:
+    bioguide: H001064
+    govtrack: 412584
+    thomas: '02170'
+  offices:
+  - address: 420 College Street SE
+    building: Lacey City Hall
+    city: Lacey
+    fax: ''
+    phone: 360-459-8514
+    state: WA
+    suite: Suite 3000
+    zip: '98503'
+  - address: 1423 East 29th Street
+    building: ''
+    city: Tacoma
+    fax: ''
+    phone: 253-722-5860
+    state: WA
+    suite: Suite 203
+    zip: '98404'
+- id:
+    bioguide: R000570
+    govtrack: 400351
+    thomas: '01560'
+  offices:
+  - address: 20 South Main Street
+    building: ''
+    city: Janesville
+    fax: 608-752-4711
+    phone: 608-752-4050
+    state: WI
+    suite: Suite 10
+    zip: 53545-3959
+  - address: 216 6th Street
+    building: ''
+    city: Racine
+    fax: 262-637-5689
+    phone: 262-637-0510
+    state: WI
+    suite: ''
+    zip: 53403-1216
+  - address: 5031 7th Avenue
+    building: ''
+    city: Kenosha
+    fax: 262-654-2156
+    phone: 262-654-1901
+    state: WI
+    suite: ''
+    zip: '53140'
+- id:
+    bioguide: P000607
+    govtrack: 412585
+    thomas: '02171'
+  offices:
+  - address: 10 East Doty Street
+    building: ''
+    city: Madison
+    fax: 608-258-0377
+    phone: 608-258-9800
+    state: WI
+    suite: Suite 405
+    zip: '53703'
+  - address: 100 State Street
+    building: ''
+    city: Beloit
+    fax: ''
+    phone: 608-365-8001
+    state: WI
+    suite: 3rd Floor
+    zip: '53511'
+- id:
+    bioguide: K000188
+    govtrack: 400218
+    thomas: 01498
+  offices:
+  - address: 205 5th Avenue South
+    building: ''
+    city: La Crosse
+    fax: 608-782-4588
+    phone: 608-782-2558
+    state: WI
+    suite: Suite 400
+    zip: 54601-9202
+  - address: 131 South Barstow Street
+    building: ''
+    city: Eau Claire
+    fax: 715-831-9272
+    phone: 715-831-9214
+    state: WI
+    suite: Suite 301
+    zip: '54701'
+- id:
+    bioguide: M001160
+    govtrack: 400661
+    thomas: 01811
+  offices:
+  - address: 316 North Milwaukee Street
+    building: ''
+    city: Milwaukee
+    fax: 414-297-1086
+    phone: 414-297-1140
+    state: WI
+    suite: Suite 406
+    zip: 53202-5818
+- id:
+    bioguide: S000244
+    govtrack: 400365
+    thomas: '01041'
+  offices:
+  - address: 120 Bishops Way
+    building: ''
+    city: Brookfield
+    fax: 262-784-9437
+    phone: 262-784-1111
+    state: WI
+    suite: Room 154
+    zip: 53005-6294
+- id:
+    bioguide: G000576
+    govtrack: 412661
+    thomas: '02276'
+  offices:
+  - address: 1020 South Main Street
+    building: ''
+    city: Fond du Lac
+    fax: ''
+    phone: 920-907-0624
+    state: WI
+    suite: Suite B
+    zip: '54935'
+- id:
+    bioguide: D000614
+    govtrack: 412488
+    thomas: '02072'
+  offices:
+  - address: 208 Grand Avenue
+    building: ''
+    city: Wausau
+    fax: 715-298-9348
+    phone: 715-298-9344
+    state: WI
+    suite: ''
+    zip: '54403'
+  - address: 823 Belknap Street
+    building: ''
+    city: Superior
+    fax: ''
+    phone: 715-392-3984
+    state: WI
+    suite: Suite 225
+    zip: '54880'
+- id:
+    bioguide: R000587
+    govtrack: 412489
+    thomas: '02073'
+  offices:
+  - address: 333 West College Avenue
+    building: ''
+    city: Appleton
+    fax: 920-380-0051
+    phone: 920-380-0061
+    state: WI
+    suite: ''
+    zip: '54911'
+  - address: 550 North Military Avenue
+    building: ''
+    city: Green Bay
+    fax: ''
+    phone: 920-471-1950
+    state: WI
+    suite: Suited 4B
+    zip: '54303'
+- id:
+    bioguide: M001180
+    govtrack: 412487
+    thomas: '02074'
+  offices:
+  - address: 1100 Main Street
+    building: Home Building
+    city: Wheeling
+    fax: 304-232-3813
+    phone: 304-232-3801
+    state: WV
+    suite: Suite 101
+    zip: '26003'
+  - address: 709 Beechurst Avenue
+    building: ''
+    city: Morgantown
+    fax: ''
+    phone: 304-284-8506
+    state: WV
+    suite: Suite 29
+    zip: '26505'
+  - address: 425 Juliana Street
+    building: Federal Building
+    city: Parksburg
+    fax: ''
+    phone: 304-422-5972
+    state: WV
+    suite: Suite 1004
+    zip: '26101'
+- id:
+    bioguide: M001195
+    govtrack: 412662
+    thomas: '02277'
+  offices:
+  - address: 405 Capitol Street
+    building: ''
+    city: Charleston
+    fax: ''
+    phone: 304-925-5964
+    state: WV
+    suite: Suite 514
+    zip: '25301'
+  - address: 300 Foxcroft Avenue
+    building: ''
+    city: Martinsburg
+    fax: ''
+    phone: 304-264-8810
+    state: WV
+    suite: Suite 102
+    zip: '25401'
+- id:
+    bioguide: J000297
+    govtrack: 412663
+    thomas: 02278
+  offices:
+  - address: 845 Fifth Avenue
+    building: ''
+    city: Huntington
+    fax: 304-529-5716
+    phone: 304-522-2201
+    state: WV
+    suite: Suite 314
+    zip: '25701'
+  - address: 223 Prince Street
+    building: ''
+    city: Beckley
+    fax: 304-250-6179
+    phone: 304-250-6177
+    state: WV
+    suite: ''
+    zip: '25801'
+- id:
+    bioguide: L000571
+    govtrack: 412294
+    thomas: 01960
+  offices:
+  - address: 100 East B Street
+    building: ''
+    city: Casper
+    fax: 307-261-6597
+    phone: 307-261-6595
+    state: WY
+    suite: Suite 4003
+    zip: '82602'
+  - address: 2120 Capitol Avenue
+    building: ''
+    city: Cheyenne
+    fax: 307-772-2597
+    phone: 307-772-2595
+    state: WY
+    suite: Suite 8005
+    zip: '82001'
+  - address: 45 East Loucks
+    building: ''
+    city: Sheridan
+    fax: 307-673-4982
+    phone: 307-673-4608
+    state: WY
+    suite: Suite 300F
+    zip: '82801'
+- id:
+    bioguide: M001153
+    govtrack: 300075
+    thomas: 01694
+  offices:
+  - address: 851 East Westpoint Drive
+    building: ''
+    city: Wasilla
+    fax: 907-376-8526
+    phone: 907-376-7665
+    state: AK
+    suite: Suite 307
+    zip: '99654'
+  - address: 510 L Street
+    building: ''
+    city: Anchorage
+    fax: 877-857-0322
+    phone: 907-271-3735
+    state: AK
+    suite: Suite 600
+    zip: '99501'
+  - address: 805 Frontage Road
+    building: ''
+    city: Kenai
+    fax: 907-283-4363
+    phone: 907-283-5808
+    state: AK
+    suite: Suite 105
+    zip: '99611'
+  - address: 1900 First Avenue
+    building: ''
+    city: Ketchikan
+    fax: 907-225-0390
+    phone: 907-225-6880
+    state: AK
+    suite: Suite 225
+    zip: '99901'
+  - address: 101 12th Avenue
+    building: ''
+    city: Fairbanks
+    fax: 907-451-7146
+    phone: 907-456-0233
+    state: AK
+    suite: Suite 329
+    zip: '99701'
+  - address: 800 Glacier Avenue
+    building: ''
+    city: Juneau
+    fax: 907-586-7201
+    phone: 907-586-7277
+    state: AK
+    suite: Suite 101
+    zip: '99801'
+- id:
+    bioguide: S001198
+    govtrack: 412665
+    thomas: 02290
+  offices:
+  - address: 510 L Street
+    building: Preston Tower
+    city: Anchorage
+    fax: 907-258-9305
+    phone: 907-271-5915
+    state: AK
+    suite: Suite 750
+    zip: '99501'
+  - address: 851 East Westpoint Drive
+    building: ''
+    city: Wasilla
+    fax: 907-357-9964
+    phone: 907-357-9956
+    state: AK
+    suite: Suite 309
+    zip: '99654'
+  - address: 800 Glacier Avenue
+    building: ''
+    city: Juneau
+    fax: 907-586-7201
+    phone: 907-586-7277
+    state: AK
+    suite: Suite 101
+    zip: '99801'
+  - address: 1900 First Avenue
+    building: ''
+    city: Ketchikan
+    fax: 907-225-0390
+    phone: 907-225-6880
+    state: AK
+    suite: Suite225
+    zip: '99901'
+  - address: 101 12th Avenue
+    building: Federal Building
+    city: Fairbanks
+    fax: 907- 451-7290
+    phone: 907-456-0261
+    state: AK
+    suite: Suite328
+    zip: '99701'
+  - address: 805 Frontage Road
+    building: ''
+    city: Kenai
+    fax: 907-283-4401
+    phone: 907-283-4000
+    state: AK
+    suite: Suite 101
+    zip: '99901'
+- id:
+    bioguide: S000320
+    govtrack: 300089
+    thomas: 01049
+  offices:
+  - address: 15 Lee Street
+    building: Federal Courthouse
+    city: Montgomery
+    fax: 334-223-7317
+    phone: 334-223-7303
+    state: AL
+    suite: Suite 208
+    zip: 36104-4055
+  - address: 1800 5th Avenue North
+    building: Federal Building
+    city: Birmingham
+    fax: 205-731-1386
+    phone: 205-731-1384
+    state: AL
+    suite: Suite 321
+    zip: 35203-2171
+  - address: 1000 Glenn Hearn Boulevard
+    building: ''
+    city: Huntsville
+    fax: 256-772-8387
+    phone: 256-772-0460
+    state: AL
+    suite: Suite 20127
+    zip: '35284'
+  - address: 2005 University Boulevard
+    building: ''
+    city: Tuscaloosa
+    fax: 205-759-5067
+    phone: 205-759-5047
+    state: AL
+    suite: Suite 2100
+    zip: '35401'
+  - address: 113 Saint Joseph Street
+    building: Federal Courthouse
+    city: Mobile
+    fax: 251-694-4166
+    phone: 251-694-4164
+    state: AL
+    suite: Suite 445
+    zip: 36602-3623
+- id:
+    bioguide: S001141
+    govtrack: 300088
+    thomas: 01548
+  offices:
+  - address: 7550 Halcyon Summit Drive
+    building: ''
+    city: Montgomery
+    fax: 334-244-7091
+    phone: 334-244-7017
+    state: AL
+    suite: Suite 150
+    zip: '36117'
+  - address: 1800 Fifth Avenue North
+    building: 341 Vance Federal Building
+    city: Birmingham
+    fax: 205-731-0221
+    phone: 205-731-1500
+    state: AL
+    suite: ''
+    zip: 35203-2171
+  - address: 200 Clinton Avenue N.W.
+    building: Regions Center
+    city: Huntsville
+    fax: 256-533-0745
+    phone: 256-533-0979
+    state: AL
+    suite: Suite 802
+    zip: 35801-4932
+  - address: 41 West I-65 Service Road North
+    building: BB&T
+    city: Mobile
+    fax: 251-414-5845
+    phone: 251-414-3083
+    state: AL
+    suite: Suite 2300-A
+    zip: 36608-1291
+  - address: 100 West Troy Street
+    building: ''
+    city: Dothan
+    fax: 334-792-4928
+    phone: 334-792-4924
+    state: AL
+    suite: Suite 302
+    zip: '36303'
+- id:
+    bioguide: B001236
+    govtrack: 400040
+    thomas: 01687
+  offices:
+  - address: 213 West Monroe
+    building: ''
+    city: Lowell
+    fax: 479-725-0408
+    phone: 479-725-0400
+    state: AR
+    suite: Suite N
+    zip: '72745'
+  - address: 1120 Garrison Avenue
+    building: ''
+    city: Fort Smith
+    fax: 479-573-0553
+    phone: 479-573-0189
+    state: AR
+    suite: Suite 2B
+    zip: '72901'
+  - address: 1001 Highway 62 East
+    building: ''
+    city: Mountain Home
+    fax: 870-424-0141
+    phone: 870-424-0129
+    state: AR
+    suite: Suite 11
+    zip: '72653'
+  - address: 300 South Church Street
+    building: ''
+    city: Jonesboro
+    fax: 870-268-6887
+    phone: 870-268-6925
+    state: AR
+    suite: Suite 400
+    zip: '72401'
+  - address: 620 East 22nd Street
+    building: ''
+    city: Stuttgart
+    fax: 870-672-6962
+    phone: 870-672-6941
+    state: AR
+    suite: Suite 204
+    zip: '72160'
+  - address: 106 West Main Street
+    building: ''
+    city: El Dorado
+    fax: 870-863-4105
+    phone: 870-863-4641
+    state: AR
+    suite: Suite 104
+    zip: '71730'
+  - address: 1401 West Capitol Avenue
+    building: ''
+    city: Little Rock
+    fax: 501-372-7163
+    phone: 501-372-7153
+    state: AR
+    suite: Suite 155
+    zip: '72201'
+- id:
+    bioguide: C001095
+    govtrack: 412508
+    thomas: 02098
+  offices:
+  - address: 1108 South Old Missouri Road
+    building: ''
+    city: Springdale
+    fax: 479-927-1092
+    phone: 479-751-0879
+    state: AR
+    suite: Suite B
+    zip: '72764'
+  - address: 106 West Main Street
+    building: ''
+    city: El Dorado
+    fax: 870-864-8571
+    phone: 870-864-8582
+    state: AR
+    suite: Suite 410
+    zip: '71730'
+  - address: 300 South Church
+    building: ''
+    city: Jonesboro
+    fax: 870-933-6596
+    phone: 870-933-6223
+    state: AR
+    suite: Suite 338
+    zip: '72401'
+  - address: 11809 Hinson Road
+    building: ''
+    city: Little Rock
+    fax: 501-223-9105
+    phone: 501-223-9081
+    state: AR
+    suite: Suite 100
+    zip: '72212'
+- id:
+    bioguide: M000303
+    govtrack: 300071
+    thomas: '00754'
+  offices:
+  - address: 2201 East Camelback Road
+    building: ''
+    city: Phoenix
+    fax: 855-952-8702
+    phone: 602-952-2410
+    state: AZ
+    suite: Suite 115
+    zip: '85016'
+  - address: 122 North Cortez Street
+    building: ''
+    city: Prescott
+    fax: 928-445-8594
+    phone: 928-445-0833
+    state: AZ
+    suite: Suite 108
+    zip: '86301'
+  - address: 407 West Congress Street
+    building: ''
+    city: Tucson
+    fax: 520-670-6637
+    phone: 520-670-6334
+    state: AZ
+    suite: Suite 103
+    zip: '85701'
+- id:
+    bioguide: F000444
+    govtrack: 400134
+    thomas: '01633'
+  offices:
+  - address: 2200 East Camelback Road
+    building: ''
+    city: Phoenix
+    fax: 602-840-4092
+    phone: 602-840-1891
+    state: AZ
+    suite: Suite 120
+    zip: '85016'
+  - address: 6840 Oracle Road
+    building: ''
+    city: Tucson
+    fax: 520-797-3232
+    phone: 520-575-8633
+    state: AZ
+    suite: Suite 150
+    zip: '85704'
+- id:
+    bioguide: F000062
+    govtrack: 300043
+    thomas: '01332'
+  offices:
+  - address: 1 Post Street
+    building: ''
+    city: San Francisco
+    fax: 415-393-0710
+    phone: 415-393-0707
+    state: CA
+    suite: Suite 2450
+    zip: '94104'
+  - address: 11111 San Monica Boulevard
+    building: ''
+    city: Los Angeles
+    fax: 310-914-7318
+    phone: 310-914-7300
+    state: CA
+    suite: Suite 915
+    zip: 90025-3343
+  - address: 2500 Tulare Street
+    building: ''
+    city: Fresno
+    fax: 559-485-9689
+    phone: 559-485-7430
+    state: CA
+    suite: Suite 4290
+    zip: '93721'
+  - address: 880 Front Street
+    building: ''
+    city: San Diego
+    fax: 619-231-1108
+    phone: 619-231-9712
+    state: CA
+    suite: Suite 4236
+    zip: 92101-8126
+- id:
+    bioguide: B000711
+    govtrack: 300011
+    thomas: '00116'
+  offices:
+  - address: 312 North Spring Street
+    building: ''
+    city: Los Angeles
+    fax: 202-224-0357
+    phone: 213-894-5000
+    state: CA
+    suite: Suite 1748
+    zip: 90012-4701
+  - address: 501 I Street
+    building: ''
+    city: Sacramento
+    fax: 202-228-3865
+    phone: 916-448-2787
+    state: CA
+    suite: Suite 7-600
+    zip: '95814'
+  - address: 70 Washington Street
+    building: ''
+    city: Oakland
+    fax: 202-224-0454
+    phone: 510-286-8537
+    state: CA
+    suite: Suite 203
+    zip: '94607'
+  - address: 600 B Street
+    building: ''
+    city: San Diego
+    fax: 202-228-3863
+    phone: 619-239-3884
+    state: CA
+    suite: Suite 2240
+    zip: 92101-4508
+  - address: 2500 Tulare Street
+    building: ''
+    city: Fresno
+    fax: 202-228-3865
+    phone: 559-497-5109
+    state: CA
+    suite: Suite 5290
+    zip: '93721'
+  - address: 3403 10th Street
+    building: ''
+    city: Riverside
+    fax: 202-228-3868
+    phone: 951-684-4849
+    state: CA
+    suite: Suite 704
+    zip: '92501'
+- id:
+    bioguide: B001267
+    govtrack: 412330
+    thomas: 01965
+  offices:
+  - address: 1200 South College Avenue
+    building: ''
+    city: Fort Collins
+    fax: 970-224-2205
+    phone: 970-224-2200
+    state: CO
+    suite: Suite 211
+    zip: '80524'
+  - address: 409 North Tejon
+    building: ''
+    city: Colorado Springs
+    fax: 719-328-1129
+    phone: 719-328-1100
+    state: CO
+    suite: Suite 107
+    zip: '80903'
+  - address: 1127 Sherman Street
+    building: ''
+    city: Denver
+    fax: 303-455-8851
+    phone: 303-455-7600
+    state: CO
+    suite: Suite 150
+    zip: '80203'
+  - address: 609 Main Street
+    building: ''
+    city: Alamosa
+    fax: 719-587-0098
+    phone: 719-587-0096
+    state: CO
+    suite: Suite 110
+    zip: '81101'
+  - address: 835 East 2nd Avenue
+    building: ''
+    city: Durango
+    fax: 970-259-9789
+    phone: 970-259-1710
+    state: CO
+    suite: Suite 206
+    zip: '81301'
+  - address: 129 West B Street
+    building: ''
+    city: Pueblo
+    fax: 719-542-7555
+    phone: 719-542-7550
+    state: CO
+    suite: ''
+    zip: '81003'
+  - address: 225 North 5th Street
+    building: ''
+    city: Grand Junction
+    fax: 970-241-8313
+    phone: 970-241-6631
+    state: CO
+    suite: Suite 511
+    zip: '81501'
+- id:
+    bioguide: G000562
+    govtrack: 412406
+    thomas: 01998
+  offices:
+  - address: 999 18th Street
+    building: ''
+    city: Denver
+    fax: ''
+    phone: ''
+    state: CO
+    suite: Suite 1525
+    zip: '80202'
+  - address: 801 8th Street
+    building: ''
+    city: Greeley
+    fax: ''
+    phone: 970-352-5546
+    state: CO
+    suite: ''
+    zip: '80631'
+- id:
+    bioguide: B001277
+    govtrack: 412490
+    thomas: '02076'
+  offices:
+  - address: 90 State House Square
+    building: ''
+    city: Hartford
+    fax: 860-258-6958
+    phone: 860-258-6940
+    state: CT
+    suite: 10th Floor
+    zip: '06103'
+  - address: 915 Lafayette Boulevard
+    building: ''
+    city: Bridgeport
+    fax: 203-330-0608
+    phone: 203-330-0598
+    state: CT
+    suite: Room 230
+    zip: '06604'
+- id:
+    bioguide: M001169
+    govtrack: 412194
+    thomas: 01837
+  offices:
+  - address: 1 Constitution Plaza
+    building: ''
+    city: Hartford
+    fax: 860-549-5091
+    phone: 860-549-8463
+    state: CT
+    suite: 7th Floor
+    zip: '06103'
+- id:
+    bioguide: C000174
+    govtrack: 300019
+    thomas: 00179
+  offices:
+  - address: 500 West Loockerman Street
+    building: ''
+    city: Dover
+    fax: 302-674-5464
+    phone: 302-674-3308
+    state: DE
+    suite: Suite 470
+    zip: '19904'
+  - address: 301 North Walnut Street
+    building: ''
+    city: Wilmington
+    fax: 302-573-6434
+    phone: 302-573-6291
+    state: DE
+    suite: Suite 102L-1
+    zip: '19801'
+  - address: 12 The Circle
+    building: ''
+    city: Georgetown
+    fax: 302-856-3001
+    phone: 302-856-7690
+    state: DE
+    suite: ''
+    zip: '19947'
+- id:
+    bioguide: C001088
+    govtrack: 412390
+    thomas: 01984
+  offices:
+  - address: 1105 North Market Street
+    building: ''
+    city: Wilmington
+    fax: 302-573-6351
+    phone: 302-573-6345
+    state: DE
+    suite: Suite 100
+    zip: 19801-1233
+  - address: 500 West Loockerman Street
+    building: ''
+    city: Dover
+    fax: 302-736-5609
+    phone: 302-736-5601
+    state: DE
+    suite: Suite 450
+    zip: '19904'
+- id:
+    bioguide: N000032
+    govtrack: 300078
+    thomas: 00859
+  offices:
+  - address: 2000 Main Street
+    building: Justice Center Annex Building
+    city: Ft. Myers
+    fax: 239-334-7710
+    phone: 239-334-7760
+    state: FL
+    suite: Suite 801
+    zip: '33901'
+  - address: 801 North Florida Avenue
+    building: Sam M. Gibbons Federal Courthouse
+    city: Tampa
+    fax: 813-225-7050
+    phone: 813- 225-7040
+    state: FL
+    suite: 4th Floor
+    zip: '33602'
+  - address: 1301 Riverplace Boulevard
+    building: ''
+    city: Jacksonville
+    fax: 904-346-4506
+    phone: 904-346-4500
+    state: FL
+    suite: Suite 2010
+    zip: '32207'
+  - address: 225 East Robinson Street
+    building: Landmark Two
+    city: Orlando
+    fax: 407-872-7165
+    phone: 888-671-4091
+    state: FL
+    suite: Suite 410
+    zip: '32801'
+  - address: 2555 Ponce De Leon Boulevard
+    building: ''
+    city: Coral Gables
+    fax: 305-536-5991
+    phone: 305-536-5999
+    state: FL
+    suite: Suite 610
+    zip: '33134'
+  - address: 3416 South University Drive
+    building: ''
+    city: Fort Lauderdale
+    fax: 954-693-4862
+    phone: 954-693-4851
+    state: FL
+    suite: ''
+    zip: '33328'
+  - address: 111 North Adams Street
+    building: U.S. Courthouse Annex
+    city: Tallahassee
+    fax: 850-942-8450
+    phone: 850-942-8415
+    state: FL
+    suite: ''
+    zip: '32301'
+  - address: 413 Clematis Street
+    building: ''
+    city: West Palm Beach
+    fax: 561-514-4078
+    phone: 561-514-0189
+    state: FL
+    suite: Suite 210
+    zip: '33401'
+- id:
+    bioguide: R000595
+    govtrack: 412491
+    thomas: 02084
+  offices:
+  - address: 201 South Orange Avenue
+    building: ''
+    city: Orlando
+    fax: 407-423-0941
+    phone: 407-254-2573
+    state: FL
+    suite: Suite 350
+    zip: '32801'
+  - address: 8669 NW 36th Street
+    building: ''
+    city: Doral
+    fax: 305-594-4014
+    phone: 305-418-8553
+    state: FL
+    suite: Suite 110
+    zip: '33166'
+  - address: 3802 Spectrum Boulevard
+    building: ''
+    city: Tampa
+    fax: ''
+    phone: 813-977-6450
+    state: FL
+    suite: Suite 106
+    zip: '33612'
+  - address: 1650 Prudential Drive
+    building: ''
+    city: Jacksonville
+    fax: ''
+    phone: 904-398-8586
+    state: FL
+    suite: Suite 220
+    zip: '32207'
+  - address: 1 North Palafox Street
+    building: ''
+    city: Pensacola
+    fax: ''
+    phone: 850-433-2603
+    state: FL
+    suite: Suite 159
+    zip: '32502'
+  - address: 3299 East Tamiami Trail
+    building: ''
+    city: Naples
+    fax: ''
+    phone: 239-213-1521
+    state: FL
+    suite: Suite 106
+    zip: '34112'
+  - address: 402 Monroe Street
+    building: ''
+    city: Tallahassee
+    fax: ''
+    phone: 850-599-9100
+    state: FL
+    suite: Suite 2105E
+    zip: '32399'
+  - address: 4580 PGA Boulevard
+    building: ''
+    city: Palm Beach Gardens
+    fax: ''
+    phone: 561-775-3360
+    state: FL
+    suite: Suite 201
+    zip: '33418'
+- id:
+    bioguide: I000055
+    govtrack: 400194
+    thomas: 01608
+  offices:
+  - address: 3625 Cumberland Boulevard
+    building: One Overton Park
+    city: Atlanta
+    fax: 770-661-0768
+    phone: 770-661-0999
+    state: GA
+    suite: Suite 970
+    zip: '30339'
+- id:
+    bioguide: P000612
+    govtrack: 412666
+    thomas: 02286
+  offices:
+  - address: 191 Peachtree Street NE
+    building: ''
+    city: Atlanta
+    fax: 404-865-0311
+    phone: 404-865-0087
+    state: GA
+    suite: Suite 3250
+    zip: '30303'
+- id:
+    bioguide: S001194
+    govtrack: 412507
+    thomas: '02173'
+  offices:
+  - address: 300 Ala Moana Boulevard
+    building: ''
+    city: Honolulu
+    fax: 808-523-2065
+    phone: 808-523-2061
+    state: HI
+    suite: Room 7-212
+    zip: '96850'
+- id:
+    bioguide: H001042
+    govtrack: 412200
+    thomas: 01844
+  offices:
+  - address: 300 Ala Moana Boulevard
+    building: Prince Kuhio Federal Building
+    city: Honolulu
+    fax: 808-545-4683
+    phone: 808-522-8970
+    state: HI
+    suite: Room 3-106
+    zip: '96850'
+- id:
+    bioguide: G000386
+    govtrack: 300048
+    thomas: '00457'
+  offices:
+  - address: 8 South 6th Street
+    building: 307 Federal Building
+    city: Council Bluffs
+    fax: 712-322-7196
+    phone: 712-322-7103
+    state: IA
+    suite: ''
+    zip: '51501'
+  - address: 320 6th Street
+    building: 120 Federal Courthouse Building
+    city: Sioux City
+    fax: 712-233-1634
+    phone: 712-233-1860
+    state: IA
+    suite: ''
+    zip: 51101-1244
+  - address: 201 West 2nd Street
+    building: ''
+    city: Davenport
+    fax: 563-322-8552
+    phone: 563-322-4331
+    state: IA
+    suite: Suite 720
+    zip: 52801-1513
+  - address: 210 Walnut Street
+    building: 721 Federal Building
+    city: Des Moines
+    fax: 515-288-5097
+    phone: 515-288-1145
+    state: IA
+    suite: ''
+    zip: 50309-2140
+  - address: 531 Commercial Street
+    building: 210 Waterloo Building
+    city: Waterloo
+    fax: 319-232-9965
+    phone: 319-232-6657
+    state: IA
+    suite: ''
+    zip: 50701-5497
+  - address: 111 7th Avenue SE, Box 13
+    building: ''
+    city: Cedar Rapids
+    fax: 319-363-7179
+    phone: 319-363-6832
+    state: IA
+    suite: Suite 6800
+    zip: '52401'
+- id:
+    bioguide: E000295
+    govtrack: 412667
+    thomas: 02283
+  offices:
+  - address: 210 Walnut Street
+    building: Federal Building
+    city: Des Moines
+    fax: 515-284-4937
+    phone: 515-284-4574
+    state: IA
+    suite: Room 733
+    zip: '50309'
+  - address: 111 Seventh Avenue SE
+    building: ''
+    city: Cedar Rapids
+    fax: 319-365-4683
+    phone: 319-365-4504
+    state: IA
+    suite: Suite 480
+    zip: 52401-2101
+  - address: 201 West Second Street
+    building: ''
+    city: Davenport
+    fax: 563-322-0854
+    phone: 563-322-0677
+    state: IA
+    suite: Suite 806
+    zip: '52801'
+  - address: 320 Sixth Street
+    building: 194 Federal Building
+    city: Sioux City
+    fax: 712-252-1638
+    phone: 712-252-1550
+    state: IA
+    suite: ''
+    zip: '51101'
+  - address: 8 South Sixth Street
+    building: 221 Federal Building
+    city: Council Bluff
+    fax: 712-352-0087
+    phone: 712-352-1167
+    state: IA
+    suite: ''
+    zip: '51501'
+- id:
+    bioguide: C000880
+    govtrack: 300030
+    thomas: '00250'
+  offices:
+  - address: 251 East Front Street
+    building: ''
+    city: Boise
+    fax: 208-334-9044
+    phone: 208-334-1776
+    state: ID
+    suite: Suite 205
+    zip: '83702'
+  - address: 610 Hubbard Street
+    building: ''
+    city: Coeur D'Alene
+    fax: 208-664-0889
+    phone: 208-664-5490
+    state: ID
+    suite: Suite 209
+    zip: '83814'
+  - address: 275 South 5th Avenue
+    building: ''
+    city: Pocatello
+    fax: 208-236-6935
+    phone: 208-236-6775
+    state: ID
+    suite: Suite 225
+    zip: '83201'
+  - address: 410 Memorial Drive
+    building: ''
+    city: Idaho Falls
+    fax: 208-529-8367
+    phone: 208-522-9779
+    state: ID
+    suite: Suite 204
+    zip: '83402'
+  - address: 313 D Street
+    building: ''
+    city: Lewiston
+    fax: 208-743-6484
+    phone: 208-743-1492
+    state: ID
+    suite: Suite 105
+    zip: '83501'
+  - address: 202 Falls Avenue
+    building: ''
+    city: Twin Falls
+    fax: 208-733-0414
+    phone: 208-734-2515
+    state: ID
+    suite: Suite 2
+    zip: '83301'
+- id:
+    bioguide: R000584
+    govtrack: 412322
+    thomas: 01896
+  offices:
+  - address: 901 Pier View Drive
+    building: ''
+    city: Idaho Falls
+    fax: 208-523-9373
+    phone: 208-523-5541
+    state: ID
+    suite: Suite 202A
+    zip: '83402'
+  - address: 1411 Falls Avenue East
+    building: ''
+    city: Twin Falls
+    fax: 208-734-3905
+    phone: 208-734-6780
+    state: ID
+    suite: Suite 201
+    zip: '83301'
+  - address: 350 North 9th Street
+    building: ''
+    city: Boise
+    fax: 208-343-2458
+    phone: 208-342-7985
+    state: ID
+    suite: Suite 302
+    zip: '83702'
+  - address: 313 D Street
+    building: ''
+    city: Lewiston
+    fax: 208-746-7275
+    phone: 208-743-0792
+    state: ID
+    suite: Suite 106
+    zip: '83501'
+  - address: 610 Hubbard
+    building: Harbor Plaza
+    city: Couer d'Alene
+    fax: 208-765-1743
+    phone: 208-667-6130
+    state: ID
+    suite: Suite 213
+    zip: '83814'
+  - address: 275 South 5th Street
+    building: ''
+    city: Pocatello
+    fax: 208-236-6820
+    phone: 208-236-6817
+    state: ID
+    suite: Suite 290
+    zip: '83201'
+- id:
+    bioguide: D000563
+    govtrack: 300038
+    thomas: '00326'
+  offices:
+  - address: 525 South Eighth Street
+    building: ''
+    city: Springfield
+    fax: 217-492-4382
+    phone: 217-492-4062
+    state: IL
+    suite: ''
+    zip: '62703'
+  - address: 230 South Dearborn
+    building: Kluczynski Federal Building
+    city: Chicago
+    fax: 312-353-0150
+    phone: 312-353-4952
+    state: IL
+    suite: 38th Floor
+    zip: '60604'
+  - address: 250 West Cherry Street
+    building: ''
+    city: Carbondale
+    fax: 618-351-1124
+    phone: 618-351-1122
+    state: IL
+    suite: Suite 115-D
+    zip: '62901'
+  - address: 1504 Third Avenue
+    building: ''
+    city: Rock Island
+    fax: 309-786-5404
+    phone: 309-786-5173
+    state: IL
+    suite: Suite 227
+    zip: '61201'
+- id:
+    bioguide: K000360
+    govtrack: 400222
+    thomas: '01647'
+  offices:
+  - address: 230 South Dearborn
+    building: ''
+    city: Chicago
+    fax: 312-886-2117
+    phone: 312-886-3506
+    state: IL
+    suite: Suite 3900
+    zip: '60604'
+  - address: 607 East Adams
+    building: ''
+    city: Springfield
+    fax: 217-492-5099
+    phone: 217-492-5089
+    state: IL
+    suite: Suite 1520
+    zip: '62701'
+- id:
+    bioguide: C000542
+    govtrack: 402675
+    thomas: 00209
+  offices:
+  - address: 10 West Market Street
+    building: ''
+    city: Indianapolis
+    fax: 317-554-0760
+    phone: 317-554-0750
+    state: IN
+    suite: 1650 Market Tower
+    zip: '46204'
+  - address: 11035 Broadway
+    building: ''
+    city: Crown Point
+    fax: 219-663-4586
+    phone: 219-663-2595
+    state: IN
+    suite: Suite A
+    zip: '46307'
+  - address: 101 Martin Luther King, Jr. Boulevard
+    building: ''
+    city: Evansville
+    fax: 812-465-6503
+    phone: 812-465-6500
+    state: IN
+    suite: ''
+    zip: '47708'
+  - address: 2 East McClain Avenue
+    building: ''
+    city: Scottsburg
+    fax: 812-754-0539
+    phone: 812-754-0520
+    state: IN
+    suite: Suite 2-A
+    zip: '47170'
+  - address: 1300 South Harrison Street
+    building: ''
+    city: Fort Wayne
+    fax: 260-420-0060
+    phone: 260-426-3151
+    state: IN
+    suite: Suite 3161
+    zip: '46802'
+- id:
+    bioguide: D000607
+    govtrack: 412205
+    thomas: 01850
+  offices:
+  - address: 115 North Pennsylvania Street
+    building: ''
+    city: Indianapolis
+    fax: 317-772-7518
+    phone: 317-226-5555
+    state: IN
+    suite: Suite 100
+    zip: '46204'
+  - address: 205 West Colfax Avenue
+    building: ''
+    city: South Bend
+    fax: 574-234-7476
+    phone: 574-288-2780
+    state: IN
+    suite: ''
+    zip: '46601'
+  - address: 123 NW 4th Street
+    building: ''
+    city: Evansville
+    fax: 812-425-5817
+    phone: 812-425-5813
+    state: IN
+    suite: Suite 417
+    zip: '47708'
+  - address: 203 East Berry Street
+    building: ''
+    city: Fort Wayne
+    fax: 260-420-4930
+    phone: 260-420-4955
+    state: IN
+    suite: Suite 702-B
+    zip: '46802'
+  - address: 5400 Federal Plaza
+    building: ''
+    city: Hammond
+    fax: 219-852-0729
+    phone: 219-852-0089
+    state: IN
+    suite: Suite 3200
+    zip: '46320'
+  - address: 702 North Shore Boulevard
+    building: ''
+    city: Jeffersonville
+    fax: 812-284-2044
+    phone: 812-284-2028
+    state: IN
+    suite: Suite LL-101
+    zip: '47103'
+- id:
+    bioguide: R000307
+    govtrack: 300083
+    thomas: 00968
+  offices:
+  - address: ''
+    building: 100 Military Plaza
+    city: Dodge City
+    fax: 620-227-2264
+    phone: 620-227-2244
+    state: KS
+    suite: PO Box 550
+    zip: '67801'
+  - address: 444 SE Quincy
+    building: Frank Carlson Federal Building
+    city: Topeka
+    fax: 785-235-3665
+    phone: 785-295-2745
+    state: KS
+    suite: Room 392
+    zip: '66683'
+  - address: 155 North Market Street
+    building: ''
+    city: Wichita
+    fax: 316-263-0273
+    phone: 316-263-0416
+    state: KS
+    suite: Suite 120
+    zip: '67202'
+  - address: 11900 College Boulevard
+    building: ''
+    city: Overland Park
+    fax: 913-451-9446
+    phone: 913-451-9343
+    state: KS
+    suite: Suite 203
+    zip: '66210'
+- id:
+    bioguide: M000934
+    govtrack: 400284
+    thomas: '01507'
+  offices:
+  - address: ''
+    building: ''
+    city: Olathe
+    fax: 913-768-1366
+    phone: 913-393-0711
+    state: KS
+    suite: PO Box 1154
+    zip: '66051'
+  - address: 1200 Main Street, Suite 402
+    building: ''
+    city: Hays
+    fax: 785-628-3791
+    phone: 785-628-6401
+    state: KS
+    suite: PO Box 249
+    zip: 67601-0249
+  - address: 3450 North Rock Road, Building 200, Suite 209
+    building: ''
+    city: Wichita
+    fax: 316-631-1297
+    phone: 316-631-1410
+    state: KS
+    suite: PO Box 781753
+    zip: '67226'
+  - address: 306 N. Broadway, Suite 125
+    building: ''
+    city: Pittsburg
+    fax: 620-232-2284
+    phone: 620-232-2286
+    state: KS
+    suite: PO Box 1372
+    zip: '66762'
+  - address: 923 Westport Place, Suite 210
+    building: ''
+    city: Manhattan
+    fax: 785-587-0789
+    phone: 785-539-8973
+    state: KS
+    suite: PO Box 067
+    zip: '66502'
+- id:
+    bioguide: M000355
+    govtrack: 300072
+    thomas: 01395
+  offices:
+  - address: 300 South Main Street
+    building: ''
+    city: London
+    fax: ''
+    phone: 606-864-2026
+    state: KY
+    suite: Suite 310
+    zip: '40741'
+  - address: 771 Corporate Drive
+    building: ''
+    city: Lexington
+    fax: ''
+    phone: 859-224-8286
+    state: KY
+    suite: Suite 108
+    zip: '40503'
+  - address: 601 West Broadway
+    building: ''
+    city: Louisville
+    fax: 502-582-5326
+    phone: 502-582-6304
+    state: KY
+    suite: Room 630
+    zip: '40202'
+  - address: 100 Fountain Avenue
+    building: ''
+    city: Paducah
+    fax: ''
+    phone: 270-442-4554
+    state: KY
+    suite: Suite 300
+    zip: '42001'
+  - address: 241 East Main Street
+    building: Federal Building
+    city: Bowling Green
+    fax: ''
+    phone: 270-781-1673
+    state: KY
+    suite: Room 102
+    zip: '42101'
+  - address: 1885 Dixie Higyway
+    building: ''
+    city: Fort Wright
+    fax: ''
+    phone: 859-578-0188
+    state: KY
+    suite: Suite 345
+    zip: '41011'
+- id:
+    bioguide: P000603
+    govtrack: 412492
+    thomas: 02082
+  offices:
+  - address: 1029 State Street
+    building: ''
+    city: Bowlling Green
+    fax: 270-782-8315
+    phone: 270-782-8303
+    state: KY
+    suite: ''
+    zip: '42101'
+  - address: 541 Buttermilk Pike
+    building: ''
+    city: Crescent Springs
+    fax: ''
+    phone: 859-426-0165
+    state: KY
+    suite: Suite 102
+    zip: '41017'
+  - address: 1100 South Main Street
+    building: ''
+    city: Hopkinsville
+    fax: ''
+    phone: 270-885-1212
+    state: KY
+    suite: Suite 12
+    zip: '42240'
+  - address: 771 Corporate Drive
+    building: ''
+    city: Lexington
+    fax: ''
+    phone: 859-219-2239
+    state: KY
+    suite: Suite 105
+    zip: '40503'
+  - address: 600 Dr. Martin Luther King Jr. Plaza
+    building: ''
+    city: Louisville
+    fax: ''
+    phone: 502-582-5341
+    state: KY
+    suite: Room 1072B
+    zip: '40202'
+  - address: 423 Frederica Street
+    building: ''
+    city: Owensboro
+    fax: ''
+    phone: 270-689-9085
+    state: KY
+    suite: Suite 305
+    zip: '42301'
+  - address: 601 Main Street
+    building: Gorman Education Center
+    city: Hazard
+    fax: 606-435-1761
+    phone: 606-435-2390
+    state: KY
+    suite: Suite 2
+    zip: '41701'
+  - address: 601 Main Street
+    building: Gorman Education Center
+    city: Hazard
+    fax: 606-435-2390
+    phone: 606-435-1761
+    state: KY
+    suite: Suite 2
+    zip: '41701'
+- id:
+    bioguide: V000127
+    govtrack: 400418
+    thomas: 01609
+  offices:
+  - address: 2800 Veterans Boulevard
+    building: ''
+    city: Metairre
+    fax: 504-589-2607
+    phone: 504-589-2753
+    state: LA
+    suite: Suite 201
+    zip: '70002'
+  - address: 1651 Louisville Avenue
+    building: ''
+    city: Monroe
+    fax: 318-325-9165
+    phone: 318-325-8120
+    state: LA
+    suite: Suite 148
+    zip: '71201'
+  - address: 920 Pierremont Road
+    building: ''
+    city: Shreveport
+    fax: 318-861-4865
+    phone: 318-861-0437
+    state: LA
+    suite: Suite 113
+    zip: '71106'
+  - address: 949 Ryan Street
+    building: ''
+    city: Lake Charles
+    fax: 337-436-3163
+    phone: 337-436-0453
+    state: LA
+    suite: Suite E
+    zip: '70601'
+  - address: 858 Convention Street
+    building: ''
+    city: Baton Rouge
+    fax: 225-383-0952
+    phone: 225-383-0331
+    state: LA
+    suite: ''
+    zip: '70802'
+  - address: 6501 Coliseum Boulevard
+    building: Plaza 28
+    city: Alexandria
+    fax: 318-448-0189
+    phone: 318-448-0169
+    state: LA
+    suite: Suite 700-A
+    zip: '71303'
+  - address: 2201 Kaliste Saloom Road
+    building: ''
+    city: Lafayette
+    fax: 337-993-9567
+    phone: 337-993-9502
+    state: LA
+    suite: Suite 201
+    zip: '70508'
+- id:
+    bioguide: C001075
+    govtrack: 412269
+    thomas: 01925
+  offices:
+  - address: 5555 Hilton Avenue
+    building: ''
+    city: Baton Rouge
+    fax: 225-929-7688
+    phone: 225-929-7711
+    state: LA
+    suite: Suite 100
+    zip: '70808'
+  - address: 3421 North Causeway Boulevard
+    building: ''
+    city: Metairie
+    fax: 504-838-0133
+    phone: 504-838-0130
+    state: LA
+    suite: Suite 204
+    zip: '70002'
+  - address: 101 La Rue France
+    building: ''
+    city: Lafayette
+    fax: 337-261-1490
+    phone: 337-261-1400
+    state: LA
+    suite: Suite 505
+    zip: '70508'
+- id:
+    bioguide: W000817
+    govtrack: 412542
+    thomas: 02182
+  offices:
+  - address: 15 New Sudbury Street
+    building: 2400 JFK Federal Building
+    city: Boston
+    fax: ''
+    phone: 617-565-3170
+    state: MA
+    suite: ''
+    zip: '02203'
+  - address: 1550 Main Street
+    building: ''
+    city: Springfield
+    fax: ''
+    phone: 413-788-2690
+    state: MA
+    suite: Suite 406
+    zip: '01103'
+- id:
+    bioguide: M000133
+    govtrack: 400253
+    thomas: '00735'
+  offices:
+  - address: 15 New Sudbury Street
+    building: JFK Federal Building
+    city: Boston
+    fax: ''
+    phone: 617-565-8519
+    state: MA
+    suite: Suite 975
+    zip: '02203'
+  - address: 222 Milliken Boulevard
+    building: ''
+    city: Fall River
+    fax: ''
+    phone: 508-677-0523
+    state: MA
+    suite: Suite 312
+    zip: '02721'
+  - address: 1550 Main Street
+    building: ''
+    city: Springfield
+    fax: ''
+    phone: 413-785-4610
+    state: MA
+    suite: 4th Floor
+    zip: '01101'
+- id:
+    bioguide: M000702
+    govtrack: 300073
+    thomas: 00802
+  offices:
+  - address: 212 West Main Street
+    building: The Gallery Plaza Building
+    city: Salisbury
+    fax: 410-546-9324
+    phone: 410-546-7711
+    state: MD
+    suite: Suite 200
+    zip: '21801'
+  - address: 32 West Washington Street
+    building: ''
+    city: Hagerstown
+    fax: 301- 797-2241
+    phone: 301-797-2826
+    state: MD
+    suite: Room 203
+    zip: '21740'
+  - address: 901 South Bond Street
+    building: ''
+    city: Baltimore
+    fax: 410-962-4760
+    phone: 410-962-4510
+    state: MD
+    suite: Suite 310
+    zip: '21231'
+  - address: 6404 Ivy Lane
+    building: ''
+    city: Greenbelt
+    fax: 301-345-7573
+    phone: 301-345-5517
+    state: MD
+    suite: Suite 406
+    zip: 20770-1407
+  - address: 60 West Street
+    building: ''
+    city: Annapolis
+    fax: 410-263-5949
+    phone: 410-263-1805
+    state: MD
+    suite: Suite 202
+    zip: 21401-2448
+- id:
+    bioguide: C000141
+    govtrack: 400064
+    thomas: '00174'
+  offices:
+  - address: 100 South Charles Street
+    building: ''
+    city: Baltimore
+    fax: 410-962-4156
+    phone: 410-962-4436
+    state: MD
+    suite: Tower I, Suite 1710
+    zip: '21201'
+  - address: 10201 Martin Luther King Jr. Highway
+    building: ''
+    city: Bowie
+    fax: 301-860-0416
+    phone: 301-860-0414
+    state: MD
+    suite: Suite 210
+    zip: '20720'
+  - address: 129 East Main Street,  PO Box 11
+    building: ''
+    city: Salisbury
+    fax: 410-546-4252
+    phone: 410-546-4250
+    state: MD
+    suite: Suite 115
+    zip: '21801'
+  - address: 13 Canal Street
+    building: ''
+    city: Cumberland
+    fax: 301-777-2959
+    phone: 301-777-2957
+    state: MD
+    suite: Room 305
+    zip: '21502'
+  - address: 451 Hungerford Drive
+    building: ''
+    city: Rockville
+    fax: 301-762-2976
+    phone: 301-762-2974
+    state: MD
+    suite: Suite 230
+    zip: '20850'
+- id:
+    bioguide: C001035
+    govtrack: 300025
+    thomas: '01541'
+  offices:
+  - address: 202 Harlow Street
+    building: ''
+    city: Bangor
+    fax: 207-990-4604
+    phone: 207-945-0417
+    state: ME
+    suite: Room 20100
+    zip: '04401'
+  - address: 160 Main Street
+    building: ''
+    city: Biddeford
+    fax: 207-283-4054
+    phone: 207-283-1101
+    state: ME
+    suite: ''
+    zip: '04005'
+  - address: 55 Lisbon Street
+    building: ''
+    city: Lewiston
+    fax: 207-782-6475
+    phone: 207-784-6969
+    state: ME
+    suite: ''
+    zip: '04240'
+  - address: 68 Seawall Street
+    building: ''
+    city: Augusta
+    fax: 207-622-5884
+    phone: 207-622-8414
+    state: ME
+    suite: Room 507
+    zip: '04330'
+  - address: 25 Sweden Street
+    building: ''
+    city: Caribou
+    fax: 207-493-7810
+    phone: 207-493-7873
+    state: ME
+    suite: Suite A
+    zip: '04736'
+  - address: 1 Canal Plaza
+    building: ''
+    city: Portland
+    fax: 207-828-0380
+    phone: 207-780-3575
+    state: ME
+    suite: Suite 802
+    zip: '04101'
+- id:
+    bioguide: K000383
+    govtrack: 412545
+    thomas: 02185
+  offices:
+  - address: 4 Gabriel Drive
+    building: ''
+    city: Augusta
+    fax: ''
+    phone: 207-622-8292
+    state: ME
+    suite: Suite 3
+    zip: '04330'
+  - address: 383 US Route 1
+    building: ''
+    city: Scarborough
+    fax: ''
+    phone: 207-883-1588
+    state: ME
+    suite: Suite 1C
+    zip: '04074'
+  - address: 169 Academy Street
+    building: ''
+    city: Presque Isle
+    fax: ''
+    phone: 207-764-5124
+    state: ME
+    suite: Suite A
+    zip: 04769
+- id:
+    bioguide: S000770
+    govtrack: 300093
+    thomas: '01531'
+  offices:
+  - address: 719 Griswold Street
+    building: ''
+    city: Detroit
+    fax: 313-961-7566
+    phone: 313-961-4330
+    state: MI
+    suite: Suite 700
+    zip: '48226'
+  - address: 1901 West Ridge
+    building: ''
+    city: Marquette
+    fax: 906-228-9162
+    phone: 906-228-8756
+    state: MI
+    suite: Suite 7
+    zip: '49855'
+  - address: 3335 South Airport Road West
+    building: ''
+    city: Traverse City
+    fax: 231-929-1250
+    phone: 231-929-1031
+    state: MI
+    suite: Suite 6B
+    zip: '49684'
+  - address: 432 North Saginaw Street
+    building: ''
+    city: Flint
+    fax: 810-720-4178
+    phone: 810-720-4172
+    state: MI
+    suite: Suite 301
+    zip: '48502'
+  - address: 221 West Lake Lansing Road
+    building: ''
+    city: East Lansing
+    fax: 517-203-1778
+    phone: 517-203-1760
+    state: MI
+    suite: Suite 100
+    zip: '48823'
+  - address: 3280 East Beltline Court, NE
+    building: ''
+    city: Grand Rapids
+    fax: 616-975-5764
+    phone: 616-975-0052
+    state: MI
+    suite: Suite 400
+    zip: '49525'
+- id:
+    bioguide: P000595
+    govtrack: 412305
+    thomas: 01929
+  offices:
+  - address: 477 Michigan Avenue
+    building: Patrick V. McNamara Federal Building
+    city: Detroit
+    fax: 313-226-6948
+    phone: 313-226-6020
+    state: MI
+    suite: Suite 1860
+    zip: 48226-2594
+  - address: 124 West Allegan Street
+    building: ''
+    city: Lansing
+    fax: ''
+    phone: 517-377-1508
+    state: MI
+    suite: Suite 1810
+    zip: '48933'
+  - address: 110 Michigan Street NW
+    building: Gerald R. Ford Federal Building
+    city: Grand Rapids
+    fax: ''
+    phone: 616-233-9150
+    state: MI
+    suite: Suite 720
+    zip: '49503'
+  - address: 515 North Washington Avenue
+    building: ''
+    city: Saginaw
+    fax: ''
+    phone: 989-754-0112
+    state: MI
+    suite: Suite 404
+    zip: '48607'
+  - address: 407 6th Street
+    building: ''
+    city: Rochester
+    fax: ''
+    phone: 248-608-8040
+    state: MI
+    suite: Suite C
+    zip: '48307'
+- id:
+    bioguide: K000367
+    govtrack: 412242
+    thomas: 01826
+  offices:
+  - address: 1130 1/2 7th Street NW
+    building: ''
+    city: Rochester
+    fax: 507-288-2922
+    phone: 507-288-5321
+    state: MN
+    suite: Suite 208
+    zip: '55901'
+  - address: 820 9th Street North
+    building: Olcott Plaza
+    city: Virginia
+    fax: 218-741-3692
+    phone: 218-741-9690
+    state: MN
+    suite: Room 105
+    zip: '55792'
+  - address: 121 4th Street South
+    building: ''
+    city: Moorhead
+    fax: 218-287-2930
+    phone: 218-287-2219
+    state: MN
+    suite: ''
+    zip: '56560'
+  - address: 1200 Washington Avenue South
+    building: ''
+    city: Minneapolis
+    fax: 612-727-5223
+    phone: 612-727-5220
+    state: MN
+    suite: Suite 250
+    zip: '55415'
+- id:
+    bioguide: F000457
+    govtrack: 412378
+    thomas: 01969
+  offices:
+  - address: 208 South Minnesota Avenue
+    building: ''
+    city: Saint Peter
+    fax: ''
+    phone: 507-931-5813
+    state: MN
+    suite: Suite 6
+    zip: '56082'
+  - address: 916 West Saint Germain Street
+    building: ''
+    city: Saint Cloud
+    fax: ''
+    phone: 320-251-2721
+    state: MN
+    suite: Suite 110
+    zip: '56301'
+  - address: 60 East Plato Boulevard
+    building: ''
+    city: St. Paul
+    fax: 651-221-1078
+    phone: 651-221-1016
+    state: MN
+    suite: Suite 220
+    zip: '55107'
+  - address: 515 West 1st Street
+    building: ''
+    city: Duluth
+    fax: ''
+    phone: 218-722-2390
+    state: MN
+    suite: Suite 104
+    zip: '55802'
+  - address: 1202-1/2 7th Street NW
+    building: ''
+    city: Rochester
+    fax: ''
+    phone: 507-288-2003
+    state: MN
+    suite: Suite 213
+    zip: '55901'
+- id:
+    bioguide: M001170
+    govtrack: 412243
+    thomas: 01820
+  offices:
+  - address: 28 North 8th Street
+    building: ''
+    city: Columbia
+    fax: 573-442-7140
+    phone: 573-442-7130
+    state: MO
+    suite: Suite 500
+    zip: '65201'
+  - address: 5850 Delmar Boulevard
+    building: ''
+    city: St. Louis
+    fax: 314-361-8649
+    phone: 314-367-1364
+    state: MO
+    suite: Suite A
+    zip: '63112'
+  - address: 555 Independence Avenue
+    building: ''
+    city: Cape Girardeau
+    fax: 573-334-4278
+    phone: 573-651-0964
+    state: MO
+    suite: Room 1600
+    zip: '63701'
+  - address: 4141 Pennsylvania
+    building: ''
+    city: Kansas City
+    fax: 816-421-2562
+    phone: 816-421-1639
+    state: MO
+    suite: Suite 101
+    zip: '64111'
+  - address: 324 Park Central West
+    building: ''
+    city: Springfield
+    fax: 417-831-1349
+    phone: 417-868-8745
+    state: MO
+    suite: Suite 101
+    zip: '65806'
+- id:
+    bioguide: B000575
+    govtrack: 400034
+    thomas: '01464'
+  offices:
+  - address: 1000 Walnut Street
+    building: ''
+    city: Kansas City
+    fax: 816-471-7338
+    phone: 816-471-7141
+    state: MO
+    suite: Suite 1560
+    zip: '64106'
+  - address: 2740-B East Sunshine
+    building: ''
+    city: Springfield
+    fax: 417-823-9662
+    phone: 417-877-7814
+    state: MO
+    suite: ''
+    zip: 65804-2047
+  - address: 7700 Bonhomme
+    building: ''
+    city: Clayton
+    fax: 314-727-3548
+    phone: 314-725-4484
+    state: MO
+    suite: '#315'
+    zip: '63105'
+  - address: 2502 Tanner Drive
+    building: ''
+    city: Cape Girardeau
+    fax: 573-334-7352
+    phone: 573-334-7044
+    state: MO
+    suite: Suite 208
+    zip: '63703'
+  - address: 1001 Cherry Street
+    building: ''
+    city: Columbia
+    fax: 573-442-8162
+    phone: 573-442-8151
+    state: MO
+    suite: Suite 104
+    zip: '65201'
+- id:
+    bioguide: C000567
+    govtrack: 300023
+    thomas: '00213'
+  offices:
+  - address: 2012 15th Street
+    building: ''
+    city: Gulfport
+    fax: ''
+    phone: 228-867-9710
+    state: MS
+    suite: Suite 451
+    zip: '39501'
+  - address: 911 East Jackson Avenue
+    building: U.S. Federal Court House
+    city: Oxford
+    fax: ''
+    phone: 662-236-1018
+    state: MS
+    suite: Suite 249
+    zip: '38655'
+  - address: 190 East Capitol Street
+    building: ''
+    city: Jackson
+    fax: ''
+    phone: 601-965-4459
+    state: MS
+    suite: Suite 550
+    zip: '39201'
+- id:
+    bioguide: W000437
+    govtrack: 400432
+    thomas: '01226'
+  offices:
+  - address: 3118 Pascagoula Street
+    building: ''
+    city: Pascagoula
+    fax: 228-762-0137
+    phone: 228-762-5400
+    state: MS
+    suite: Suite 179
+    zip: '39567'
+  - address: 321 Losher Street
+    building: ''
+    city: Hernando
+    fax: 662-429-6002
+    phone: 662-429-1002
+    state: MS
+    suite: PO Box 385
+    zip: '38632'
+  - address: 501 East Court Street
+    building: U.S. Federal Court House
+    city: Jackson
+    fax: 601-965-4007
+    phone: 601-965-4644
+    state: MS
+    suite: Suite 3-500
+    zip: 39201-2409
+  - address: 2909 13th Street
+    building: ''
+    city: Gulfport
+    fax: 228-871-7196
+    phone: 228-871-7017
+    state: MS
+    suite: Suite 303
+    zip: '39501'
+  - address: 330 West Jefferson Street, Suite B
+    building: ''
+    city: Tupelo
+    fax: 662-844-5030
+    phone: 662-844-5010
+    state: MS
+    suite: PO Box 3777
+    zip: '38803'
+- id:
+    bioguide: T000464
+    govtrack: 412244
+    thomas: 01829
+  offices:
+  - address: 125 West Granite
+    building: Silver Bow Center
+    city: Butte
+    fax: 406-782-4717
+    phone: 406-723-3277
+    state: MT
+    suite: Suite 200
+    zip: '59701'
+  - address: 208 North Montana Avenue
+    building: Capital One Center
+    city: Helena
+    fax: 406-449-5462
+    phone: 406-449-5401
+    state: MT
+    suite: Suite 202
+    zip: '59601'
+  - address: 122 West Towne
+    building: ''
+    city: Glendive
+    fax: 406-365-8836
+    phone: 406-365-2391
+    state: MT
+    suite: ''
+    zip: '59330'
+  - address: 2900 4th Avenue North
+    building: Judge Jameson Federal Building
+    city: Billings
+    fax: 406-252-7768
+    phone: 406-252-0550
+    state: MT
+    suite: Suite 201
+    zip: '59101'
+  - address: 1 East Main Street
+    building: Avant Courier Building
+    city: Bozeman
+    fax: 406-586-7647
+    phone: 406-586-4450
+    state: MT
+    suite: Suite 202
+    zip: '59715'
+  - address: 8 Third Street East
+    building: ''
+    city: Kalispell
+    fax: 406-257-3974
+    phone: 406-257-3360
+    state: MT
+    suite: ''
+    zip: '59901'
+  - address: 119 First Avenue North
+    building: ''
+    city: Great Falls
+    fax: 406-452-9586
+    phone: 406-452-9585
+    state: MT
+    suite: Suite 102
+    zip: '59401'
+  - address: 130 West Front Street
+    building: ''
+    city: Missoula
+    fax: 406-728-2193
+    phone: 406-728-3003
+    state: MT
+    suite: ''
+    zip: '59802'
+- id:
+    bioguide: D000618
+    govtrack: 412549
+    thomas: 02138
+  offices:
+  - address: 122 West Towne Street
+    building: ''
+    city: Glendive
+    fax: ''
+    phone: 406-365-7002
+    state: MT
+    suite: ''
+    zip: '59330'
+  - address: 30 West 14th Street
+    building: Empire Block
+    city: Helena
+    fax: ''
+    phone: 406-449-5480
+    state: MT
+    suite: Suite 206
+    zip: '59601'
+  - address: 280 East Front Street
+    building: ''
+    city: Missoula
+    fax: ''
+    phone: 406-329-3123
+    state: MT
+    suite: Suite 100
+    zip: '59802'
+  - address: 220 West Lamme Street
+    building: ''
+    city: Bozeman
+    fax: ''
+    phone: 406-587-3446
+    state: MT
+    suite: Suite 1D
+    zip: '59715'
+  - address: 222 North 32nd Street
+    building: ''
+    city: Billings
+    fax: ''
+    phone: 406-245-6822
+    state: MT
+    suite: Suite 100
+    zip: '59101'
+  - address: 8 Third Street East
+    building: ''
+    city: Kalispell
+    fax: 406-756-1152
+    phone: 406-756-1150
+    state: MT
+    suite: ''
+    zip: '59901'
+  - address: 245 East Park Street
+    building: ''
+    city: Butte
+    fax: 406-782-6553
+    phone: 406-782-8700
+    state: MT
+    suite: ''
+    zip: '59701'
+  - address: 104 4th Street North
+    building: ''
+    city: Great Falls
+    fax: 406-727-3726
+    phone: 406-761-1574
+    state: MT
+    suite: Suite 302
+    zip: '59401'
+- id:
+    bioguide: B001135
+    govtrack: 400054
+    thomas: '00153'
+  offices:
+  - address: 201 North Front Street
+    building: ''
+    city: Wilmington
+    fax: 910-251-7975
+    phone: 888-848-1833
+    state: NC
+    suite: Suite 809
+    zip: '28401'
+  - address: 100 Coast Line Street
+    building: ''
+    city: Rocky Mount
+    fax: 252-977-7902
+    phone: 252-977-9522
+    state: NC
+    suite: Room 210
+    zip: '27804'
+  - address: 2000 West First Street
+    building: ''
+    city: Winston-Salem
+    fax: 336-725-4493
+    phone: 800-685-8916
+    state: NC
+    suite: Suite 508
+    zip: '27104'
+- id:
+    bioguide: T000476
+    govtrack: 412668
+    thomas: 02291
+  offices:
+  - address: 310 New Bern Avenue
+    building: ''
+    city: Raleigh
+    fax: 919-856-4053
+    phone: 919-856-4630
+    state: NC
+    suite: Suite 122
+    zip: '27601'
+  - address: 301 South Evans Street
+    building: ''
+    city: Greenville
+    fax: 252-329-0290
+    phone: 252-329-0371
+    state: NC
+    suite: Suite 102
+    zip: '27858'
+  - address: 1520 South Boulevard
+    building: ''
+    city: Charlotte
+    fax: 704-334-2405
+    phone: 704-334-2448
+    state: NC
+    suite: Suite 205
+    zip: '28203'
+  - address: ''
+    building: 7 Historic Courthouse Square
+    city: Hendersonville
+    fax: 828-693-9274
+    phone: 828-693-8750
+    state: NC
+    suite: Suite 112
+    zip: '28792'
+  - address: 1840 Eastchester Drive
+    building: ''
+    city: High Point
+    fax: 336-885-0692
+    phone: 336-885-0685
+    state: NC
+    suite: ''
+    zip: '27265'
+- id:
+    bioguide: H001061
+    govtrack: 412494
+    thomas: 02079
+  offices:
+  - address: 220 East Rosser Avenue
+    building: Federal Building
+    city: Bismarck
+    fax: 701-250-4484
+    phone: 701-250-4618
+    state: ND
+    suite: Room 312
+    zip: '58501'
+  - address: 101 First Street
+    building: ''
+    city: Fargo
+    fax: 701-239-5112
+    phone: 701-239-5389
+    state: ND
+    suite: Suite 107
+    zip: '58103'
+  - address: 102 North Fourth Street
+    building: Federal Building
+    city: Grand Forks
+    fax: ''
+    phone: 701-746-8972
+    state: ND
+    suite: Room 108
+    zip: '58203'
+  - address: 315 Main Street, South
+    building: ''
+    city: Minot
+    fax: 701-838-1381
+    phone: 701-838-1361
+    state: ND
+    suite: Suite 204
+    zip: '58701'
+- id:
+    bioguide: H001069
+    govtrack: 412554
+    thomas: '02174'
+  offices:
+  - address: 220 East Rosser Avenue
+    building: Federal Building
+    city: Bismarck
+    fax: 701-258-1254
+    phone: 701-258-4648
+    state: ND
+    suite: Suite 228
+    zip: '58501'
+  - address: 657 Second Avenue North
+    building: Federal Building
+    city: Fargo
+    fax: 701-232-6449
+    phone: 701-232-8030
+    state: ND
+    suite: Suite 306
+    zip: '58102'
+  - address: 40 1st Avenue West
+    building: ''
+    city: Dickinson
+    fax: 701-225-3287
+    phone: 701-225-0974
+    state: ND
+    suite: Suite 202
+    zip: '58601'
+  - address: 33 South Third Street
+    building: ''
+    city: Grand Forks
+    fax: 701-746-1990
+    phone: 701-775-9601
+    state: ND
+    suite: Suite B
+    zip: '58201'
+  - address: 100 First Street SW
+    building: Federal Building
+    city: Minot
+    fax: 701-838-8196
+    phone: 701-852-0703
+    state: ND
+    suite: Suite 105
+    zip: '58701'
+- id:
+    bioguide: F000463
+    govtrack: 412556
+    thomas: 02179
+  offices:
+  - address: 11819 Miracle Hills Drive
+    building: ''
+    city: Omaha
+    fax: 402-391-4725
+    phone: 402-391-3411
+    state: NE
+    suite: Suite 205
+    zip: '68154'
+  - address: 440 North 8th Street
+    building: ''
+    city: Lincoln
+    fax: 402-476-8753
+    phone: 402-441-4600
+    state: NE
+    suite: Suite 120
+    zip: '68508'
+  - address: 1110 Circle Drive
+    building: ''
+    city: Scottsbluff
+    fax: 308-630-2321
+    phone: 308-630-2329
+    state: NE
+    suite: Suite F2
+    zip: '69361'
+  - address: 20 West 23rd Street
+    building: ''
+    city: Kearney
+    fax: 308-234-3684
+    phone: 308-234-2361
+    state: NE
+    suite: ''
+    zip: '68847'
+- id:
+    bioguide: S001197
+    govtrack: 412671
+    thomas: 02289
+  offices:
+  - address: ' 115 Railway Street'
+    building: ''
+    city: Scottsbluff
+    fax: ''
+    phone: 308-632-6032
+    state: NE
+    suite: Suite C102
+    zip: '69361'
+  - address: 4111 Fourth Avenue
+    building: ''
+    city: Kearney
+    fax: ''
+    phone: 308-233-3677
+    state: NE
+    suite: Suite 26
+    zip: '68845'
+  - address: 1128 Lincoln Mall
+    building: ''
+    city: Lincoln
+    fax: ''
+    phone: 402-476-1400
+    state: NE
+    suite: Suite 305
+    zip: '68508'
+  - address: 304 North 168th Circle
+    building: ''
+    city: Omaha
+    fax: ''
+    phone: 402-550-8040
+    state: NE
+    suite: Suite 213
+    zip: '68118'
+- id:
+    bioguide: S001181
+    govtrack: 412323
+    thomas: 01901
+  offices:
+  - address: 50 Opera House Square
+    building: ''
+    city: Claremont
+    fax: 603-542-6582
+    phone: 603-542-4872
+    state: NH
+    suite: ''
+    zip: '03743'
+  - address: 60 Main Street
+    building: ''
+    city: Nashua
+    fax: 603-883-0489
+    phone: 603-883-0196
+    state: NH
+    suite: ''
+    zip: '03060'
+  - address: 2 Wall Street
+    building: ''
+    city: Manchester
+    fax: 603-647-9352
+    phone: 603-647-7500
+    state: NH
+    suite: Suite 220
+    zip: '03101'
+  - address: 961 Main Street
+    building: ''
+    city: Berlin
+    fax: 603-752-6305
+    phone: 603-752-6300
+    state: NH
+    suite: ''
+    zip: '03570'
+  - address: 340 Central Avenue
+    building: ''
+    city: Dover
+    fax: 603-750-4046
+    phone: 603-750-3004
+    state: NH
+    suite: Suite 205
+    zip: 03820
+  - address: 12 Gilbo Avenue
+    building: ''
+    city: Keene
+    fax: ''
+    phone: 603-358-6604
+    state: NH
+    suite: Suite C
+    zip: '03431'
+- id:
+    bioguide: A000368
+    govtrack: 412493
+    thomas: '02075'
+  offices:
+  - address: 1200 Elm Street
+    building: ''
+    city: Manchester
+    fax: 603-622-0422
+    phone: 603-622-7979
+    state: NH
+    suite: Suite 2
+    zip: 03101-2503
+  - address: 144 Main Street
+    building: ''
+    city: Nashua
+    fax: ''
+    phone: 603-880-3335
+    state: NH
+    suite: ''
+    zip: '03060'
+  - address: 14 Manchester Square
+    building: ''
+    city: Portsmouth
+    fax: ''
+    phone: 603-436-7161
+    state: NH
+    suite: Suite 140
+    zip: 03801
+  - address: 19 Pleasant Street
+    building: ''
+    city: Berlin
+    fax: 603-752-7704
+    phone: 603-752-7702
+    state: NH
+    suite: Suite 13B
+    zip: '03570'
+- id:
+    bioguide: M000639
+    govtrack: 400272
+    thomas: 00791
+  offices:
+  - address: ''
+    building: One Gateway Center
+    city: Newark
+    fax: 973-645-0502
+    phone: 973-645-3030
+    state: NJ
+    suite: 11th Floor
+    zip: '07102'
+  - address: 208 White Horse Pike
+    building: ''
+    city: Barrington
+    fax: 856-546-1526
+    phone: 856-757-5353
+    state: NJ
+    suite: Suite 18
+    zip: 08007
+- id:
+    bioguide: B001288
+    govtrack: 412598
+    thomas: 02194
+  offices:
+  - address: 11-43 Raymond Plaza West
+    building: One Gateway Center
+    city: Newark
+    fax: 973-639-8723
+    phone: 973-639-8700
+    state: NJ
+    suite: 23rd Floor
+    zip: '07102'
+  - address: 2 Riverside Drive
+    building: One Port Center
+    city: Camden
+    fax: 856-338-8936
+    phone: 856-338-8922
+    state: NJ
+    suite: Suite 505
+    zip: 08101
+- id:
+    bioguide: U000039
+    govtrack: 400413
+    thomas: '01567'
+  offices:
+  - address: 201 North Church Street
+    building: ''
+    city: Las Cruces
+    fax: 575-523-6589
+    phone: 575-526-5475
+    state: NM
+    suite: Suite 201B
+    zip: '88001'
+  - address: 219 Central Avenue NW
+    building: ''
+    city: Albuquerque
+    fax: 505-346-6720
+    phone: 505-346-6791
+    state: NM
+    suite: Suite 210
+    zip: '87102'
+  - address: 120 South Federal Place
+    building: ''
+    city: Santa Fe
+    fax: 505-988-6514
+    phone: 505-988-6511
+    state: NM
+    suite: Suite 302
+    zip: '87501'
+  - address: 102 West Hagerman Street
+    building: ''
+    city: Carlsbad
+    fax: ''
+    phone: 575-234-0366
+    state: NM
+    suite: Suite A
+    zip: '88220'
+  - address: 100 South Avenue A
+    building: ''
+    city: Portales
+    fax: ''
+    phone: 575-356-6811
+    state: NM
+    suite: Suite 113
+    zip: '88130'
+- id:
+    bioguide: H001046
+    govtrack: 412281
+    thomas: 01937
+  offices:
+  - address: 7450 East Main Street
+    building: ''
+    city: Farmington
+    fax: 505-325-6035
+    phone: 505-325-5030
+    state: NM
+    suite: Suite A
+    zip: '87402'
+  - address: 200 East Fourth Street
+    building: ''
+    city: Roswell
+    fax: 575-622-3538
+    phone: 575-622-7113
+    state: NM
+    suite: Suite 300
+    zip: '88201'
+  - address: 625 Silver Avenue SW
+    building: ''
+    city: Albuquerque
+    fax: 505-346-6780
+    phone: 505-346-6601
+    state: NM
+    suite: Suite 130
+    zip: '87102'
+  - address: 505 South Main
+    building: Loretto Towne Center
+    city: Las Cruces
+    fax: 575-523-6584
+    phone: 575-523-6561
+    state: NM
+    suite: Suite 148
+    zip: '88001'
+  - address: 123 East Marcy Street
+    building: ''
+    city: Santa Fe
+    fax: 505-992-8435
+    phone: 505-988-6647
+    state: NM
+    suite: Suite 103
+    zip: '87501'
+- id:
+    bioguide: R000146
+    govtrack: 300082
+    thomas: 00952
+  offices:
+  - address: 600 East Williams Street
+    building: ''
+    city: Carson City
+    fax: 775-883-1980
+    phone: 775-882-7343
+    state: NV
+    suite: Suite 304
+    zip: 89701-4048
+  - address: 333 Las Vegas Boulevard South
+    building: Lloyd D. George Building
+    city: Las Vegas
+    fax: 702-388-5030
+    phone: 702-388-5020
+    state: NV
+    suite: Suite 8016
+    zip: '89101'
+  - address: 400 South Virginia Street
+    building: Bruce R. Thompson Courthouse and Federal Building
+    city: Reno
+    fax: 775-686-5757
+    phone: 775-686-5750
+    state: NV
+    suite: Suite 902
+    zip: 89501-2193
+- id:
+    bioguide: H001041
+    govtrack: 412218
+    thomas: 01863
+  offices:
+  - address: 8930 West Sunset Road
+    building: ''
+    city: Las Vegas
+    fax: 702-388-6501
+    phone: 702-388-6605
+    state: NV
+    suite: Suite 230
+    zip: '89148'
+  - address: 400 South Virginia Street
+    building: Bruce Thompson Federal Building
+    city: Reno
+    fax: 775-686-5729
+    phone: 775-686-5770
+    state: NV
+    suite: Suite 738
+    zip: '89501'
+  - address: 3290 East Idaho Street
+    building: ''
+    city: Elko
+    fax: 775-738-2004
+    phone: 775-738-2002
+    state: NV
+    suite: Suite 2A
+    zip: '89801'
+- id:
+    bioguide: S000148
+    govtrack: 300087
+    thomas: '01036'
+  offices:
+  - address: 15 Henry Street
+    building: ''
+    city: Binghamton
+    fax: 607-772-8124
+    phone: 607-772-6792
+    state: NY
+    suite: Room 100 A-F
+    zip: '13901'
+  - address: 1 Clinton Square
+    building: Leo W. O'Brien Federal Office Building
+    city: Albany
+    fax: 518-431-4076
+    phone: 518-431-4070
+    state: NY
+    suite: Room 420
+    zip: '12207'
+  - address: 100 State Street
+    building: ''
+    city: Rochester
+    fax: 585-263-3173
+    phone: 585-263-5866
+    state: NY
+    suite: Room 3040
+    zip: '14614'
+  - address: 145 Pine Lawn Road
+    building: ''
+    city: Melville
+    fax: 631-753-0997
+    phone: 631-753-0978
+    state: NY
+    suite: '# 300'
+    zip: '11747'
+  - address: 100 South Clinton Street
+    building: ''
+    city: Syracuse
+    fax: 315-423-5185
+    phone: 315-423-5471
+    state: NY
+    suite: Room 841
+    zip: 13261-7318
+  - address: 780 Third Avenue
+    building: ''
+    city: New York
+    fax: 202-228-2838
+    phone: 212-486-4430
+    state: NY
+    suite: Suite 2301
+    zip: '10017'
+  - address: 1 Park Place
+    building: ''
+    city: Peekskill
+    fax: 914-734-1673
+    phone: 914-734-1532
+    state: NY
+    suite: Suite 100
+    zip: '10566'
+  - address: 130 South Elmwood Avenue
+    building: ''
+    city: Buffalo
+    fax: 716-846-4113
+    phone: 716-846-4111
+    state: NY
+    suite: '#660'
+    zip: '14202'
+- id:
+    bioguide: G000555
+    govtrack: 412223
+    thomas: 01866
+  offices:
+  - address: 155 Pinelawn Road
+    building: ''
+    city: Melville
+    fax: 631-249-2847
+    phone: 631-249-2825
+    state: NY
+    suite: Suite 250 North
+    zip: '11747'
+  - address: 100 State Street
+    building: Kenneth B. Keating Federal Office Building
+    city: Rochester
+    fax: 585-263-6247
+    phone: 585-263-6250
+    state: NY
+    suite: Room 4195
+    zip: '14614'
+  - address: 1 Clinton Square
+    building: Leo W. O'Brien Federal Building
+    city: Albany
+    fax: 518-431-0128
+    phone: 518-431-0120
+    state: NY
+    suite: Room 821
+    zip: '12207'
+  - address: 780 Third Avenue
+    building: ''
+    city: New York
+    fax: 212-688-7444
+    phone: 212-688-6262
+    state: NY
+    suite: Suite 2601
+    zip: '10017'
+  - address: 726 Exchange Street
+    building: ''
+    city: Buffalo
+    fax: 716-854-9731
+    phone: 716-854-9725
+    state: NY
+    suite: Suite 511
+    zip: '14210'
+  - address: 100 South Clinton Street, Room 1470
+    building: James M. Hanley Federal Building
+    city: Syracuse
+    fax: 315-448-0476
+    phone: 315-448-0470
+    state: NY
+    suite: PO Box 7378
+    zip: '13261'
+- id:
+    bioguide: B000944
+    govtrack: 400050
+    thomas: '00136'
+  offices:
+  - address: 425 Walnut Street
+    building: ''
+    city: Cincinnati
+    fax: 513-684-1029
+    phone: 513-684-1021
+    state: OH
+    suite: Suite 2310
+    zip: '45202'
+  - address: 801 West Superior Avenue
+    building: ''
+    city: Cleveland
+    fax: 216-522-2239
+    phone: 216-522-7272
+    state: OH
+    suite: Suite 1400
+    zip: '44113'
+  - address: 200 West Erie Avenue
+    building: ''
+    city: Lorain
+    fax: 440-242-4108
+    phone: 440-242-4100
+    state: OH
+    suite: Suite 312
+    zip: '44052'
+  - address: 200 North High Street
+    building: ''
+    city: Columbus
+    fax: 614-469-2171
+    phone: 614-469-2083
+    state: OH
+    suite: Room 614
+    zip: '43215'
+- id:
+    bioguide: P000449
+    govtrack: 400325
+    thomas: 00924
+  offices:
+  - address: 37 West Broad Street
+    building: ''
+    city: Columbus
+    fax: ''
+    phone: 614-469-6774
+    state: OH
+    suite: Room 310
+    zip: '43215'
+  - address: 312 Walnut Street
+    building: ''
+    city: Cincinnati
+    fax: ''
+    phone: 513-684-3265
+    state: OH
+    suite: Suite 3075
+    zip: '45202'
+  - address: 1240 East 9th Street
+    building: ''
+    city: Cleveland
+    fax: ''
+    phone: 216-522-7095
+    state: OH
+    suite: Room 3061
+    zip: '44199'
+  - address: 420 Madison Avenue
+    building: ''
+    city: Toledo
+    fax: 419-259-3899
+    phone: 419-259-3895
+    state: OH
+    suite: Room 1210
+    zip: '43604'
+- id:
+    bioguide: I000024
+    govtrack: 300055
+    thomas: 00583
+  offices:
+  - address: 215 East Choctaw
+    building: ''
+    city: McAlester
+    fax: 918-426-0935
+    phone: 918-426-0933
+    state: OK
+    suite: Suite 106
+    zip: '74501'
+  - address: 302 North Independence
+    building: ''
+    city: Enid
+    fax: 580-234-5094
+    phone: 580-234-5105
+    state: OK
+    suite: Suite 104
+    zip: 73701-4025
+  - address: 1924 South Utica Avenue
+    building: ''
+    city: Tulsa
+    fax: 918-748-5119
+    phone: 918-748-5111
+    state: OK
+    suite: Suite 530
+    zip: 74104-6511
+  - address: 1900 NW Expressway
+    building: ''
+    city: Oklahoma City
+    fax: 405-608-4120
+    phone: 405-608-4381
+    state: OK
+    suite: Suite 1210
+    zip: '73118'
+- id:
+    bioguide: L000575
+    govtrack: 412464
+    thomas: '02050'
+  offices:
+  - address: 1015 North Broadway
+    building: ''
+    city: Oklahoma City
+    fax: 405-234-9909
+    phone: 405-231-4941
+    state: OK
+    suite: Suite 310
+    zip: '73102'
+  - address: 5810 East Skelly Drive
+    building: The Remington Tower
+    city: Tulsa
+    fax: ''
+    phone: 918-581-7651
+    state: OK
+    suite: Suite 1000
+    zip: '74135'
+- id:
+    bioguide: W000779
+    govtrack: 300100
+    thomas: '01247'
+  offices:
+  - address: 405 East 8th Avenue
+    building: ''
+    city: Eugene
+    fax: 541-431-0610
+    phone: 541-431-0229
+    state: OR
+    suite: Suite 2020
+    zip: '97401'
+  - address: 131 NW Hawthorne Ave.
+    building: The Jamison Building
+    city: Bend
+    fax: 541-330-6266
+    phone: 541-330-9142
+    state: OR
+    suite: Suite 107
+    zip: 97701-2957
+  - address: 707 13th Street SE
+    building: ''
+    city: Salem
+    fax: 503-589-4749
+    phone: 503-589-4555
+    state: OR
+    suite: Suite 285
+    zip: 97301-4038
+  - address: 105 Fir Street
+    building: SAC Annex Building
+    city: La Grande
+    fax: 541-963-0885
+    phone: 541-962-7691
+    state: OR
+    suite: Suite 201
+    zip: 97850-2661
+  - address: 911 NE 11th Avenue
+    building: ''
+    city: Portland
+    fax: 503-326-7528
+    phone: 503-326-7525
+    state: OR
+    suite: Suite 630
+    zip: '97232'
+  - address: 310 West 6th Street
+    building: Federal Courthouse
+    city: Medford
+    fax: 541-858-5126
+    phone: 541-858-5122
+    state: OR
+    suite: Room 118
+    zip: 97501-2768
+- id:
+    bioguide: M001176
+    govtrack: 412325
+    thomas: 01900
+  offices:
+  - address: 121 SW Salmon Street
+    building: One World Trade Center
+    city: Portland
+    fax: 503-326-2900
+    phone: 503-326-3386
+    state: OR
+    suite: Suite 1400
+    zip: '97204'
+  - address: 161 High Street SE
+    building: ''
+    city: Salem
+    fax: ''
+    phone: 503-362-8102
+    state: OR
+    suite: Suite 250
+    zip: '97301'
+  - address: 310 SE Second Street
+    building: ''
+    city: Pendleton
+    fax: ''
+    phone: 541-278-1129
+    state: OR
+    suite: Suite 105
+    zip: '97801'
+  - address: 405 East 8th Avenue
+    building: ''
+    city: Eugene
+    fax: 541-465-6808
+    phone: 541-465-6750
+    state: OR
+    suite: Suite 2010
+    zip: '97401'
+  - address: 131 NW Hawthorne
+    building: Jamison Building
+    city: Bend
+    fax: 541-318-1396
+    phone: 541-318-1298
+    state: OR
+    suite: Suite 208
+    zip: '97701'
+  - address: 10 South Bartlett Street
+    building: ''
+    city: Medford
+    fax: ''
+    phone: 541-608-9102
+    state: OR
+    suite: Suie 201
+    zip: '97501'
+- id:
+    bioguide: C001070
+    govtrack: 412246
+    thomas: 01828
+  offices:
+  - address: 310 Grant Street
+    building: Grant Building
+    city: Pittsburgh
+    fax: 412-803-7379
+    phone: 412-803-7370
+    state: PA
+    suite: Suite 2415
+    zip: '15219'
+  - address: 17 South Park Row
+    building: ''
+    city: Erie
+    fax: 814-874-5084
+    phone: 814-874-5080
+    state: PA
+    suite: Suite B-150
+    zip: '16501'
+  - address: 817 East Bishop Street
+    building: ''
+    city: Bellefonte
+    fax: 814-357-0318
+    phone: 814-357-0314
+    state: PA
+    suite: Suite C
+    zip: '16823'
+  - address: 417 Lackawanna Avenue
+    building: ''
+    city: Scranton
+    fax: 570-941-0937
+    phone: 570-941-0930
+    state: PA
+    suite: Suite 303
+    zip: '18503'
+  - address: 840 Hamilton Street
+    building: ''
+    city: Allentown
+    fax: 610-782-9474
+    phone: 610-782-9470
+    state: PA
+    suite: Suite 301
+    zip: '18101'
+  - address: 22 South Third Street
+    building: ''
+    city: Harrisburg
+    fax: 717-231-7542
+    phone: 717-231-7540
+    state: PA
+    suite: Suite 6A
+    zip: '17101'
+  - address: 2000 Market Street
+    building: ''
+    city: Philadelphia
+    fax: 215-405-9669
+    phone: 215-405-9660
+    state: PA
+    suite: Suite 610
+    zip: '19103'
+- id:
+    bioguide: T000461
+    govtrack: 400408
+    thomas: 02085
+  offices:
+  - address: 1150 South Cedar Crest Boulevard
+    building: ''
+    city: Allentown
+    fax: 610-434-1844
+    phone: 610-434-1444
+    state: PA
+    suite: Suite 101
+    zip: '18103'
+  - address: 17 South Park Row
+    building: Federal Building
+    city: Erie
+    fax: 814-455-9925
+    phone: 814-453-3010
+    state: PA
+    suite: Suite B-120
+    zip: '16501'
+  - address: 228 Walnut Street
+    building: Federal Building
+    city: Harrisburg
+    fax: 717-782-4920
+    phone: 717-782-3951
+    state: PA
+    suite: Suite 1104
+    zip: '17101'
+  - address: 100 West Station Square Drive
+    building: ''
+    city: Pittsburgh
+    fax: 412-803-3504
+    phone: 412-803-3501
+    state: PA
+    suite: Suite 225
+    zip: '15219'
+  - address: 1628 John F. Kennedy Boulevard
+    building: 8 Penn Center
+    city: Philadelphia
+    fax: 215-241-1095
+    phone: 215-241-1090
+    state: PA
+    suite: Suite 1702
+    zip: '19103'
+  - address: 538 Spruce Street
+    building: ''
+    city: Scranton
+    fax: 570-941-3544
+    phone: 570-941-3540
+    state: PA
+    suite: Suite 302
+    zip: '18503'
+  - address: 1397 Eisenhower Boulevard
+    building: Richland Square III
+    city: Johnstown
+    fax: 814-266-5973
+    phone: 814-266-5970
+    state: PA
+    suite: Suite 302
+    zip: '15904'
+- id:
+    bioguide: R000122
+    govtrack: 300081
+    thomas: 00949
+  offices:
+  - address: One Exchange Terrace
+    building: U.S. District Courthouse
+    city: Providence
+    fax: 202-224-4680
+    phone: 401-528-5200
+    state: RI
+    suite: Suite 408
+    zip: 02903
+  - address: 1000 Chapel View Boulevard
+    building: ''
+    city: Cranston
+    fax: 401-464-6837
+    phone: 401-943-3100
+    state: RI
+    suite: Suite 290
+    zip: 02920
+- id:
+    bioguide: W000802
+    govtrack: 412247
+    thomas: 01823
+  offices:
+  - address: 170 Westminster Street
+    building: ''
+    city: Providence
+    fax: 401-453-5085
+    phone: 401-453-5294
+    state: RI
+    suite: Suite 1100
+    zip: 02903
+- id:
+    bioguide: G000359
+    govtrack: 300047
+    thomas: '00452'
+  offices:
+  - address: 235 East Main Street
+    building: ''
+    city: Rock Hill
+    fax: ''
+    phone: 803-366-2828
+    state: SC
+    suite: Suite 100
+    zip: '29730'
+  - address: 124 Exchange Street
+    building: ''
+    city: Pendleton
+    fax: ''
+    phone: 864-646-4090
+    state: SC
+    suite: Suite A
+    zip: 29670-1312
+  - address: 401 West Evans Street
+    building: McMillan Federal Building
+    city: Florence
+    fax: 843-669-9015
+    phone: 843-669-1505
+    state: SC
+    suite: Suite 111
+    zip: '29501'
+  - address: 130 South Main Street
+    building: ''
+    city: Greenville
+    fax: 864-250-4322
+    phone: 864-250-1417
+    state: SC
+    suite: 7th Floor
+    zip: '29601'
+  - address: 530 Johnnie Dodds Boulevard
+    building: ''
+    city: Mount Pleasant
+    fax: 843-971-3669
+    phone: 843-849-3887
+    state: SC
+    suite: Suite 202
+    zip: '29464'
+  - address: 508 Hampton Street
+    building: ''
+    city: Columbia
+    fax: 803-933-0957
+    phone: 803-933-0112
+    state: SC
+    suite: Suite 202
+    zip: '29201'
+- id:
+    bioguide: S001184
+    govtrack: 412471
+    thomas: '02056'
+  offices:
+  - address: 2500 City Hall Lane
+    building: ''
+    city: North Charleston
+    fax: 805-802-9355
+    phone: 843-727-4525
+    state: SC
+    suite: 3rd Floor
+    zip: '29406'
+  - address: 1301 Gervais Street
+    building: ''
+    city: Columbia
+    fax: 805-802-9355
+    phone: 803-771-6112
+    state: SC
+    suite: Suite 825
+    zip: '29201'
+  - address: 104 South Main Street
+    building: ''
+    city: Greenville
+    fax: 805-802-9355
+    phone: 864-233-5366
+    state: SC
+    suite: Suite 803
+    zip: '29601'
+- id:
+    bioguide: T000250
+    govtrack: 400546
+    thomas: '01534'
+  offices:
+  - address: 320 South First Street
+    building: ''
+    city: Aberdeen
+    fax: 605-225-8468
+    phone: 605-225-8823
+    state: SD
+    suite: Suite 101
+    zip: '57401'
+  - address: 246 Founders Park Drive
+    building: ''
+    city: Rapid City
+    fax: 605-348-7208
+    phone: 605-348-7551
+    state: SD
+    suite: Suite 102
+    zip: '57701'
+  - address: 5015 South Bur Oak
+    building: ''
+    city: Sioux Falls
+    fax: 605-334-2591
+    phone: 605-334-9596
+    state: SD
+    suite: Suite B
+    zip: '57108'
+- id:
+    bioguide: R000605
+    govtrack: 412669
+    thomas: 02288
+  offices:
+  - address: 1313 West Main Street
+    building: ''
+    city: Rapid City
+    fax: 605-343-5348
+    phone: 605-343-5035
+    state: SD
+    suite: ''
+    zip: '57701'
+  - address: 320 North Main Avenue
+    building: ''
+    city: Sioux Falls
+    fax: 605-343-5348
+    phone: 605-336-0486
+    state: SD
+    suite: Suite A
+    zip: '57014'
+  - address: 514 South Main Street
+    building: ''
+    city: Aberdeen
+    fax: ''
+    phone: 605-225-0366
+    state: SD
+    suite: Suite 100
+    zip: '57401'
+  - address: 111 West Capitol Avenue
+    building: ''
+    city: Pierre
+    fax: 605-224-1379
+    phone: 605-224-1450
+    state: SD
+    suite: Suite 210
+    zip: '57501'
+- id:
+    bioguide: A000360
+    govtrack: 300002
+    thomas: 01695
+  offices:
+  - address: 900 Georgia Avenue
+    building: Joel E. Soloman Federal Building
+    city: Chattanooga
+    fax: 423-752-5342
+    phone: 423-752-5337
+    state: TN
+    suite: '#260'
+    zip: '37402'
+  - address: 2525 Highway 75
+    building: Tri-Cities Regional Airport
+    city: Blountville
+    fax: 423-325-6236
+    phone: 423-325-6240
+    state: TN
+    suite: Suite 101
+    zip: '37617'
+  - address: 111 Murray Guard Drive
+    building: ''
+    city: Jackson
+    fax: 731-664-3129
+    phone: 731-664-0289
+    state: TN
+    suite: Suite D
+    zip: '38305'
+  - address: 3322 West End Avenue
+    building: ''
+    city: Nashville
+    fax: 615-269-4803
+    phone: 615-736-5129
+    state: TN
+    suite: '#120'
+    zip: '37203'
+  - address: 800 Market Street
+    building: Howard H. Baker, Jr., U.S. Court House
+    city: Knoxville
+    fax: 865-545-4252
+    phone: 865-545-4253
+    state: TN
+    suite: Suite 112
+    zip: '37902'
+  - address: 167 North Main Street
+    building: Clifford Davis-Odell Horton Federal Building
+    city: Memphis
+    fax: 901-544-4227
+    phone: 901-544-4224
+    state: TN
+    suite: Suite 1068
+    zip: '38103'
+- id:
+    bioguide: C001071
+    govtrack: 412248
+    thomas: 01825
+  offices:
+  - address: 1105 East Jackson Boulevard
+    building: ''
+    city: Jonesborough
+    fax: 423-753-3679
+    phone: 423-753-2263
+    state: TN
+    suite: Suite 4
+    zip: '37659'
+  - address: 800 Market Street
+    building: ''
+    city: Knoxville
+    fax: 865-637-9886
+    phone: 865-637-4180
+    state: TN
+    suite: Suite 121
+    zip: '37902'
+  - address: 91 Stonebridge Boulevard
+    building: ''
+    city: Jackson
+    fax: 731-664-4670
+    phone: 731-664-2294
+    state: TN
+    suite: Suite 103
+    zip: '38305'
+  - address: 10 West Martin Luther King Boulevard
+    building: ''
+    city: Chattanooga
+    fax: 423-756-5313
+    phone: 423-756-2757
+    state: TN
+    suite: 6th Floor
+    zip: '37402'
+  - address: 100 Peabody Place
+    building: ''
+    city: Memphis
+    fax: 901-575-3528
+    phone: 901-683-1910
+    state: TN
+    suite: Suite 1125
+    zip: '38103'
+  - address: 3322 West End Avenue
+    building: ''
+    city: Nashville
+    fax: 615-279-9488
+    phone: 615-279-8125
+    state: TN
+    suite: Suite 610
+    zip: '37203'
+- id:
+    bioguide: C001056
+    govtrack: 300027
+    thomas: 01692
+  offices:
+  - address: 5001 Spring Valley Road
+    building: ''
+    city: Dallas
+    fax: 972-239-2110
+    phone: 972-239-1310
+    state: TX
+    suite: Suite 1125 E
+    zip: '75244'
+  - address: 600 Navarro
+    building: ''
+    city: San Antonio
+    fax: 210-224-8569
+    phone: 210-224-7485
+    state: TX
+    suite: Suite 210
+    zip: '78205'
+  - address: 100 East Ferguson Street
+    building: Regions Bank Building
+    city: Tyler
+    fax: 903-593-0920
+    phone: 903-593-0902
+    state: TX
+    suite: Suite 1004
+    zip: '75702'
+  - address: 5300 Memorial Drive
+    building: ''
+    city: Houston
+    fax: 713-572-3777
+    phone: 713-572-3337
+    state: TX
+    suite: Suite 980
+    zip: '77007'
+  - address: 221 West 6th Street
+    building: Chase Tower
+    city: Austin
+    fax: 512-469-6020
+    phone: 512-469-6034
+    state: TX
+    suite: Suite 1530
+    zip: '78701'
+  - address: 222 East Van Buren
+    building: ''
+    city: Harlingen
+    fax: 956-423-0193
+    phone: 956-423-0162
+    state: TX
+    suite: Suite 404
+    zip: '78550'
+  - address: 1500 Broadway
+    building: Wells Fargo Center
+    city: Lubbock
+    fax: 806-472-7536
+    phone: 806-472-7533
+    state: TX
+    suite: Suite 1230
+    zip: '79401'
+- id:
+    bioguide: C001098
+    govtrack: 412573
+    thomas: '02175'
+  offices:
+  - address: 300 East 8th
+    building: ''
+    city: Austin
+    fax: ''
+    phone: 512-916-5834
+    state: TX
+    suite: Suite 961
+    zip: '78701'
+  - address: 3626 North Hall Street
+    building: Lee Park Tower II
+    city: Dallas
+    fax: ''
+    phone: 214-599-8749
+    state: TX
+    suite: Suite 410
+    zip: '75219'
+  - address: 808 Travis Street
+    building: ''
+    city: Houston
+    fax: ''
+    phone: 713-718-3057
+    state: TX
+    suite: Suite 1420
+    zip: '77002'
+  - address: 9901 IH-10W
+    building: ''
+    city: San Antonio
+    fax: ''
+    phone: 210-340-2885
+    state: TX
+    suite: Suite 950
+    zip: '78226'
+  - address: 305 South Broadway
+    building: ''
+    city: Tyler
+    fax: ''
+    phone: 903-593-5130
+    state: TX
+    suite: Suite 501
+    zip: '75702'
+  - address: 200 South 10th Street
+    building: ''
+    city: McAllen
+    fax: ''
+    phone: 956-686-7339
+    state: TX
+    suite: Suite 1603
+    zip: '78501'
+- id:
+    bioguide: H000338
+    govtrack: 300052
+    thomas: '01351'
+  offices:
+  - address: 324 25th Street
+    building: Federal Building
+    city: Ogden
+    fax: 801-394-4503
+    phone: 801-625-5672
+    state: UT
+    suite: Room 1006
+    zip: '84401'
+  - address: 125 South State Street
+    building: Federal Building
+    city: Salt Lake City
+    fax: 801-524-4379
+    phone: 801-524-4380
+    state: UT
+    suite: Room 8402
+    zip: '84138'
+  - address: 196 East Tabernacle
+    building: Federal Building
+    city: St. George
+    fax: 435-634-1796
+    phone: 435-634-1795
+    state: UT
+    suite: Room 14
+    zip: '84770'
+  - address: 77 North Main Street
+    building: ''
+    city: Cedar City
+    fax: 435-586-2147
+    phone: 435-586-8435
+    state: UT
+    suite: Suite 112
+    zip: '84720'
+  - address: 51 South University Avenue
+    building: ''
+    city: Provo
+    fax: 801-374-5005
+    phone: 801-375-7881
+    state: UT
+    suite: Suite 320
+    zip: '84601'
+- id:
+    bioguide: L000577
+    govtrack: 412495
+    thomas: 02080
+  offices:
+  - address: 125 South State
+    building: Wallace F. Bennett Federal Building
+    city: Salt Lake City
+    fax: 801-524-5730
+    phone: 801-524-5933
+    state: UT
+    suite: Suite 4225
+    zip: '84138'
+  - address: 285 West Tabernacle
+    building: ''
+    city: St. George
+    fax: ''
+    phone: 435-628-5514
+    state: UT
+    suite: Suite 200
+    zip: '84770'
+- id:
+    bioguide: W000805
+    govtrack: 412321
+    thomas: 01897
+  offices:
+  - address: 8000 Towers Crescent Drive
+    building: ''
+    city: Vienna
+    fax: 703-442-0408
+    phone: 703-442-0670
+    state: VA
+    suite: Suite 200
+    zip: '22182'
+  - address: 101 West Main Street
+    building: ''
+    city: Norfolk
+    fax: 757-441-6250
+    phone: 757-441-3079
+    state: VA
+    suite: Suite 4900
+    zip: '23510'
+  - address: 919 East Main Street
+    building: ''
+    city: Richmond
+    fax: 804-775-2319
+    phone: 804-775-2314
+    state: VA
+    suite: Suite 630
+    zip: 23219-4625
+  - address: 180 West Main Street
+    building: ''
+    city: Abingdon
+    fax: 276-628-1036
+    phone: 276-628-8158
+    state: VA
+    suite: ''
+    zip: '24210'
+  - address: 110 Kirk Avenue SW
+    building: ''
+    city: Roanoke
+    fax: 540-857-2800
+    phone: 540-857-2676
+    state: VA
+    suite: ''
+    zip: '24011'
+- id:
+    bioguide: K000384
+    govtrack: 412582
+    thomas: '02176'
+  offices:
+  - address: 919 East Main Street
+    building: ''
+    city: Richmond
+    fax: 804-771-8313
+    phone: 804-771-2221
+    state: VA
+    suite: Suite 970
+    zip: '23219'
+  - address: 222 Central Park Drive
+    building: ''
+    city: Virginia Beach
+    fax: 757-518-1679
+    phone: 757-518-1674
+    state: VA
+    suite: Suite 120
+    zip: '23462'
+  - address: 756 Park Avenue NW
+    building: ''
+    city: Norton
+    fax: 276-679-4929
+    phone: 276-679-4925
+    state: VA
+    suite: PO Box 1300
+    zip: '24273'
+  - address: 9408 Grant Avenue
+    building: ''
+    city: Manassas
+    fax: 703-361-3198
+    phone: 703-361-3192
+    state: VA
+    suite: Suite 202
+    zip: '20110'
+  - address: 611 South Jefferson Street
+    building: ''
+    city: Roanoke
+    fax: 540-682-5697
+    phone: 540-682-5693
+    state: VA
+    suite: Suite 5B
+    zip: '24011'
+  - address: 121 Russell Road
+    building: ''
+    city: Abingdon
+    fax: 276-679-4792
+    phone: 276-679-4790
+    state: VA
+    suite: Suite 2
+    zip: '24210'
+- id:
+    bioguide: L000174
+    govtrack: 300065
+    thomas: 01383
+  offices:
+  - address: 199 Main Street
+    building: ''
+    city: Burlington
+    fax: 802-658-1009
+    phone: 800-642-3193
+    state: VT
+    suite: 4th Floor
+    zip: '05401'
+  - address: 87 State Street
+    building: ''
+    city: Montpelier
+    fax: 802-229-1915
+    phone: 802-229-0569
+    state: VT
+    suite: PO Box 933
+    zip: '05602'
+- id:
+    bioguide: S000033
+    govtrack: 400357
+    thomas: '01010'
+  offices:
+  - address: 36 Chickering Drive
+    building: ''
+    city: Brattleboro
+    fax: 802-254-9207
+    phone: 802-254-8732
+    state: VT
+    suite: Suite 103
+    zip: '05301'
+  - address: 1 Church Street
+    building: ''
+    city: Burlington
+    fax: 802-860-6370
+    phone: 802-862-0697
+    state: VT
+    suite: Suite 300
+    zip: '05401'
+  - address: 357 Western Avenue
+    building: ''
+    city: St. Johnsbury
+    fax: 802-748-0302
+    phone: 802-748-9269
+    state: VT
+    suite: Suite 1B
+    zip: 05819-2795
+- id:
+    bioguide: M001111
+    govtrack: 300076
+    thomas: 01409
+  offices:
+  - address: 1323 Officer's Row
+    building: The Marshall House
+    city: Vancouver
+    fax: 360-696-7798
+    phone: 360-696-7797
+    state: WA
+    suite: ''
+    zip: '98661'
+  - address: 915 2nd Avenue
+    building: Jackson Federal Building
+    city: Seattle
+    fax: 206-553-0891
+    phone: 206-553-5545
+    state: WA
+    suite: Suite 2988
+    zip: '98174'
+  - address: 402 East Yakima Avenue
+    building: ''
+    city: Yakima
+    fax: 509-453-7731
+    phone: 509-453-7462
+    state: WA
+    suite: Suite 420
+    zip: '98901'
+  - address: 10 North Post Street
+    building: ''
+    city: Spokane
+    fax: 509-624-9561
+    phone: 509-624-9515
+    state: WA
+    suite: Suite 600
+    zip: '99201'
+  - address: 2930 Wetmore Avenue
+    building: ''
+    city: Everett
+    fax: 425-259-7152
+    phone: 425-259-6515
+    state: WA
+    suite: Suite 903
+    zip: '98201'
+  - address: 950 Pacific Avenue
+    building: ''
+    city: Tacoma
+    fax: 253-572-9488
+    phone: 253-572-3636
+    state: WA
+    suite: '#650'
+    zip: '98402'
+- id:
+    bioguide: C000127
+    govtrack: 300018
+    thomas: '00172'
+  offices:
+  - address: 915 Second Avenue
+    building: ''
+    city: Seattle
+    fax: 206-220-6404
+    phone: 206-220-6400
+    state: WA
+    suite: Suite 3206
+    zip: '98174'
+  - address: 825 Jadwin Avenue
+    building: ''
+    city: Richland
+    fax: 509-946-6937
+    phone: 509-946-8106
+    state: WA
+    suite: '#206'
+    zip: '99352'
+  - address: 2930 Wetmore Avenue
+    building: ''
+    city: Everett
+    fax: 425-303-8351
+    phone: 425-303-0114
+    state: WA
+    suite: Suite 9B
+    zip: '98201'
+  - address: West 920 Riverside
+    building: U.S. Courthouse
+    city: Spokane
+    fax: 509-353-2547
+    phone: 509-353-2507
+    state: WA
+    suite: '# 697'
+    zip: '99201'
+  - address: 1313 Officers Row
+    building: Marshall House
+    city: Vancouver
+    fax: 360-696-7844
+    phone: 360-696-7838
+    state: WA
+    suite: ''
+    zip: '98661'
+  - address: 950 Pacific Avenue
+    building: ''
+    city: Tacoma
+    fax: 253-572-5879
+    phone: 253-572-2281
+    state: WA
+    suite: Suite 615
+    zip: '98402'
+- id:
+    bioguide: J000293
+    govtrack: 412496
+    thomas: 02086
+  offices:
+  - address: 219 Washington Avenue
+    building: ''
+    city: Oshkosh
+    fax: 920-230-7262
+    phone: 920-230-7250
+    state: WI
+    suite: Suite 100
+    zip: '54901'
+  - address: 517 East Wisconsin Avenue
+    building: ''
+    city: Milwaukee
+    fax: 414-276-7284
+    phone: 414-276-7282
+    state: WI
+    suite: Suite 408
+    zip: '53202'
+- id:
+    bioguide: B001230
+    govtrack: 400013
+    thomas: 01558
+  offices:
+  - address: 633 West Wisconsin Avenue
+    building: ''
+    city: Milwaukee
+    fax: ''
+    phone: 414-297-4451
+    state: WI
+    suite: Suite 1920
+    zip: '53203'
+  - address: 30 West Mifflin Street
+    building: ''
+    city: Madison
+    fax: ''
+    phone: 608-264-5338
+    state: WI
+    suite: Suite 700
+    zip: '53703'
+  - address: 205 5th Avenue South
+    building: ''
+    city: La Crosse
+    fax: ''
+    phone: 608-796-0045
+    state: WI
+    suite: Room 216
+    zip: '54601'
+  - address: 402 Graham Street
+    building: ''
+    city: Eau Claire
+    fax: ''
+    phone: 715-832-8424
+    state: WI
+    suite: Suite 206
+    zip: '54701'
+  - address: 1039 West Mason
+    building: ''
+    city: Green Bay
+    fax: ''
+    phone: ''
+    state: WI
+    suite: Suite 119
+    zip: '54303'
+  - address: 2100 Stewart Avenue
+    building: ''
+    city: Wausau
+    fax: ''
+    phone: 715-261-2611
+    state: WI
+    suite: Suite 250B
+    zip: '54401'
+- id:
+    bioguide: M001183
+    govtrack: 412391
+    thomas: 01983
+  offices:
+  - address: 900 Pennsylvania Avenue
+    building: ''
+    city: Charleston
+    fax: 304-343-7144
+    phone: 304-342-5855
+    state: WV
+    suite: Suite 629
+    zip: '25302'
+  - address: 261 Aikens Center
+    building: ''
+    city: Martinsburg
+    fax: 304-262-3039
+    phone: 304-368-0567
+    state: WV
+    suite: Suite 305
+    zip: 25404-6203
+  - address: 230 Adams Street
+    building: ''
+    city: Fairmont
+    fax: 304-368-0198
+    phone: 304-284-8663
+    state: WV
+    suite: ''
+    zip: '26554'
+- id:
+    bioguide: C001047
+    govtrack: 400061
+    thomas: '01676'
+  offices:
+  - address: 405 Capitol Street
+    building: ''
+    city: Charleston
+    fax: 304-347-5371
+    phone: 304-347-5372
+    state: WV
+    suite: Suite 508
+    zip: 25301-1749
+  - address: 49 Donley Street
+    building: ''
+    city: Morgantown
+    fax: ''
+    phone: 304-292-2310
+    state: WV
+    suite: Suite 504
+    zip: ' 26501'
+  - address: 220 North Kanawha Street
+    building: ''
+    city: Beckley
+    fax: ''
+    phone: 304-347-5372
+    state: WV
+    suite: Suite 1
+    zip: '25801'
+- id:
+    bioguide: E000285
+    govtrack: 300041
+    thomas: '01542'
+  offices:
+  - address: 2120 Capitol Avenue
+    building: Federal Center
+    city: Cheyenne
+    fax: 307-772-2480
+    phone: 307-772-2477
+    state: WY
+    suite: Suite 2007
+    zip: '82001'
+  - address: 100 East B Street
+    building: Dick Cheney Federal Building
+    city: Casper
+    fax: 307-261-6574
+    phone: 307-261-6572
+    state: WY
+    suite: Suite 3201
+    zip: '82602'
+  - address: 400 South Kendrick Avenue
+    building: ''
+    city: Gillette
+    fax: 307-682-6501
+    phone: 307-682-6268
+    state: WY
+    suite: Suite 303
+    zip: '82716'
+  - address: 1285 Sheridan Avenue
+    building: ''
+    city: Cody
+    fax: 307-527-9476
+    phone: 307-527-9444
+    state: WY
+    suite: Suite 210
+    zip: '82414'
+  - address: 1110 Maple Way
+    building: ''
+    city: Jackson
+    fax: 307-739-9520
+    phone: 307-739-9507
+    state: WY
+    suite: PO Box 12470
+    zip: '83002'
+- id:
+    bioguide: B001261
+    govtrack: 412251
+    thomas: 01881
+  offices:
+  - address: 2 North Main Street
+    building: ''
+    city: Sheridan
+    fax: 307-672-8227
+    phone: 307-672-6456
+    state: WY
+    suite: Suite 206
+    zip: '82801'
+  - address: 324 East Washington Avenue
+    building: ''
+    city: Riverton
+    fax: 307-856-5901
+    phone: 307-856-6642
+    state: WY
+    suite: ''
+    zip: 85201-3458
+  - address: 1575 Dewar Drive
+    building: ''
+    city: Rock Springs
+    fax: 307-362-5129
+    phone: 307-362-5012
+    state: WY
+    suite: Suite 218
+    zip: '82901'
+  - address: 2120 Capitol Avenue
+    building: ''
+    city: Cheyenne
+    fax: 307-638-3512
+    phone: 307-772-2451
+    state: WY
+    suite: Suite 2013
+    zip: '82001'
+  - address: 100 East B Street
+    building: Federal Building
+    city: Casper
+    fax: 307-265-6706
+    phone: 307-261-6413
+    state: WY
+    suite: Suite 2201
+    zip: 82601-1962


### PR DESCRIPTION
This adds district office data for current Members of Congress, as discussed in #343 .

Contains a list of offices for each MOC, with address, phone, and fax (where available). Entries are keyed by bioguide, thomas, and govtrack ids (as is done with the social media data).