### PR TITLE
Sen. Ed Markey has a new Twitter handle: SenMarkey

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -1864,7 +1864,7 @@
     thomas: '00735'
     govtrack: 400253
   social:
-    twitter: MarkeyMemo
+    twitter: SenMarkey
     facebook: EdJMarkey
     youtube: RepMarkey
     facebook_id: '6846731378'


### PR DESCRIPTION
Is [SenMarkey](https://twitter.com/SenMarkey). Was [MarkeyMemo](https://twitter.com/MarkeyMemo). Appears on http://www.markey.senate.gov/.