### PR TITLE
Move to import house contacts from the Clerk XML feed

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -26516,7 +26516,8 @@
   name:
     first: Paul
     last: Ryan
-    official_full: Paul Ryan
+    official_full: Paul D. Ryan
+    middle: D.
   bio:
     birthday: '1970-01-29'
     gender: M

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -2968,6 +2968,8 @@
     last: Aderholt
     official_full: Robert B. Aderholt
     middle: B.
+    list: Aderholt, Robert
+    formal: Mr. Aderholt
   bio:
     birthday: '1965-07-22'
     gender: M
@@ -3077,6 +3079,8 @@
     first: Justin
     last: Amash
     official_full: Justin Amash
+    list: Amash, Justin
+    formal: Mr. Amash
   bio:
     birthday: '1980-04-18'
     gender: M
@@ -3269,6 +3273,8 @@
     first: Lou
     last: Barletta
     official_full: Lou Barletta
+    list: Barletta, Lou
+    formal: Mr. Barletta
   bio:
     birthday: '1956-01-28'
     gender: M
@@ -3330,6 +3336,8 @@
     first: Joe
     last: Barton
     official_full: Joe Barton
+    list: Barton, Joe
+    formal: Mr. Barton
   bio:
     birthday: '1949-09-15'
     gender: M
@@ -3474,6 +3482,8 @@
     first: Karen
     last: Bass
     official_full: Karen Bass
+    list: Bass, Karen
+    formal: Ms. Bass
   bio:
     birthday: '1953-10-03'
     gender: F
@@ -3535,6 +3545,8 @@
     first: Xavier
     last: Becerra
     official_full: Xavier Becerra
+    list: Becerra, Xavier
+    formal: Mr. Becerra
   bio:
     birthday: '1958-01-26'
     gender: M
@@ -3656,6 +3668,8 @@
     first: Dan
     last: Benishek
     official_full: Dan Benishek
+    list: Benishek, Dan
+    formal: Mr. Benishek
   bio:
     birthday: '1952-04-20'
     gender: M
@@ -3764,6 +3778,8 @@
     last: Bilirakis
     official_full: Gus M. Bilirakis
     middle: M.
+    list: Bilirakis, Gus
+    formal: Mr. Bilirakis
   bio:
     birthday: '1963-02-08'
     gender: M
@@ -3843,6 +3859,8 @@
     first: Rob
     last: Bishop
     official_full: Rob Bishop
+    list: Bishop, Rob
+    formal: Mr. Bishop of Utah
   bio:
     birthday: '1951-07-13'
     gender: M
@@ -3935,6 +3953,8 @@
     last: Bishop
     suffix: Jr.
     official_full: Sanford D. Bishop, Jr.
+    list: Bishop, Sanford
+    formal: Mr. Bishop of Georgia
   bio:
     birthday: '1947-02-04'
     gender: M
@@ -4055,6 +4075,8 @@
     first: Diane
     last: Black
     official_full: Diane Black
+    list: Black, Diane
+    formal: Mrs. Black
   bio:
     birthday: '1951-01-16'
     gender: F
@@ -4116,6 +4138,8 @@
     first: Marsha
     last: Blackburn
     official_full: Marsha Blackburn
+    list: Blackburn, Marsha
+    formal: Mrs. Blackburn
   bio:
     birthday: '1952-06-06'
     gender: F
@@ -4207,6 +4231,8 @@
     first: Earl
     last: Blumenauer
     official_full: Earl Blumenauer
+    list: Blumenauer, Earl
+    formal: Mr. Blumenauer
   bio:
     birthday: '1948-08-16'
     gender: M
@@ -4518,6 +4544,8 @@
     middle: Z.
     last: Bordallo
     official_full: Madeleine Z. Bordallo
+    list: Bordallo, Madeleine
+    formal: Ms. Bordallo
   bio:
     birthday: '1933-05-31'
     gender: F
@@ -4611,6 +4639,8 @@
     last: Boustany
     suffix: Jr.
     official_full: Charles W. Boustany, Jr.
+    list: Boustany, Charles
+    formal: Mr. Boustany
   bio:
     birthday: '1956-02-21'
     gender: M
@@ -4783,6 +4813,8 @@
     first: Kevin
     last: Brady
     official_full: Kevin Brady
+    list: Brady, Kevin
+    formal: Mr. Brady of Texas
   bio:
     birthday: '1955-04-11'
     gender: M
@@ -4893,6 +4925,8 @@
     middle: A.
     last: Brady
     official_full: Robert A. Brady
+    list: Brady, Robert
+    formal: Mr. Brady of Pennsylvania
   bio:
     birthday: '1945-04-07'
     gender: M
@@ -5001,6 +5035,8 @@
     first: Mo
     last: Brooks
     official_full: Mo Brooks
+    list: Brooks, Mo
+    formal: Mr. Brooks of Alabama
   bio:
     birthday: '1954-04-29'
     gender: M
@@ -5063,6 +5099,8 @@
     first: Corrine
     last: Brown
     official_full: Corrine Brown
+    list: Brown, Corrine
+    formal: Ms. Brown of Florida
   bio:
     birthday: '1946-11-11'
     gender: F
@@ -5184,6 +5222,8 @@
     first: Vern
     last: Buchanan
     official_full: Vern Buchanan
+    list: Buchanan, Vern
+    formal: Mr. Buchanan
   bio:
     gender: M
     birthday: '1951-05-08'
@@ -5260,6 +5300,8 @@
     first: Larry
     last: Bucshon
     official_full: Larry Bucshon
+    list: Bucshon, Larry
+    formal: Mr. Bucshon
   bio:
     birthday: '1962-05-31'
     gender: M
@@ -5321,6 +5363,8 @@
     middle: C.
     last: Burgess
     official_full: Michael C. Burgess
+    list: Burgess, Michael
+    formal: Mr. Burgess
   bio:
     birthday: '1950-12-23'
     gender: M
@@ -5495,6 +5539,8 @@
     suffix: Jr.
     nickname: G.K.
     official_full: G. K. Butterfield
+    list: Butterfield, G.
+    formal: Mr. Butterfield
   bio:
     birthday: '1947-04-27'
     gender: M
@@ -5584,6 +5630,8 @@
     first: Ken
     last: Calvert
     official_full: Ken Calvert
+    list: Calvert, Ken
+    formal: Mr. Calvert
   bio:
     birthday: '1953-06-08'
     gender: M
@@ -5805,6 +5853,8 @@
     first: Lois
     last: Capps
     official_full: Lois Capps
+    list: Capps, Lois
+    formal: Mrs. Capps
   bio:
     birthday: '1938-01-10'
     gender: F
@@ -5919,6 +5969,8 @@
     middle: E.
     last: Capuano
     official_full: Michael E. Capuano
+    list: Capuano, Michael
+    formal: Mr. Capuano
   bio:
     birthday: '1952-01-09'
     gender: M
@@ -6021,6 +6073,8 @@
     last: Carney
     official_full: John C. Carney, Jr.
     middle: C.
+    list: Carney, John
+    formal: Mr. Carney
   bio:
     birthday: '1956-05-20'
     gender: M
@@ -6083,6 +6137,8 @@
     first: André
     last: Carson
     official_full: André Carson
+    list: Carson, André
+    formal: Mr. Carson of Indiana
   bio:
     birthday: '1974-10-16'
     gender: M
@@ -6163,6 +6219,8 @@
     middle: R.
     last: Carter
     official_full: John R. Carter
+    list: Carter, John
+    formal: Mr. Carter of Texas
   bio:
     birthday: '1941-11-06'
     gender: M
@@ -6324,6 +6382,8 @@
     first: Kathy
     last: Castor
     official_full: Kathy Castor
+    list: Castor, Kathy
+    formal: Ms. Castor of Florida
   bio:
     gender: F
     birthday: '1966-08-20'
@@ -6400,6 +6460,8 @@
     first: Steve
     last: Chabot
     official_full: Steve Chabot
+    list: Chabot, Steve
+    formal: Mr. Chabot
   bio:
     birthday: '1953-01-22'
     gender: M
@@ -6507,6 +6569,8 @@
     first: Jason
     last: Chaffetz
     official_full: Jason Chaffetz
+    list: Chaffetz, Jason
+    formal: Mr. Chaffetz
   bio:
     birthday: '1967-03-26'
     gender: M
@@ -6575,6 +6639,8 @@
     first: Judy
     last: Chu
     official_full: Judy Chu
+    list: Chu, Judy
+    formal: Ms. Judy Chu of California
   bio:
     birthday: '1953-07-07'
     gender: F
@@ -6645,6 +6711,8 @@
     last: Cicilline
     official_full: David N. Cicilline
     middle: N.
+    list: Cicilline, David
+    formal: Mr. Cicilline
   bio:
     birthday: '1961-07-15'
     gender: M
@@ -6707,6 +6775,8 @@
     middle: D.
     last: Clarke
     official_full: Yvette D. Clarke
+    list: Clarke, Yvette
+    formal: Ms. Clarke of New York
   bio:
     birthday: '1964-11-21'
     gender: F
@@ -6784,6 +6854,8 @@
     last: Clay
     suffix: Jr.
     official_full: Wm. Lacy Clay
+    list: Clay, Wm.
+    formal: Mr. Clay
   bio:
     birthday: '1956-07-27'
     gender: M
@@ -6882,6 +6954,8 @@
     last: Cleaver
     suffix: II
     official_full: Emanuel Cleaver
+    list: Cleaver, Emanuel
+    formal: Mr. Cleaver
   bio:
     birthday: '1944-10-26'
     gender: M
@@ -6966,6 +7040,8 @@
     last: Clyburn
     nickname: Jim
     official_full: James E. Clyburn
+    list: Clyburn, James
+    formal: Mr. Clyburn
   bio:
     birthday: '1940-07-21'
     gender: M
@@ -7167,6 +7243,8 @@
     first: Mike
     last: Coffman
     official_full: Mike Coffman
+    list: Coffman, Mike
+    formal: Mr. Coffman
   bio:
     gender: M
     birthday: '1955-03-19'
@@ -7235,6 +7313,8 @@
     first: Steve
     last: Cohen
     official_full: Steve Cohen
+    list: Cohen, Steve
+    formal: Mr. Cohen
   bio:
     birthday: '1949-05-24'
     gender: M
@@ -7311,6 +7391,8 @@
     first: Tom
     last: Cole
     official_full: Tom Cole
+    list: Cole, Tom
+    formal: Mr. Cole
   bio:
     birthday: '1949-04-28'
     gender: M
@@ -7404,6 +7486,8 @@
     middle: Michael
     last: Conaway
     official_full: K. Michael Conaway
+    list: Conaway, K.
+    formal: Mr. Conaway
   bio:
     birthday: '1948-06-11'
     gender: M
@@ -7485,6 +7569,8 @@
     middle: E.
     last: Connolly
     official_full: Gerald E. Connolly
+    list: Connolly, Gerald
+    formal: Mr. Connolly
   bio:
     birthday: '1950-03-30'
     gender: M
@@ -7555,6 +7641,8 @@
     last: Conyers
     suffix: Jr.
     official_full: John Conyers, Jr.
+    list: Conyers, John
+    formal: Mr. Conyers
   bio:
     birthday: '1929-05-16'
     gender: M
@@ -7762,6 +7850,8 @@
     first: Jim
     last: Cooper
     official_full: Jim Cooper
+    list: Cooper, Jim
+    formal: Mr. Cooper
   bio:
     birthday: '1954-06-19'
     gender: M
@@ -7888,6 +7978,8 @@
     first: Jim
     last: Costa
     official_full: Jim Costa
+    list: Costa, Jim
+    formal: Mr. Costa
   bio:
     birthday: '1952-04-13'
     gender: M
@@ -7970,6 +8062,8 @@
     first: Joe
     last: Courtney
     official_full: Joe Courtney
+    list: Courtney, Joe
+    formal: Mr. Courtney
   bio:
     birthday: '1953-04-06'
     gender: M
@@ -8121,6 +8215,8 @@
     last: Crawford
     official_full: Eric A. "Rick" Crawford
     nickname: Rick
+    list: Crawford, Eric
+    formal: Mr. Crawford
   bio:
     birthday: '1966-01-22'
     gender: M
@@ -8182,6 +8278,8 @@
     first: Ander
     last: Crenshaw
     official_full: Ander Crenshaw
+    list: Crenshaw, Ander
+    formal: Mr. Crenshaw
   bio:
     birthday: '1944-09-01'
     gender: M
@@ -8278,6 +8376,8 @@
     last: Crowley
     official_full: Joseph Crowley
     nickname: Joe
+    list: Crowley, Joseph
+    formal: Mr. Crowley
   bio:
     birthday: '1962-03-16'
     gender: M
@@ -8380,6 +8480,8 @@
     first: Henry
     last: Cuellar
     official_full: Henry Cuellar
+    list: Cuellar, Henry
+    formal: Mr. Cuellar
   bio:
     birthday: '1955-09-19'
     gender: M
@@ -8464,6 +8566,8 @@
     middle: Abney
     last: Culberson
     official_full: John Abney Culberson
+    list: Culberson, John
+    formal: Mr. Culberson
   bio:
     birthday: '1956-08-24'
     gender: M
@@ -8562,6 +8666,8 @@
     middle: E.
     last: Cummings
     official_full: Elijah E. Cummings
+    list: Cummings, Elijah
+    formal: Mr. Cummings
   bio:
     birthday: '1951-01-18'
     gender: M
@@ -8678,6 +8784,8 @@
     middle: K.
     last: Davis
     official_full: Danny K. Davis
+    list: Davis, Danny
+    formal: Mr. Danny K. Davis of Illinois
   bio:
     birthday: '1941-09-06'
     gender: M
@@ -8787,6 +8895,8 @@
     middle: A.
     last: Davis
     official_full: Susan A. Davis
+    list: Davis, Susan
+    formal: Mrs. Davis of California
   bio:
     birthday: '1944-04-13'
     gender: F
@@ -8884,6 +8994,8 @@
     middle: A.
     last: DeFazio
     official_full: Peter A. DeFazio
+    list: DeFazio, Peter
+    formal: Mr. DeFazio
   bio:
     birthday: '1947-05-27'
     gender: M
@@ -9021,6 +9133,8 @@
     first: Diana
     last: DeGette
     official_full: Diana DeGette
+    list: DeGette, Diana
+    formal: Ms. DeGette
   bio:
     birthday: '1957-07-29'
     gender: F
@@ -9131,6 +9245,8 @@
     middle: L.
     last: DeLauro
     official_full: Rosa L. DeLauro
+    list: DeLauro, Rosa
+    formal: Ms. DeLauro
   bio:
     birthday: '1943-03-02'
     gender: F
@@ -9257,6 +9373,8 @@
     first: Jeff
     last: Denham
     official_full: Jeff Denham
+    list: Denham, Jeff
+    formal: Mr. Denham
   bio:
     birthday: '1967-07-29'
     gender: M
@@ -9319,6 +9437,8 @@
     middle: W.
     last: Dent
     official_full: Charles W. Dent
+    list: Dent, Charles
+    formal: Mr. Dent
   bio:
     birthday: '1960-05-24'
     gender: M
@@ -9400,6 +9520,8 @@
     first: Scott
     last: DesJarlais
     official_full: Scott DesJarlais
+    list: DesJarlais, Scott
+    formal: Mr. DesJarlais
   bio:
     birthday: '1964-02-21'
     gender: M
@@ -9462,6 +9584,8 @@
     middle: E.
     last: Deutch
     official_full: Theodore E. Deutch
+    list: Deutch, Theodore
+    formal: Mr. Deutch
   bio:
     birthday: '1966-05-07'
     gender: M
@@ -9531,6 +9655,8 @@
     first: Mario
     last: Diaz-Balart
     official_full: Mario Diaz-Balart
+    list: Diaz-Balart, Mario
+    formal: Mr. Diaz-Balart
   bio:
     birthday: '1961-09-25'
     gender: M
@@ -9624,6 +9750,8 @@
     first: Lloyd
     last: Doggett
     official_full: Lloyd Doggett
+    list: Doggett, Lloyd
+    formal: Mr. Doggett
   bio:
     birthday: '1946-10-06'
     gender: M
@@ -9808,6 +9936,8 @@
     suffix: Jr.
     nickname: Mike
     official_full: Michael F. Doyle
+    list: Doyle, Michael
+    formal: Mr. Michael F. Doyle of Pennsylvania
   bio:
     birthday: '1953-08-05'
     gender: M
@@ -9924,6 +10054,8 @@
     last: Duffy
     official_full: Sean P. Duffy
     middle: P.
+    list: Duffy, Sean
+    formal: Mr. Duffy
   bio:
     birthday: '1971-10-03'
     gender: M
@@ -9984,6 +10116,8 @@
     first: Jeff
     last: Duncan
     official_full: Jeff Duncan
+    list: Duncan, Jeff
+    formal: Mr. Duncan of South Carolina
   bio:
     birthday: '1966-01-07'
     gender: M
@@ -10047,6 +10181,8 @@
     suffix: Jr.
     nickname: Jimmy
     official_full: John J. Duncan, Jr.
+    list: Duncan, John
+    formal: Mr. Duncan of Tennessee
   bio:
     birthday: '1947-07-21'
     gender: M
@@ -10189,6 +10325,8 @@
     middle: F.
     last: Edwards
     official_full: Donna F. Edwards
+    list: Edwards, Donna
+    formal: Ms. Edwards
   bio:
     birthday: '1958-06-28'
     gender: F
@@ -10265,6 +10403,8 @@
     first: Keith
     last: Ellison
     official_full: Keith Ellison
+    list: Ellison, Keith
+    formal: Mr. Ellison
   bio:
     birthday: '1963-08-04'
     gender: M
@@ -10342,6 +10482,8 @@
     last: Ellmers
     official_full: Renee L. Ellmers
     middle: L.
+    list: Ellmers, Renee
+    formal: Mrs. Ellmers of North Carolina
   bio:
     birthday: '1964-02-09'
     gender: F
@@ -10403,6 +10545,8 @@
     middle: L.
     last: Engel
     official_full: Eliot L. Engel
+    list: Engel, Eliot
+    formal: Mr. Engel
   bio:
     birthday: '1947-02-18'
     gender: M
@@ -10534,6 +10678,8 @@
     middle: G.
     last: Eshoo
     official_full: Anna G. Eshoo
+    list: Eshoo, Anna
+    formal: Ms. Eshoo
   bio:
     birthday: '1942-12-13'
     gender: F
@@ -10655,6 +10801,8 @@
     first: Blake
     last: Farenthold
     official_full: Blake Farenthold
+    list: Farenthold, Blake
+    formal: Mr. Farenthold
   bio:
     birthday: '1961-12-12'
     gender: M
@@ -10715,6 +10863,8 @@
     first: Sam
     last: Farr
     official_full: Sam Farr
+    list: Farr, Sam
+    formal: Mr. Farr
   bio:
     birthday: '1941-07-04'
     gender: M
@@ -10836,6 +10986,8 @@
     first: Chaka
     last: Fattah
     official_full: Chaka Fattah
+    list: Fattah, Chaka
+    formal: Mr. Fattah
   bio:
     birthday: '1956-11-21'
     gender: M
@@ -10951,6 +11103,8 @@
     last: Fincher
     official_full: Stephen Lee Fincher
     middle: Lee
+    list: Fincher, Stephen
+    formal: Mr. Fincher
   bio:
     birthday: '1973-02-07'
     gender: M
@@ -11012,6 +11166,8 @@
     middle: G.
     last: Fitzpatrick
     official_full: Michael G. Fitzpatrick
+    list: Fitzpatrick, Michael
+    formal: Mr. Fitzpatrick
   bio:
     birthday: '1963-06-28'
     gender: M
@@ -11167,6 +11323,8 @@
     official_full: Charles J. "Chuck" Fleischmann
     middle: J. "Chuck"
     nickname: Chuck
+    list: Fleischmann, Charles
+    formal: Mr. Fleischmann
   bio:
     birthday: '1962-10-11'
     gender: M
@@ -11228,6 +11386,8 @@
     first: John
     last: Fleming
     official_full: John Fleming
+    list: Fleming, John
+    formal: Mr. Fleming
   bio:
     gender: M
     birthday: '1951-07-05'
@@ -11301,6 +11461,8 @@
     first: Bill
     last: Flores
     official_full: Bill Flores
+    list: Flores, Bill
+    formal: Mr. Flores
   bio:
     birthday: '1954-02-25'
     gender: M
@@ -11363,6 +11525,8 @@
     middle: Randy
     last: Forbes
     official_full: J. Randy Forbes
+    list: Forbes, J.
+    formal: Mr. Forbes
   bio:
     birthday: '1952-02-17'
     gender: M
@@ -11460,6 +11624,8 @@
     first: Jeff
     last: Fortenberry
     official_full: Jeff Fortenberry
+    list: Fortenberry, Jeff
+    formal: Mr. Fortenberry
   bio:
     gender: M
     birthday: '1960-12-27'
@@ -11542,6 +11708,8 @@
     first: Virginia
     last: Foxx
     official_full: Virginia Foxx
+    list: Foxx, Virginia
+    formal: Ms. Foxx
   bio:
     birthday: '1943-06-29'
     gender: F
@@ -11625,6 +11793,8 @@
     first: Trent
     last: Franks
     official_full: Trent Franks
+    list: Franks, Trent
+    formal: Mr. Franks of Arizona
   bio:
     birthday: '1957-06-19'
     gender: M
@@ -11716,6 +11886,8 @@
     middle: P.
     last: Frelinghuysen
     official_full: Rodney P. Frelinghuysen
+    list: Frelinghuysen, Rodney
+    formal: Mr. Frelinghuysen
   bio:
     birthday: '1946-04-29'
     gender: M
@@ -11839,6 +12011,8 @@
     last: Fudge
     official_full: Marcia L. Fudge
     middle: L.
+    list: Fudge, Marcia
+    formal: Ms. Fudge
   bio:
     gender: F
     birthday: '1952-10-29'
@@ -11914,6 +12088,8 @@
     first: John
     last: Garamendi
     official_full: John Garamendi
+    list: Garamendi, John
+    formal: Mr. Garamendi
   bio:
     birthday: '1945-01-24'
     gender: M
@@ -12043,6 +12219,8 @@
     first: Scott
     last: Garrett
     official_full: Scott Garrett
+    list: Garrett, Scott
+    formal: Mr. Garrett
   bio:
     birthday: '1959-07-09'
     gender: M
@@ -12133,6 +12311,8 @@
     first: Bob
     last: Gibbs
     official_full: Bob Gibbs
+    list: Gibbs, Bob
+    formal: Mr. Gibbs
   bio:
     birthday: '1954-06-14'
     gender: M
@@ -12194,6 +12374,8 @@
     middle: P.
     last: Gibson
     official_full: Christopher P. Gibson
+    list: Gibson, Christopher
+    formal: Mr. Gibson
   bio:
     birthday: '1964-05-13'
     gender: M
@@ -12256,6 +12438,8 @@
     last: Gohmert
     suffix: Jr.
     official_full: Louie Gohmert
+    list: Gohmert, Louie
+    formal: Mr. Gohmert
   bio:
     birthday: '1953-08-18'
     gender: M
@@ -12339,6 +12523,8 @@
     first: Bob
     last: Goodlatte
     official_full: Bob Goodlatte
+    list: Goodlatte, Bob
+    formal: Mr. Goodlatte
   bio:
     birthday: '1952-09-22'
     gender: M
@@ -12461,6 +12647,8 @@
     last: Gosar
     official_full: Paul A. Gosar
     middle: A.
+    list: Gosar, Paul
+    formal: Mr. Gosar
   bio:
     birthday: '1958-11-22'
     gender: M
@@ -12522,6 +12710,8 @@
     first: Trey
     last: Gowdy
     official_full: Trey Gowdy
+    list: Gowdy, Trey
+    formal: Mr. Gowdy
   bio:
     birthday: '1964-08-22'
     gender: M
@@ -12582,6 +12772,8 @@
     first: Kay
     last: Granger
     official_full: Kay Granger
+    list: Granger, Kay
+    formal: Ms. Granger
   bio:
     birthday: '1943-01-18'
     gender: F
@@ -12782,6 +12974,8 @@
     first: Sam
     last: Graves
     official_full: Sam Graves
+    list: Graves, Sam
+    formal: Mr. Graves of Missouri
   bio:
     birthday: '1963-11-07'
     gender: M
@@ -12879,6 +13073,8 @@
     first: Tom
     last: Graves
     official_full: Tom Graves
+    list: Graves, Tom
+    formal: Mr. Graves of Georgia
   bio:
     birthday: '1970-02-03'
     gender: M
@@ -12948,6 +13144,8 @@
     first: Al
     last: Green
     official_full: Al Green
+    list: Green, Al
+    formal: Mr. Al Green of Texas
   bio:
     birthday: '1947-09-01'
     gender: M
@@ -13030,6 +13228,8 @@
     first: Gene
     last: Green
     official_full: Gene Green
+    list: Green, Gene
+    formal: Mr. Gene Green of Texas
   bio:
     birthday: '1947-10-17'
     gender: M
@@ -13152,6 +13352,8 @@
     middle: Morgan
     last: Griffith
     official_full: H. Morgan Griffith
+    list: Griffith, H.
+    formal: Mr. Griffith
   bio:
     birthday: '1958-03-15'
     gender: M
@@ -13214,6 +13416,8 @@
     middle: M.
     last: Grijalva
     official_full: Raúl M. Grijalva
+    list: Grijalva, Raúl
+    formal: Mr. Grijalva
   bio:
     birthday: '1948-02-19'
     gender: M
@@ -13305,6 +13509,8 @@
     first: Brett
     last: Guthrie
     official_full: Brett Guthrie
+    list: Guthrie, Brett
+    formal: Mr. Guthrie
   bio:
     gender: M
     birthday: '1964-02-18'
@@ -13375,6 +13581,8 @@
     middle: V.
     last: Gutiérrez
     official_full: Luis V. Gutiérrez
+    list: Gutiérrez, Luis
+    formal: Mr. Gutiérrez
   bio:
     birthday: '1953-12-10'
     gender: M
@@ -13496,6 +13704,8 @@
     last: Hanna
     official_full: Richard L. Hanna
     middle: L.
+    list: Hanna, Richard
+    formal: Mr. Hanna
   bio:
     birthday: '1951-01-25'
     gender: M
@@ -13556,6 +13766,8 @@
     first: Gregg
     last: Harper
     official_full: Gregg Harper
+    list: Harper, Gregg
+    formal: Mr. Harper
   bio:
     birthday: '1956-06-01'
     gender: M
@@ -13624,6 +13836,8 @@
     first: Andy
     last: Harris
     official_full: Andy Harris
+    list: Harris, Andy
+    formal: Mr. Harris
   bio:
     birthday: '1957-01-25'
     gender: M
@@ -13685,6 +13899,8 @@
     first: Vicky
     last: Hartzler
     official_full: Vicky Hartzler
+    list: Hartzler, Vicky
+    formal: Mrs. Hartzler
   bio:
     birthday: '1960-10-13'
     gender: F
@@ -13747,6 +13963,8 @@
     middle: L.
     last: Hastings
     official_full: Alcee L. Hastings
+    list: Hastings, Alcee
+    formal: Mr. Hastings
   bio:
     birthday: '1936-09-05'
     gender: M
@@ -13869,6 +14087,8 @@
     last: Heck
     official_full: Joseph J. Heck
     middle: J.
+    list: Heck, Joseph
+    formal: Mr. Heck of Nevada
   bio:
     birthday: '1961-10-30'
     gender: M
@@ -13988,6 +14208,8 @@
     first: Jeb
     last: Hensarling
     official_full: Jeb Hensarling
+    list: Hensarling, Jeb
+    formal: Mr. Hensarling
   bio:
     birthday: '1957-05-29'
     gender: M
@@ -14078,6 +14300,8 @@
     first: Jaime
     last: Herrera Beutler
     official_full: Jaime Herrera Beutler
+    list: Herrera Beutler, Jaime
+    formal: Ms. Herrera Beutler
   bio:
     birthday: '1978-11-03'
     gender: F
@@ -14139,6 +14363,8 @@
     first: Brian
     last: Higgins
     official_full: Brian Higgins
+    list: Higgins, Brian
+    formal: Mr. Higgins
   bio:
     birthday: '1959-10-06'
     gender: M
@@ -14222,6 +14448,8 @@
     middle: A.
     last: Himes
     official_full: James A. Himes
+    list: Himes, James
+    formal: Mr. Himes
   bio:
     birthday: '1966-07-05'
     gender: M
@@ -14291,6 +14519,8 @@
     first: Rubén
     last: Hinojosa
     official_full: Rubén Hinojosa
+    list: Hinojosa, Rubén
+    formal: Mr. Hinojosa
   bio:
     birthday: '1940-08-20'
     gender: M
@@ -14506,6 +14736,8 @@
     last: Honda
     nickname: Mike
     official_full: Michael M. Honda
+    list: Honda, Michael
+    formal: Mr. Honda
   bio:
     birthday: '1941-06-27'
     gender: M
@@ -14604,6 +14836,8 @@
     middle: H.
     last: Hoyer
     official_full: Steny H. Hoyer
+    list: Hoyer, Steny
+    formal: Mr. Hoyer
   bio:
     birthday: '1939-06-14'
     gender: M
@@ -14781,6 +15015,8 @@
     first: Tim
     last: Huelskamp
     official_full: Tim Huelskamp
+    list: Huelskamp, Tim
+    formal: Mr. Huelskamp
   bio:
     birthday: '1968-11-11'
     gender: M
@@ -14842,6 +15078,8 @@
     first: Bill
     last: Huizenga
     official_full: Bill Huizenga
+    list: Huizenga, Bill
+    formal: Mr. Huizenga of Michigan
   bio:
     birthday: '1969-01-31'
     gender: M
@@ -14903,6 +15141,8 @@
     first: Randy
     last: Hultgren
     official_full: Randy Hultgren
+    list: Hultgren, Randy
+    formal: Mr. Hultgren
   bio:
     birthday: '1966-03-01'
     gender: M
@@ -14963,6 +15203,8 @@
     first: Duncan
     last: Hunter
     official_full: Duncan Hunter
+    list: Hunter, Duncan
+    formal: Mr. Hunter
   bio:
     birthday: '1976-12-07'
     gender: M
@@ -15035,6 +15277,8 @@
     first: Robert
     last: Hurt
     official_full: Robert Hurt
+    list: Hurt, Robert
+    formal: Mr. Hurt of Virginia
   bio:
     birthday: '1969-06-16'
     gender: M
@@ -15165,6 +15409,8 @@
     first: Steve
     last: Israel
     official_full: Steve Israel
+    list: Israel, Steve
+    formal: Mr. Israel
   bio:
     birthday: '1958-05-30'
     gender: M
@@ -15264,6 +15510,8 @@
     last: Issa
     official_full: Darrell E. Issa
     middle: E.
+    list: Issa, Darrell
+    formal: Mr. Issa
   bio:
     birthday: '1953-11-01'
     gender: M
@@ -15359,6 +15607,8 @@
     first: Sheila
     last: Jackson Lee
     official_full: Sheila Jackson Lee
+    list: Jackson Lee, Sheila
+    formal: Ms. Jackson Lee
   bio:
     birthday: '1950-01-12'
     gender: F
@@ -15474,6 +15724,8 @@
     first: Lynn
     last: Jenkins
     official_full: Lynn Jenkins
+    list: Jenkins, Lynn
+    formal: Ms. Jenkins of Kansas
   bio:
     gender: F
     birthday: '1963-06-10'
@@ -15543,6 +15795,8 @@
     first: Bill
     last: Johnson
     official_full: Bill Johnson
+    list: Johnson, Bill
+    formal: Mr. Johnson of Ohio
   bio:
     birthday: '1954-11-10'
     gender: M
@@ -15604,6 +15858,8 @@
     middle: Bernice
     last: Johnson
     official_full: Eddie Bernice Johnson
+    list: Johnson, Eddie
+    formal: Ms. Eddie Bernice Johnson of Texas
   bio:
     birthday: '1935-12-03'
     gender: F
@@ -15728,6 +15984,8 @@
     suffix: Jr.
     nickname: Hank
     official_full: Henry C. "Hank" Johnson, Jr.
+    list: Johnson, Henry
+    formal: Mr. Johnson of Georgia
   bio:
     gender: M
     birthday: '1954-10-02'
@@ -15841,6 +16099,8 @@
     first: Sam
     last: Johnson
     official_full: Sam Johnson
+    list: Johnson, Sam
+    formal: Mr. Sam Johnson of Texas
   bio:
     birthday: '1930-10-11'
     gender: M
@@ -15970,6 +16230,8 @@
     last: Jones
     suffix: Jr.
     official_full: Walter B. Jones
+    list: Jones, Walter
+    formal: Mr. Jones
   bio:
     birthday: '1943-02-10'
     gender: M
@@ -16088,6 +16350,8 @@
     first: Jim
     last: Jordan
     official_full: Jim Jordan
+    list: Jordan, Jim
+    formal: Mr. Jordan
   bio:
     gender: M
     birthday: '1964-02-17'
@@ -16163,6 +16427,8 @@
     first: Marcy
     last: Kaptur
     official_full: Marcy Kaptur
+    list: Kaptur, Marcy
+    formal: Ms. Kaptur
   bio:
     birthday: '1946-06-17'
     gender: F
@@ -16314,6 +16580,8 @@
     last: Keating
     official_full: William R. Keating
     middle: R.
+    list: Keating, William
+    formal: Mr. Keating
   bio:
     birthday: '1952-09-06'
     gender: M
@@ -16375,6 +16643,8 @@
     first: Mike
     last: Kelly
     official_full: Mike Kelly
+    list: Kelly, Mike
+    formal: Mr. Kelly of Pennsylvania
   bio:
     birthday: '1948-05-10'
     gender: M
@@ -16436,6 +16706,8 @@
     first: Ron
     last: Kind
     official_full: Ron Kind
+    list: Kind, Ron
+    formal: Mr. Kind
   bio:
     birthday: '1963-03-16'
     gender: M
@@ -16547,6 +16819,8 @@
     last: King
     nickname: Pete
     official_full: Peter T. King
+    list: King, Peter
+    formal: Mr. King of New York
   bio:
     birthday: '1944-04-05'
     gender: M
@@ -16668,6 +16942,8 @@
     first: Steve
     last: King
     official_full: Steve King
+    list: King, Steve
+    formal: Mr. King of Iowa
   bio:
     birthday: '1949-05-28'
     gender: M
@@ -16759,6 +17035,8 @@
     first: Adam
     last: Kinzinger
     official_full: Adam Kinzinger
+    list: Kinzinger, Adam
+    formal: Mr. Kinzinger of Illinois
   bio:
     birthday: '1978-02-27'
     gender: M
@@ -16901,6 +17179,8 @@
     first: John
     last: Kline
     official_full: John Kline
+    list: Kline, John
+    formal: Mr. Kline
   bio:
     birthday: '1947-09-06'
     gender: M
@@ -16993,6 +17273,8 @@
     last: Labrador
     official_full: Raúl R. Labrador
     middle: R.
+    list: Labrador, Raúl
+    formal: Mr. Labrador
   bio:
     birthday: '1967-12-08'
     gender: M
@@ -17054,6 +17336,8 @@
     first: Doug
     last: Lamborn
     official_full: Doug Lamborn
+    list: Lamborn, Doug
+    formal: Mr. Lamborn
   bio:
     birthday: '1954-05-24'
     gender: M
@@ -17130,6 +17414,8 @@
     first: Leonard
     last: Lance
     official_full: Leonard Lance
+    list: Lance, Leonard
+    formal: Mr. Lance
   bio:
     birthday: '1952-06-25'
     gender: M
@@ -17201,6 +17487,8 @@
     last: Langevin
     nickname: Jim
     official_full: James R. Langevin
+    list: Langevin, James
+    formal: Mr. Langevin
   bio:
     birthday: '1964-04-22'
     gender: M
@@ -17356,6 +17644,8 @@
     first: Rick
     last: Larsen
     official_full: Rick Larsen
+    list: Larsen, Rick
+    formal: Mr. Larsen of Washington
   bio:
     birthday: '1965-06-15'
     gender: M
@@ -17453,6 +17743,8 @@
     middle: B.
     last: Larson
     official_full: John B. Larson
+    list: Larson, John
+    formal: Mr. Larson of Connecticut
   bio:
     birthday: '1948-07-22'
     gender: M
@@ -17556,6 +17848,8 @@
     middle: E.
     last: Latta
     official_full: Robert E. Latta
+    list: Latta, Robert
+    formal: Mr. Latta
   bio:
     birthday: '1956-04-18'
     gender: M
@@ -17712,6 +18006,8 @@
     first: Barbara
     last: Lee
     official_full: Barbara Lee
+    list: Lee, Barbara
+    formal: Ms. Lee
   bio:
     birthday: '1946-07-16'
     gender: F
@@ -17859,6 +18155,8 @@
     middle: M.
     last: Levin
     official_full: Sander M. Levin
+    list: Levin, Sander
+    formal: Mr. Levin
   bio:
     birthday: '1931-09-06'
     gender: M
@@ -18013,6 +18311,8 @@
     first: John
     last: Lewis
     official_full: John Lewis
+    list: Lewis, John
+    formal: Mr. Lewis
   bio:
     birthday: '1940-02-21'
     gender: M
@@ -18152,6 +18452,8 @@
     first: Daniel
     last: Lipinski
     official_full: Daniel Lipinski
+    list: Lipinski, Daniel
+    formal: Mr. Lipinski
   bio:
     birthday: '1966-07-15'
     gender: M
@@ -18238,6 +18540,8 @@
     middle: A.
     last: LoBiondo
     official_full: Frank A. LoBiondo
+    list: LoBiondo, Frank
+    formal: Mr. LoBiondo
   bio:
     birthday: '1946-05-12'
     gender: M
@@ -18353,6 +18657,8 @@
     first: David
     last: Loebsack
     official_full: David Loebsack
+    list: Loebsack, David
+    formal: Mr. Loebsack
   bio:
     birthday: '1952-12-23'
     gender: M
@@ -18429,6 +18735,8 @@
     first: Zoe
     last: Lofgren
     official_full: Zoe Lofgren
+    list: Lofgren, Zoe
+    formal: Ms. Lofgren
   bio:
     birthday: '1947-12-21'
     gender: F
@@ -18543,6 +18851,8 @@
     first: Billy
     last: Long
     official_full: Billy Long
+    list: Long, Billy
+    formal: Mr. Long
   bio:
     birthday: '1955-08-11'
     gender: M
@@ -18605,6 +18915,8 @@
     middle: M.
     last: Lowey
     official_full: Nita M. Lowey
+    list: Lowey, Nita
+    formal: Mrs. Lowey
   bio:
     birthday: '1937-07-05'
     gender: F
@@ -18739,6 +19051,8 @@
     middle: D.
     last: Lucas
     official_full: Frank D. Lucas
+    list: Lucas, Frank
+    formal: Mr. Lucas
   bio:
     birthday: '1960-01-06'
     gender: M
@@ -18859,6 +19173,8 @@
     first: Blaine
     last: Luetkemeyer
     official_full: Blaine Luetkemeyer
+    list: Luetkemeyer, Blaine
+    formal: Mr. Luetkemeyer
   bio:
     gender: M
     birthday: '1952-05-07'
@@ -18928,6 +19244,8 @@
     middle: Ray
     last: Luján
     official_full: Ben Ray Luján
+    list: Luján, Ben
+    formal: Mr. Ben Ray Luján of New Mexico
   bio:
     gender: M
     birthday: '1972-06-07'
@@ -18998,6 +19316,8 @@
     middle: M.
     last: Lummis
     official_full: Cynthia M. Lummis
+    list: Lummis, Cynthia
+    formal: Mrs. Lummis
   bio:
     gender: F
     birthday: '1954-09-10'
@@ -19069,6 +19389,8 @@
     middle: F.
     last: Lynch
     official_full: Stephen F. Lynch
+    list: Lynch, Stephen
+    formal: Mr. Lynch
   bio:
     birthday: '1955-03-31'
     gender: M
@@ -19166,6 +19488,8 @@
     middle: B.
     last: Maloney
     official_full: Carolyn B. Maloney
+    list: Maloney, Carolyn
+    formal: Mrs. Carolyn B. Maloney of New York
   bio:
     birthday: '1946-02-19'
     gender: F
@@ -19286,6 +19610,8 @@
     first: Kenny
     last: Marchant
     official_full: Kenny Marchant
+    list: Marchant, Kenny
+    formal: Mr. Marchant
   bio:
     birthday: '1951-02-23'
     gender: M
@@ -19369,6 +19695,8 @@
     first: Tom
     last: Marino
     official_full: Tom Marino
+    list: Marino, Tom
+    formal: Mr. Marino
   bio:
     birthday: '1952-08-15'
     gender: M
@@ -19620,6 +19948,8 @@
     middle: O.
     last: Matsui
     official_full: Doris O. Matsui
+    list: Matsui, Doris
+    formal: Ms. Matsui
   bio:
     birthday: '1944-09-25'
     gender: F
@@ -19785,6 +20115,8 @@
     first: Kevin
     last: McCarthy
     official_full: Kevin McCarthy
+    list: McCarthy, Kevin
+    formal: Mr. McCarthy
   bio:
     birthday: '1965-01-26'
     gender: M
@@ -19878,6 +20210,8 @@
     middle: T.
     last: McCaul
     official_full: Michael T. McCaul
+    list: McCaul, Michael
+    formal: Mr. McCaul
   bio:
     birthday: '1962-01-14'
     gender: M
@@ -19959,6 +20293,8 @@
     first: Tom
     last: McClintock
     official_full: Tom McClintock
+    list: McClintock, Tom
+    formal: Mr. McClintock
   bio:
     birthday: '1956-07-10'
     gender: M
@@ -20028,6 +20364,8 @@
     first: Betty
     last: McCollum
     official_full: Betty McCollum
+    list: McCollum, Betty
+    formal: Ms. McCollum
   bio:
     birthday: '1954-07-12'
     gender: F
@@ -20124,6 +20462,8 @@
     first: Jim
     last: McDermott
     official_full: Jim McDermott
+    list: McDermott, Jim
+    formal: Mr. McDermott
   bio:
     birthday: '1936-12-28'
     gender: M
@@ -20258,6 +20598,8 @@
     last: McGovern
     nickname: Jim
     official_full: James P. McGovern
+    list: McGovern, James
+    formal: Mr. McGovern
   bio:
     birthday: '1959-11-20'
     gender: M
@@ -20368,6 +20710,8 @@
     middle: T.
     last: McHenry
     official_full: Patrick T. McHenry
+    list: McHenry, Patrick
+    formal: Mr. McHenry
   bio:
     birthday: '1975-10-22'
     gender: M
@@ -20451,6 +20795,8 @@
     last: McKinley
     official_full: David B. McKinley
     middle: B.
+    list: McKinley, David
+    formal: Mr. McKinley
   bio:
     birthday: '1947-03-28'
     gender: M
@@ -20512,6 +20858,8 @@
     first: Cathy
     last: McMorris Rodgers
     official_full: Cathy McMorris Rodgers
+    list: McMorris Rodgers, Cathy
+    formal: Mrs. McMorris Rodgers
   bio:
     birthday: '1969-05-22'
     gender: F
@@ -20593,6 +20941,8 @@
     first: Jerry
     last: McNerney
     official_full: Jerry McNerney
+    list: McNerney, Jerry
+    formal: Mr. McNerney
   bio:
     gender: M
     birthday: '1951-06-18'
@@ -20669,6 +21019,8 @@
     first: Patrick
     last: Meehan
     official_full: Patrick Meehan
+    list: Meehan, Patrick
+    formal: Mr. Meehan
   bio:
     birthday: '1955-10-20'
     gender: M
@@ -20730,6 +21082,8 @@
     middle: W.
     last: Meeks
     official_full: Gregory W. Meeks
+    list: Meeks, Gregory
+    formal: Mr. Meeks
   bio:
     birthday: '1953-09-25'
     gender: M
@@ -20840,6 +21194,8 @@
     middle: L.
     last: Mica
     official_full: John L. Mica
+    list: Mica, John
+    formal: Mr. Mica
   bio:
     birthday: '1943-01-27'
     gender: M
@@ -21062,6 +21418,8 @@
     last: Miller
     official_full: Candice S. Miller
     middle: S.
+    list: Miller, Candice
+    formal: Mrs. Miller of Michigan
   bio:
     birthday: '1954-05-07'
     gender: F
@@ -21153,6 +21511,8 @@
     first: Jeff
     last: Miller
     official_full: Jeff Miller
+    list: Miller, Jeff
+    formal: Mr. Miller of Florida
   bio:
     birthday: '1959-06-27'
     gender: M
@@ -21250,6 +21610,8 @@
     first: Gwen
     last: Moore
     official_full: Gwen Moore
+    list: Moore, Gwen
+    formal: Ms. Moore
   bio:
     birthday: '1951-04-18'
     gender: F
@@ -21420,6 +21782,8 @@
     first: Mick
     last: Mulvaney
     official_full: Mick Mulvaney
+    list: Mulvaney, Mick
+    formal: Mr. Mulvaney
   bio:
     birthday: '1967-07-21'
     gender: M
@@ -21605,6 +21969,8 @@
     first: Tim
     last: Murphy
     official_full: Tim Murphy
+    list: Murphy, Tim
+    formal: Mr. Murphy of Pennsylvania
   bio:
     birthday: '1952-09-11'
     gender: M
@@ -21755,6 +22121,8 @@
     first: Jerrold
     last: Nadler
     official_full: Jerrold Nadler
+    list: Nadler, Jerrold
+    formal: Mr. Nadler
   bio:
     birthday: '1947-06-13'
     gender: M
@@ -21882,6 +22250,8 @@
     middle: F.
     last: Napolitano
     official_full: Grace F. Napolitano
+    list: Napolitano, Grace
+    formal: Mrs. Napolitano
   bio:
     birthday: '1936-12-04'
     gender: F
@@ -21985,6 +22355,8 @@
     middle: E.
     last: Neal
     official_full: Richard E. Neal
+    list: Neal, Richard
+    formal: Mr. Neal
   bio:
     birthday: '1949-02-14'
     gender: M
@@ -22118,6 +22490,8 @@
     first: Randy
     last: Neugebauer
     official_full: Randy Neugebauer
+    list: Neugebauer, Randy
+    formal: Mr. Neugebauer
   bio:
     birthday: '1949-12-24'
     gender: M
@@ -22210,6 +22584,8 @@
     last: Noem
     official_full: Kristi L. Noem
     middle: L.
+    list: Noem, Kristi
+    formal: Mrs. Noem
   bio:
     birthday: '1971-11-30'
     gender: F
@@ -22270,6 +22646,8 @@
     middle: Holmes
     last: Norton
     official_full: Eleanor Holmes Norton
+    list: Norton, Eleanor
+    formal: Ms. Norton
   bio:
     birthday: '1937-06-13'
     gender: F
@@ -22397,6 +22775,8 @@
     last: Nugent
     official_full: Richard B. Nugent
     middle: B.
+    list: Nugent, Richard
+    formal: Mr. Nugent
   bio:
     birthday: '1951-05-26'
     gender: M
@@ -22457,6 +22837,8 @@
     first: Devin
     last: Nunes
     official_full: Devin Nunes
+    list: Nunes, Devin
+    formal: Mr. Nunes
   bio:
     birthday: '1973-10-01'
     gender: M
@@ -22547,6 +22929,8 @@
     first: Pete
     last: Olson
     official_full: Pete Olson
+    list: Olson, Pete
+    formal: Mr. Olson
   bio:
     birthday: '1962-12-09'
     gender: M
@@ -22616,6 +23000,8 @@
     last: Palazzo
     official_full: Steven M. Palazzo
     middle: M.
+    list: Palazzo, Steven
+    formal: Mr. Palazzo
   bio:
     birthday: '1970-02-21'
     gender: M
@@ -22678,6 +23064,8 @@
     last: Pallone
     suffix: Jr.
     official_full: Frank Pallone, Jr.
+    list: Pallone, Frank
+    formal: Mr. Pallone
   bio:
     birthday: '1951-10-30'
     gender: M
@@ -22817,6 +23205,8 @@
     last: Pascrell
     suffix: Jr.
     official_full: Bill Pascrell, Jr.
+    list: Pascrell, Bill
+    formal: Mr. Pascrell
   bio:
     birthday: '1937-01-25'
     gender: M
@@ -22967,6 +23357,8 @@
     first: Erik
     last: Paulsen
     official_full: Erik Paulsen
+    list: Paulsen, Erik
+    formal: Mr. Paulsen
   bio:
     birthday: '1965-05-14'
     gender: M
@@ -23038,6 +23430,8 @@
     last: Pearce
     nickname: Steve
     official_full: Stevan Pearce
+    list: Pearce, Stevan
+    formal: Mr. Pearce
   bio:
     birthday: '1947-08-24'
     gender: M
@@ -23117,6 +23511,8 @@
     first: Nancy
     last: Pelosi
     official_full: Nancy Pelosi
+    list: Pelosi, Nancy
+    formal: Ms. Pelosi
   bio:
     birthday: '1940-03-26'
     gender: F
@@ -23271,6 +23667,8 @@
     first: Ed
     last: Perlmutter
     official_full: Ed Perlmutter
+    list: Perlmutter, Ed
+    formal: Mr. Perlmutter
   bio:
     birthday: '1953-05-01'
     gender: M
@@ -23418,6 +23816,8 @@
     middle: C.
     last: Peterson
     official_full: Collin C. Peterson
+    list: Peterson, Collin
+    formal: Mr. Peterson
   bio:
     birthday: '1944-06-29'
     gender: M
@@ -23543,6 +23943,8 @@
     middle: R.
     last: Pierluisi
     official_full: Pedro R. Pierluisi
+    list: Pierluisi, Pedro
+    formal: Mr. Pierluisi
   bio:
     gender: M
     birthday: '1959-04-26'
@@ -23593,6 +23995,8 @@
     first: Chellie
     last: Pingree
     official_full: Chellie Pingree
+    list: Pingree, Chellie
+    formal: Ms. Pingree
   bio:
     birthday: '1955-04-02'
     gender: F
@@ -23663,6 +24067,8 @@
     middle: R.
     last: Pitts
     official_full: Joseph R. Pitts
+    list: Pitts, Joseph
+    formal: Mr. Pitts
   bio:
     birthday: '1939-10-10'
     gender: M
@@ -23772,6 +24178,8 @@
     first: Ted
     last: Poe
     official_full: Ted Poe
+    list: Poe, Ted
+    formal: Mr. Poe of Texas
   bio:
     birthday: '1948-09-10'
     gender: M
@@ -23855,6 +24263,8 @@
     first: Jared
     last: Polis
     official_full: Jared Polis
+    list: Polis, Jared
+    formal: Mr. Polis
   bio:
     gender: M
     birthday: '1975-05-12'
@@ -23924,6 +24334,8 @@
     first: Mike
     last: Pompeo
     official_full: Mike Pompeo
+    list: Pompeo, Mike
+    formal: Mr. Pompeo
   bio:
     birthday: '1963-12-30'
     gender: M
@@ -24071,6 +24483,8 @@
     first: Bill
     last: Posey
     official_full: Bill Posey
+    list: Posey, Bill
+    formal: Mr. Posey
   bio:
     birthday: '1947-12-18'
     gender: M
@@ -24141,6 +24555,8 @@
     middle: E.
     last: Price
     official_full: David E. Price
+    list: Price, David
+    formal: Mr. Price of North Carolina
   bio:
     birthday: '1940-08-17'
     gender: M
@@ -24274,6 +24690,8 @@
     first: Tom
     last: Price
     official_full: Tom Price
+    list: Price, Tom
+    formal: Mr. Tom Price of Georgia
   bio:
     birthday: '1954-10-08'
     gender: M
@@ -24356,6 +24774,8 @@
     first: Mike
     last: Quigley
     official_full: Mike Quigley
+    list: Quigley, Mike
+    formal: Mr. Quigley
   bio:
     birthday: '1958-10-17'
     gender: M
@@ -24426,6 +24846,8 @@
     middle: B.
     last: Rangel
     official_full: Charles B. Rangel
+    list: Rangel, Charles
+    formal: Mr. Rangel
   bio:
     birthday: '1930-06-11'
     gender: M
@@ -24613,6 +25035,8 @@
     last: Reed
     suffix: II
     official_full: Tom Reed
+    list: Reed, Tom
+    formal: Mr. Reed
   bio:
     birthday: '1971-11-18'
     gender: M
@@ -24681,6 +25105,8 @@
     middle: G.
     last: Reichert
     official_full: David G. Reichert
+    list: Reichert, David
+    formal: Mr. Reichert
   bio:
     birthday: '1950-08-29'
     gender: M
@@ -24862,6 +25288,8 @@
     last: Renacci
     official_full: James B. Renacci
     middle: B.
+    list: Renacci, James
+    formal: Mr. Renacci
   bio:
     birthday: '1958-12-03'
     gender: M
@@ -24924,6 +25352,8 @@
     last: Ribble
     official_full: Reid J. Ribble
     middle: J.
+    list: Ribble, Reid
+    formal: Mr. Ribble
   bio:
     birthday: '1956-04-05'
     gender: M
@@ -24986,6 +25416,8 @@
     last: Richmond
     official_full: Cedric L. Richmond
     middle: L.
+    list: Richmond, Cedric
+    formal: Mr. Richmond
   bio:
     birthday: '1973-09-13'
     gender: M
@@ -25048,6 +25480,8 @@
     last: Rigell
     nickname: Scott
     official_full: E. Scott Rigell
+    list: Rigell, E.
+    formal: Mr. Rigell
   bio:
     birthday: '1960-05-28'
     gender: M
@@ -25109,6 +25543,8 @@
     first: Martha
     last: Roby
     official_full: Martha Roby
+    list: Roby, Martha
+    formal: Mrs. Roby
   bio:
     birthday: '1976-07-27'
     gender: F
@@ -25171,6 +25607,8 @@
     nickname: Phil
     last: Roe
     official_full: David P. Roe
+    list: Roe, David
+    formal: Mr. Roe of Tennessee
   bio:
     gender: M
     birthday: '1945-07-21'
@@ -25239,6 +25677,8 @@
     last: Rogers
     nickname: Hal
     official_full: Harold Rogers
+    list: Rogers, Harold
+    formal: Mr. Rogers of Kentucky
   bio:
     birthday: '1937-12-31'
     gender: M
@@ -25396,6 +25836,8 @@
     first: Mike
     last: Rogers
     official_full: Mike Rogers
+    list: Rogers, Mike
+    formal: Mr. Rogers of Alabama
   bio:
     birthday: '1958-07-16'
     gender: M
@@ -25485,6 +25927,8 @@
     first: Dana
     last: Rohrabacher
     official_full: Dana Rohrabacher
+    list: Rohrabacher, Dana
+    formal: Mr. Rohrabacher
   bio:
     birthday: '1947-06-21'
     gender: M
@@ -25618,6 +26062,8 @@
     first: Todd
     last: Rokita
     official_full: Todd Rokita
+    list: Rokita, Todd
+    formal: Mr. Rokita
   bio:
     birthday: '1970-02-09'
     gender: M
@@ -25679,6 +26125,8 @@
     middle: J.
     last: Rooney
     official_full: Thomas J. Rooney
+    list: Rooney, Thomas
+    formal: Mr. Rooney of Florida
   bio:
     birthday: '1970-11-21'
     gender: M
@@ -25748,6 +26196,8 @@
     first: Ileana
     last: Ros-Lehtinen
     official_full: Ileana Ros-Lehtinen
+    list: Ros-Lehtinen, Ileana
+    formal: Ms. Ros-Lehtinen
   bio:
     birthday: '1952-07-15'
     gender: F
@@ -25883,6 +26333,8 @@
     middle: J.
     last: Roskam
     official_full: Peter J. Roskam
+    list: Roskam, Peter
+    formal: Mr. Roskam
   bio:
     birthday: '1961-09-13'
     gender: M
@@ -25960,6 +26412,8 @@
     last: Ross
     official_full: Dennis A. Ross
     middle: A.
+    list: Ross, Dennis
+    formal: Mr. Ross
   bio:
     birthday: '1959-10-18'
     gender: M
@@ -26020,6 +26474,8 @@
     first: Lucille
     last: Roybal-Allard
     official_full: Lucille Roybal-Allard
+    list: Roybal-Allard, Lucille
+    formal: Ms. Roybal-Allard
   bio:
     birthday: '1941-06-12'
     gender: F
@@ -26145,6 +26601,8 @@
     last: Royce
     nickname: Ed
     official_full: Edward R. Royce
+    list: Royce, Edward
+    formal: Mr. Royce
   bio:
     birthday: '1951-10-12'
     gender: M
@@ -26304,6 +26762,8 @@
     middle: A. Dutch
     last: Ruppersberger
     official_full: C. A. Dutch Ruppersberger
+    list: Ruppersberger, C.
+    formal: Mr. Ruppersberger
   bio:
     birthday: '1946-01-31'
     gender: M
@@ -26396,6 +26856,8 @@
     middle: L.
     last: Rush
     official_full: Bobby L. Rush
+    list: Rush, Bobby
+    formal: Mr. Rush
   bio:
     birthday: '1946-11-23'
     gender: M
@@ -26515,9 +26977,11 @@
     wikidata: Q203966
   name:
     first: Paul
+    middle: D.
     last: Ryan
     official_full: Paul D. Ryan
-    middle: D.
+    list: Ryan, Paul
+    formal: Mr. Ryan of Wisconsin
   bio:
     birthday: '1970-01-29'
     gender: M
@@ -26625,6 +27089,8 @@
     first: Tim
     last: Ryan
     official_full: Tim Ryan
+    list: Ryan, Tim
+    formal: Mr. Ryan of Ohio
   bio:
     birthday: '1973-07-16'
     gender: M
@@ -26714,6 +27180,8 @@
     last: Sablan
     official_full: Gregorio Kilili Camacho Sablan
     middle: Kilili Camacho
+    list: Sablan, Gregorio
+    formal: Mr. Sablan
   bio:
     gender: M
     birthday: '1955-01-19'
@@ -26790,6 +27258,8 @@
     first: Loretta
     last: Sanchez
     official_full: Loretta Sanchez
+    list: Sanchez, Loretta
+    formal: Ms. Loretta Sanchez of California
   bio:
     birthday: '1960-01-07'
     gender: F
@@ -26902,6 +27372,8 @@
     middle: P.
     last: Sarbanes
     official_full: John P. Sarbanes
+    list: Sarbanes, John
+    formal: Mr. Sarbanes
   bio:
     birthday: '1962-05-22'
     gender: M
@@ -26981,6 +27453,8 @@
     first: Steve
     last: Scalise
     official_full: Steve Scalise
+    list: Scalise, Steve
+    formal: Mr. Scalise
   bio:
     birthday: '1965-10-06'
     gender: M
@@ -27067,6 +27541,8 @@
     last: Schakowsky
     nickname: Jan
     official_full: Janice D. Schakowsky
+    list: Schakowsky, Janice
+    formal: Ms. Schakowsky
   bio:
     birthday: '1944-05-26'
     gender: F
@@ -27171,6 +27647,8 @@
     middle: B.
     last: Schiff
     official_full: Adam B. Schiff
+    list: Schiff, Adam
+    formal: Mr. Schiff
   bio:
     birthday: '1960-06-22'
     gender: M
@@ -27267,6 +27745,8 @@
     first: Kurt
     last: Schrader
     official_full: Kurt Schrader
+    list: Schrader, Kurt
+    formal: Mr. Schrader
   bio:
     birthday: '1951-10-19'
     gender: M
@@ -27447,6 +27927,8 @@
     first: David
     last: Schweikert
     official_full: David Schweikert
+    list: Schweikert, David
+    formal: Mr. Schweikert
   bio:
     birthday: '1962-03-03'
     gender: M
@@ -27507,6 +27989,8 @@
     first: Austin
     last: Scott
     official_full: Austin Scott
+    list: Scott, Austin
+    formal: Mr. Austin Scott of Georgia
   bio:
     birthday: '1969-12-10'
     gender: M
@@ -27568,6 +28052,8 @@
     first: David
     last: Scott
     official_full: David Scott
+    list: Scott, David
+    formal: Mr. David Scott of Georgia
   bio:
     birthday: '1945-06-27'
     gender: M
@@ -27661,6 +28147,8 @@
     last: Scott
     nickname: Bobby
     official_full: Robert C. "Bobby" Scott
+    list: Scott, Robert
+    formal: Mr. Scott of Virginia
   bio:
     birthday: '1947-04-30'
     gender: M
@@ -27849,6 +28337,8 @@
     last: Sensenbrenner
     suffix: Jr.
     official_full: F. James Sensenbrenner, Jr.
+    list: Sensenbrenner, F.
+    formal: Mr. Sensenbrenner
   bio:
     birthday: '1943-06-14'
     gender: M
@@ -28012,6 +28502,8 @@
     middle: E.
     last: Serrano
     official_full: José E. Serrano
+    list: Serrano, José
+    formal: Mr. Serrano
   bio:
     birthday: '1943-10-24'
     gender: M
@@ -28145,6 +28637,8 @@
     first: Pete
     last: Sessions
     official_full: Pete Sessions
+    list: Sessions, Pete
+    formal: Mr. Sessions
   bio:
     birthday: '1955-03-22'
     gender: M
@@ -28255,6 +28749,8 @@
     last: Sewell
     official_full: Terri A. Sewell
     middle: A.
+    list: Sewell, Terri
+    formal: Ms. Sewell of Alabama
   bio:
     birthday: '1965-01-01'
     gender: F
@@ -28413,6 +28909,8 @@
     first: Brad
     last: Sherman
     official_full: Brad Sherman
+    list: Sherman, Brad
+    formal: Mr. Sherman
   bio:
     birthday: '1954-10-24'
     gender: M
@@ -28522,6 +29020,8 @@
     first: John
     last: Shimkus
     official_full: John Shimkus
+    list: Shimkus, John
+    formal: Mr. Shimkus
   bio:
     birthday: '1958-02-21'
     gender: M
@@ -28630,6 +29130,8 @@
     first: Bill
     last: Shuster
     official_full: Bill Shuster
+    list: Shuster, Bill
+    formal: Mr. Shuster
   bio:
     birthday: '1961-01-10'
     gender: M
@@ -28731,6 +29233,8 @@
     last: Simpson
     nickname: Mike
     official_full: Michael K. Simpson
+    list: Simpson, Michael
+    formal: Mr. Simpson
   bio:
     birthday: '1950-09-08'
     gender: M
@@ -28834,6 +29338,8 @@
     first: Albio
     last: Sires
     official_full: Albio Sires
+    list: Sires, Albio
+    formal: Mr. Sires
   bio:
     birthday: '1951-01-26'
     gender: M
@@ -28916,6 +29422,8 @@
     middle: McIntosh
     last: Slaughter
     official_full: Louise McIntosh Slaughter
+    list: Slaughter, Louise
+    formal: Ms. Slaughter
   bio:
     birthday: '1929-08-14'
     gender: F
@@ -29055,6 +29563,8 @@
     first: Adam
     last: Smith
     official_full: Adam Smith
+    list: Smith, Adam
+    formal: Mr. Smith of Washington
   bio:
     birthday: '1965-06-15'
     gender: M
@@ -29164,6 +29674,8 @@
     first: Adrian
     last: Smith
     official_full: Adrian Smith
+    list: Smith, Adrian
+    formal: Mr. Smith of Nebraska
   bio:
     birthday: '1970-12-19'
     gender: M
@@ -29241,6 +29753,8 @@
     last: Smith
     nickname: Chris
     official_full: Christopher H. Smith
+    list: Smith, Christopher
+    formal: Mr. Smith of New Jersey
   bio:
     birthday: '1953-03-04'
     gender: M
@@ -29398,6 +29912,8 @@
     first: Lamar
     last: Smith
     official_full: Lamar Smith
+    list: Smith, Lamar
+    formal: Mr. Smith of Texas
   bio:
     birthday: '1947-11-19'
     gender: M
@@ -29536,6 +30052,8 @@
     first: Jackie
     last: Speier
     official_full: Jackie Speier
+    list: Speier, Jackie
+    formal: Ms. Speier
   bio:
     birthday: '1950-05-14'
     gender: F
@@ -29612,6 +30130,8 @@
     first: Steve
     last: Stivers
     official_full: Steve Stivers
+    list: Stivers, Steve
+    formal: Mr. Stivers
   bio:
     birthday: '1965-03-24'
     gender: M
@@ -29675,6 +30195,8 @@
     middle: A.
     last: Stutzman
     official_full: Marlin A. Stutzman
+    list: Stutzman, Marlin
+    formal: Mr. Stutzman
   bio:
     birthday: '1976-08-31'
     gender: M
@@ -29743,6 +30265,8 @@
     middle: T.
     last: Sánchez
     official_full: Linda T. Sánchez
+    list: Sánchez, Linda
+    formal: Ms. Linda T. Sánchez of California
   bio:
     birthday: '1969-01-28'
     gender: F
@@ -29837,6 +30361,8 @@
     middle: G.
     last: Thompson
     official_full: Bennie G. Thompson
+    list: Thompson, Bennie
+    formal: Mr. Thompson of Mississippi
   bio:
     birthday: '1948-01-28'
     gender: M
@@ -29957,6 +30483,8 @@
     first: Mike
     last: Thompson
     official_full: Mike Thompson
+    list: Thompson, Mike
+    formal: Mr. Thompson of California
   bio:
     birthday: '1951-01-24'
     gender: M
@@ -30059,6 +30587,8 @@
     first: Glenn
     last: Thompson
     official_full: Glenn Thompson
+    list: Thompson, Glenn
+    formal: Mr. Thompson of Pennsylvania
   bio:
     birthday: '1959-07-27'
     gender: M
@@ -30128,6 +30658,8 @@
     first: Mac
     last: Thornberry
     official_full: Mac Thornberry
+    list: Thornberry, Mac
+    formal: Mr. Thornberry
   bio:
     birthday: '1958-07-15'
     gender: M
@@ -30308,6 +30840,8 @@
     last: Tiberi
     nickname: Pat
     official_full: Patrick J. Tiberi
+    list: Tiberi, Patrick
+    formal: Mr. Tiberi
   bio:
     birthday: '1962-10-21'
     gender: M
@@ -30406,6 +30940,8 @@
     last: Tipton
     official_full: Scott R. Tipton
     middle: R.
+    list: Tipton, Scott
+    formal: Mr. Tipton
   bio:
     birthday: '1956-11-09'
     gender: M
@@ -30466,6 +31002,8 @@
     first: Paul
     last: Tonko
     official_full: Paul Tonko
+    list: Tonko, Paul
+    formal: Mr. Tonko
   bio:
     birthday: '1949-06-18'
     gender: M
@@ -30596,6 +31134,8 @@
     first: Niki
     last: Tsongas
     official_full: Niki Tsongas
+    list: Tsongas, Niki
+    formal: Ms. Tsongas
   bio:
     birthday: '1946-04-26'
     gender: F
@@ -30677,6 +31217,8 @@
     middle: R.
     last: Turner
     official_full: Michael R. Turner
+    list: Turner, Michael
+    formal: Mr. Turner
   bio:
     birthday: '1960-01-11'
     gender: M
@@ -30767,6 +31309,8 @@
     first: Fred
     last: Upton
     official_full: Fred Upton
+    list: Upton, Fred
+    formal: Mr. Upton
   bio:
     birthday: '1953-04-23'
     gender: M
@@ -30906,6 +31450,8 @@
     last: Van Hollen
     suffix: Jr.
     official_full: Chris Van Hollen
+    list: Van Hollen, Chris
+    formal: Mr. Van Hollen
   bio:
     birthday: '1959-01-10'
     gender: M
@@ -30997,6 +31543,8 @@
     middle: M.
     last: Velázquez
     official_full: Nydia M. Velázquez
+    list: Velázquez, Nydia
+    formal: Ms. Velázquez
   bio:
     birthday: '1953-03-28'
     gender: F
@@ -31117,6 +31665,8 @@
     middle: J.
     last: Visclosky
     official_full: Peter J. Visclosky
+    list: Visclosky, Peter
+    formal: Mr. Visclosky
   bio:
     birthday: '1949-08-13'
     gender: M
@@ -31329,6 +31879,8 @@
     first: Tim
     last: Walberg
     official_full: Tim Walberg
+    list: Walberg, Tim
+    formal: Mr. Walberg
   bio:
     gender: M
     birthday: '1951-04-12'
@@ -31397,6 +31949,8 @@
     first: Greg
     last: Walden
     official_full: Greg Walden
+    list: Walden, Greg
+    formal: Mr. Walden
   bio:
     birthday: '1957-01-10'
     gender: M
@@ -31501,6 +32055,8 @@
     middle: J.
     last: Walz
     official_full: Timothy J. Walz
+    list: Walz, Timothy
+    formal: Mr. Walz
   bio:
     birthday: '1964-04-06'
     gender: M
@@ -31577,6 +32133,8 @@
     first: Debbie
     last: Wasserman Schultz
     official_full: Debbie Wasserman Schultz
+    list: Wasserman Schultz, Debbie
+    formal: Ms. Wasserman Schultz
   bio:
     birthday: '1966-09-27'
     gender: F
@@ -31660,6 +32218,8 @@
     first: Maxine
     last: Waters
     official_full: Maxine Waters
+    list: Waters, Maxine
+    formal: Ms. Maxine Waters of California
   bio:
     birthday: '1938-08-15'
     gender: F
@@ -31788,6 +32348,8 @@
     first: Daniel
     last: Webster
     official_full: Daniel Webster
+    list: Webster, Daniel
+    formal: Mr. Webster of Florida
   bio:
     birthday: '1949-04-27'
     gender: M
@@ -31850,6 +32412,8 @@
     first: Peter
     last: Welch
     official_full: Peter Welch
+    list: Welch, Peter
+    formal: Mr. Welch
   bio:
     gender: M
     birthday: '1947-05-02'
@@ -31927,6 +32491,8 @@
     middle: A.
     last: Westmoreland
     official_full: Lynn A. Westmoreland
+    list: Westmoreland, Lynn
+    formal: Mr. Westmoreland
   bio:
     birthday: '1950-04-02'
     gender: M
@@ -32009,6 +32575,8 @@
     first: Ed
     last: Whitfield
     official_full: Ed Whitfield
+    list: Whitfield, Ed
+    formal: Mr. Whitfield
   bio:
     birthday: '1943-05-25'
     gender: M
@@ -32124,6 +32692,8 @@
     first: Joe
     last: Wilson
     official_full: Joe Wilson
+    list: Wilson, Joe
+    formal: Mr. Wilson of South Carolina
   bio:
     birthday: '1947-07-31'
     gender: M
@@ -32222,6 +32792,8 @@
     last: Wilson
     official_full: Frederica S. Wilson
     middle: S.
+    list: Wilson, Frederica
+    formal: Ms. Wilson of Florida
   bio:
     birthday: '1942-11-05'
     gender: F
@@ -32284,6 +32856,8 @@
     middle: J.
     last: Wittman
     official_full: Robert J. Wittman
+    list: Wittman, Robert
+    formal: Mr. Wittman
   bio:
     birthday: '1959-02-03'
     gender: M
@@ -32361,6 +32935,8 @@
     first: Steve
     last: Womack
     official_full: Steve Womack
+    list: Womack, Steve
+    formal: Mr. Womack
   bio:
     birthday: '1957-02-18'
     gender: M
@@ -32421,6 +32997,8 @@
     first: Rob
     last: Woodall
     official_full: Rob Woodall
+    list: Woodall, Rob
+    formal: Mr. Woodall
   bio:
     birthday: '1970-02-11'
     gender: M
@@ -32592,6 +33170,8 @@
     middle: A.
     last: Yarmuth
     official_full: John A. Yarmuth
+    list: Yarmuth, John
+    formal: Mr. Yarmuth
   bio:
     birthday: '1947-11-04'
     gender: M
@@ -32666,6 +33246,8 @@
     first: Kevin
     last: Yoder
     official_full: Kevin Yoder
+    list: Yoder, Kevin
+    formal: Mr. Yoder
   bio:
     birthday: '1976-01-08'
     gender: M
@@ -32727,6 +33309,8 @@
     first: Don
     last: Young
     official_full: Don Young
+    list: Young, Don
+    formal: Mr. Young of Alaska
   bio:
     birthday: '1933-06-09'
     gender: M
@@ -32909,6 +33493,8 @@
     last: Young
     official_full: Todd C. Young
     middle: C.
+    list: Young, Todd
+    formal: Mr. Young of Indiana
   bio:
     birthday: '1972-08-24'
     gender: M
@@ -33043,6 +33629,8 @@
     first: Janice
     last: Hahn
     official_full: Janice Hahn
+    list: Hahn, Janice
+    formal: Ms. Hahn
   bio:
     birthday: '1952-03-30'
     gender: F
@@ -33108,6 +33696,8 @@
     middle: E.
     last: Amodei
     official_full: Mark E. Amodei
+    list: Amodei, Mark
+    formal: Mr. Amodei
   bio:
     birthday: '1958-06-12'
     gender: M
@@ -33170,6 +33760,8 @@
     first: Suzanne
     last: Bonamici
     official_full: Suzanne Bonamici
+    list: Bonamici, Suzanne
+    formal: Ms. Bonamici
   bio:
     birthday: '1954-10-14'
     gender: F
@@ -33232,6 +33824,8 @@
     middle: K.
     last: DelBene
     official_full: Suzan K. DelBene
+    list: DelBene, Suzan
+    formal: Ms. DelBene
   bio:
     birthday: '1962-02-17'
     gender: F
@@ -33291,6 +33885,8 @@
     first: Thomas
     last: Massie
     official_full: Thomas Massie
+    list: Massie, Thomas
+    formal: Mr. Massie
   bio:
     birthday: '1971-01-13'
     gender: M
@@ -33351,6 +33947,8 @@
     last: Payne
     suffix: Jr.
     official_full: Donald M. Payne, Jr.
+    list: Payne, Donald
+    formal: Mr. Payne
   bio:
     birthday: '1958-12-17'
     gender: M
@@ -33465,6 +34063,8 @@
     first: Matt
     last: Salmon
     official_full: Matt Salmon
+    list: Salmon, Matt
+    formal: Mr. Salmon
   bio:
     birthday: '1958-01-21'
     gender: M
@@ -33534,6 +34134,8 @@
     first: Bill
     last: Foster
     official_full: Bill Foster
+    list: Foster, Bill
+    formal: Mr. Foster
   bio:
     birthday: '1955-10-07'
     gender: M
@@ -33598,6 +34200,8 @@
     first: Alan
     last: Grayson
     official_full: Alan Grayson
+    list: Grayson, Alan
+    formal: Mr. Grayson
   bio:
     birthday: '1958-03-13'
     gender: M
@@ -33655,6 +34259,8 @@
     first: Ann
     last: Kirkpatrick
     official_full: Ann Kirkpatrick
+    list: Kirkpatrick, Ann
+    formal: Mrs. Kirkpatrick
   bio:
     gender: F
     birthday: '1950-03-24'
@@ -33712,6 +34318,8 @@
     first: Dina
     last: Titus
     official_full: Dina Titus
+    list: Titus, Dina
+    formal: Ms. Titus
   bio:
     gender: F
     birthday: '1950-05-23'
@@ -33815,6 +34423,8 @@
     first: Kyrsten
     last: Sinema
     official_full: Kyrsten Sinema
+    list: Sinema, Kyrsten
+    formal: Ms. Sinema
   bio:
     gender: F
     birthday: '1976-07-12'
@@ -33865,6 +34475,8 @@
     first: Doug
     last: LaMalfa
     official_full: Doug LaMalfa
+    list: LaMalfa, Doug
+    formal: Mr. LaMalfa
   bio:
     gender: M
     birthday: '1960-07-02'
@@ -33914,6 +34526,8 @@
     first: Jared
     last: Huffman
     official_full: Jared Huffman
+    list: Huffman, Jared
+    formal: Mr. Huffman
   bio:
     gender: M
     birthday: '1964-02-18'
@@ -33963,6 +34577,8 @@
     first: Ami
     last: Bera
     official_full: Ami Bera
+    list: Bera, Ami
+    formal: Mr. Bera
   bio:
     gender: M
     birthday: '1965-03-02'
@@ -34012,6 +34628,8 @@
     first: Paul
     last: Cook
     official_full: Paul Cook
+    list: Cook, Paul
+    formal: Mr. Cook
   bio:
     gender: M
     birthday: '1943-03-03'
@@ -34059,6 +34677,8 @@
     first: Eric
     last: Swalwell
     official_full: Eric Swalwell
+    list: Swalwell, Eric
+    formal: Mr. Swalwell of California
   bio:
     gender: M
     birthday: '1980-11-16'
@@ -34105,6 +34725,8 @@
     last: Valadao
     middle: G.
     official_full: David G. Valadao
+    list: Valadao, David
+    formal: Mr. Valadao
   bio:
     gender: M
     birthday: '1977-04-14'
@@ -34155,6 +34777,8 @@
     first: Julia
     last: Brownley
     official_full: Julia Brownley
+    list: Brownley, Julia
+    formal: Ms. Brownley of California
   bio:
     gender: F
     birthday: '1952-08-28'
@@ -34204,6 +34828,8 @@
     first: Tony
     last: Cárdenas
     official_full: Tony Cárdenas
+    list: Cárdenas, Tony
+    formal: Mr. Cárdenas
   bio:
     gender: M
     birthday: '1963-03-31'
@@ -34253,6 +34879,8 @@
     first: Raul
     last: Ruiz
     official_full: Raul Ruiz
+    list: Ruiz, Raul
+    formal: Mr. Ruiz
   bio:
     gender: M
     birthday: '1972-08-25'
@@ -34301,6 +34929,8 @@
     first: Mark
     last: Takano
     official_full: Mark Takano
+    list: Takano, Mark
+    formal: Mr. Takano
   bio:
     gender: M
     birthday: '1960-12-10'
@@ -34350,6 +34980,8 @@
     last: Lowenthal
     middle: S.
     official_full: Alan S. Lowenthal
+    list: Lowenthal, Alan
+    formal: Mr. Lowenthal
   bio:
     gender: M
     birthday: '1941-03-08'
@@ -34399,6 +35031,8 @@
     first: Juan
     last: Vargas
     official_full: Juan Vargas
+    list: Vargas, Juan
+    formal: Mr. Vargas
   bio:
     gender: M
     birthday: '1961-03-07'
@@ -34449,6 +35083,8 @@
     last: Peters
     middle: H.
     official_full: Scott H. Peters
+    list: Peters, Scott
+    formal: Mr. Peters
   bio:
     gender: M
     birthday: '1958-06-17'
@@ -34500,6 +35136,8 @@
     last: Esty
     middle: H.
     official_full: Elizabeth H. Esty
+    list: Esty, Elizabeth
+    formal: Ms. Esty
   bio:
     gender: F
     birthday: '1959-08-25'
@@ -34550,6 +35188,8 @@
     last: Yoho
     middle: S.
     official_full: Ted S. Yoho
+    list: Yoho, Ted
+    formal: Mr. Yoho
   bio:
     gender: M
     birthday: '1955-04-13'
@@ -34597,6 +35237,8 @@
     first: Ron
     last: DeSantis
     official_full: Ron DeSantis
+    list: DeSantis, Ron
+    formal: Mr. DeSantis
   bio:
     gender: M
     birthday: '1978-09-14'
@@ -34646,6 +35288,8 @@
     first: Patrick
     last: Murphy
     official_full: Patrick Murphy
+    list: Murphy, Patrick
+    formal: Mr. Murphy of Florida
   bio:
     gender: M
     birthday: '1983-03-30'
@@ -34697,6 +35341,8 @@
     first: Lois
     last: Frankel
     official_full: Lois Frankel
+    list: Frankel, Lois
+    formal: Ms. Frankel of Florida
   bio:
     gender: F
     birthday: '1948-05-16'
@@ -34746,6 +35392,8 @@
     first: Doug
     last: Collins
     official_full: Doug Collins
+    list: Collins, Doug
+    formal: Mr. Collins of Georgia
   bio:
     gender: M
     birthday: '1966-08-16'
@@ -34796,6 +35444,8 @@
     first: Tulsi
     last: Gabbard
     official_full: Tulsi Gabbard
+    list: Gabbard, Tulsi
+    formal: Ms. Gabbard
   bio:
     gender: F
     birthday: '1981-04-12'
@@ -34846,6 +35496,8 @@
     first: Tammy
     last: Duckworth
     official_full: Tammy Duckworth
+    list: Duckworth, Tammy
+    formal: Ms. Duckworth
   bio:
     gender: F
     birthday: '1968-03-12'
@@ -34893,6 +35545,8 @@
     first: Rodney
     last: Davis
     official_full: Rodney Davis
+    list: Davis, Rodney
+    formal: Mr. Rodney Davis of Illinois
   bio:
     gender: M
     birthday: '1970-01-05'
@@ -34942,6 +35596,8 @@
     first: Cheri
     last: Bustos
     official_full: Cheri Bustos
+    list: Bustos, Cheri
+    formal: Mrs. Bustos
   bio:
     gender: F
     birthday: '1961-10-17'
@@ -34992,6 +35648,8 @@
     first: Jackie
     last: Walorski
     official_full: Jackie Walorski
+    list: Walorski, Jackie
+    formal: Mrs. Walorski
   bio:
     gender: F
     birthday: '1963-08-17'
@@ -35043,6 +35701,8 @@
     last: Brooks
     middle: W.
     official_full: Susan W. Brooks
+    list: Brooks, Susan
+    formal: Mrs. Brooks of Indiana
   bio:
     gender: F
     birthday: '1960-08-25'
@@ -35092,6 +35752,8 @@
     first: Luke
     last: Messer
     official_full: Luke Messer
+    list: Messer, Luke
+    formal: Mr. Messer
   bio:
     gender: M
     birthday: '1969-02-27'
@@ -35142,6 +35804,8 @@
     last: Barr
     nickname: Andy
     official_full: Andy Barr
+    list: Barr, Andy
+    formal: Mr. Barr
   bio:
     gender: M
     birthday: '1973-07-24'
@@ -35229,6 +35893,8 @@
     suffix: III
     middle: P.
     official_full: Joseph P. Kennedy III
+    list: Kennedy, Joseph
+    formal: Mr. Kennedy
   bio:
     gender: M
     birthday: '1980-10-04'
@@ -35290,6 +35956,8 @@
     last: Delaney
     middle: K.
     official_full: John K. Delaney
+    list: Delaney, John
+    formal: Mr. Delaney
   bio:
     gender: M
     birthday: '1963-04-16'
@@ -35378,6 +36046,8 @@
     last: Kildee
     middle: T.
     official_full: Daniel T. Kildee
+    list: Kildee, Daniel
+    formal: Mr. Kildee
   bio:
     gender: M
     birthday: '1958-08-11'
@@ -35430,6 +36100,8 @@
     middle: M.
     last: Nolan
     official_full: Richard M. Nolan
+    list: Nolan, Richard
+    formal: Mr. Nolan
   bio:
     birthday: '1943-12-17'
     gender: M
@@ -35497,6 +36169,8 @@
     first: Ann
     last: Wagner
     official_full: Ann Wagner
+    list: Wagner, Ann
+    formal: Mrs. Wagner
   bio:
     gender: F
     birthday: '1962-09-13'
@@ -35593,6 +36267,8 @@
     first: Richard
     last: Hudson
     official_full: Richard Hudson
+    list: Hudson, Richard
+    formal: Mr. Hudson
   bio:
     gender: M
     birthday: '1971-11-04'
@@ -35642,6 +36318,8 @@
     first: Robert
     last: Pittenger
     official_full: Robert Pittenger
+    list: Pittenger, Robert
+    formal: Mr. Pittenger
   bio:
     gender: M
     birthday: '1948-08-15'
@@ -35691,6 +36369,8 @@
     first: Mark
     last: Meadows
     official_full: Mark Meadows
+    list: Meadows, Mark
+    formal: Mr. Meadows
   bio:
     gender: M
     birthday: '1959-07-28'
@@ -35739,6 +36419,8 @@
     first: George
     last: Holding
     official_full: George Holding
+    list: Holding, George
+    formal: Mr. Holding
   bio:
     gender: M
     birthday: '1968-04-17'
@@ -35828,6 +36510,8 @@
     first: Kevin
     last: Cramer
     official_full: Kevin Cramer
+    list: Cramer, Kevin
+    formal: Mr. Cramer
   bio:
     gender: M
     birthday: '1961-01-21'
@@ -35918,6 +36602,8 @@
     last: Kuster
     middle: M.
     official_full: Ann M. Kuster
+    list: Kuster, Ann
+    formal: Ms. Kuster
   bio:
     gender: F
     birthday: '1956-09-05'
@@ -35968,6 +36654,8 @@
     first: Michelle
     last: Lujan Grisham
     official_full: Michelle Lujan Grisham
+    list: Lujan Grisham, Michelle
+    formal: Ms. Michelle Lujan Grisham of New Mexico
   bio:
     gender: F
     birthday: '1959-10-24'
@@ -36018,6 +36706,8 @@
     first: Grace
     last: Meng
     official_full: Grace Meng
+    list: Meng, Grace
+    formal: Ms. Meng
   bio:
     gender: F
     birthday: '1975-10-01'
@@ -36067,6 +36757,8 @@
     last: Jeffries
     middle: S.
     official_full: Hakeem S. Jeffries
+    list: Jeffries, Hakeem
+    formal: Mr. Jeffries
   bio:
     gender: M
     birthday: '1970-08-04'
@@ -36115,6 +36807,8 @@
     last: Maloney
     middle: Patrick
     official_full: Sean Patrick Maloney
+    list: Maloney, Sean
+    formal: Mr. Sean Patrick Maloney of New York
   bio:
     gender: M
     birthday: '1966-07-30'
@@ -36163,6 +36857,8 @@
     first: Chris
     last: Collins
     official_full: Chris Collins
+    list: Collins, Chris
+    formal: Mr. Collins of New York
   bio:
     gender: M
     birthday: '1950-05-20'
@@ -36212,6 +36908,8 @@
     last: Wenstrup
     middle: R.
     official_full: Brad R. Wenstrup
+    list: Wenstrup, Brad
+    formal: Mr. Wenstrup
   bio:
     gender: M
     birthday: '1958-06-17'
@@ -36259,6 +36957,8 @@
     first: Joyce
     last: Beatty
     official_full: Joyce Beatty
+    list: Beatty, Joyce
+    formal: Mrs. Beatty
   bio:
     gender: F
     birthday: '1950-03-12'
@@ -36308,6 +37008,8 @@
     last: Joyce
     middle: P.
     official_full: David P. Joyce
+    list: Joyce, David
+    formal: Mr. Joyce
   bio:
     gender: M
     birthday: '1957-03-17'
@@ -36357,6 +37059,8 @@
     first: Jim
     last: Bridenstine
     official_full: Jim Bridenstine
+    list: Bridenstine, Jim
+    formal: Mr. Bridenstine
   bio:
     gender: M
     birthday: '1975-06-15'
@@ -36406,6 +37110,8 @@
     first: Markwayne
     last: Mullin
     official_full: Markwayne Mullin
+    list: Mullin, Markwayne
+    formal: Mr. Mullin
   bio:
     gender: M
     birthday: '1977-07-26'
@@ -36455,6 +37161,8 @@
     first: Scott
     last: Perry
     official_full: Scott Perry
+    list: Perry, Scott
+    formal: Mr. Perry
   bio:
     gender: M
     birthday: '1962-05-27'
@@ -36505,6 +37213,8 @@
     last: Rothfus
     middle: J.
     official_full: Keith J. Rothfus
+    list: Rothfus, Keith
+    formal: Mr. Rothfus
   bio:
     gender: M
     birthday: '1962-04-25'
@@ -36553,6 +37263,8 @@
     first: Matt
     last: Cartwright
     official_full: Matt Cartwright
+    list: Cartwright, Matt
+    formal: Mr. Cartwright
   bio:
     gender: M
     birthday: '1961-05-01'
@@ -36602,6 +37314,8 @@
     first: Tom
     last: Rice
     official_full: Tom Rice
+    list: Rice, Tom
+    formal: Mr. Rice of South Carolina
   bio:
     gender: M
     birthday: '1957-08-04'
@@ -36688,6 +37402,8 @@
     last: Weber
     middle: K.
     official_full: Randy K. Weber, Sr.
+    list: Weber, Randy
+    formal: Mr. Weber of Texas
   bio:
     gender: M
     birthday: '1953-07-02'
@@ -36737,6 +37453,8 @@
     first: Beto
     last: O'Rourke
     official_full: Beto O'Rourke
+    list: O'Rourke, Beto
+    formal: Mr. O'Rourke
   bio:
     gender: M
     birthday: '1972-09-26'
@@ -36784,6 +37502,8 @@
     first: Joaquin
     last: Castro
     official_full: Joaquin Castro
+    list: Castro, Joaquin
+    formal: Mr. Castro of Texas
   bio:
     gender: M
     birthday: '1974-09-16'
@@ -36834,6 +37554,8 @@
     first: Roger
     last: Williams
     official_full: Roger Williams
+    list: Williams, Roger
+    formal: Mr. Williams
   bio:
     gender: M
     birthday: '1949-09-13'
@@ -36884,6 +37606,8 @@
     last: Veasey
     middle: A.
     official_full: Marc A. Veasey
+    list: Veasey, Marc
+    formal: Mr. Veasey
   bio:
     gender: M
     birthday: '1971-01-03'
@@ -36932,6 +37656,8 @@
     first: Filemon
     last: Vela
     official_full: Filemon Vela
+    list: Vela, Filemon
+    formal: Mr. Vela
   bio:
     gender: M
     birthday: '1963-02-13'
@@ -36981,6 +37707,8 @@
     first: Chris
     last: Stewart
     official_full: Chris Stewart
+    list: Stewart, Chris
+    formal: Mr. Stewart
   bio:
     gender: M
     birthday: '1960-07-15'
@@ -37068,6 +37796,8 @@
     first: Derek
     last: Kilmer
     official_full: Derek Kilmer
+    list: Kilmer, Derek
+    formal: Mr. Kilmer
   bio:
     gender: M
     birthday: '1974-01-01'
@@ -37115,6 +37845,8 @@
     first: Denny
     last: Heck
     official_full: Denny Heck
+    list: Heck, Denny
+    formal: Mr. Heck of Washington
   bio:
     gender: M
     birthday: '1952-07-29'
@@ -37164,6 +37896,8 @@
     first: Mark
     last: Pocan
     official_full: Mark Pocan
+    list: Pocan, Mark
+    formal: Mr. Pocan
   bio:
     gender: M
     birthday: '1964-08-14'
@@ -37214,6 +37948,8 @@
     first: Robin
     last: Kelly
     official_full: Robin L. Kelly
+    list: Kelly, Robin
+    formal: Ms. Kelly of Illinois
     middle: L.
   bio:
     gender: F
@@ -37266,6 +38002,8 @@
     last: Sanford
     nickname: Mark
     official_full: Mark Sanford
+    list: Sanford, Mark
+    formal: Mr. Sanford
   bio:
     birthday: '1960-05-28'
     gender: M
@@ -37332,6 +38070,8 @@
     first: Jason
     last: Smith
     official_full: Jason Smith
+    list: Smith, Jason
+    formal: Mr. Smith of Missouri
   bio:
     birthday: '1980-06-16'
     gender: M
@@ -37429,6 +38169,8 @@
     middle: M.
     last: Clark
     official_full: Katherine M. Clark
+    list: Clark, Katherine
+    formal: Ms. Clark of Massachusetts
   bio:
     birthday: '1963-07-17'
     gender: F
@@ -37473,6 +38215,8 @@
     first: Bradley
     last: Byrne
     official_full: Bradley Byrne
+    list: Byrne, Bradley
+    formal: Mr. Byrne
   bio:
     birthday: '1955-02-16'
     gender: M
@@ -37518,6 +38262,8 @@
     middle: W.
     last: Jolly
     official_full: David W. Jolly
+    list: Jolly, David
+    formal: Mr. Jolly
   bio:
     birthday: '1972-10-31'
     gender: M
@@ -37562,6 +38308,8 @@
     nickname: Curt
     last: Clawson
     official_full: Curt Clawson
+    list: Clawson, Curt
+    formal: Mr. Clawson of Florida
   bio:
     gender: M
     birthday: '1959-09-28'
@@ -37603,6 +38351,8 @@
     nickname: Dave
     last: Brat
     official_full: Dave Brat
+    list: Brat, Dave
+    formal: Mr. Brat
   bio:
     gender: M
     birthday: '1964-07-27'
@@ -37647,6 +38397,8 @@
     first: Donald
     last: Norcross
     official_full: Donald Norcross
+    list: Norcross, Donald
+    formal: Mr. Norcross
   bio:
     gender: M
     birthday: '1958-12-13'
@@ -37691,6 +38443,8 @@
     first: Alma
     last: Adams
     official_full: Alma S. Adams
+    list: Adams, Alma
+    formal: Ms. Adams
     middle: S.
   bio:
     gender: F
@@ -37736,6 +38490,8 @@
     first: Robert
     last: Dold
     official_full: Robert J. Dold
+    list: Dold, Robert
+    formal: Mr. Dold
     middle: J.
   bio:
     birthday: '1969-06-23'
@@ -37779,6 +38535,8 @@
     first: Frank
     last: Guinta
     official_full: Frank C. Guinta
+    list: Guinta, Frank
+    formal: Mr. Guinta
     middle: C.
   bio:
     birthday: '1970-09-26'
@@ -37820,6 +38578,8 @@
     first: Gary
     last: Palmer
     official_full: Gary J. Palmer
+    list: Palmer, Gary
+    formal: Mr. Palmer
     middle: J.
   bio:
     gender: M
@@ -37850,6 +38610,8 @@
     first: J.
     last: Hill
     official_full: J. French Hill
+    list: Hill, J.
+    formal: Mr. Hill
     middle: French
   bio:
     gender: M
@@ -37880,6 +38642,8 @@
     first: Bruce
     last: Westerman
     official_full: Bruce Westerman
+    list: Westerman, Bruce
+    formal: Mr. Westerman
   bio:
     gender: M
     birthday: '1967-11-18'
@@ -37909,6 +38673,8 @@
     first: Martha
     last: McSally
     official_full: Martha McSally
+    list: McSally, Martha
+    formal: Ms. McSally
   bio:
     gender: F
     birthday: '1966-03-22'
@@ -37938,6 +38704,8 @@
     first: Ruben
     last: Gallego
     official_full: Ruben Gallego
+    list: Gallego, Ruben
+    formal: Mr. Gallego
   bio:
     gender: M
     birthday: '1979-11-20'
@@ -37966,6 +38734,8 @@
     first: Mark
     last: DeSaulnier
     official_full: Mark DeSaulnier
+    list: DeSaulnier, Mark
+    formal: Mr. DeSaulnier
   bio:
     gender: M
     birthday: '1952-03-31'
@@ -37995,6 +38765,8 @@
     first: Stephen
     last: Knight
     official_full: Stephen Knight
+    list: Knight, Stephen
+    formal: Mr. Knight
   bio:
     gender: M
     birthday: '1966-12-17'
@@ -38024,6 +38796,8 @@
     first: Pete
     last: Aguilar
     official_full: Pete Aguilar
+    list: Aguilar, Pete
+    formal: Mr. Aguilar
   bio:
     gender: M
     birthday: '1979-06-19'
@@ -38053,6 +38827,8 @@
     first: Ted
     last: Lieu
     official_full: Ted Lieu
+    list: Lieu, Ted
+    formal: Mr. Ted Lieu of California
   bio:
     gender: M
     birthday: '1969-03-29'
@@ -38083,6 +38859,8 @@
     first: Norma
     last: Torres
     official_full: Norma J. Torres
+    list: Torres, Norma
+    formal: Mrs. Torres
     middle: J.
   bio:
     gender: F
@@ -38114,6 +38892,8 @@
     first: Mimi
     last: Walters
     official_full: Mimi Walters
+    list: Walters, Mimi
+    formal: Mrs. Mimi Walters of California
   bio:
     gender: F
     birthday: '1962-05-14'
@@ -38144,6 +38924,8 @@
     first: Ken
     last: Buck
     official_full: Ken Buck
+    list: Buck, Ken
+    formal: Mr. Buck
   bio:
     gender: M
     birthday: '1959-02-16'
@@ -38174,6 +38956,8 @@
     first: Gwen
     last: Graham
     official_full: Gwen Graham
+    list: Graham, Gwen
+    formal: Ms. Graham
   bio:
     gender: F
     birthday: '1963-01-31'
@@ -38203,6 +38987,8 @@
     first: Carlos
     last: Curbelo
     official_full: Carlos Curbelo
+    list: Curbelo, Carlos
+    formal: Mr. Curbelo of Florida
   bio:
     gender: M
     birthday: '1980-03-01'
@@ -38231,6 +39017,8 @@
     first: Earl
     last: Carter
     official_full: Earl L. "Buddy" Carter
+    list: Carter, Earl
+    formal: Mr. Carter of Georgia
     middle: L. "Buddy"
   bio:
     gender: M
@@ -38261,6 +39049,8 @@
     first: Jody
     last: Hice
     official_full: Jody B. Hice
+    list: Hice, Jody
+    formal: Mr. Jody B. Hice of Georgia
     middle: B.
   bio:
     gender: M
@@ -38291,6 +39081,8 @@
     first: Barry
     last: Loudermilk
     official_full: Barry Loudermilk
+    list: Loudermilk, Barry
+    formal: Mr. Loudermilk
   bio:
     gender: M
     birthday: '1963-12-22'
@@ -38320,6 +39112,8 @@
     first: Rick
     last: Allen
     official_full: Rick W. Allen
+    list: Allen, Rick
+    formal: Mr. Allen
     middle: W.
   bio:
     gender: M
@@ -38350,6 +39144,8 @@
     first: Mark
     last: Takai
     official_full: Mark Takai
+    list: Takai, Mark
+    formal: Mr. Takai
   bio:
     gender: M
     birthday: '1967-07-01'
@@ -38379,6 +39175,8 @@
     first: Rod
     last: Blum
     official_full: Rod Blum
+    list: Blum, Rod
+    formal: Mr. Blum
   bio:
     gender: M
     birthday: '1955-04-26'
@@ -38408,6 +39206,8 @@
     first: David
     last: Young
     official_full: David Young
+    list: Young, David
+    formal: Mr. Young of Iowa
   bio:
     gender: M
     birthday: '1968-05-11'
@@ -38436,6 +39236,8 @@
     first: Mike
     last: Bost
     official_full: Mike Bost
+    list: Bost, Mike
+    formal: Mr. Bost
   bio:
     gender: M
     birthday: '1960-12-30'
@@ -38465,6 +39267,8 @@
     first: Ralph
     last: Abraham
     official_full: Ralph Lee Abraham
+    list: Abraham, Ralph
+    formal: Mr. Abraham
     middle: Lee
   bio:
     gender: M
@@ -38495,6 +39299,8 @@
     first: Garret
     last: Graves
     official_full: Garret Graves
+    list: Graves, Garret
+    formal: Mr. Graves of Louisiana
   bio:
     gender: M
     birthday: '1972-01-31'
@@ -38524,6 +39330,8 @@
     first: Seth
     last: Moulton
     official_full: Seth Moulton
+    list: Moulton, Seth
+    formal: Mr. Moulton
   bio:
     gender: M
     birthday: '1978-10-24'
@@ -38554,6 +39362,8 @@
     first: Bruce
     last: Poliquin
     official_full: Bruce Poliquin
+    list: Poliquin, Bruce
+    formal: Mr. Poliquin
   bio:
     gender: M
     birthday: '1953-11-01'
@@ -38583,6 +39393,8 @@
     first: John
     last: Moolenaar
     official_full: John R. Moolenaar
+    list: Moolenaar, John
+    formal: Mr. Moolenaar
     middle: R.
   bio:
     gender: M
@@ -38613,6 +39425,8 @@
     first: Mike
     last: Bishop
     official_full: Mike Bishop
+    list: Bishop, Mike
+    formal: Mr. Bishop of Michigan
   bio:
     gender: M
     birthday: '1967-03-18'
@@ -38642,6 +39456,8 @@
     first: David
     last: Trott
     official_full: David A. Trott
+    list: Trott, David
+    formal: Mr. Trott
     middle: A.
   bio:
     gender: M
@@ -38672,6 +39488,8 @@
     first: Debbie
     last: Dingell
     official_full: Debbie Dingell
+    list: Dingell, Debbie
+    formal: Mrs. Dingell
   bio:
     gender: F
     birthday: '1953-11-23'
@@ -38702,6 +39520,8 @@
     first: Brenda
     last: Lawrence
     official_full: Brenda L. Lawrence
+    list: Lawrence, Brenda
+    formal: Mrs. Lawrence
     middle: L.
   bio:
     gender: F
@@ -38732,6 +39552,8 @@
     first: Tom
     last: Emmer
     official_full: Tom Emmer
+    list: Emmer, Tom
+    formal: Mr. Emmer of Minnesota
   bio:
     gender: M
     birthday: '1961-03-03'
@@ -38761,6 +39583,8 @@
     first: Ryan
     last: Zinke
     official_full: Ryan K. Zinke
+    list: Zinke, Ryan
+    formal: Mr. Zinke
     middle: K.
   bio:
     gender: M
@@ -38791,6 +39615,8 @@
     first: David
     last: Rouzer
     official_full: David Rouzer
+    list: Rouzer, David
+    formal: Mr. Rouzer
   bio:
     gender: M
     birthday: '1972-02-16'
@@ -38820,6 +39646,8 @@
     first: Brad
     last: Ashford
     official_full: Brad Ashford
+    list: Ashford, Brad
+    formal: Mr. Ashford
   bio:
     gender: M
     birthday: '1949-11-10'
@@ -38849,6 +39677,8 @@
     first: Thomas
     last: MacArthur
     official_full: Thomas MacArthur
+    list: MacArthur, Thomas
+    formal: Mr. MacArthur
   bio:
     gender: M
     birthday: '1960-10-16'
@@ -38879,6 +39709,8 @@
     first: Bonnie
     last: Watson Coleman
     official_full: Bonnie Watson Coleman
+    list: Watson Coleman, Bonnie
+    formal: Mrs. Watson Coleman
   bio:
     gender: F
     birthday: '1945-02-06'
@@ -38908,6 +39740,8 @@
     first: Cresent
     last: Hardy
     official_full: Cresent Hardy
+    list: Hardy, Cresent
+    formal: Mr. Hardy
   bio:
     gender: M
     birthday: '1957-06-23'
@@ -38937,6 +39771,8 @@
     first: Lee
     last: Zeldin
     official_full: Lee M. Zeldin
+    list: Zeldin, Lee
+    formal: Mr. Zeldin
     middle: M.
   bio:
     gender: M
@@ -38968,6 +39804,8 @@
     first: Kathleen
     last: Rice
     official_full: Kathleen M. Rice
+    list: Rice, Kathleen
+    formal: Miss Rice of New York
     middle: M.
   bio:
     gender: F
@@ -38999,6 +39837,8 @@
     first: Elise
     last: Stefanik
     official_full: Elise M. Stefanik
+    list: Stefanik, Elise
+    formal: Ms. Stefanik
     middle: M.
   bio:
     gender: F
@@ -39029,6 +39869,8 @@
     first: John
     last: Katko
     official_full: John Katko
+    list: Katko, John
+    formal: Mr. Katko
   bio:
     gender: M
     birthday: '1962-11-09'
@@ -39058,6 +39900,8 @@
     first: Steve
     last: Russell
     official_full: Steve Russell
+    list: Russell, Steve
+    formal: Mr. Russell
   bio:
     gender: M
     birthday: '1963-05-25'
@@ -39087,6 +39931,8 @@
     first: Ryan
     last: Costello
     official_full: Ryan A. Costello
+    list: Costello, Ryan
+    formal: Mr. Costello of Pennsylvania
     middle: A.
   bio:
     gender: M
@@ -39117,6 +39963,8 @@
     first: Brendan
     last: Boyle
     official_full: Brendan F. Boyle
+    list: Boyle, Brendan
+    formal: Mr. Brendan F. Boyle of Pennsylvania
     middle: F.
   bio:
     gender: M
@@ -39147,6 +39995,8 @@
     first: John
     last: Ratcliffe
     official_full: John Ratcliffe
+    list: Ratcliffe, John
+    formal: Mr. Ratcliffe
   bio:
     gender: M
     birthday: '1965-10-20'
@@ -39176,6 +40026,8 @@
     first: Will
     last: Hurd
     official_full: Will Hurd
+    list: Hurd, Will
+    formal: Mr. Hurd of Texas
   bio:
     gender: M
     birthday: '1977-08-19'
@@ -39204,6 +40056,8 @@
     first: Brian
     last: Babin
     official_full: Brian Babin
+    list: Babin, Brian
+    formal: Mr. Babin
   bio:
     gender: M
     birthday: '1948-03-23'
@@ -39234,6 +40088,8 @@
     first: Mia
     last: Love
     official_full: Mia B. Love
+    list: Love, Mia
+    formal: Mrs. Love
     middle: B.
   bio:
     gender: F
@@ -39264,6 +40120,8 @@
     first: Donald
     last: Beyer
     official_full: Donald S. Beyer, Jr.
+    list: Beyer, Donald
+    formal: Mr. Beyer
     middle: S.
   bio:
     gender: M
@@ -39295,6 +40153,8 @@
     first: Barbara
     last: Comstock
     official_full: Barbara Comstock
+    list: Comstock, Barbara
+    formal: Mrs. Comstock
   bio:
     gender: F
     birthday: '1959-06-30'
@@ -39324,6 +40184,8 @@
     first: Stacey
     last: Plaskett
     official_full: Stacey E. Plaskett
+    list: Plaskett, Stacey
+    formal: Ms. Plaskett
     middle: E.
   bio:
     gender: F
@@ -39354,6 +40216,8 @@
     first: Dan
     last: Newhouse
     official_full: Dan Newhouse
+    list: Newhouse, Dan
+    formal: Mr. Newhouse
   bio:
     gender: M
     birthday: '1955-07-10'
@@ -39383,6 +40247,8 @@
     first: Glenn
     last: Grothman
     official_full: Glenn Grothman
+    list: Grothman, Glenn
+    formal: Mr. Grothman
   bio:
     gender: M
     birthday: '1955-07-03'
@@ -39412,6 +40278,8 @@
     first: Alexander
     last: Mooney
     official_full: Alexander X. Mooney
+    list: Mooney, Alexander
+    formal: Mr. Mooney of West Virginia
     middle: X.
   bio:
     gender: M
@@ -39442,6 +40310,8 @@
     first: Evan
     last: Jenkins
     official_full: Evan H. Jenkins
+    list: Jenkins, Evan
+    formal: Mr. Jenkins of West Virginia
     middle: H.
   bio:
     gender: M
@@ -39472,6 +40342,8 @@
     first: Aumua Amata
     last: Radewagen
     official_full: Aumua Amata Coleman Radewagen
+    list: Radewagen, Aumua Amata
+    formal: Mrs. Radewagen
     middle: Coleman
   bio:
     gender: F
@@ -39653,6 +40525,8 @@
     first: Mark
     last: Walker
     official_full: Mark Walker
+    list: Walker, Mark
+    formal: Mr. Walker
   bio:
     gender: M
     birthday: '1969-05-20'
@@ -39717,6 +40591,8 @@
     last: Donovan
     suffix: Jr.
     official_full: Daniel M. Donovan Jr.
+    list: Donovan, Daniel
+    formal: Mr. Donovan
   bio:
     gender: M
     birthday: '1956-11-06'
@@ -39747,6 +40623,8 @@
     first: Trent
     last: Kelly
     official_full: Trent Kelly
+    list: Kelly, Trent
+    formal: Mr. Kelly of Mississippi
   bio:
     gender: M
     birthday: '1966-03-01'
@@ -39779,6 +40657,8 @@
     first: Darin
     last: LaHood
     official_full: Darin LaHood
+    list: LaHood, Darin
+    formal: Mr. LaHood
   bio:
     gender: M
     birthday: '1968-07-05'

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -3283,7 +3283,6 @@
     washington_post: gIQAhoxEAP
   name:
     first: Joe
-    middle: Linus
     last: Barton
     official_full: Joe Barton
   bio:
@@ -3883,7 +3882,7 @@
     middle: D.
     last: Bishop
     suffix: Jr.
-    official_full: Sanford D. Bishop Jr.
+    official_full: Sanford D. Bishop, Jr.
   bio:
     birthday: '1947-02-04'
     gender: M
@@ -4061,7 +4060,6 @@
     icpsr: 20351
   name:
     first: Marsha
-    middle: W.
     last: Blackburn
     official_full: Marsha Blackburn
   bio:
@@ -4691,7 +4689,7 @@
     middle: W.
     last: Boustany
     suffix: Jr.
-    official_full: Charles W. Boustany Jr.
+    official_full: Charles W. Boustany, Jr.
   bio:
     birthday: '1956-02-21'
     gender: M
@@ -4860,7 +4858,6 @@
     icpsr: 29760
   name:
     first: Kevin
-    middle: P.
     last: Brady
     official_full: Kevin Brady
   bio:
@@ -4969,7 +4966,7 @@
     icpsr: 29777
   name:
     first: Robert
-    middle: Alan
+    middle: A.
     last: Brady
     official_full: Robert A. Brady
   bio:
@@ -5561,8 +5558,8 @@
     washington_post: gIQAA20hDP
     icpsr: 20340
   name:
-    first: George
-    middle: Kenneth
+    first: G.
+    middle: K.
     last: Butterfield
     suffix: Jr.
     nickname: G.K.
@@ -5653,7 +5650,6 @@
     icpsr: 29323
   name:
     first: Ken
-    middle: S.
     last: Calvert
     official_full: Ken Calvert
   bio:
@@ -6087,7 +6083,7 @@
   name:
     first: John
     last: Carney
-    official_full: John C. Carney Jr.
+    official_full: John C. Carney, Jr.
     middle: C.
   bio:
     birthday: '1956-05-20'
@@ -6460,7 +6456,6 @@
     icpsr: 29550
   name:
     first: Steve
-    middle: J.
     last: Chabot
     official_full: Steve Chabot
   bio:
@@ -6634,7 +6629,6 @@
     icpsr: 20955
   name:
     first: Judy
-    middle: M.
     last: Chu
     official_full: Judy Chu
   bio:
@@ -7604,7 +7598,7 @@
     first: John
     last: Conyers
     suffix: Jr.
-    official_full: John Conyers Jr.
+    official_full: John Conyers, Jr.
   bio:
     birthday: '1929-05-16'
     gender: M
@@ -8162,7 +8156,7 @@
     icpsr: 21106
   name:
     first: Eric
-    middle: A.
+    middle: A. "Rick"
     last: Crawford
     official_full: Eric A. "Rick" Crawford
     nickname: Rick
@@ -9055,7 +9049,6 @@
     icpsr: 29710
   name:
     first: Diana
-    middle: L.
     last: DeGette
     official_full: Diana DeGette
   bio:
@@ -9652,7 +9645,6 @@
     icpsr: 29571
   name:
     first: Lloyd
-    middle: A.
     last: Doggett
     official_full: Lloyd Doggett
   bio:
@@ -10072,7 +10064,7 @@
     last: Duncan
     suffix: Jr.
     nickname: Jimmy
-    official_full: John J. Duncan Jr.
+    official_full: John J. Duncan, Jr.
   bio:
     birthday: '1947-07-21'
     gender: M
@@ -10287,7 +10279,6 @@
     icpsr: 20727
   name:
     first: Keith
-    middle: Maurice
     last: Ellison
     official_full: Keith Ellison
   bio:
@@ -11180,7 +11171,7 @@
     first: Charles
     last: Fleischmann
     official_full: Charles J. "Chuck" Fleischmann
-    middle: J.
+    middle: J. "Chuck"
     nickname: Chuck
   bio:
     birthday: '1962-10-11'
@@ -11469,7 +11460,6 @@
     icpsr: 20518
   name:
     first: Jeff
-    middle: Lane
     last: Fortenberry
     official_full: Jeff Fortenberry
   bio:
@@ -12254,7 +12244,6 @@
     icpsr: 20527
   name:
     first: Louie
-    middle: B.
     last: Gohmert
     suffix: Jr.
     official_full: Louie Gohmert
@@ -12338,7 +12327,6 @@
     icpsr: 39308
   name:
     first: Bob
-    middle: W.
     last: Goodlatte
     official_full: Bob Goodlatte
   bio:
@@ -12777,7 +12765,6 @@
     icpsr: 20124
   name:
     first: Sam
-    middle: B.
     last: Graves
     official_full: Sam Graves
   bio:
@@ -13023,7 +13010,6 @@
     icpsr: 39304
   name:
     first: Gene
-    middle: Eugene
     last: Green
     official_full: Gene Green
   bio:
@@ -14119,7 +14105,6 @@
     icpsr: 20519
   name:
     first: Brian
-    middle: M.
     last: Higgins
     official_full: Brian Higgins
   bio:
@@ -14270,7 +14255,6 @@
     icpsr: 29763
   name:
     first: Rubén
-    middle: E.
     last: Hinojosa
     official_full: Rubén Hinojosa
   bio:
@@ -14935,7 +14919,6 @@
     icpsr: 20963
   name:
     first: Duncan
-    middle: D.
     last: Hunter
     official_full: Duncan Hunter
   bio:
@@ -15135,7 +15118,6 @@
     icpsr: 20129
   name:
     first: Steve
-    middle: J.
     last: Israel
     official_full: Steve Israel
   bio:
@@ -15690,11 +15672,11 @@
     icpsr: 20712
   name:
     first: Henry
-    middle: C.
+    middle: C. "Hank"
     last: Johnson
     suffix: Jr.
     nickname: Hank
-    official_full: Henry C. "Hank" Johnson Jr.
+    official_full: Henry C. "Hank" Johnson, Jr.
   bio:
     gender: M
     birthday: '1954-10-02'
@@ -15804,7 +15786,6 @@
     icpsr: 29143
   name:
     first: Sam
-    middle: Robert
     last: Johnson
     official_full: Sam Johnson
   bio:
@@ -16394,7 +16375,6 @@
     icpsr: 29769
   name:
     first: Ron
-    middle: James
     last: Kind
     official_full: Ron Kind
   bio:
@@ -16625,7 +16605,6 @@
     icpsr: 20325
   name:
     first: Steve
-    middle: A.
     last: King
     official_full: Steve King
   bio:
@@ -16856,7 +16835,6 @@
     icpsr: 20333
   name:
     first: John
-    middle: Paul
     last: Kline
     official_full: John Kline
   bio:
@@ -17955,7 +17933,6 @@
     washington_post: gIQAaw4SAP
   name:
     first: John
-    middle: R.
     last: Lewis
     official_full: John Lewis
   bio:
@@ -18094,7 +18071,6 @@
     icpsr: 20508
   name:
     first: Daniel
-    middle: William
     last: Lipinski
     official_full: Daniel Lipinski
   bio:
@@ -19217,7 +19193,6 @@
     icpsr: 20532
   name:
     first: Kenny
-    middle: Ewell
     last: Marchant
     official_full: Kenny Marchant
   bio:
@@ -19952,7 +19927,6 @@
     icpsr: 20122
   name:
     first: Betty
-    middle: Louise
     last: McCollum
     official_full: Betty McCollum
   bio:
@@ -20048,7 +20022,6 @@
     washington_post: gIQApQvNKP
   name:
     first: Jim
-    middle: A.
     last: McDermott
     official_full: Jim McDermott
   bio:
@@ -21661,7 +21634,6 @@
     icpsr: 29377
   name:
     first: Jerrold
-    middle: L.
     last: Nadler
     official_full: Jerrold Nadler
   bio:
@@ -22357,7 +22329,6 @@
     icpsr: 20307
   name:
     first: Devin
-    middle: G.
     last: Nunes
     official_full: Devin Nunes
   bio:
@@ -22575,10 +22546,9 @@
     washington_post: gIQAMsEdKP
   name:
     first: Frank
-    middle: J.
     last: Pallone
     suffix: Jr.
-    official_full: Frank Pallone Jr.
+    official_full: Frank Pallone, Jr.
   bio:
     birthday: '1951-10-30'
     gender: M
@@ -22714,10 +22684,9 @@
     icpsr: 29741
   name:
     first: Bill
-    middle: J.
     last: Pascrell
     suffix: Jr.
-    official_full: Bill Pascrell Jr.
+    official_full: Bill Pascrell, Jr.
   bio:
     birthday: '1937-01-25'
     gender: M
@@ -22933,7 +22902,6 @@
     icpsr: 20337
   name:
     first: Stevan
-    middle: E.
     last: Pearce
     nickname: Steve
     official_full: Stevan Pearce
@@ -23309,7 +23277,7 @@
     icpsr: 29127
   name:
     first: Collin
-    middle: Clark
+    middle: C.
     last: Peterson
     official_full: Collin C. Peterson
   bio:
@@ -24491,7 +24459,6 @@
     icpsr: 21101
   name:
     first: Tom
-    middle: W.
     last: Reed
     suffix: II
     official_full: Tom Reed
@@ -24919,7 +24886,7 @@
     washington_post: gIQA7lZVKP
     icpsr: 21185
   name:
-    first: Edward
+    first: E.
     middle: Scott
     last: Rigell
     nickname: Scott
@@ -25354,7 +25321,6 @@
     washington_post: gIQAWYNqAP
   name:
     first: Dana
-    middle: T.
     last: Rohrabacher
     official_full: Dana Rohrabacher
   bio:
@@ -26376,7 +26342,6 @@
     icpsr: 29939
   name:
     first: Paul
-    middle: D.
     last: Ryan
     official_full: Paul Ryan
   bio:
@@ -26479,7 +26444,6 @@
     icpsr: 20343
   name:
     first: Tim
-    middle: J.
     last: Ryan
     official_full: Tim Ryan
   bio:
@@ -26643,7 +26607,6 @@
     house_history: 21168
   name:
     first: Loretta
-    middle: B.
     last: Sanchez
     official_full: Loretta Sanchez
   bio:
@@ -26833,7 +26796,6 @@
     house_history: 22608
   name:
     first: Steve
-    middle: Joseph
     last: Scalise
     official_full: Steve Scalise
   bio:
@@ -27504,7 +27466,7 @@
     house_history: 21368
   name:
     first: Robert
-    middle: C.
+    middle: C. "Bobby"
     last: Scott
     nickname: Bobby
     official_full: Robert C. "Bobby" Scott
@@ -27693,7 +27655,7 @@
     middle: James
     last: Sensenbrenner
     suffix: Jr.
-    official_full: F. James Sensenbrenner Jr.
+    official_full: F. James Sensenbrenner, Jr.
   bio:
     birthday: '1943-06-14'
     gender: M
@@ -27986,7 +27948,6 @@
     house_history: 21446
   name:
     first: Pete
-    middle: A.
     last: Sessions
     official_full: Pete Sessions
   bio:
@@ -28252,7 +28213,6 @@
     house_history: 21565
   name:
     first: Brad
-    middle: J.
     last: Sherman
     official_full: Brad Sherman
   bio:
@@ -28361,7 +28321,6 @@
     house_history: 21589
   name:
     first: John
-    middle: M.
     last: Shimkus
     official_full: John Shimkus
   bio:
@@ -29230,7 +29189,6 @@
     house_history: 21856
   name:
     first: Lamar
-    middle: S.
     last: Smith
     official_full: Lamar Smith
   bio:
@@ -29784,7 +29742,6 @@
     house_history: 23200
   name:
     first: Mike
-    middle: Michael
     last: Thompson
     official_full: Mike Thompson
   bio:
@@ -29954,7 +29911,6 @@
     house_history: 22922
   name:
     first: Mac
-    middle: M.
     last: Thornberry
     official_full: Mac Thornberry
   bio:
@@ -30417,7 +30373,6 @@
     house_history: 23209
   name:
     first: Niki
-    middle: S.
     last: Tsongas
     official_full: Niki Tsongas
   bio:
@@ -30587,7 +30542,6 @@
     washington_post: gIQATEgtAP
   name:
     first: Fred
-    middle: Stephen
     last: Upton
     official_full: Fred Upton
   bio:
@@ -31212,7 +31166,6 @@
     house_history: 24165
   name:
     first: Greg
-    middle: P.
     last: Walden
     official_full: Greg Walden
   bio:
@@ -31315,7 +31268,7 @@
     house_history: 24181
   name:
     first: Timothy
-    middle: James
+    middle: J.
     last: Walz
     official_full: Timothy J. Walz
   bio:
@@ -31932,7 +31885,6 @@
     house_history: 24173
   name:
     first: Joe
-    middle: G.
     last: Wilson
     official_full: Joe Wilson
   bio:
@@ -32528,7 +32480,6 @@
     washington_post: gIQAsCfJAP
   name:
     first: Don
-    middle: E.
     last: Young
     official_full: Don Young
   bio:
@@ -33146,7 +33097,7 @@
     middle: M.
     last: Payne
     suffix: Jr.
-    official_full: Donald M. Payne Jr.
+    official_full: Donald M. Payne, Jr.
   bio:
     birthday: '1958-12-17'
     gender: M
@@ -34898,7 +34849,7 @@
     washington_post: gIQAwh5WKP
     icpsr: 21333
   name:
-    first: Garland
+    first: Andy
     last: Barr
     nickname: Andy
     official_full: Andy Barr
@@ -36281,9 +36232,8 @@
     washington_post: 3a43408e-4bbb-11e2-8758-b64a2997a921
     icpsr: 21358
   name:
-    first: Matthew
+    first: Matt
     last: Cartwright
-    middle: A.
     official_full: Matt Cartwright
   bio:
     gender: M
@@ -36416,7 +36366,7 @@
     first: Randy
     last: Weber
     middle: K.
-    official_full: Randy K. Weber Sr.
+    official_full: Randy K. Weber, Sr.
   bio:
     gender: M
     birthday: '1953-07-02'
@@ -36932,6 +36882,7 @@
     first: Robin
     last: Kelly
     official_full: Robin L. Kelly
+    middle: L.
   bio:
     gender: F
     birthday: '1956-04-30'
@@ -36978,7 +36929,7 @@
     icpsr: 29565
     house_history: 21195
   name:
-    first: Marshall
+    first: Mark
     last: Sanford
     nickname: Mark
     official_full: Mark Sanford
@@ -37045,7 +36996,6 @@
     icpsr: 21373
   name:
     first: Jason
-    middle: T.
     last: Smith
     official_full: Jason Smith
   bio:
@@ -37268,7 +37218,7 @@
     - H4FL19074
     maplight: 2060
   name:
-    first: Curtis
+    first: Curt
     nickname: Curt
     last: Clawson
     official_full: Curt Clawson
@@ -37308,8 +37258,7 @@
     house_history: 15032409257
     maplight: 2061
   name:
-    first: David
-    middle: Alan
+    first: Dave
     nickname: Dave
     last: Brat
     official_full: Dave Brat
@@ -37354,7 +37303,6 @@
     maplight: 2062
   name:
     first: Donald
-    middle: W.
     last: Norcross
     official_full: Donald Norcross
   bio:
@@ -37400,6 +37348,7 @@
     first: Alma
     last: Adams
     official_full: Alma S. Adams
+    middle: S.
   bio:
     gender: F
     birthday: '1946-05-27'
@@ -37440,9 +37389,10 @@
     icpsr: 21127
     maplight: 1432
   name:
-    first: Bob
+    first: Robert
     last: Dold
     official_full: Robert J. Dold
+    middle: J.
   bio:
     birthday: '1969-06-23'
     gender: M
@@ -37484,6 +37434,7 @@
     first: Frank
     last: Guinta
     official_full: Frank C. Guinta
+    middle: C.
   bio:
     birthday: '1970-09-26'
     gender: M
@@ -37522,6 +37473,7 @@
     first: Gary
     last: Palmer
     official_full: Gary J. Palmer
+    middle: J.
   bio:
     gender: M
     birthday: '1954-05-14'
@@ -37546,9 +37498,10 @@
     thomas: '02223'
     maplight: 2065
   name:
-    first: French
+    first: J.
     last: Hill
     official_full: J. French Hill
+    middle: French
   bio:
     gender: M
     birthday: '1956-12-05'
@@ -37680,7 +37633,7 @@
     thomas: '02228'
     maplight: 2070
   name:
-    first: Steve
+    first: Stephen
     last: Knight
     official_full: Stephen Knight
   bio:
@@ -37765,6 +37718,7 @@
     first: Norma
     last: Torres
     official_full: Norma J. Torres
+    middle: J.
   bio:
     gender: F
     birthday: '1965-04-04'
@@ -37899,9 +37853,10 @@
     thomas: '02236'
     maplight: 2078
   name:
-    first: Buddy
+    first: Earl
     last: Carter
     official_full: Earl L. "Buddy" Carter
+    middle: L. "Buddy"
   bio:
     gender: M
     birthday: '1957-09-06'
@@ -37929,6 +37884,7 @@
     first: Jody
     last: Hice
     official_full: Jody B. Hice
+    middle: B.
   bio:
     gender: M
     birthday: '1960-04-22'
@@ -37983,6 +37939,7 @@
     first: Rick
     last: Allen
     official_full: Rick W. Allen
+    middle: W.
   bio:
     gender: M
     birthday: '1951-11-07'
@@ -38117,6 +38074,7 @@
     first: Ralph
     last: Abraham
     official_full: Ralph Lee Abraham
+    middle: Lee
   bio:
     gender: M
     birthday: '1954-09-16'
@@ -38226,6 +38184,7 @@
     first: John
     last: Moolenaar
     official_full: John R. Moolenaar
+    middle: R.
   bio:
     gender: M
     birthday: '1961-05-08'
@@ -38277,9 +38236,10 @@
     thomas: '02250'
     maplight: 2092
   name:
-    first: Dave
+    first: David
     last: Trott
     official_full: David A. Trott
+    middle: A.
   bio:
     gender: M
     birthday: '1960-10-16'
@@ -38335,6 +38295,7 @@
     first: Brenda
     last: Lawrence
     official_full: Brenda L. Lawrence
+    middle: L.
   bio:
     gender: F
     birthday: '1954-10-18'
@@ -38389,6 +38350,7 @@
     first: Ryan
     last: Zinke
     official_full: Ryan K. Zinke
+    middle: K.
   bio:
     gender: M
     birthday: '1961-11-01'
@@ -38467,7 +38429,7 @@
     thomas: '02258'
     maplight: 2099
   name:
-    first: Tom
+    first: Thomas
     last: MacArthur
     official_full: Thomas MacArthur
   bio:
@@ -38552,6 +38514,7 @@
     first: Lee
     last: Zeldin
     official_full: Lee M. Zeldin
+    middle: M.
   bio:
     gender: M
     birthday: '1980-01-30'
@@ -38580,6 +38543,7 @@
     first: Kathleen
     last: Rice
     official_full: Kathleen M. Rice
+    middle: M.
   bio:
     gender: F
     birthday: '1965-02-15'
@@ -38608,6 +38572,7 @@
     first: Elise
     last: Stefanik
     official_full: Elise M. Stefanik
+    middle: M.
   bio:
     gender: F
     birthday: '1984-07-02'
@@ -38689,6 +38654,7 @@
     first: Ryan
     last: Costello
     official_full: Ryan A. Costello
+    middle: A.
   bio:
     gender: M
     birthday: '1976-09-07'
@@ -38716,6 +38682,7 @@
     first: Brendan
     last: Boyle
     official_full: Brendan F. Boyle
+    middle: F.
   bio:
     gender: M
     birthday: '1977-02-06'
@@ -38824,6 +38791,7 @@
     first: Mia
     last: Love
     official_full: Mia B. Love
+    middle: B.
   bio:
     gender: F
     birthday: '1975-12-06'
@@ -38850,7 +38818,8 @@
   name:
     first: Donald
     last: Beyer
-    official_full: Donald S. Beyer Jr.
+    official_full: Donald S. Beyer, Jr.
+    middle: S.
   bio:
     gender: M
     birthday: '1950-06-20'
@@ -38906,6 +38875,7 @@
     first: Stacey
     last: Plaskett
     official_full: Stacey E. Plaskett
+    middle: E.
   bio:
     gender: F
     birthday: '1964-05-13'
@@ -38984,9 +38954,10 @@
     thomas: '02277'
     maplight: 2118
   name:
-    first: Alex
+    first: Alexander
     last: Mooney
     official_full: Alexander X. Mooney
+    middle: X.
   bio:
     gender: M
     birthday: '1971-06-05'
@@ -39014,6 +38985,7 @@
     first: Evan
     last: Jenkins
     official_full: Evan H. Jenkins
+    middle: H.
   bio:
     gender: M
     birthday: '1960-09-12'
@@ -39038,9 +39010,10 @@
     house_history: 15032412349
     maplight: 2120
   name:
-    first: Aumua
-    last: Amata
+    first: Aumua Amata
+    last: Radewagen
     official_full: Aumua Amata Coleman Radewagen
+    middle: Coleman
   bio:
     gender: F
     birthday: '1947-12-29'

--- a/scripts/house_contacts.py
+++ b/scripts/house_contacts.py
@@ -6,15 +6,11 @@ import requests
 import lxml
 import re
 from datetime import datetime
-import utils
-from utils import download, load_data, save_data, parse_date
+
+from utils import load_data, save_data, parse_date
 
 def run():
 	today = datetime.now().date()
-
-	# default to not caching
-	cache = utils.flags().get('cache', False)
-	force = not cache
 
 	y = load_data("legislators-current.yaml")
 

--- a/scripts/house_contacts.py
+++ b/scripts/house_contacts.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-# Update current congressmen's mailing address from clerk.house.gov.
+# Update current congressmember's contact info from clerk XML feed
 
-import lxml.html, io
+import requests
+import lxml
 import re
 from datetime import datetime
 import utils
@@ -17,6 +18,10 @@ def run():
 
 	y = load_data("legislators-current.yaml")
 
+	# TODO use download util?
+	xml = requests.get("http://clerk.house.gov/xml/lists/MemberData.xml")
+	root=lxml.etree.fromstring(xml.content)
+
 	for moc in y:
 		try:
 			term = moc["terms"][-1]
@@ -30,45 +35,61 @@ def run():
 			print("Member's last listed term is not current", moc, term["start"])
 			continue
 
-		# Specify districts e.g. WA-02 on the command line to only update those.
-		# if len(sys.argv) > 1 and ("%s-%02d" % (term["state"], term["district"])) not in sys.argv: continue
-
 		if "class" in term: del term["class"]
 
-		url = "http://clerk.house.gov/member_info/mem_contact_info.aspx?statdis=%s%02d" % (term["state"], term["district"])
-		cache = "legislators/house/%s%02d.html" % (term["state"], term["district"])
-		try:
-			# the meta tag say it's iso-8859-1, but... names are actually in utf8...
-			body = download(url, cache, force)
-			dom = lxml.html.parse(io.StringIO(body)).getroot()
-		except lxml.etree.XMLSyntaxError:
-			print("Error parsing: ", url)
-			continue
+		ssdd = "%s%02d" % (term["state"], term["district"])
 
-		name = str(dom.cssselect("#results h3")[0].text_content())
-		addressinfo = str(dom.cssselect("#results p")[0].text_content())
+		query_str = "./members/member/[statedistrict='%s']" % ssdd
+		# TODO: Follow up
+		query_str = query_str.replace("AS00", "AQ00")
+		#print(query_str)
 
-		# Sanity check that the name is similar.
-		if name != moc["name"].get("official_full", ""):
-			cfname = moc["name"]["first"] + " " + moc["name"]["last"]
-			print("Warning: Are these the same people?", name.encode("utf8"), "|", cfname.encode("utf8"))
+		mi = root.findall(query_str)[0].find('member-info')
 
-		# Parse the address out of the address p tag.
-		addressinfo = "; ".join(line.strip() for line in addressinfo.split("\n") if line.strip() != "")
-		m = re.match(r"[\w\s]+-(\d+(st|nd|rd|th)|At Large|Delegate|Resident Commissioner), ([A-Za-z]*)(.+); Phone: (.*)", addressinfo, re.DOTALL)
-		if not m:
-			print("Error parsing address info: ", name.encode("utf8"), ":", addressinfo.encode("utf8"))
-			continue
+		if (mi.find('bioguideID').text != moc['id']['bioguide']):
+			print("Warning: Bioguide ID did not match for %s%02d" % (term["state"], term["district"]))
 
-		address = m.group(4)
-		phone = re.sub("^\((\d\d\d)\) ", lambda m : m.group(1) + "-", m.group(5)) # replace (XXX) area code with XXX- for compatibility w/ existing format
+		firstname = mi.find('firstname').text
+		middlename = mi.find('middlename').text #could be empty
+		lastname = mi.find('lastname').text
 
-		office = address.split(";")[0].replace("HOB", "House Office Building")
+		#TODO: follow up, why no official name?
+		if mi.find('official-name') is None:
+			print("Warning: No official-name tag for %s" % ssdd)
+			officialname = None
+		else:
+			officialname = mi.find('official-name').text
 
-		moc["name"]["official_full"] = name
+		office_room = mi.find('office-room').text
+		office_building = mi.find('office-building').text
+
+		office_building_full = office_building.replace("RHOB", "Rayburn HOB")
+		office_building_full = office_building_full.replace("CHOB", "Cannon HOB")
+		office_building_full = office_building_full.replace("LHOB", "Longworth HOB")
+
+		office_zip = mi.find('office-zip').text
+		office_zip_suffix = mi.find('office-zip-suffix').text
+
+		office = "{} {}".format(office_room, office_building_full.replace("HOB", "House Office Building"))
+		address = "{} {}; Washington DC {}-{}".format(office_room, office_building_full, office_zip, office_zip_suffix)
+
+		phone = mi.find('phone').text
+		phone_parsed = re.sub("^\((\d\d\d)\) ", lambda m : m.group(1) + "-", phone) # replace (XXX) area code with XXX- for compatibility w/ existing format
+
+		moc["name"]["first"] = firstname
+		if (middlename):
+			moc["name"]["middle"] = middlename
+		else:
+			if ("middle" in moc["name"]):
+				del moc["name"]["middle"]
+		moc["name"]["last"] = lastname
+
+		# TODO: leave if none?
+		if (officialname):
+			moc["name"]["official_full"] = officialname
 		term["address"] = address
 		term["office"] = office
-		term["phone"] = phone
+		term["phone"] = phone_parsed
 
 	save_data(y, "legislators-current.yaml")
 


### PR DESCRIPTION
From #276, the Clerk of the House provides XML for member information.  There are several name fields in the XML that the Clerk provides that do not directly match the name fields in legislators-current.