### PR TITLE
added google_entity ids

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -16,6 +16,7 @@
     washington_post: gIQA3O2w9O
     icpsr: 29389
     wikidata: Q381880
+    google_entity: kg:/m/034s80
   name:
     first: Sherrod
     last: Brown
@@ -113,6 +114,7 @@
     washington_post: gIQAZxKkDP
     icpsr: 39310
     wikidata: Q22250
+    google_entity: kg:/m/01x68t
   name:
     first: Maria
     last: Cantwell
@@ -179,6 +181,7 @@
     maplight: 182
     washington_post: gIQAGMu99O
     wikidata: Q723295
+    google_entity: kg:/m/025k3k
   name:
     first: Benjamin
     middle: L.
@@ -294,6 +297,7 @@
     maplight: 545
     washington_post: gIQA3bm69O
     wikidata: Q457432
+    google_entity: kg:/m/01xw7t
   name:
     first: Thomas
     middle: Richard
@@ -383,6 +387,7 @@
     washington_post: gIQABeor9O
     icpsr: 40703
     wikidata: Q887841
+    google_entity: kg:/m/047ymw
   name:
     first: Robert
     middle: P.
@@ -437,6 +442,7 @@
     washington_post: gIQADOuy9O
     icpsr: 40705
     wikidata: Q331719
+    google_entity: kg:/m/0d9fz3
   name:
     first: Bob
     last: Corker
@@ -488,6 +494,7 @@
     washington_post: gIQAnrCyDP
     icpsr: 49300
     wikidata: Q230733
+    google_entity: kg:/m/01gqws
   name:
     first: Dianne
     last: Feinstein
@@ -559,6 +566,7 @@
     maplight: 574
     washington_post: gIQAzJiz9O
     wikidata: Q381157
+    google_entity: kg:/m/016mj4
   name:
     first: Orrin
     middle: G.
@@ -643,6 +651,7 @@
     washington_post: gIQA5G259O
     icpsr: 40700
     wikidata: Q22237
+    google_entity: kg:/m/05fbpt
   name:
     first: Amy
     middle: Jean
@@ -695,6 +704,7 @@
     washington_post: gIQAiqnb9O
     icpsr: 40701
     wikidata: Q22260
+    google_entity: kg:/m/040_w4
   name:
     first: Claire
     last: McCaskill
@@ -747,6 +757,7 @@
     washington_post: gIQAYgYw6O
     icpsr: 29373
     wikidata: Q888132
+    google_entity: kg:/m/033d3p
   name:
     first: Robert
     last: Menéndez
@@ -853,6 +864,7 @@
     maplight: 598
     washington_post: gIQAlLuy9O
     wikidata: Q358437
+    google_entity: kg:/m/01_pb_
   name:
     first: Bill
     last: Nelson
@@ -948,6 +960,7 @@
     icpsr: 29147
     house_history: 21173
     wikidata: Q359442
+    google_entity: kg:/m/01_gbv
   name:
     first: Bernard
     last: Sanders
@@ -1053,6 +1066,7 @@
     icpsr: 29732
     house_history: 22090
     wikidata: Q241092
+    google_entity: kg:/m/01xh64
   name:
     first: Debbie
     middle: Ann
@@ -1124,6 +1138,7 @@
     washington_post: gIQAw67AAP
     icpsr: 40702
     wikidata: Q529351
+    google_entity: kg:/m/066cdp
   name:
     first: Jon
     last: Tester
@@ -1174,6 +1189,7 @@
     washington_post: gIQA7KHw9O
     icpsr: 40704
     wikidata: Q652066
+    google_entity: kg:/m/07qw94
   name:
     first: Sheldon
     last: Whitehouse
@@ -1224,6 +1240,7 @@
     washington_post: gIQASOzBAP
     icpsr: 40707
     wikidata: Q720521
+    google_entity: kg:/m/02rsm32
   name:
     first: John
     middle: A.
@@ -1277,6 +1294,7 @@
     icpsr: 29534
     house_history: 23734
     wikidata: Q390491
+    google_entity: kg:/m/025xxb
   name:
     first: Roger
     middle: F.
@@ -1374,6 +1392,7 @@
     washington_post: gIQAzZQL9O
     icpsr: 40304
     wikidata: Q419976
+    google_entity: kg:/m/01rbs3
   name:
     first: Lamar
     last: Alexander
@@ -1435,6 +1454,7 @@
     maplight: 549
     washington_post: gIQAJk599O
     wikidata: Q723896
+    google_entity: kg:/m/01fmcd
   name:
     first: Thad
     last: Cochran
@@ -1538,6 +1558,7 @@
     washington_post: gIQAPvDu9O
     icpsr: 49703
     wikidata: Q22279
+    google_entity: kg:/m/020y8m
   name:
     first: Susan
     middle: M.
@@ -1605,6 +1626,7 @@
     washington_post: gIQAy80L9O
     icpsr: 40305
     wikidata: Q719568
+    google_entity: kg:/m/01xcqs
   name:
     first: John
     last: Cornyn
@@ -1681,6 +1703,7 @@
     maplight: 563
     washington_post: gIQArl8V9O
     wikidata: Q434804
+    google_entity: kg:/m/01xcd1
   name:
     first: Richard
     middle: J.
@@ -1814,6 +1837,7 @@
     washington_post: gIQAAWfCAP
     icpsr: 49706
     wikidata: Q432431
+    google_entity: kg:/m/021ph1
   name:
     first: Michael
     middle: B.
@@ -1883,6 +1907,7 @@
     washington_post: gIQAEdOu9O
     icpsr: 29566
     wikidata: Q22212
+    google_entity: kg:/m/01_pdg
   name:
     first: Lindsey
     middle: O.
@@ -1970,6 +1995,7 @@
     maplight: 576
     washington_post: gIQASu669O
     wikidata: Q723134
+    google_entity: kg:/m/021kpl
   name:
     first: James
     middle: M.
@@ -2068,6 +2094,7 @@
     maplight: 593
     washington_post: gIQAYR2b9O
     wikidata: Q355522
+    google_entity: kg:/m/01z6ls
   name:
     first: Mitch
     last: McConnell
@@ -2166,6 +2193,7 @@
     washington_post: gIQAosnb9O
     icpsr: 40908
     wikidata: Q1368405
+    google_entity: kg:/m/026k60f
   name:
     first: Jeff
     last: Merkley
@@ -2220,6 +2248,7 @@
     washington_post: gIQAT2gt9O
     icpsr: 29142
     wikidata: Q528979
+    google_entity: kg:/m/0202mc
   name:
     first: John
     middle: F.
@@ -2306,6 +2335,7 @@
     washington_post: gIQAWIdW9O
     icpsr: 40902
     wikidata: Q721871
+    google_entity: kg:/m/06y9p0
   name:
     first: James
     last: Risch
@@ -2358,6 +2388,7 @@
     maplight: 602
     washington_post: gIQAUECAAP
     wikidata: Q538375
+    google_entity: kg:/m/01_pdv
   name:
     first: Pat
     last: Roberts
@@ -2472,6 +2503,7 @@
     washington_post: gIQAHXOBAP
     icpsr: 49700
     wikidata: Q358443
+    google_entity: kg:/m/020yjg
   name:
     first: Jefferson
     middle: B.
@@ -2541,6 +2573,7 @@
     icpsr: 40906
     house_history: 22618
     wikidata: Q270316
+    google_entity: kg:/m/01rrm2
   name:
     first: Jeanne
     last: Shaheen
@@ -2595,6 +2628,7 @@
     washington_post: gIQAv2eM9O
     icpsr: 29924
     wikidata: Q957690
+    google_entity: kg:/m/033t35
   name:
     first: Tom
     middle: S.
@@ -2690,6 +2724,7 @@
     washington_post: gIQAUqPM9O
     icpsr: 40909
     wikidata: Q453893
+    google_entity: kg:/m/024mm1
   name:
     first: Mark
     last: Warner
@@ -2744,6 +2779,7 @@
     washington_post: gIQAz4Kt9O
     icpsr: 20735
     wikidata: Q22222
+    google_entity: kg:/m/0gnfc4
   name:
     first: Kirsten
     middle: E.
@@ -2809,6 +2845,7 @@
     washington_post: gIQAnCqo9O
     icpsr: 40904
     wikidata: Q319084
+    google_entity: kg:/m/01lct6
   name:
     first: Alan
     middle: Stuart
@@ -2862,6 +2899,7 @@
     washington_post: gIQAaKfTKP
     icpsr: 40916
     wikidata: Q923242
+    google_entity: kg:/m/082d3d
   name:
     first: Chris
     middle: Andrew
@@ -2913,6 +2951,7 @@
     washington_post: gIQA82bVBP
     icpsr: 40915
     wikidata: Q538868
+    google_entity: kg:/m/04lc5t
   name:
     first: Joe
     last: Manchin
@@ -2963,6 +3002,7 @@
     washington_post: gIQAw6QSAP
     icpsr: 29701
     wikidata: Q672671
+    google_entity: kg:/m/024p03
   name:
     first: Robert
     last: Aderholt
@@ -3073,6 +3113,7 @@
     washington_post: gIQAMkzZKP
     icpsr: 21143
     wikidata: Q1714165
+    google_entity: kg:/m/0c00p_n
   name:
     first: Justin
     last: Amash
@@ -3135,6 +3176,7 @@
     washington_post: gIQA6LfTKP
     icpsr: 41106
     wikidata: Q22354
+    google_entity: kg:/m/0g9g4r
   name:
     first: Kelly
     last: Ayotte
@@ -3175,6 +3217,7 @@
     washington_post: gIQAgHwPAP
     icpsr: 29940
     wikidata: Q40628
+    google_entity: kg:/m/024v02
   name:
     first: Tammy
     last: Baldwin
@@ -3265,6 +3308,7 @@
     washington_post: gIQA3fVUKP
     icpsr: 21171
     wikidata: Q25568
+    google_entity: kg:/m/03wcvjl
   name:
     first: Lou
     last: Barletta
@@ -3326,6 +3370,7 @@
     maplight: 139
     washington_post: gIQAhoxEAP
     wikidata: Q966261
+    google_entity: kg:/m/03rspq
   name:
     first: Joe
     middle: Linus
@@ -3471,6 +3516,7 @@
     washington_post: gIQA45LZKP
     icpsr: 21110
     wikidata: Q461739
+    google_entity: kg:/m/027g9m6
   name:
     first: Karen
     last: Bass
@@ -3532,6 +3578,7 @@
     washington_post: gIQAenAR9O
     icpsr: 29316
     wikidata: Q1855840
+    google_entity: kg:/m/024trk
   name:
     first: Xavier
     last: Becerra
@@ -3653,6 +3700,7 @@
     washington_post: gIQAOvErKP
     icpsr: 21141
     wikidata: Q1158992
+    google_entity: kg:/m/0bmf7qt
   name:
     first: Dan
     last: Benishek
@@ -3714,6 +3762,7 @@
     washington_post: gIQA8vao9O
     icpsr: 40910
     wikidata: Q554792
+    google_entity: kg:/m/05b60qf
   name:
     first: Michael
     middle: F.
@@ -3760,6 +3809,7 @@
     washington_post: gIQAjtHPAP
     icpsr: 20758
     wikidata: Q1555314
+    google_entity: kg:/m/0dy3z1
   name:
     first: Gus
     last: Bilirakis
@@ -3840,6 +3890,7 @@
     washington_post: gIQALHQPAP
     icpsr: 20357
     wikidata: Q433857
+    google_entity: kg:/m/02tn41
   name:
     first: Rob
     last: Bishop
@@ -3930,6 +3981,7 @@
     icpsr: 29339
     house_history: 7697
     wikidata: Q983428
+    google_entity: kg:/m/02554k
   name:
     first: Sanford
     middle: D.
@@ -4052,6 +4104,7 @@
     washington_post: gIQAtZuYKP
     icpsr: 21180
     wikidata: Q515935
+    google_entity: kg:/m/0cyvxl
   name:
     first: Diane
     last: Black
@@ -4113,6 +4166,7 @@
     washington_post: gIQALZuKAP
     icpsr: 20351
     wikidata: Q458971
+    google_entity: kg:/m/01fnkt
   name:
     first: Marsha
     middle: W.
@@ -4205,6 +4259,7 @@
     washington_post: gIQAqvaOAP
     icpsr: 29588
     wikidata: Q748066
+    google_entity: kg:/m/033tw8
   name:
     first: Earl
     last: Blumenauer
@@ -4319,6 +4374,7 @@
     washington_post: gIQAeNwz6O
     icpsr: 41101
     wikidata: Q2023708
+    google_entity: kg:/m/03tg8m
   name:
     first: Richard
     last: Blumenthal
@@ -4359,6 +4415,7 @@
     washington_post: gIQAUcQL9O
     icpsr: 29735
     wikidata: Q1525924
+    google_entity: kg:/m/034fn4
   name:
     first: Roy
     last: Blunt
@@ -4446,6 +4503,7 @@
     washington_post: gIQAxKQPAP
     icpsr: 20101
     wikidata: Q1344707
+    google_entity: kg:/m/024s3v
   name:
     first: John
     last: Boozman
@@ -4515,6 +4573,7 @@
     house_history: 10389
     maplight: 160
     wikidata: Q292988
+    google_entity: kg:/m/01s_xp
   name:
     first: Madeleine
     middle: Z.
@@ -4607,6 +4666,7 @@
     washington_post: gIQAiMQPAP
     icpsr: 20514
     wikidata: Q972735
+    google_entity: kg:/m/04wdx3
   name:
     first: Charles
     middle: W.
@@ -4694,6 +4754,7 @@
     maplight: 539
     washington_post: gIQArxPM9O
     wikidata: Q237560
+    google_entity: kg:/m/01c1n5
   name:
     first: Barbara
     last: Boxer
@@ -4781,6 +4842,7 @@
     washington_post: gIQATjbPAP
     icpsr: 29760
     wikidata: Q472241
+    google_entity: kg:/m/03tq00
   name:
     first: Kevin
     middle: P.
@@ -4891,6 +4953,7 @@
     washington_post: gIQATngIAP
     icpsr: 29777
     wikidata: Q434522
+    google_entity: kg:/m/03tq5z
   name:
     first: Robert
     middle: Alan
@@ -5000,6 +5063,7 @@
     washington_post: gIQAdMkz6O
     icpsr: 21193
     wikidata: Q1941306
+    google_entity: kg:/m/0c3xdjf
   name:
     first: Mo
     last: Brooks
@@ -5062,6 +5126,7 @@
     icpsr: 29328
     house_history: 7695
     wikidata: Q461512
+    google_entity: kg:/m/0251xd
   name:
     first: Corrine
     last: Brown
@@ -5183,6 +5248,7 @@
     washington_post: gIQA8OnhDP
     icpsr: 20709
     wikidata: Q2517229
+    google_entity: kg:/m/0gtjsp
   name:
     first: Vern
     last: Buchanan
@@ -5259,6 +5325,7 @@
     washington_post: gIQAD7JXKP
     icpsr: 21132
     wikidata: Q944286
+    google_entity: kg:/m/0dd9k_y
   name:
     first: Larry
     last: Bucshon
@@ -5319,6 +5386,7 @@
     washington_post: gIQAyRzBAP
     icpsr: 20355
     wikidata: Q539521
+    google_entity: kg:/m/03tq8_
   name:
     first: Michael
     middle: C.
@@ -5413,6 +5481,7 @@
     washington_post: gIQAMX709O
     icpsr: 29548
     wikidata: Q331278
+    google_entity: kg:/m/03g_s9
   name:
     first: Richard
     middle: M.
@@ -5491,6 +5560,7 @@
     washington_post: gIQAA20hDP
     icpsr: 20340
     wikidata: Q983532
+    google_entity: kg:/m/03g_pq
   name:
     first: George
     middle: Kenneth
@@ -5583,6 +5653,7 @@
     washington_post: gIQAORoVBP
     icpsr: 29323
     wikidata: Q538978
+    google_entity: kg:/m/024xl1
   name:
     first: Ken
     middle: S.
@@ -5707,6 +5778,7 @@
     icpsr: 20146
     lis: S372
     wikidata: Q459618
+    google_entity: kg:/m/024pwq
   name:
     first: Shelley
     middle: Moore
@@ -5805,6 +5877,7 @@
     washington_post: gIQAarASAP
     icpsr: 29774
     wikidata: Q459693
+    google_entity: kg:/m/024tfg
   name:
     first: Lois
     last: Capps
@@ -5918,6 +5991,7 @@
     washington_post: gIQAzL6PAP
     icpsr: 29919
     wikidata: Q551578
+    google_entity: kg:/m/028vsm
   name:
     first: Michael
     middle: E.
@@ -6020,6 +6094,7 @@
     washington_post: gIQABIMZKP
     icpsr: 21113
     wikidata: Q505302
+    google_entity: kg:/m/027_8wk
   name:
     first: John
     last: Carney
@@ -6083,6 +6158,7 @@
     washington_post: gIQAPh8PAP
     icpsr: 20757
     wikidata: Q517649
+    google_entity: kg:/m/03qcvz1
   name:
     first: André
     last: Carson
@@ -6162,6 +6238,7 @@
     washington_post: gIQAcLQNAP
     icpsr: 20356
     wikidata: Q369814
+    google_entity: kg:/m/03whyr
   name:
     first: John
     middle: R.
@@ -6256,6 +6333,7 @@
     icpsr: 20919
     lis: S373
     wikidata: Q861999
+    google_entity: kg:/m/0286t7r
   name:
     first: Bill
     last: Cassidy
@@ -6324,6 +6402,7 @@
     washington_post: gIQAEoCLAP
     icpsr: 20708
     wikidata: Q458492
+    google_entity: kg:/m/0dq1v6
   name:
     first: Kathy
     last: Castor
@@ -6400,6 +6479,7 @@
     washington_post: gIQAiE5TKP
     icpsr: 29550
     wikidata: Q506694
+    google_entity: kg:/m/0343vk
   name:
     first: Steve
     middle: J.
@@ -6508,6 +6588,7 @@
     washington_post: gIQAm9WMAP
     icpsr: 20949
     wikidata: Q1683881
+    google_entity: kg:/m/047blr4
   name:
     first: Jason
     last: Chaffetz
@@ -6576,6 +6657,7 @@
     washington_post: gIQA1yiFAP
     icpsr: 20955
     wikidata: Q460035
+    google_entity: kg:/m/0krsk2
   name:
     first: Judy
     middle: M.
@@ -6646,6 +6728,7 @@
     washington_post: gIQA6P5YKP
     icpsr: 21172
     wikidata: Q938498
+    google_entity: kg:/m/04t97v
   name:
     first: David
     last: Cicilline
@@ -6708,6 +6791,7 @@
     washington_post: gIQAOxvIAP
     icpsr: 20733
     wikidata: Q461679
+    google_entity: kg:/m/06h90t
   name:
     first: Yvette
     middle: D.
@@ -6784,6 +6868,7 @@
     washington_post: gIQA1BJQAP
     icpsr: 20147
     wikidata: Q959455
+    google_entity: kg:/m/024vjr
   name:
     first: Wm.
     middle: Lacy
@@ -6883,6 +6968,7 @@
     washington_post: gIQANj8PAP
     icpsr: 20517
     wikidata: Q1334654
+    google_entity: kg:/m/04cbbm
   name:
     first: Emanuel
     last: Cleaver
@@ -6966,6 +7052,7 @@
     washington_post: gIQAv50L9O
     icpsr: 39301
     wikidata: Q1289889
+    google_entity: kg:/m/03c469
   name:
     first: James
     middle: E.
@@ -7093,6 +7180,7 @@
     maplight: 1407
     washington_post: gIQAGGdaAP
     wikidata: Q632321
+    google_entity: kg:/m/0jl26
   name:
     first: Daniel
     middle: Ray
@@ -7169,6 +7257,7 @@
     washington_post: gIQA5XQQAP
     icpsr: 20906
     wikidata: Q547218
+    google_entity: kg:/m/03gy95d
   name:
     first: Mike
     last: Coffman
@@ -7237,6 +7326,7 @@
     washington_post: gIQAxQaQAP
     icpsr: 20748
     wikidata: Q512330
+    google_entity: kg:/m/04lf9tk
   name:
     first: Steve
     last: Cohen
@@ -7313,6 +7403,7 @@
     washington_post: gIQATSaQAP
     icpsr: 20344
     wikidata: Q173839
+    google_entity: kg:/m/03tqb0
   name:
     first: Tom
     last: Cole
@@ -7405,6 +7496,7 @@
     washington_post: gIQAkUaQAP
     icpsr: 20531
     wikidata: Q538944
+    google_entity: kg:/m/04cmt7
   name:
     first: K.
     middle: Michael
@@ -7486,6 +7578,7 @@
     washington_post: gIQA3zDRAP
     icpsr: 20952
     wikidata: Q1514859
+    google_entity: kg:/m/04f40kn
   name:
     first: Gerald
     middle: E.
@@ -7556,6 +7649,7 @@
     maplight: 195
     washington_post: gIQA4cvo9O
     wikidata: Q1370968
+    google_entity: kg:/m/02hy5d
   name:
     first: John
     last: Conyers
@@ -7764,6 +7858,7 @@
     maplight: 196
     washington_post: gIQABq669O
     wikidata: Q973737
+    google_entity: kg:/m/03tm2p
   name:
     first: Jim
     last: Cooper
@@ -7890,6 +7985,7 @@
     washington_post: gIQAwvJSAP
     icpsr: 20501
     wikidata: Q675869
+    google_entity: kg:/m/04chm2
   name:
     first: Jim
     last: Costa
@@ -7972,6 +8068,7 @@
     washington_post: gIQAQONRAP
     icpsr: 20706
     wikidata: Q434470
+    google_entity: kg:/m/0700nd
   name:
     first: Joe
     last: Courtney
@@ -8050,6 +8147,7 @@
     washington_post: gIQA3hslDP
     icpsr: 29345
     wikidata: Q734319
+    google_entity: kg:/m/021pgp
   name:
     first: Michael
     middle: D.
@@ -8121,6 +8219,7 @@
     washington_post: gIQAlMfVKP
     icpsr: 21106
     wikidata: Q2151554
+    google_entity: kg:/m/0czb3pp
   name:
     first: Eric
     middle: A.
@@ -8184,6 +8283,7 @@
     washington_post: gIQASSNRAP
     icpsr: 20111
     wikidata: Q490511
+    google_entity: kg:/m/0251y2
   name:
     first: Ander
     last: Crenshaw
@@ -8279,6 +8379,7 @@
     washington_post: gIQACIr09O
     icpsr: 29925
     wikidata: Q971318
+    google_entity: kg:/m/03v10s
   name:
     first: Joseph
     last: Crowley
@@ -8382,6 +8483,7 @@
     washington_post: gIQAHjjSAP
     icpsr: 20533
     wikidata: Q539562
+    google_entity: kg:/m/04clj6
   name:
     first: Henry
     last: Cuellar
@@ -8465,6 +8567,7 @@
     washington_post: gIQArjZfAP
     icpsr: 20139
     wikidata: Q671976
+    google_entity: kg:/m/03sfhc
   name:
     first: John
     middle: Abney
@@ -8563,6 +8666,7 @@
     washington_post: gIQAKaxDAP
     icpsr: 29587
     wikidata: Q934898
+    google_entity: kg:/m/025k9h
   name:
     first: Elijah
     middle: E.
@@ -8679,6 +8783,7 @@
     washington_post: gIQAgWpbKP
     icpsr: 29717
     wikidata: Q1164657
+    google_entity: kg:/m/0256k7
   name:
     first: Danny
     middle: K.
@@ -8788,6 +8893,7 @@
     washington_post: gIQAumASAP
     icpsr: 20108
     wikidata: Q460675
+    google_entity: kg:/m/024xs5
   name:
     first: Susan
     middle: A.
@@ -8885,6 +8991,7 @@
     maplight: 213
     washington_post: gIQAS87AAP
     wikidata: Q1758507
+    google_entity: kg:/m/033ttx
   name:
     first: Peter
     middle: A.
@@ -9023,6 +9130,7 @@
     washington_post: gIQADVSDAP
     icpsr: 29710
     wikidata: Q437159
+    google_entity: kg:/m/024z95
   name:
     first: Diana
     middle: L.
@@ -9133,6 +9241,7 @@
     washington_post: gIQAkOCT9O
     icpsr: 29109
     wikidata: Q434952
+    google_entity: kg:/m/024zn0
   name:
     first: Rosa
     middle: L.
@@ -9260,6 +9369,7 @@
     washington_post: gIQA6BMZKP
     icpsr: 21109
     wikidata: Q1686295
+    google_entity: kg:/m/02q4gng
   name:
     first: Jeff
     last: Denham
@@ -9321,6 +9431,7 @@
     washington_post: gIQAY7qLAP
     icpsr: 20526
     wikidata: Q556034
+    google_entity: kg:/m/04fcm3
   name:
     first: Charles
     middle: W.
@@ -9403,6 +9514,7 @@
     washington_post: gIQAQg5WKP
     icpsr: 21179
     wikidata: Q2260839
+    google_entity: kg:/m/09k4h2_
   name:
     first: Scott
     last: DesJarlais
@@ -9464,6 +9576,7 @@
     washington_post: gIQAgpzZKP
     icpsr: 20959
     wikidata: Q245724
+    google_entity: kg:/m/03cg3qs
   name:
     first: Theodore
     middle: E.
@@ -9534,6 +9647,7 @@
     washington_post: gIQAvrSaAP
     icpsr: 20316
     wikidata: Q767270
+    google_entity: kg:/m/02536z
   name:
     first: Mario
     last: Diaz-Balart
@@ -9627,6 +9741,7 @@
     washington_post: gIQA0jEdKP
     icpsr: 29571
     wikidata: Q363817
+    google_entity: kg:/m/03flzn
   name:
     first: Lloyd
     middle: A.
@@ -9745,6 +9860,7 @@
     washington_post: gIQAM8hOAP
     icpsr: 20717
     wikidata: Q1691395
+    google_entity: kg:/m/0gmx64
   name:
     first: Joe
     last: Donnelly
@@ -9809,6 +9925,7 @@
     washington_post: gIQAlqEdKP
     icpsr: 29561
     wikidata: Q1344200
+    google_entity: kg:/m/03tqjg
   name:
     first: Michael
     middle: F.
@@ -9927,6 +10044,7 @@
     washington_post: gIQAx21QKP
     icpsr: 21189
     wikidata: Q1729888
+    google_entity: kg:/m/026m6hd
   name:
     first: Sean
     last: Duffy
@@ -9988,6 +10106,7 @@
     washington_post: gIQAfghZKP
     icpsr: 21174
     wikidata: Q1027026
+    google_entity: kg:/m/0ddgp1k
   name:
     first: Jeff
     last: Duncan
@@ -10048,6 +10167,7 @@
     maplight: 228
     washington_post: gIQA7YKbKP
     wikidata: Q653994
+    google_entity: kg:/m/0450rl
   name:
     first: John
     middle: J.
@@ -10192,6 +10312,7 @@
     washington_post: gIQAqUKbKP
     icpsr: 20763
     wikidata: Q461663
+    google_entity: kg:/m/0dr_x8
   name:
     first: Donna
     middle: F.
@@ -10269,6 +10390,7 @@
     washington_post: gIQA98OxDP
     icpsr: 20727
     wikidata: Q40589
+    google_entity: kg:/m/0dlwms
   name:
     first: Keith
     middle: Maurice
@@ -10346,6 +10468,7 @@
     washington_post: gIQAATqZKP
     icpsr: 21159
     wikidata: Q515971
+    google_entity: kg:/m/0dsdyjp
   name:
     first: Renee
     last: Ellmers
@@ -10407,6 +10530,7 @@
     maplight: 233
     washington_post: gIQAxS2pAP
     wikidata: Q1329618
+    google_entity: kg:/m/03tt1r
   name:
     first: Eliot
     middle: L.
@@ -10538,6 +10662,7 @@
     washington_post: gIQAdlYxDP
     icpsr: 29312
     wikidata: Q291193
+    google_entity: kg:/m/024t6x
   name:
     first: Anna
     middle: G.
@@ -10660,6 +10785,7 @@
     washington_post: gIQA6OqZKP
     icpsr: 21184
     wikidata: Q881255
+    google_entity: kg:/m/0ds2ztj
   name:
     first: Blake
     last: Farenthold
@@ -10720,6 +10846,7 @@
     washington_post: gIQAPPNqAP
     icpsr: 29313
     wikidata: Q675348
+    google_entity: kg:/m/024t9w
   name:
     first: Sam
     last: Farr
@@ -10841,6 +10968,7 @@
     washington_post: gIQAvQNqAP
     icpsr: 29559
     wikidata: Q1059265
+    google_entity: kg:/m/03dsph
   name:
     first: Chaka
     last: Fattah
@@ -10955,6 +11083,7 @@
     washington_post: gIQAnqGVKP
     icpsr: 21181
     wikidata: Q2344713
+    google_entity: kg:/m/0ddgg4w
   name:
     first: Stephen
     last: Fincher
@@ -11016,6 +11145,7 @@
     washington_post: gIQApV5UKP
     icpsr: 20524
     wikidata: Q45951
+    google_entity: kg:/m/04bbg5
   name:
     first: Michael
     middle: G.
@@ -11086,6 +11216,7 @@
     washington_post: gIQAU2XIAP
     icpsr: 20100
     wikidata: Q929581
+    google_entity: kg:/m/024p7j
   name:
     first: Jeff
     last: Flake
@@ -11170,6 +11301,7 @@
     washington_post: gIQAav8tKP
     icpsr: 21178
     wikidata: Q521959
+    google_entity: kg:/m/0ddd54f
   name:
     first: Charles
     last: Fleischmann
@@ -11233,6 +11365,7 @@
     washington_post: gIQARR2pAP
     icpsr: 20918
     wikidata: Q1699486
+    google_entity: kg:/m/04z_dt3
   name:
     first: John
     last: Fleming
@@ -11306,6 +11439,7 @@
     washington_post: gIQA9K9UKP
     icpsr: 21182
     wikidata: Q862103
+    google_entity: kg:/m/0bs1ntq
   name:
     first: Bill
     last: Flores
@@ -11367,6 +11501,7 @@
     washington_post: gIQAqP2pAP
     icpsr: 20143
     wikidata: Q2130783
+    google_entity: kg:/m/026gv8q
   name:
     first: J.
     middle: Randy
@@ -11465,6 +11600,7 @@
     washington_post: gIQAfqrHAP
     icpsr: 20518
     wikidata: Q1397331
+    google_entity: kg:/m/04fcch
   name:
     first: Jeff
     middle: Lane
@@ -11548,6 +11684,7 @@
     washington_post: gIQARSNqAP
     icpsr: 20521
     wikidata: Q458453
+    google_entity: kg:/m/02b5dz
   name:
     first: Virginia
     last: Foxx
@@ -11631,6 +11768,7 @@
     washington_post: gIQAbTtMAP
     icpsr: 20304
     wikidata: Q1397303
+    google_entity: kg:/m/024p5b
   name:
     first: Trent
     last: Franks
@@ -11721,6 +11859,7 @@
     washington_post: gIQAFP2pAP
     icpsr: 29541
     wikidata: Q338190
+    google_entity: kg:/m/03bktp
   name:
     first: Rodney
     middle: P.
@@ -11844,6 +11983,7 @@
     washington_post: gIQAjN2pAP
     icpsr: 20941
     wikidata: Q461746
+    google_entity: kg:/m/04n11v9
   name:
     first: Marcia
     last: Fudge
@@ -11920,6 +12060,7 @@
     washington_post: gIQAZT3s6O
     icpsr: 20958
     wikidata: Q1340268
+    google_entity: kg:/m/05fvls
   name:
     first: John
     last: Garamendi
@@ -11991,6 +12132,7 @@
     icpsr: 21112
     lis: S377
     wikidata: Q1135774
+    google_entity: kg:/m/0czd33q
   name:
     first: Cory
     last: Gardner
@@ -12049,6 +12191,7 @@
     washington_post: gIQAutKHAP
     icpsr: 20336
     wikidata: Q981424
+    google_entity: kg:/m/033f6x
   name:
     first: Scott
     last: Garrett
@@ -12139,6 +12282,7 @@
     washington_post: gIQAlN3VKP
     icpsr: 21165
     wikidata: Q887945
+    google_entity: kg:/m/07qwv4
   name:
     first: Bob
     last: Gibbs
@@ -12199,6 +12343,7 @@
     washington_post: gIQAHlhZKP
     icpsr: 21156
     wikidata: Q32722
+    google_entity: kg:/m/0dddh8h
   name:
     first: Christopher
     middle: P.
@@ -12261,6 +12406,7 @@
     washington_post: gIQA0GxpAP
     icpsr: 20527
     wikidata: Q532647
+    google_entity: kg:/m/0490h9
   name:
     first: Louie
     middle: B.
@@ -12346,6 +12492,7 @@
     washington_post: gIQACAHpAP
     icpsr: 39308
     wikidata: Q887952
+    google_entity: kg:/m/0284s7
   name:
     first: Bob
     middle: W.
@@ -12468,6 +12615,7 @@
     washington_post: gIQAzppVKP
     icpsr: 21103
     wikidata: Q2059832
+    google_entity: kg:/m/0czdqz0
   name:
     first: Paul
     last: Gosar
@@ -12530,6 +12678,7 @@
     washington_post: gIQAAozZKP
     icpsr: 21175
     wikidata: Q1822266
+    google_entity: kg:/m/0c3x3rz
   name:
     first: Trey
     last: Gowdy
@@ -12590,6 +12739,7 @@
     washington_post: gIQAJGdW9O
     icpsr: 29762
     wikidata: Q468807
+    google_entity: kg:/m/03tndx
   name:
     first: Kay
     last: Granger
@@ -12700,6 +12850,7 @@
     maplight: 570
     washington_post: gIQAxsWx9O
     wikidata: Q529294
+    google_entity: kg:/m/020ymy
   name:
     first: Charles
     middle: E.
@@ -12790,6 +12941,7 @@
     washington_post: gIQAEvXIAP
     icpsr: 20124
     wikidata: Q465638
+    google_entity: kg:/m/03tnfy
   name:
     first: Sam
     middle: B.
@@ -12888,6 +13040,7 @@
     washington_post: gIQA82YuKP
     icpsr: 20962
     wikidata: Q1647301
+    google_entity: kg:/m/0c02hpl
   name:
     first: Tom
     last: Graves
@@ -12957,6 +13110,7 @@
     washington_post: gIQA7bXzDP
     icpsr: 20529
     wikidata: Q749039
+    google_entity: kg:/m/01364q
   name:
     first: Al
     last: Green
@@ -13039,6 +13193,7 @@
     washington_post: gIQAYwnpAP
     icpsr: 39304
     wikidata: Q539587
+    google_entity: kg:/m/03v12k
   name:
     first: Gene
     middle: Eugene
@@ -13161,6 +13316,7 @@
     washington_post: gIQA8LqZKP
     icpsr: 21191
     wikidata: Q1684857
+    google_entity: kg:/m/025vdrq
   name:
     first: H.
     middle: Morgan
@@ -13223,6 +13379,7 @@
     washington_post: gIQATZnOAP
     icpsr: 20305
     wikidata: Q946606
+    google_entity: kg:/m/024s1z
   name:
     first: Raúl
     middle: M.
@@ -13315,6 +13472,7 @@
     washington_post: gIQAh9rq6O
     icpsr: 20916
     wikidata: Q910794
+    google_entity: kg:/m/0411qqt
   name:
     first: Brett
     last: Guthrie
@@ -13384,6 +13542,7 @@
     washington_post: gIQADVuzDP
     icpsr: 29348
     wikidata: Q718127
+    google_entity: kg:/m/0256d5
   name:
     first: Luis
     middle: V.
@@ -13505,6 +13664,7 @@
     washington_post: gIQAQdiXKP
     icpsr: 21157
     wikidata: Q32718
+    google_entity: kg:/m/0ds4mn_
   name:
     first: Richard
     last: Hanna
@@ -13566,6 +13726,7 @@
     washington_post: gIQAg8GpAP
     icpsr: 20925
     wikidata: Q1545023
+    google_entity: kg:/m/0406s7r
   name:
     first: Gregg
     last: Harper
@@ -13634,6 +13795,7 @@
     washington_post: gIQAN7ZTAP
     icpsr: 21139
     wikidata: Q506639
+    google_entity: kg:/m/02852wc
   name:
     first: Andy
     last: Harris
@@ -13695,6 +13857,7 @@
     washington_post: gIQApt5WKP
     icpsr: 21149
     wikidata: Q375389
+    google_entity: kg:/m/09v2dv4
   name:
     first: Vicky
     last: Hartzler
@@ -13756,6 +13919,7 @@
     washington_post: gIQAz5GpAP
     icpsr: 29337
     wikidata: Q1758631
+    google_entity: kg:/m/02534d
   name:
     first: Alcee
     middle: L.
@@ -13878,6 +14042,7 @@
     washington_post: gIQAviVUKP
     icpsr: 21151
     wikidata: Q24243
+    google_entity: kg:/m/03b_hhb
   name:
     first: Joseph
     last: Heck
@@ -13942,6 +14107,7 @@
     washington_post: gIQAkCzTAP
     icpsr: 20930
     wikidata: Q565374
+    google_entity: kg:/m/02qkv0r
   name:
     first: Martin
     last: Heinrich
@@ -13998,6 +14164,7 @@
     washington_post: gIQANKaU9O
     icpsr: 20352
     wikidata: Q538785
+    google_entity: kg:/m/0h23n6
   name:
     first: Jeb
     last: Hensarling
@@ -14088,6 +14255,7 @@
     washington_post: gIQAHQfVKP
     icpsr: 21187
     wikidata: Q168592
+    google_entity: kg:/m/0cz8yx2
   name:
     first: Jaime
     last: Herrera Beutler
@@ -14149,6 +14317,7 @@
     washington_post: gIQAnP7UAP
     icpsr: 20519
     wikidata: Q505581
+    google_entity: kg:/m/04fc7g
   name:
     first: Brian
     middle: M.
@@ -14232,6 +14401,7 @@
     washington_post: gIQAtLEM9O
     icpsr: 20907
     wikidata: Q1689111
+    google_entity: kg:/m/03w9x9v
   name:
     first: James
     middle: A.
@@ -14302,6 +14472,7 @@
     washington_post: gIQAvN7UAP
     icpsr: 29763
     wikidata: Q256517
+    google_entity: kg:/m/03fvy5
   name:
     first: Rubén
     middle: E.
@@ -14414,6 +14585,7 @@
     washington_post: gIQARL7UAP
     icpsr: 20713
     wikidata: Q16476
+    google_entity: kg:/m/0357cd
   name:
     first: Mazie
     middle: K.
@@ -14479,6 +14651,7 @@
     washington_post: gIQA8Pwz6O
     icpsr: 41107
     wikidata: Q374762
+    google_entity: kg:/m/01qb45
   name:
     first: John
     last: Hoeven
@@ -14516,6 +14689,7 @@
     washington_post: gIQA8Id2DP
     icpsr: 20103
     wikidata: Q399621
+    google_entity: kg:/m/021yd1
   name:
     first: Michael
     middle: M.
@@ -14615,6 +14789,7 @@
     maplight: 293
     washington_post: gIQA9KQN9O
     wikidata: Q516515
+    google_entity: kg:/m/025k5p
   name:
     first: Steny
     middle: H.
@@ -14793,6 +14968,7 @@
     washington_post: gIQABtpVK
     icpsr: 21134
     wikidata: Q2434073
+    google_entity: kg:/m/05mr6d8
   name:
     first: Tim
     last: Huelskamp
@@ -14854,6 +15030,7 @@
     washington_post: gIQAOyHaKP
     icpsr: 21142
     wikidata: Q862199
+    google_entity: kg:/m/05b0j1w
   name:
     first: Bill
     last: Huizenga
@@ -14915,6 +15092,7 @@
     washington_post: gIQAHoGVKP
     icpsr: 21129
     wikidata: Q556404
+    google_entity: kg:/m/0h0lr9
   name:
     first: Randy
     last: Hultgren
@@ -14975,6 +15153,7 @@
     washington_post: gIQAFspUAP
     icpsr: 20963
     wikidata: Q540521
+    google_entity: kg:/m/047tpf2
   name:
     first: Duncan
     middle: D.
@@ -15048,6 +15227,7 @@
     washington_post: gIQAfrpVKP
     icpsr: 21186
     wikidata: Q2157642
+    google_entity: kg:/m/04ygsqx
   name:
     first: Robert
     last: Hurt
@@ -15111,6 +15291,7 @@
     washington_post: gIQAkTA2DP
     icpsr: 29909
     wikidata: Q130024
+    google_entity: kg:/m/02556q
   name:
     first: John
     middle: H.
@@ -15178,6 +15359,7 @@
     washington_post: gIQAt0jCAP
     icpsr: 20129
     wikidata: Q2096271
+    google_entity: kg:/m/03v3c9
   name:
     first: Steve
     middle: J.
@@ -15277,6 +15459,7 @@
     washington_post: gIQAaSzFAP
     icpsr: 20107
     wikidata: Q1166592
+    google_entity: kg:/m/01r7wc
   name:
     first: Darrell
     last: Issa
@@ -15373,6 +15556,7 @@
     washington_post: gIQAenpUAP
     icpsr: 29573
     wikidata: Q461734
+    google_entity: kg:/m/02fj6h
   name:
     first: Sheila
     last: Jackson Lee
@@ -15488,6 +15672,7 @@
     washington_post: gIQA8hpUAP
     icpsr: 20915
     wikidata: Q456217
+    google_entity: kg:/m/02qdzmy
   name:
     first: Lynn
     last: Jenkins
@@ -15557,6 +15742,7 @@
     washington_post: gIQAHF5YKP
     icpsr: 21162
     wikidata: Q862215
+    google_entity: kg:/m/03g_vd8
   name:
     first: Bill
     last: Johnson
@@ -15617,6 +15803,7 @@
     washington_post: gIQAutVSAP
     icpsr: 39305
     wikidata: Q461526
+    google_entity: kg:/m/03tn1w
   name:
     first: Eddie
     middle: Bernice
@@ -15739,6 +15926,7 @@
     washington_post: gIQAC8oUAP
     icpsr: 20712
     wikidata: Q983537
+    google_entity: kg:/m/0flgyy
   name:
     first: Henry
     middle: C.
@@ -15818,6 +16006,7 @@
     washington_post: gIQAYIfTKP
     icpsr: 41111
     wikidata: Q970272
+    google_entity: kg:/m/0cmdpzc
   name:
     first: Ron
     last: Johnson
@@ -15855,6 +16044,7 @@
     washington_post: gIQAltpUAP
     icpsr: 29143
     wikidata: Q539470
+    google_entity: kg:/m/02_21s
   name:
     first: Sam
     middle: Robert
@@ -15983,6 +16173,7 @@
     washington_post: gIQALhiUAP
     icpsr: 29546
     wikidata: Q512537
+    google_entity: kg:/m/03g_r5
   name:
     first: Walter
     middle: B.
@@ -16103,6 +16294,7 @@
     washington_post: gIQAjcfUAP
     icpsr: 20738
     wikidata: Q186215
+    google_entity: kg:/m/04l4x5
   name:
     first: Jim
     last: Jordan
@@ -16178,6 +16370,7 @@
     maplight: 312
     washington_post: gIQApw7AAP
     wikidata: Q436537
+    google_entity: kg:/m/039s3l
   name:
     first: Marcy
     last: Kaptur
@@ -16328,6 +16521,7 @@
     washington_post: gIQA23JXKP
     icpsr: 21140
     wikidata: Q775412
+    google_entity: kg:/m/09v6g7c
   name:
     first: William
     last: Keating
@@ -16390,6 +16584,7 @@
     washington_post: gIQAXuVWKP
     icpsr: 21167
     wikidata: Q1431761
+    google_entity: kg:/m/0ds6wcw
   name:
     first: Mike
     last: Kelly
@@ -16451,6 +16646,7 @@
     washington_post: gIQA0kXHAP
     icpsr: 29769
     wikidata: Q505222
+    google_entity: kg:/m/024ty6
   name:
     first: Ron
     middle: James
@@ -16561,6 +16757,7 @@
     washington_post: gIQAr6fAAP
     icpsr: 29375
     wikidata: Q953554
+    google_entity: kg:/m/03tk4w
   name:
     first: Peter
     middle: T.
@@ -16684,6 +16881,7 @@
     washington_post: gIQA958MAP
     icpsr: 20325
     wikidata: Q749710
+    google_entity: kg:/m/025b7g
   name:
     first: Steve
     middle: A.
@@ -16776,6 +16974,7 @@
     washington_post: gIQARqVWKP
     icpsr: 21128
     wikidata: Q349955
+    google_entity: kg:/m/05q9ypn
   name:
     first: Adam
     last: Kinzinger
@@ -16839,6 +17038,7 @@
     washington_post: gIQAfhXHAP
     icpsr: 20115
     wikidata: Q339046
+    google_entity: kg:/m/0256rr
   name:
     first: Mark
     middle: Steven
@@ -16918,6 +17118,7 @@
     washington_post: gIQAW0U3DP
     icpsr: 20333
     wikidata: Q465843
+    google_entity: kg:/m/02h1yr
   name:
     first: John
     middle: Paul
@@ -17010,6 +17211,7 @@
     washington_post: gIQAfl8vKP
     icpsr: 21125
     wikidata: Q555393
+    google_entity: kg:/m/0c3zfwm
   name:
     first: Raúl
     last: Labrador
@@ -17072,6 +17274,7 @@
     washington_post: gIQAN69TAP
     icpsr: 20704
     wikidata: Q371106
+    google_entity: kg:/m/0fsgdd
   name:
     first: Doug
     last: Lamborn
@@ -17148,6 +17351,7 @@
     washington_post: gIQAi49TAP
     icpsr: 20929
     wikidata: Q1819021
+    google_entity: kg:/m/077cs4
   name:
     first: Leonard
     last: Lance
@@ -17217,6 +17421,7 @@
     washington_post: gIQABs8MAP
     icpsr: 20136
     wikidata: Q1397290
+    google_entity: kg:/m/02tvqy
   name:
     first: James
     middle: R.
@@ -17317,6 +17522,7 @@
     icpsr: 21166
     lis: S378
     wikidata: Q45940
+    google_entity: kg:/m/0dgrrx6
   name:
     first: James
     last: Lankford
@@ -17374,6 +17580,7 @@
     maplight: 333
     icpsr: 20145
     wikidata: Q503529
+    google_entity: kg:/m/025953
   name:
     first: Rick
     last: Larsen
@@ -17470,6 +17677,7 @@
     washington_post: gIQAmHHN9O
     icpsr: 29908
     wikidata: Q357832
+    google_entity: kg:/m/024zl9
   name:
     first: John
     middle: B.
@@ -17573,6 +17781,7 @@
     washington_post: gIQAYPcwKP
     icpsr: 20755
     wikidata: Q888061
+    google_entity: kg:/m/02z6_j1
   name:
     first: Robert
     middle: E.
@@ -17653,6 +17862,7 @@
     maplight: 586
     washington_post: gIQAQnnb9O
     wikidata: Q59315
+    google_entity: kg:/m/0202kf
   name:
     first: Patrick
     middle: J.
@@ -17730,6 +17940,7 @@
     washington_post: gIQArxTS9O
     icpsr: 29778
     wikidata: Q289317
+    google_entity: kg:/m/024sjy
   name:
     first: Barbara
     last: Lee
@@ -17839,6 +18050,7 @@
     washington_post: gIQAwTVWKP
     icpsr: 41110
     wikidata: Q627098
+    google_entity: kg:/m/09v5q9x
   name:
     first: Mike
     last: Lee
@@ -17876,6 +18088,7 @@
     maplight: 339
     washington_post: gIQAv24SAP
     wikidata: Q971943
+    google_entity: kg:/m/02n8p2
   name:
     first: Sander
     middle: M.
@@ -18031,6 +18244,7 @@
     maplight: 341
     washington_post: gIQAaw4SAP
     wikidata: Q45380
+    google_entity: kg:/m/0b419w
   name:
     first: John
     middle: R.
@@ -18171,6 +18385,7 @@
     washington_post: gIQAJLoPMP
     icpsr: 20508
     wikidata: Q518424
+    google_entity: kg:/m/0508fv
   name:
     first: Daniel
     middle: William
@@ -18257,6 +18472,7 @@
     washington_post: gIQA0WNqAP
     icpsr: 29539
     wikidata: Q616850
+    google_entity: kg:/m/025y0c
   name:
     first: Frank
     middle: A.
@@ -18373,6 +18589,7 @@
     washington_post: gIQAzr4SAP
     icpsr: 20720
     wikidata: Q771586
+    google_entity: kg:/m/0gtmqs
   name:
     first: David
     last: Loebsack
@@ -18449,6 +18666,7 @@
     washington_post: gIQAi3CLAP
     icpsr: 29504
     wikidata: Q218217
+    google_entity: kg:/m/024t94
   name:
     first: Zoe
     last: Lofgren
@@ -18563,6 +18781,7 @@
     washington_post: gIQA4szZKP
     icpsr: 21150
     wikidata: Q863171
+    google_entity: kg:/m/0ds17_9
   name:
     first: Billy
     last: Long
@@ -18624,6 +18843,7 @@
     maplight: 346
     washington_post: gIQAWtY09O
     wikidata: Q460652
+    google_entity: kg:/m/03tv8l
   name:
     first: Nita
     middle: M.
@@ -18758,6 +18978,7 @@
     washington_post: gIQAtwMLAP
     icpsr: 29393
     wikidata: Q246049
+    google_entity: kg:/m/033tnk
   name:
     first: Frank
     middle: D.
@@ -18879,6 +19100,7 @@
     washington_post: gIQAn2WgAP
     icpsr: 20926
     wikidata: Q522181
+    google_entity: kg:/m/04ycpq1
   name:
     first: Blaine
     last: Luetkemeyer
@@ -18947,6 +19169,7 @@
     washington_post: gIQAHFzTAP
     icpsr: 20932
     wikidata: Q324256
+    google_entity: kg:/m/0412qzq
   name:
     first: Ben
     middle: Ray
@@ -19017,6 +19240,7 @@
     washington_post: gIQAWmVSAP
     icpsr: 20953
     wikidata: Q456064
+    google_entity: kg:/m/02qvjv3
   name:
     first: Cynthia
     middle: M.
@@ -19088,6 +19312,7 @@
     washington_post: gIQAMEoVBP
     icpsr: 20119
     wikidata: Q2344921
+    google_entity: kg:/m/028vsz
   name:
     first: Stephen
     middle: F.
@@ -19185,6 +19410,7 @@
     washington_post: gIQAcoKHAP
     icpsr: 29379
     wikidata: Q455833
+    google_entity: kg:/m/03txd5
   name:
     first: Carolyn
     middle: B.
@@ -19306,6 +19532,7 @@
     washington_post: gIQAZ91QKP
     icpsr: 20532
     wikidata: Q368184
+    google_entity: kg:/m/04cvjb
   name:
     first: Kenny
     middle: Ewell
@@ -19390,6 +19617,7 @@
     washington_post: gIQAjRiXKP
     icpsr: 21170
     wikidata: Q2439864
+    google_entity: kg:/m/02qv_mf
   name:
     first: Tom
     last: Marino
@@ -19453,6 +19681,7 @@
     maplight: 351
     washington_post: gIQAdQUz9O
     wikidata: Q1282411
+    google_entity: kg:/m/028vr4
   name:
     first: Edward
     middle: J.
@@ -19640,6 +19869,7 @@
     washington_post: gIQAK2naKP
     icpsr: 20538
     wikidata: Q399561
+    google_entity: kg:/m/059hdf
   name:
     first: Doris
     middle: O.
@@ -19728,6 +19958,7 @@
     maplight: 592
     washington_post: gIQAXQHr9O
     wikidata: Q10390
+    google_entity: kg:/m/0bymv
   name:
     first: John
     middle: S.
@@ -19806,6 +20037,7 @@
     washington_post: gIQA7DQW9O
     icpsr: 20703
     wikidata: Q766866
+    google_entity: kg:/m/074qxm
   name:
     first: Kevin
     last: McCarthy
@@ -19898,6 +20130,7 @@
     washington_post: gIQAwuBTMP
     icpsr: 20530
     wikidata: Q539509
+    google_entity: kg:/m/0492cz
   name:
     first: Michael
     middle: T.
@@ -19980,6 +20213,7 @@
     washington_post: gIQAr0cdKP
     icpsr: 20903
     wikidata: Q535887
+    google_entity: kg:/m/01r6jp
   name:
     first: Tom
     last: McClintock
@@ -20049,6 +20283,7 @@
     washington_post: gIQAukFTKP
     icpsr: 20122
     wikidata: Q434893
+    google_entity: kg:/m/0249hy
   name:
     first: Betty
     middle: Louise
@@ -20146,6 +20381,7 @@
     maplight: 359
     washington_post: gIQApQvNKP
     wikidata: Q321457
+    google_entity: kg:/m/0249sh
   name:
     first: Jim
     middle: A.
@@ -20279,6 +20515,7 @@
     washington_post: gIQAZRKbKP
     icpsr: 29729
     wikidata: Q1337459
+    google_entity: kg:/m/028vn7
   name:
     first: James
     middle: P.
@@ -20390,6 +20627,7 @@
     washington_post: gIQA70nx9O
     icpsr: 20522
     wikidata: Q2057809
+    google_entity: kg:/m/02b4rz
   name:
     first: Patrick
     middle: T.
@@ -20473,6 +20711,7 @@
     washington_post: gIQALnNUKP
     icpsr: 21188
     wikidata: Q1175610
+    google_entity: kg:/m/0crj8tf
   name:
     first: David
     last: McKinley
@@ -20535,6 +20774,7 @@
     washington_post: gIQABLyUMP
     icpsr: 20535
     wikidata: Q293343
+    google_entity: kg:/m/03dlf3
   name:
     first: Cathy
     last: McMorris Rodgers
@@ -20616,6 +20856,7 @@
     washington_post: gIQAlHAVBP
     icpsr: 20702
     wikidata: Q1344743
+    google_entity: kg:/m/07zk65
   name:
     first: Jerry
     last: McNerney
@@ -20692,6 +20933,7 @@
     washington_post: gIQA2yGVKP
     icpsr: 21168
     wikidata: Q2056533
+    google_entity: kg:/m/03m4jty
   name:
     first: Patrick
     last: Meehan
@@ -20752,6 +20994,7 @@
     washington_post: gIQAQwSKAP
     icpsr: 29776
     wikidata: Q1545391
+    google_entity: kg:/m/024_3b
   name:
     first: Gregory
     middle: W.
@@ -20862,6 +21105,7 @@
     washington_post: gIQAGSEKAP
     icpsr: 29331
     wikidata: Q918506
+    google_entity: kg:/m/02520m
   name:
     first: John
     middle: L.
@@ -20988,6 +21232,7 @@
     maplight: 594
     washington_post: gIQApKSAAP
     wikidata: Q261147
+    google_entity: kg:/m/0206nm
   name:
     first: Barbara
     middle: A.
@@ -21084,6 +21329,7 @@
     washington_post: gIQAVsJbKP
     icpsr: 20331
     wikidata: Q435777
+    google_entity: kg:/m/03tl30
   name:
     first: Candice
     last: Miller
@@ -21176,6 +21422,7 @@
     washington_post: gIQATNjVMP
     icpsr: 20110
     wikidata: Q970478
+    google_entity: kg:/m/0251vm
   name:
     first: Jeff
     last: Miller
@@ -21273,6 +21520,7 @@
     washington_post: gIQArDiKAP
     icpsr: 20537
     wikidata: Q461698
+    google_entity: kg:/m/04cvds
   name:
     first: Gwen
     last: Moore
@@ -21358,6 +21606,7 @@
     washington_post: gIQAdVZfAP
     icpsr: 29722
     wikidata: Q1365787
+    google_entity: kg:/m/024s8t
   name:
     first: Jerry
     last: Moran
@@ -21443,6 +21692,7 @@
     washington_post: gIQA2dVUKP
     icpsr: 21176
     wikidata: Q1235731
+    google_entity: kg:/m/0cp1sr_
   name:
     first: Mick
     last: Mulvaney
@@ -21505,6 +21755,7 @@
     washington_post: gIQA6VzBAP
     icpsr: 40300
     wikidata: Q22360
+    google_entity: kg:/m/0202kt
   name:
     first: Lisa
     middle: A.
@@ -21564,6 +21815,7 @@
     washington_post: gIQAXlFYMP
     icpsr: 20707
     wikidata: Q1077594
+    google_entity: kg:/m/0cy_dh
   name:
     first: Christopher
     middle: S.
@@ -21628,6 +21880,7 @@
     washington_post: gIQAND0HAP
     icpsr: 20346
     wikidata: Q2434181
+    google_entity: kg:/m/0517t7
   name:
     first: Tim
     last: Murphy
@@ -21720,6 +21973,7 @@
     washington_post: gIQARXaU9O
     icpsr: 49308
     wikidata: Q258825
+    google_entity: kg:/m/018qx5
   name:
     first: Patty
     last: Murray
@@ -21778,6 +22032,7 @@
     washington_post: gIQALyRYMP
     icpsr: 29377
     wikidata: Q505598
+    google_entity: kg:/m/03tk11
   name:
     first: Jerrold
     middle: L.
@@ -21905,6 +22160,7 @@
     washington_post: gIQAW3cdKP
     icpsr: 29903
     wikidata: Q469139
+    google_entity: kg:/m/024v0s
   name:
     first: Grace
     middle: F.
@@ -22008,6 +22264,7 @@
     maplight: 387
     washington_post: gIQA7V4aKP
     wikidata: Q1464697
+    google_entity: kg:/m/028vm4
   name:
     first: Richard
     middle: E.
@@ -22142,6 +22399,7 @@
     washington_post: gIQA5hZfAP
     icpsr: 20353
     wikidata: Q539536
+    google_entity: kg:/m/03tn5k
   name:
     first: Randy
     last: Neugebauer
@@ -22233,6 +22491,7 @@
     washington_post: gIQABw1QKP
     icpsr: 21177
     wikidata: Q465749
+    google_entity: kg:/m/0c3xgn9
   name:
     first: Kristi
     last: Noem
@@ -22293,6 +22552,7 @@
     maplight: 390
     washington_post: 73c1161a-64c5-11e2-85f5-a8a9228e55e7
     wikidata: Q461649
+    google_entity: kg:/m/01s_vp
   name:
     first: Eleanor
     middle: Holmes
@@ -22420,6 +22680,7 @@
     washington_post: gIQAt0HaKP
     icpsr: 21115
     wikidata: Q2148853
+    google_entity: kg:/m/0czc10m
   name:
     first: Richard
     last: Nugent
@@ -22481,6 +22742,7 @@
     washington_post: gIQAt1EGAP
     icpsr: 20307
     wikidata: Q539493
+    google_entity: kg:/m/024tds
   name:
     first: Devin
     middle: G.
@@ -22572,6 +22834,7 @@
     washington_post: gIQAdHcTKP
     icpsr: 20948
     wikidata: Q2073303
+    google_entity: kg:/m/0407vf_
   name:
     first: Pete
     last: Olson
@@ -22640,6 +22903,7 @@
     washington_post: gIQAlE0YMP
     icpsr: 21148
     wikidata: Q24230
+    google_entity: kg:/m/0c3y_s5
   name:
     first: Steven
     last: Palazzo
@@ -22702,6 +22966,7 @@
     maplight: 402
     washington_post: gIQAMsEdKP
     wikidata: Q965289
+    google_entity: kg:/m/0g6t5w
   name:
     first: Frank
     middle: J.
@@ -22842,6 +23107,7 @@
     washington_post: gIQAbraOAP
     icpsr: 29741
     wikidata: Q529090
+    google_entity: kg:/m/03txs_
   name:
     first: Bill
     middle: J.
@@ -22953,6 +23219,7 @@
     washington_post: gIQA5AakAP
     icpsr: 41104
     wikidata: Q463557
+    google_entity: kg:/m/05pdb7q
   name:
     first: Rand
     last: Paul
@@ -22994,6 +23261,7 @@
     washington_post: gIQALqDbKP
     icpsr: 20924
     wikidata: Q466085
+    google_entity: kg:/m/0407tc8
   name:
     first: Erik
     last: Paulsen
@@ -23064,6 +23332,7 @@
     washington_post: gIQAZbOZMP
     icpsr: 20337
     wikidata: Q947168
+    google_entity: kg:/m/02z7784
   name:
     first: Stevan
     middle: E.
@@ -23145,6 +23414,7 @@
     maplight: 408
     washington_post: gIQAF3PM9O
     wikidata: Q170581
+    google_entity: kg:/m/012v1t
   name:
     first: Nancy
     last: Pelosi
@@ -23299,6 +23569,7 @@
     washington_post: gIQAyxjSAP
     icpsr: 20705
     wikidata: Q331507
+    google_entity: kg:/m/07n9ns
   name:
     first: Ed
     last: Perlmutter
@@ -23377,6 +23648,7 @@
     icpsr: 20923
     lis: S380
     wikidata: Q1494930
+    google_entity: kg:/m/02x0lnt
   name:
     first: Gary
     middle: C.
@@ -23445,6 +23717,7 @@
     washington_post: gIQAIQ6GAP
     icpsr: 29127
     wikidata: Q434458
+    google_entity: kg:/m/02h2my
   name:
     first: Collin
     middle: Clark
@@ -23570,6 +23843,7 @@
     house_history: 20030
     maplight: 788
     wikidata: Q2277878
+    google_entity: kg:/m/02r7csl
   name:
     first: Pedro
     middle: R.
@@ -23621,6 +23895,7 @@
     washington_post: gIQAr8cW9O
     icpsr: 20920
     wikidata: Q457243
+    google_entity: kg:/m/05gflq
   name:
     first: Chellie
     last: Pingree
@@ -23690,6 +23965,7 @@
     washington_post: gIQAOAMOAP
     icpsr: 29752
     wikidata: Q1674465
+    google_entity: kg:/m/03twrl
   name:
     first: Joseph
     middle: R.
@@ -23800,6 +24076,7 @@
     washington_post: gIQAqEAdKP
     icpsr: 20528
     wikidata: Q532661
+    google_entity: kg:/m/04928s
   name:
     first: Ted
     last: Poe
@@ -23883,6 +24160,7 @@
     washington_post: gIQAnqrJAP
     icpsr: 20904
     wikidata: Q935734
+    google_entity: kg:/m/02qckk4
   name:
     first: Jared
     last: Polis
@@ -23952,6 +24230,7 @@
     washington_post: gIQAXNLWKP
     icpsr: 21136
     wikidata: Q473239
+    google_entity: kg:/m/0cnxjk7
   name:
     first: Mike
     last: Pompeo
@@ -24015,6 +24294,7 @@
     washington_post: gIQAGuioAP
     icpsr: 29386
     wikidata: Q926069
+    google_entity: kg:/m/0343xg
   name:
     first: Robert
     middle: J.
@@ -24099,6 +24379,7 @@
     washington_post: gIQAx8mRAP
     icpsr: 20909
     wikidata: Q862373
+    google_entity: kg:/m/0281vxy
   name:
     first: Bill
     last: Posey
@@ -24168,6 +24449,7 @@
     maplight: 420
     washington_post: gIQAd3ZCAP
     wikidata: Q984010
+    google_entity: kg:/m/04z48c
   name:
     first: David
     middle: E.
@@ -24302,6 +24584,7 @@
     washington_post: gIQAaTFu9O
     icpsr: 20505
     wikidata: Q1415243
+    google_entity: kg:/m/04z48c
   name:
     first: Tom
     last: Price
@@ -24384,6 +24667,7 @@
     washington_post: gIQAMV709O
     icpsr: 20954
     wikidata: Q465767
+    google_entity: kg:/m/0fccwh
   name:
     first: Mike
     last: Quigley
@@ -24452,6 +24736,7 @@
     maplight: 426
     washington_post: gIQACn7y9O
     wikidata: Q368091
+    google_entity: kg:/m/024_vw
   name:
     first: Charles
     nickname: Charlie
@@ -24640,6 +24925,7 @@
     washington_post: gIQAVOXZKP
     icpsr: 21101
     wikidata: Q2440035
+    google_entity: kg:/m/07kf86m
   name:
     first: Tom
     middle: W.
@@ -24709,6 +24995,7 @@
     washington_post: gIQAemFTKP
     icpsr: 20536
     wikidata: Q456464
+    google_entity: kg:/m/03dllc
   name:
     first: David
     middle: G.
@@ -24793,6 +25080,7 @@
     maplight: 601
     washington_post: gIQA8MlN9O
     wikidata: Q314459
+    google_entity: kg:/m/0204x1
   name:
     first: Harry
     middle: M.
@@ -24890,6 +25178,7 @@
     washington_post: gIQARWEUKP
     icpsr: 21164
     wikidata: Q976676
+    google_entity: kg:/m/025v2hb
   name:
     first: James
     last: Renacci
@@ -24952,6 +25241,7 @@
     washington_post: gIQAYpZVKP
     icpsr: 21190
     wikidata: Q2139894
+    google_entity: kg:/m/0dddvmy
   name:
     first: Reid
     last: Ribble
@@ -25014,6 +25304,7 @@
     washington_post: gIQAUvGVKP
     icpsr: 21137
     wikidata: Q561284
+    google_entity: kg:/m/0bbw8s3
   name:
     first: Cedric
     last: Richmond
@@ -25075,6 +25366,7 @@
     washington_post: gIQA7lZVKP
     icpsr: 21185
     wikidata: Q2800221
+    google_entity: kg:/m/0bx_0mz
   name:
     first: Edward
     middle: Scott
@@ -25138,6 +25430,7 @@
     washington_post: gIQAGcVUKP
     icpsr: 21192
     wikidata: Q439117
+    google_entity: kg:/m/0drx5mb
   name:
     first: Martha
     last: Roby
@@ -25198,6 +25491,7 @@
     washington_post: gIQArh0q6O
     icpsr: 20947
     wikidata: Q1665842
+    google_entity: kg:/m/04gtg5_
   name:
     first: David
     middle: P.
@@ -25267,6 +25561,7 @@
     maplight: 434
     washington_post: gIQAovNCAP
     wikidata: Q547153
+    google_entity: kg:/m/025jnx
   name:
     first: Harold
     last: Rogers
@@ -25425,6 +25720,7 @@
     washington_post: gIQAkR2cKP
     icpsr: 20301
     wikidata: Q693238
+    google_entity: kg:/m/024n_s
   name:
     first: Mike
     last: Rogers
@@ -25514,6 +25810,7 @@
     maplight: 436
     washington_post: gIQAWYNqAP
     wikidata: Q983055
+    google_entity: kg:/m/02gtr
   name:
     first: Dana
     middle: T.
@@ -25648,6 +25945,7 @@
     washington_post: gIQAJQXZKP
     icpsr: 21131
     wikidata: Q1521384
+    google_entity: kg:/m/0bll9p
   name:
     first: Todd
     last: Rokita
@@ -25708,6 +26006,7 @@
     washington_post: gIQADjiUAP
     icpsr: 20910
     wikidata: Q506110
+    google_entity: kg:/m/04jl2j4
   name:
     first: Thomas
     middle: J.
@@ -25778,6 +26077,7 @@
     maplight: 437
     washington_post: gIQAVGfJAP
     wikidata: Q265791
+    google_entity: kg:/m/02530d
   name:
     first: Ileana
     last: Ros-Lehtinen
@@ -25912,6 +26212,7 @@
     washington_post: gIQAN1SKAP
     icpsr: 20715
     wikidata: Q968214
+    google_entity: kg:/m/0gj190
   name:
     first: Peter
     middle: J.
@@ -25989,6 +26290,7 @@
     washington_post: gIQAP9JXKP
     icpsr: 21117
     wikidata: Q1188940
+    google_entity: kg:/m/04zh9h
   name:
     first: Dennis
     last: Ross
@@ -26050,6 +26352,7 @@
     washington_post: gIQAozxLAP
     icpsr: 29317
     wikidata: Q469115
+    google_entity: kg:/m/024txf
   name:
     first: Lucille
     last: Roybal-Allard
@@ -26173,6 +26476,7 @@
     washington_post: gIQACovbKP
     icpsr: 29321
     wikidata: Q1282477
+    google_entity: kg:/m/024xcy
   name:
     first: Edward
     middle: R.
@@ -26296,6 +26600,7 @@
     washington_post: gIQA5xxt6O
     icpsr: 41102
     wikidata: Q324546
+    google_entity: kg:/m/0dpr5f
   name:
     first: Marco
     last: Rubio
@@ -26333,6 +26638,7 @@
     washington_post: gIQAUKkDAP
     icpsr: 20329
     wikidata: Q981559
+    google_entity: kg:/m/025k36
   name:
     first: C.
     middle: A. Dutch
@@ -26425,6 +26731,7 @@
     washington_post: gIQAPjFgAP
     icpsr: 29346
     wikidata: Q888599
+    google_entity: kg:/m/0255x3
   name:
     first: Bobby
     middle: L.
@@ -26547,6 +26854,7 @@
     washington_post: gIQAUWiV9O
     icpsr: 29939
     wikidata: Q203966
+    google_entity: kg:/m/024v2j
   name:
     first: Paul
     middle: D.
@@ -26655,6 +26963,7 @@
     washington_post: gIQAQAddKP
     icpsr: 20343
     wikidata: Q513960
+    google_entity: kg:/m/039tr9
   name:
     first: Tim
     middle: J.
@@ -26744,6 +27053,7 @@
     maplight: 794
     house_history: 22610
     wikidata: Q3116336
+    google_entity: kg:/m/04ycmvy
   name:
     first: Gregorio
     last: Sablan
@@ -26821,6 +27131,7 @@
     icpsr: 29709
     house_history: 21168
     wikidata: Q469094
+    google_entity: kg:/m/0jbty
   name:
     first: Loretta
     middle: B.
@@ -26933,6 +27244,7 @@
     icpsr: 20724
     house_history: 22592
     wikidata: Q984509
+    google_entity: kg:/m/08_r8n
   name:
     first: John
     middle: P.
@@ -27013,6 +27325,7 @@
     icpsr: 20759
     house_history: 22608
     wikidata: Q1857141
+    google_entity: kg:/m/0br34c
   name:
     first: Steve
     middle: Joseph
@@ -27098,6 +27411,7 @@
     icpsr: 29911
     house_history: 22550
     wikidata: Q440885
+    google_entity: kg:/m/0256nw
   name:
     first: Janice
     middle: D.
@@ -27203,6 +27517,7 @@
     icpsr: 20104
     house_history: 22560
     wikidata: Q350843
+    google_entity: kg:/m/024tls
   name:
     first: Adam
     middle: B.
@@ -27300,6 +27615,7 @@
     icpsr: 20944
     house_history: 22616
     wikidata: Q1387868
+    google_entity: kg:/m/0412ntl
   name:
     first: Kurt
     last: Schrader
@@ -27371,6 +27687,7 @@
     washington_post: gIQAOSQN9O
     house_history: 21322
     wikidata: Q380900
+    google_entity: kg:/m/01w74d
   name:
     first: Charles
     middle: E.
@@ -27480,6 +27797,7 @@
     icpsr: 21105
     house_history: 22621
     wikidata: Q1176561
+    google_entity: kg:/m/03wbpxj
   name:
     first: David
     last: Schweikert
@@ -27540,6 +27858,7 @@
     icpsr: 21123
     house_history: 22631
     wikidata: Q781167
+    google_entity: kg:/m/076zn3y
   name:
     first: Austin
     last: Scott
@@ -27601,6 +27920,7 @@
     icpsr: 20321
     house_history: 22574
     wikidata: Q132071
+    google_entity: kg:/m/01wbw5
   name:
     first: David
     last: Scott
@@ -27692,6 +28012,7 @@
     icpsr: 39307
     house_history: 21368
     wikidata: Q888668
+    google_entity: kg:/m/03twgl
   name:
     first: Robert
     middle: C.
@@ -27817,6 +28138,7 @@
     icpsr: 21173
     house_history: 22623
     wikidata: Q561315
+    google_entity: kg:/m/0c407g6
   name:
     first: Tim
     last: Scott
@@ -27880,6 +28202,7 @@
     washington_post: gIQAk3QFAP
     house_history: 21438
     wikidata: Q952268
+    google_entity: kg:/m/024tp2
   name:
     first: F.
     middle: James
@@ -28044,6 +28367,7 @@
     washington_post: gIQAsIfJAP
     house_history: 21443
     wikidata: Q460267
+    google_entity: kg:/m/03s6z9
   name:
     first: José
     middle: E.
@@ -28178,6 +28502,7 @@
     icpsr: 29759
     house_history: 21446
     wikidata: Q437852
+    google_entity: kg:/m/03v39l
   name:
     first: Pete
     middle: A.
@@ -28288,6 +28613,7 @@
     icpsr: 21102
     house_history: 22624
     wikidata: Q461621
+    google_entity: kg:/m/05pbszt
   name:
     first: Terri
     last: Sewell
@@ -28351,6 +28677,7 @@
     washington_post: gIQARAfM9O
     house_history: 21534
     wikidata: Q472254
+    google_entity: kg:/m/020yj1
   name:
     first: Richard
     middle: C.
@@ -28447,6 +28774,7 @@
     icpsr: 29707
     house_history: 21565
     wikidata: Q672919
+    google_entity: kg:/m/024tkr
   name:
     first: Brad
     middle: J.
@@ -28557,6 +28885,7 @@
     icpsr: 29718
     house_history: 21589
     wikidata: Q1701747
+    google_entity: kg:/m/02573y
   name:
     first: John
     middle: M.
@@ -28666,6 +28995,7 @@
     icpsr: 20134
     house_history: 22568
     wikidata: Q862455
+    google_entity: kg:/m/03tm89
   name:
     first: Bill
     last: Shuster
@@ -28765,6 +29095,7 @@
     icpsr: 29910
     house_history: 22556
     wikidata: Q549521
+    google_entity: kg:/m/0255tn
   name:
     first: Michael
     middle: K.
@@ -28870,6 +29201,7 @@
     icpsr: 20542
     house_history: 22587
     wikidata: Q527509
+    google_entity: kg:/m/08bt8r
   name:
     first: Albio
     last: Sires
@@ -28951,6 +29283,7 @@
     washington_post: gIQA2WJY9O
     house_history: 21738
     wikidata: Q299833
+    google_entity: kg:/m/03tvt9
   name:
     first: Louise
     middle: McIntosh
@@ -29091,6 +29424,7 @@
     icpsr: 29768
     house_history: 21774
     wikidata: Q350916
+    google_entity: kg:/m/0tfc
   name:
     first: Adam
     last: Smith
@@ -29200,6 +29534,7 @@
     icpsr: 20729
     house_history: 22600
     wikidata: Q373443
+    google_entity: kg:/m/03f4vb
   name:
     first: Adrian
     last: Smith
@@ -29275,6 +29610,7 @@
     washington_post: gIQA3TasAP
     house_history: 21787
     wikidata: Q981167
+    google_entity: kg:/m/033f4d
   name:
     first: Christopher
     middle: H.
@@ -29434,6 +29770,7 @@
     washington_post: gIQA2CjGAP
     house_history: 21856
     wikidata: Q685149
+    google_entity: kg:/m/03twnt
   name:
     first: Lamar
     middle: S.
@@ -29573,6 +29910,7 @@
     icpsr: 20762
     house_history: 22606
     wikidata: Q218544
+    google_entity: kg:/m/06k27l
   name:
     first: Jackie
     last: Speier
@@ -29649,6 +29987,7 @@
     icpsr: 21163
     house_history: 22627
     wikidata: Q324099
+    google_entity: kg:/m/08xnqw
   name:
     first: Steve
     last: Stivers
@@ -29711,6 +30050,7 @@
     icpsr: 21100
     house_history: 22629
     wikidata: Q1902106
+    google_entity: kg:/m/06zk1_1
   name:
     first: Marlin
     middle: A.
@@ -29779,6 +30119,7 @@
     icpsr: 20310
     house_history: 22572
     wikidata: Q291143
+    google_entity: kg:/m/024xc7
   name:
     first: Linda
     middle: T.
@@ -29873,6 +30214,7 @@
     icpsr: 29368
     house_history: 22870
     wikidata: Q817877
+    google_entity: kg:/m/033tc5
   name:
     first: Bennie
     middle: G.
@@ -29994,6 +30336,7 @@
     icpsr: 29901
     house_history: 23200
     wikidata: Q1323196
+    google_entity: kg:/m/024sdl
   name:
     first: Mike
     middle: Michael
@@ -30097,6 +30440,7 @@
     icpsr: 20946
     house_history: 23213
     wikidata: Q1531120
+    google_entity: kg:/m/0409b0_
   name:
     first: Glenn
     last: Thompson
@@ -30166,6 +30510,7 @@
     icpsr: 29572
     house_history: 22922
     wikidata: Q539444
+    google_entity: kg:/m/03dnvd
   name:
     first: Mac
     middle: M.
@@ -30282,6 +30627,7 @@
     icpsr: 29754
     house_history: 22937
     wikidata: Q462981
+    google_entity: kg:/m/03ybyn
   name:
     first: John
     last: Thune
@@ -30345,6 +30691,7 @@
     icpsr: 20130
     house_history: 23204
     wikidata: Q603467
+    google_entity: kg:/m/02zfh_
   name:
     first: Patrick
     middle: J.
@@ -30444,6 +30791,7 @@
     icpsr: 21111
     house_history: 23219
     wikidata: Q782994
+    google_entity: kg:/m/0bn82p
   name:
     first: Scott
     last: Tipton
@@ -30505,6 +30853,7 @@
     icpsr: 20934
     house_history: 23217
     wikidata: Q1373548
+    google_entity: kg:/m/0gzy4c
   name:
     first: Paul
     last: Tonko
@@ -30576,6 +30925,7 @@
     icpsr: 29935
     house_history: 23202
     wikidata: Q971308
+    google_entity: kg:/m/02_kk7
   name:
     first: Patrick
     middle: J.
@@ -30635,6 +30985,7 @@
     icpsr: 20754
     house_history: 23209
     wikidata: Q440246
+    google_entity: kg:/m/02qn5w8
   name:
     first: Niki
     middle: S.
@@ -30716,6 +31067,7 @@
     icpsr: 20342
     house_history: 23206
     wikidata: Q505722
+    google_entity: kg:/m/03440l
   name:
     first: Michael
     middle: R.
@@ -30807,6 +31159,7 @@
     maplight: 499
     washington_post: gIQATEgtAP
     wikidata: Q505236
+    google_entity: kg:/m/02d4c3
   name:
     first: Fred
     middle: Stephen
@@ -30946,6 +31299,7 @@
     washington_post: gIQAPhsc9O
     icpsr: 20330
     wikidata: Q1077819
+    google_entity: kg:/m/025kb5
   name:
     first: Chris
     last: Van Hollen
@@ -31037,6 +31391,7 @@
     washington_post: gIQAHvY09O
     icpsr: 29378
     wikidata: Q434890
+    google_entity: kg:/m/03sjbt
   name:
     first: Nydia
     middle: M.
@@ -31157,6 +31512,7 @@
     maplight: 502
     washington_post: gIQA8WtdKP
     wikidata: Q514660
+    google_entity: kg:/m/022r85
   name:
     first: Peter
     middle: J.
@@ -31305,6 +31661,7 @@
     washington_post: gIQAHam69O
     icpsr: 29918
     wikidata: Q519780
+    google_entity: kg:/m/025jr2
   name:
     first: David
     last: Vitter
@@ -31370,6 +31727,7 @@
     icpsr: 20725
     house_history: 24179
     wikidata: Q978618
+    google_entity: kg:/m/0d7n3m
   name:
     first: Tim
     last: Walberg
@@ -31438,6 +31796,7 @@
     icpsr: 29932
     house_history: 24165
     wikidata: Q1397359
+    google_entity: kg:/m/033tx_
   name:
     first: Greg
     middle: P.
@@ -31542,6 +31901,7 @@
     icpsr: 20726
     house_history: 24181
     wikidata: Q2434360
+    google_entity: kg:/m/06wntz
   name:
     first: Timothy
     middle: James
@@ -31619,6 +31979,7 @@
     icpsr: 20504
     house_history: 24177
     wikidata: Q50104
+    google_entity: kg:/m/04cmyw
   name:
     first: Debbie
     last: Wasserman Schultz
@@ -31702,6 +32063,7 @@
     icpsr: 29106
     house_history: 23438
     wikidata: Q461727
+    google_entity: kg:/m/024tyk
   name:
     first: Maxine
     last: Waters
@@ -31830,6 +32192,7 @@
     icpsr: 21116
     house_history: 24192
     wikidata: Q1163099
+    google_entity: kg:/m/0dm0x
   name:
     first: Daniel
     last: Webster
@@ -31892,6 +32255,7 @@
     icpsr: 20750
     house_history: 24183
     wikidata: Q1112656
+    google_entity: kg:/m/0db4gl
   name:
     first: Peter
     last: Welch
@@ -31968,6 +32332,7 @@
     icpsr: 20506
     house_history: 24175
     wikidata: Q505730
+    google_entity: kg:/m/04cmw9
   name:
     first: Lynn
     middle: A.
@@ -32051,6 +32416,7 @@
     icpsr: 29525
     house_history: 23704
     wikidata: Q544795
+    google_entity: kg:/m/025b9d
   name:
     first: Ed
     last: Whitfield
@@ -32166,6 +32532,7 @@
     icpsr: 20138
     house_history: 24173
     wikidata: Q928855
+    google_entity: kg:/m/03tll0
   name:
     first: Joe
     middle: G.
@@ -32264,6 +32631,7 @@
     icpsr: 21118
     house_history: 24196
     wikidata: Q461504
+    google_entity: kg:/m/03cg3tv
   name:
     first: Frederica
     last: Wilson
@@ -32326,6 +32694,7 @@
     icpsr: 20756
     house_history: 24189
     wikidata: Q541251
+    google_entity: kg:/m/03cx7ld
   name:
     first: Robert
     middle: J.
@@ -32404,6 +32773,7 @@
     icpsr: 21108
     house_history: 24197
     wikidata: Q1029527
+    google_entity: kg:/m/0cmcvkz
   name:
     first: Steve
     last: Womack
@@ -32464,6 +32834,7 @@
     icpsr: 21122
     house_history: 24199
     wikidata: Q2156128
+    google_entity: kg:/m/0cz8ryh
   name:
     first: Rob
     last: Woodall
@@ -32527,6 +32898,7 @@
     washington_post: gIQAfn599O
     house_history: 24150
     wikidata: Q529344
+    google_entity: kg:/m/0178p9
   name:
     first: Ron
     last: Wyden
@@ -32634,6 +33006,7 @@
     washington_post: gIQAIuVYBP
     icpsr: 20723
     wikidata: Q699970
+    google_entity: kg:/m/0bb00g
   name:
     first: John
     middle: A.
@@ -32709,6 +33082,7 @@
     washington_post: gIQAJsGVKP
     icpsr: 21135
     wikidata: Q187037
+    google_entity: kg:/m/06w90zv
   name:
     first: Kevin
     last: Yoder
@@ -32770,6 +33144,7 @@
     maplight: 525
     washington_post: gIQAsCfJAP
     wikidata: Q1239590
+    google_entity: kg:/m/024p1k
   name:
     first: Don
     middle: E.
@@ -32952,6 +33327,7 @@
     washington_post: gIQA1LLWKP
     icpsr: 21133
     wikidata: Q25483
+    google_entity: kg:/m/0ds030m
   name:
     first: Todd
     last: Young
@@ -33016,6 +33392,7 @@
     washington_post: gIQAljK0DP
     icpsr: 20730
     wikidata: Q251763
+    google_entity: kg:/m/0g92xz
   name:
     first: Dean
     last: Heller
@@ -33087,6 +33464,7 @@
     washington_post: gIQAVGFB9S
     icpsr: 21195
     wikidata: Q512071
+    google_entity: kg:/m/09g7l4
   name:
     first: Janice
     last: Hahn
@@ -33151,6 +33529,7 @@
     washington_post: gJQAwGAWBW
     icpsr: 21196
     wikidata: Q23944
+    google_entity: kg:/m/03bzdkn
   name:
     first: Mark
     middle: E.
@@ -33214,6 +33593,7 @@
     washington_post: 02f1e8a6-747e-11e2-95e4-6148e45d7adb
     icpsr: 21198
     wikidata: Q45946
+    google_entity: kg:/m/02q453x
   name:
     first: Suzanne
     last: Bonamici
@@ -33275,6 +33655,7 @@
     icpsr: 31101
     house_history: 15032387032
     wikidata: Q2091892
+    google_entity: kg:/m/05p0dnk
   name:
     first: Suzan
     middle: K.
@@ -33335,6 +33716,7 @@
     washington_post: 841a4814-4bbc-11e2-8758-b64a2997a921
     icpsr: 31102
     wikidata: Q2426031
+    google_entity: kg:/m/0h_cb6v
   name:
     first: Thomas
     last: Massie
@@ -33393,6 +33775,7 @@
     washington_post: gIQA5yLeKP
     icpsr: 31103
     wikidata: Q1240224
+    google_entity: kg:/m/0jwr2v8
   name:
     first: Donald
     middle: M.
@@ -33457,6 +33840,7 @@
     washington_post: a91363f0-5047-11e2-950a-7863a013264b
     icpsr: 41112
     wikidata: Q1827902
+    google_entity: kg:/m/0dd109
   name:
     first: Brian
     middle: Emanuel
@@ -33509,6 +33893,7 @@
     icpsr: 29500
     house_history: 21154
     wikidata: Q1909268
+    google_entity: kg:/m/03_8gd
   name:
     first: Matt
     last: Salmon
@@ -33578,6 +33963,7 @@
     washington_post: gIQAnjxyDP
     icpsr: 20749
     wikidata: Q2903389
+    google_entity: kg:/m/0dtn2x
   name:
     first: Bill
     last: Foster
@@ -33642,6 +34028,7 @@
     washington_post: gIQAp6qMAP
     icpsr: 20908
     wikidata: Q1281084
+    google_entity: kg:/m/04gtp5n
   name:
     first: Alan
     last: Grayson
@@ -33699,6 +34086,7 @@
     washington_post: gIQAeTvs6O
     icpsr: 20902
     wikidata: Q558460
+    google_entity: kg:/m/02qtczp
   name:
     first: Ann
     last: Kirkpatrick
@@ -33756,6 +34144,7 @@
     icpsr: 20927
     house_history: 23215
     wikidata: Q524440
+    google_entity: kg:/m/07hwl2
   name:
     first: Dina
     last: Titus
@@ -33812,6 +34201,7 @@
     icpsr: 21301
     lis: S374
     wikidata: Q3090307
+    google_entity: kg:/m/02g3ds
   name:
     first: Tom
     last: Cotton
@@ -33859,6 +34249,7 @@
     icpsr: 21300
     house_history: 15032387755
     wikidata: Q1556541
+    google_entity: kg:/m/03qnndb
   name:
     first: Kyrsten
     last: Sinema
@@ -33909,6 +34300,7 @@
     washington_post: 3ca0c2b0-4bb7-11e2-8758-b64a2997a921
     icpsr: 21302
     wikidata: Q1703840
+    google_entity: kg:/m/0288tnx
   name:
     first: Doug
     last: LaMalfa
@@ -33958,6 +34350,7 @@
     washington_post: 1fca09ea-4bbb-11e2-8758-b64a2997a921
     icpsr: 21303
     wikidata: Q3276717
+    google_entity: kg:/m/0ksfyx
   name:
     first: Jared
     last: Huffman
@@ -34007,6 +34400,7 @@
     washington_post: gIQAaC5TKP
     icpsr: 21304
     wikidata: Q3389105
+    google_entity: kg:/m/0dgqnts
   name:
     first: Ami
     last: Bera
@@ -34056,6 +34450,7 @@
     washington_post: 7b7f60a0-4bbb-11e2-8758-b64a2997a921
     icpsr: 21305
     wikidata: Q3408766
+    google_entity: kg:/m/0djsxj
   name:
     first: Paul
     last: Cook
@@ -34103,6 +34498,7 @@
     washington_post: df3311a4-4bbc-11e2-8758-b64a2997a921
     icpsr: 21306
     wikidata: Q3466996
+    google_entity: kg:/m/0ncq55g
   name:
     first: Eric
     last: Swalwell
@@ -34148,6 +34544,7 @@
     washington_post: 648810a8-4bb7-11e2-8758-b64a2997a921
     icpsr: 21307
     wikidata: Q3528567
+    google_entity: kg:/m/0g55rlx
   name:
     first: David
     last: Valadao
@@ -34199,6 +34596,7 @@
     icpsr: 21308
     house_history: 15032386871
     wikidata: Q3577073
+    google_entity: kg:/m/027z42z
   name:
     first: Julia
     last: Brownley
@@ -34248,6 +34646,7 @@
     washington_post: 56b232a2-4bbb-11e2-8758-b64a2997a921
     icpsr: 21309
     wikidata: Q3620422
+    google_entity: kg:/m/0cgzsw
   name:
     first: Tony
     last: Cárdenas
@@ -34297,6 +34696,7 @@
     washington_post: e540f502-4bbc-11e2-8758-b64a2997a921
     icpsr: 21311
     wikidata: Q3701994
+    google_entity: kg:/m/0ctnsv
   name:
     first: Raul
     last: Ruiz
@@ -34345,6 +34745,7 @@
     washington_post: 1234320e-4bbd-11e2-8758-b64a2997a921
     icpsr: 21312
     wikidata: Q399593
+    google_entity: kg:/m/0k3lj_y
   name:
     first: Mark
     last: Takano
@@ -34393,6 +34794,7 @@
     washington_post: e40cda5c-4bb2-11e2-8758-b64a2997a921
     icpsr: 21313
     wikidata: Q3740782
+    google_entity: kg:/m/027jz0m
   name:
     first: Alan
     last: Lowenthal
@@ -34443,6 +34845,7 @@
     washington_post: ec1c449e-4bbc-11e2-8758-b64a2997a921
     icpsr: 21314
     wikidata: Q3791701
+    google_entity: kg:/m/076bp4
   name:
     first: Juan
     last: Vargas
@@ -34492,6 +34895,7 @@
     washington_post: a73993a4-4bbc-11e2-8758-b64a2997a921
     icpsr: 21315
     wikidata: Q3791514
+    google_entity: kg:/m/02rymxd
   name:
     first: Scott
     last: Peters
@@ -34543,6 +34947,7 @@
     icpsr: 21316
     house_history: 15032387067
     wikidata: Q3090454
+    google_entity: kg:/m/0l8ll7_
   name:
     first: Elizabeth
     last: Esty
@@ -34593,6 +34998,7 @@
     washington_post: 5b1d8114-4bbd-11e2-8758-b64a2997a921
     icpsr: 21317
     wikidata: Q3090476
+    google_entity: kg:/m/0l8lwvh
   name:
     first: Ted
     last: Yoho
@@ -34641,6 +35047,7 @@
     washington_post: 9f576f4a-4bbb-11e2-8758-b64a2997a921
     icpsr: 21318
     wikidata: Q3105215
+    google_entity: kg:/m/0l8mn35
   name:
     first: Ron
     last: DeSantis
@@ -34690,6 +35097,7 @@
     washington_post: 6b2c5c48-4bbc-11e2-8758-b64a2997a921
     icpsr: 21319
     wikidata: Q3182011
+    google_entity: kg:/m/0n47ttk
   name:
     first: Patrick
     last: Murphy
@@ -34741,6 +35149,7 @@
     icpsr: 21321
     house_history: 15032387115
     wikidata: Q3182451
+    google_entity: kg:/m/0gjdw8_
   name:
     first: Lois
     last: Frankel
@@ -34790,6 +35199,7 @@
     washington_post: 1d0e1ae2-4bb7-11e2-8758-b64a2997a921
     icpsr: 21323
     wikidata: Q3162841
+    google_entity: kg:/m/04qywk
   name:
     first: Doug
     last: Collins
@@ -34840,6 +35250,7 @@
     icpsr: 21324
     house_history: 15032387167
     wikidata: Q32620
+    google_entity: kg:/m/0cnyrfq
   name:
     first: Tulsi
     last: Gabbard
@@ -34890,6 +35301,7 @@
     icpsr: 21325
     house_history: 15032387037
     wikidata: Q3036410
+    google_entity: kg:/m/09vqjr
   name:
     first: Tammy
     last: Duckworth
@@ -34937,6 +35349,7 @@
     washington_post: 96fa7cca-4bbb-11e2-8758-b64a2997a921
     icpsr: 21328
     wikidata: Q134035
+    google_entity: kg:/m/0jwttjt
   name:
     first: Rodney
     last: Davis
@@ -34986,6 +35399,7 @@
     icpsr: 21329
     house_history: 15032386872
     wikidata: Q723148
+    google_entity: kg:/m/0jwwtrm
   name:
     first: Cheri
     last: Bustos
@@ -35036,6 +35450,7 @@
     icpsr: 21330
     house_history: 15032387909
     wikidata: Q3157413
+    google_entity: kg:/m/0ksf92
   name:
     first: Jackie
     last: Walorski
@@ -35086,6 +35501,7 @@
     icpsr: 21331
     house_history: 15032386870
     wikidata: Q3225324
+    google_entity: kg:/m/0jt8ng2
   name:
     first: Susan
     last: Brooks
@@ -35136,6 +35552,7 @@
     washington_post: 458bd608-4bbc-11e2-8758-b64a2997a921
     icpsr: 21332
     wikidata: Q3225316
+    google_entity: kg:/m/0n48dw8
   name:
     first: Luke
     last: Messer
@@ -35185,6 +35602,7 @@
     washington_post: gIQAwh5WKP
     icpsr: 21333
     wikidata: Q3828645
+    google_entity: kg:/m/03wcvjl
   name:
     first: Garland
     last: Barr
@@ -35235,6 +35653,7 @@
     icpsr: 41301
     house_history: 15032390639
     wikidata: Q434706
+    google_entity: kg:/m/01qh39
   name:
     first: Elizabeth
     last: Warren
@@ -35271,6 +35690,7 @@
     washington_post: e7a2a990-4bbb-11e2-8758-b64a2997a921
     icpsr: 21335
     wikidata: Q1707784
+    google_entity: kg:/m/0j28kl9
   name:
     first: Joseph
     last: Kennedy
@@ -35333,6 +35753,7 @@
     washington_post: 8e7e3d34-4bbb-11e2-8758-b64a2997a921
     icpsr: 21334
     wikidata: Q2688821
+    google_entity: kg:/m/09g8h5d
   name:
     first: John
     last: Delaney
@@ -35383,6 +35804,7 @@
     washington_post: f79ee714-4bb6-11e2-8758-b64a2997a921
     icpsr: 41300
     wikidata: Q544464
+    google_entity: kg:/m/02hfx0
   name:
     first: Angus
     last: King
@@ -35421,6 +35843,7 @@
     washington_post: 2ef59d70-4bb7-11e2-8758-b64a2997a921
     icpsr: 21372
     wikidata: Q3880272
+    google_entity: kg:/m/0n4c3yt
   name:
     first: Daniel
     last: Kildee
@@ -35473,6 +35896,7 @@
     ballotpedia: Rick Nolan
     maplight: 1730
     wikidata: Q2151594
+    google_entity: kg:/m/0dgfyp
   name:
     first: Richard
     middle: M.
@@ -35541,6 +35965,7 @@
     icpsr: 21337
     house_history: 15032387908
     wikidata: Q3917251
+    google_entity: kg:/m/07q9w8
   name:
     first: Ann
     last: Wagner
@@ -35590,6 +36015,7 @@
     icpsr: 21338
     lis: S375
     wikidata: Q3200900
+    google_entity: kg:/m/03qlc5t
   name:
     first: Steve
     last: Daines
@@ -35637,6 +36063,7 @@
     washington_post: 22ad1ec6-4bbc-11e2-8758-b64a2997a921
     icpsr: 21346
     wikidata: Q3956999
+    google_entity: kg:/m/0nbwfxs
   name:
     first: Richard
     last: Hudson
@@ -35686,6 +36113,7 @@
     washington_post: 99d73b26-4bbc-11e2-8758-b64a2997a921
     icpsr: 21347
     wikidata: Q3956848
+    google_entity: kg:/m/02b5bx
   name:
     first: Robert
     last: Pittenger
@@ -35735,6 +36163,7 @@
     washington_post: 4e4cac9a-4bbc-11e2-8758-b64a2997a921
     icpsr: 21348
     wikidata: Q3956796
+    google_entity: kg:/m/0lqdy32
   name:
     first: Mark
     last: Meadows
@@ -35783,6 +36212,7 @@
     washington_post: f31bb79e-4bbb-11e2-8758-b64a2997a921
     icpsr: 21349
     wikidata: Q3956828
+    google_entity: kg:/m/0hgp6py
   name:
     first: George
     last: Holding
@@ -35834,6 +36264,7 @@
     icpsr: 41303
     house_history: 15032390641
     wikidata: Q50597
+    google_entity: kg:/m/02f501
   name:
     first: Heidi
     last: Heitkamp
@@ -35872,6 +36303,7 @@
     washington_post: 6a855e58-4bbb-11e2-8758-b64a2997a921
     icpsr: 21350
     wikidata: Q3957020
+    google_entity: kg:/m/02rhrnw
   name:
     first: Kevin
     last: Cramer
@@ -35923,6 +36355,7 @@
     icpsr: 41302
     house_history: 15032390640
     wikidata: Q2580649
+    google_entity: kg:/m/0c4cp0
   name:
     first: Deb
     last: Fischer
@@ -35961,6 +36394,7 @@
     icpsr: 21340
     house_history: 15032387341
     wikidata: Q3917208
+    google_entity: kg:/m/064p47_
   name:
     first: Ann
     last: Kuster
@@ -36012,6 +36446,7 @@
     icpsr: 21341
     house_history: 15032387385
     wikidata: Q3917203
+    google_entity: kg:/m/0n3vkrv
   name:
     first: Michelle
     last: Lujan Grisham
@@ -36062,6 +36497,7 @@
     icpsr: 21342
     house_history: 15032387500
     wikidata: Q5591303
+    google_entity: kg:/m/04ld76x
   name:
     first: Grace
     last: Meng
@@ -36110,6 +36546,7 @@
     washington_post: 08cb2674-4bbc-11e2-8758-b64a2997a921
     icpsr: 21343
     wikidata: Q5640425
+    google_entity: kg:/m/025_74m
   name:
     first: Hakeem
     last: Jeffries
@@ -36158,6 +36595,7 @@
     washington_post: 7935c716-4bbc-11e2-8758-b64a2997a921
     icpsr: 21344
     wikidata: Q2262244
+    google_entity: kg:/m/0b697g
   name:
     first: Sean
     last: Maloney
@@ -36207,6 +36645,7 @@
     washington_post: f06054ec-4bb6-11e2-8758-b64a2997a921
     icpsr: 21345
     wikidata: Q5106218
+    google_entity: kg:/m/03cv81x
   name:
     first: Chris
     last: Collins
@@ -36255,6 +36694,7 @@
     washington_post: 738c1fea-4bb7-11e2-8758-b64a2997a921
     icpsr: 21351
     wikidata: Q892413
+    google_entity: kg:/m/0j63b7n
   name:
     first: Brad
     last: Wenstrup
@@ -36303,6 +36743,7 @@
     icpsr: 21352
     house_history: 15032386867
     wikidata: Q976417
+    google_entity: kg:/m/03lcwb
   name:
     first: Joyce
     last: Beatty
@@ -36351,6 +36792,7 @@
     washington_post: 6d3ab89a-4bb7-11e2-8758-b64a2997a921
     icpsr: 21353
     wikidata: Q976778
+    google_entity: kg:/m/0ktwnp_
   name:
     first: David
     last: Joyce
@@ -36401,6 +36843,7 @@
     washington_post: 1ba9a374-4bbc-11e2-8758-b64a2997a921
     icpsr: 21354
     wikidata: Q3601035
+    google_entity: kg:/m/0jwyd6r
   name:
     first: Jim
     last: Bridenstine
@@ -36450,6 +36893,7 @@
     washington_post: 55872562-4bbc-11e2-8758-b64a2997a921
     icpsr: 21355
     wikidata: Q3448772
+    google_entity: kg:/m/0lq78pn
   name:
     first: Markwayne
     last: Mullin
@@ -36499,6 +36943,7 @@
     washington_post: a05aac8a-4bbc-11e2-8758-b64a2997a921
     icpsr: 21356
     wikidata: Q7437040
+    google_entity: kg:/m/04mwt6y
   name:
     first: Scott
     last: Perry
@@ -36548,6 +36993,7 @@
     washington_post: f31f081c-4bbc-11e2-8758-b64a2997a921
     icpsr: 21357
     wikidata: Q5978897
+    google_entity: kg:/m/0ds0r5g
   name:
     first: Keith
     last: Rothfus
@@ -36597,6 +37043,7 @@
     washington_post: 3a43408e-4bbb-11e2-8758-b64a2997a921
     icpsr: 21358
     wikidata: Q4111531
+    google_entity: kg:/m/0j_6b9d
   name:
     first: Matthew
     last: Cartwright
@@ -36647,6 +37094,7 @@
     washington_post: 33a9ef8c-4bbd-11e2-8758-b64a2997a921
     icpsr: 21359
     wikidata: Q3956858
+    google_entity: kg:/m/03wg1mb
   name:
     first: Tom
     last: Rice
@@ -36696,6 +37144,7 @@
     washington_post: b8d4a00a-4bbb-11e2-8758-b64a2997a921
     icpsr: 41304
     wikidata: Q2036942
+    google_entity: kg:/m/07j6ty
   name:
     first: Ted
     last: Cruz
@@ -36732,6 +37181,7 @@
     washington_post: 407de97a-4bbd-11e2-8758-b64a2997a921
     icpsr: 21360
     wikidata: Q4014569
+    google_entity: kg:/m/0km63t0
   name:
     first: Randy
     last: Weber
@@ -36782,6 +37232,7 @@
     washington_post: 4308607c-4bb7-11e2-8758-b64a2997a921
     icpsr: 21361
     wikidata: Q4014532
+    google_entity: kg:/m/0dty9d
   name:
     first: Beto
     last: O'Rourke
@@ -36829,6 +37280,7 @@
     washington_post: 625d409c-4bbb-11e2-8758-b64a2997a921
     icpsr: 21362
     wikidata: Q1167934
+    google_entity: kg:/m/0bmclg
   name:
     first: Joaquin
     last: Castro
@@ -36879,6 +37331,7 @@
     washington_post: 46eb6828-4bbd-11e2-8758-b64a2997a921
     icpsr: 21364
     wikidata: Q4014560
+    google_entity: kg:/m/09x4r
   name:
     first: Roger
     last: Williams
@@ -36928,6 +37381,7 @@
     washington_post: 01e1bbba-4bbd-11e2-8758-b64a2997a921
     icpsr: 21365
     wikidata: Q4068811
+    google_entity: kg:/m/0kmnfw5
   name:
     first: Marc
     last: Veasey
@@ -36977,6 +37431,7 @@
     washington_post: 9636abe4-5505-11e2-bf3e-76c0a789346f
     icpsr: 21366
     wikidata: Q4069225
+    google_entity: kg:/m/0ll43fz
   name:
     first: Filemon
     last: Vela
@@ -37026,6 +37481,7 @@
     washington_post: 57b0efa8-4bb7-11e2-8758-b64a2997a921
     icpsr: 21367
     wikidata: Q4068880
+    google_entity: kg:/m/0f114l
   name:
     first: Chris
     last: Stewart
@@ -37076,6 +37532,7 @@
     washington_post: gIQAem3o9O
     icpsr: 41305
     wikidata: Q359888
+    google_entity: kg:/m/053f8h
   name:
     first: Timothy
     last: Kaine
@@ -37113,6 +37570,7 @@
     washington_post: 3518ebbc-4bb7-11e2-8758-b64a2997a921
     icpsr: 21368
     wikidata: Q4068828
+    google_entity: kg:/m/03w9yd6
   name:
     first: Derek
     last: Kilmer
@@ -37160,6 +37618,7 @@
     washington_post: 07bb54a2-4bb7-11e2-8758-b64a2997a921
     icpsr: 21369
     wikidata: Q4068793
+    google_entity: kg:/m/075stz
   name:
     first: Denny
     last: Heck
@@ -37209,6 +37668,7 @@
     washington_post: 933d8a40-4bbc-11e2-8758-b64a2997a921
     icpsr: 21370
     wikidata: Q1900355
+    google_entity: kg:/m/0gyhpz
   name:
     first: Mark
     last: Pocan
@@ -37259,6 +37719,7 @@
     house_history: 15032393262
     maplight: 2045
     wikidata: Q3437091
+    google_entity: kg:/m/036qym
   name:
     first: Robin
     last: Kelly
@@ -37309,6 +37770,7 @@
     icpsr: 29565
     house_history: 21195
     wikidata: Q11669
+    google_entity: kg:/m/02c6ck
   name:
     first: Marshall
     last: Sanford
@@ -37376,6 +37838,7 @@
     cspan: 71083
     icpsr: 21373
     wikidata: Q6163589
+    google_entity: kg:/m/02vlgvd
   name:
     first: Jason
     middle: T.
@@ -37425,6 +37888,7 @@
     cspan: 84679
     maplight: 2051
     wikidata: Q1135767
+    google_entity: kg:/m/06p430
   name:
     first: Cory
     middle: Anthony
@@ -37473,6 +37937,7 @@
     house_history: 15032398493
     maplight: 2053
     wikidata: Q6376330
+    google_entity: kg:/m/0fpjc8b
   name:
     first: Katherine
     middle: M.
@@ -37518,6 +37983,7 @@
     cspan: 73486
     maplight: 2054
     wikidata: Q4954892
+    google_entity: kg:/m/09g6kty
   name:
     first: Bradley
     last: Byrne
@@ -37562,6 +38028,7 @@
     - H4FL13101
     maplight: 2056
     wikidata: Q15963996
+    google_entity: kg:/m/0_8ply4
   name:
     first: David
     middle: W.
@@ -37606,6 +38073,7 @@
     maplight: 2060
     wikidata: Q16728087
     wikipedia: Curt Clawson
+    google_entity: kg:/m/03wphq2
   name:
     first: Curtis
     nickname: Curt
@@ -37647,6 +38115,7 @@
     house_history: 15032409257
     maplight: 2061
     wikidata: Q17160419
+    google_entity: kg:/m/010qykqw
   name:
     first: David
     middle: Alan
@@ -37693,6 +38162,7 @@
     house_history: 15032409258
     maplight: 2062
     wikidata: Q5294942
+    google_entity: kg:/m/09g8b1_
   name:
     first: Donald
     middle: W.
@@ -37738,6 +38208,7 @@
     house_history: 15032409256
     maplight: 2063
     wikidata: Q4733597
+    google_entity: kg:/m/02b45d
   name:
     first: Alma
     last: Adams
@@ -37782,6 +38253,7 @@
     icpsr: 21127
     maplight: 1432
     wikidata: Q2156912
+    google_entity: kg:/m/0b6j_nb
   name:
     first: Bob
     last: Dold
@@ -37824,6 +38296,7 @@
     icpsr: 21152
     maplight: 1457
     wikidata: Q24250
+    google_entity: kg:/m/08s8q3
   name:
     first: Frank
     last: Guinta
@@ -37864,6 +38337,7 @@
     maplight: 2064
     wikidata: Q17386504
     wikipedia: Gary Palmer (politician)
+    google_entity: kg:/m/0115nklq
   name:
     first: Gary
     last: Palmer
@@ -37893,6 +38367,7 @@
     maplight: 2065
     wikidata: Q18631366
     wikipedia: French Hill (politician)
+    google_entity: kg:/m/0127p1zk
   name:
     first: French
     last: Hill
@@ -37922,6 +38397,7 @@
     maplight: 2066
     wikidata: Q16197421
     wikipedia: Bruce Westerman
+    google_entity: kg:/m/0wklff5
   name:
     first: Bruce
     last: Westerman
@@ -37951,6 +38427,7 @@
     maplight: 2067
     wikidata: Q6774492
     wikipedia: Martha McSally
+    google_entity: kg:/m/027fybv
   name:
     first: Martha
     last: McSally
@@ -37980,6 +38457,7 @@
     maplight: 2068
     wikidata: Q16218474
     wikipedia: Ruben Gallego
+    google_entity: kg:/m/0wy0mz5
   name:
     first: Ruben
     last: Gallego
@@ -38008,6 +38486,7 @@
     maplight: 2069
     wikidata: Q6767311
     wikipedia: Mark DeSaulnier
+    google_entity: kg:/m/0289gkw
   name:
     first: Mark
     last: DeSaulnier
@@ -38037,6 +38516,7 @@
     maplight: 2070
     wikidata: Q7613060
     wikipedia: Steve Knight (politician)
+    google_entity: kg:/m/05zjrvq
   name:
     first: Steve
     last: Knight
@@ -38066,6 +38546,7 @@
     maplight: 2071
     wikidata: Q7171821
     wikipedia: Pete Aguilar
+    google_entity: kg:/m/0jwv0xf
   name:
     first: Pete
     last: Aguilar
@@ -38095,6 +38576,7 @@
     maplight: 2072
     wikidata: Q7693450
     wikipedia: Ted Lieu
+    google_entity: kg:/m/0f3y2w
   name:
     first: Ted
     last: Lieu
@@ -38125,6 +38607,7 @@
     maplight: 2073
     wikidata: Q3343727
     wikipedia: Norma Torres
+    google_entity: kg:/m/03wd1hs
   name:
     first: Norma
     last: Torres
@@ -38155,6 +38638,7 @@
     maplight: 2074
     wikidata: Q6862199
     wikipedia: Mimi Walters
+    google_entity: kg:/m/077r0l
   name:
     first: Mimi
     last: Walters
@@ -38185,6 +38669,7 @@
     maplight: 2075
     wikidata: Q1439421
     wikipedia: Ken Buck
+    google_entity: kg:/m/05zzjd2
   name:
     first: Ken
     last: Buck
@@ -38215,6 +38700,7 @@
     maplight: 2076
     wikidata: Q16195097
     wikipedia: Gwen Graham
+    google_entity: kg:/m/0wk57s1
   name:
     first: Gwen
     last: Graham
@@ -38244,6 +38730,7 @@
     maplight: 2077
     wikidata: Q18631533
     wikipedia: Carlos Curbelo (politician)
+    google_entity: kg:/m/0127nzmk
   name:
     first: Carlos
     last: Curbelo
@@ -38272,6 +38759,7 @@
     maplight: 2078
     wikidata: Q16240994
     wikipedia: Buddy Carter
+    google_entity: kg:/m/0w32xj9
   name:
     first: Buddy
     last: Carter
@@ -38301,6 +38789,7 @@
     maplight: 2079
     wikidata: Q6208081
     wikipedia: Jody Hice
+    google_entity: kg:/m/0640dpx
   name:
     first: Jody
     last: Hice
@@ -38330,6 +38819,7 @@
     maplight: 2080
     wikidata: Q16731643
     wikipedia: Barry Loudermilk
+    google_entity: kg:/m/0wqdmcm
   name:
     first: Barry
     last: Loudermilk
@@ -38359,6 +38849,7 @@
     maplight: 2081
     wikidata: Q18683976
     wikipedia: Rick W. Allen
+    google_entity: kg:/m/047bdf
   name:
     first: Rick
     last: Allen
@@ -38388,6 +38879,7 @@
     maplight: 2082
     wikidata: Q16197299
     wikipedia: Mark Takai
+    google_entity: kg:/m/0yp0gs4
   name:
     first: Mark
     last: Takai
@@ -38417,6 +38909,7 @@
     maplight: 2083
     wikidata: Q18684853
     wikipedia: Rod Blum
+    google_entity: kg:/m/0127p02j
   name:
     first: Rod
     last: Blum
@@ -38446,6 +38939,7 @@
     maplight: 2084
     wikidata: Q19321008
     wikipedia: David Young (politician)
+    google_entity: kg:/m/0127pc92
   name:
     first: David
     last: Young
@@ -38474,6 +38968,7 @@
     maplight: 2085
     wikidata: Q6846090
     wikipedia: Mike Bost
+    google_entity: kg:/m/0kry42
   name:
     first: Mike
     last: Bost
@@ -38503,6 +38998,7 @@
     maplight: 2086
     wikidata: Q18683775
     wikipedia: Ralph Abraham (politician)
+    google_entity: kg:/m/012dwd7_
   name:
     first: Ralph
     last: Abraham
@@ -38532,6 +39028,7 @@
     maplight: 2087
     wikidata: Q18686454
     wikipedia: Garret Graves
+    google_entity: kg:/m/012bxlbr
   name:
     first: Garret
     last: Graves
@@ -38561,6 +39058,7 @@
     maplight: 2088
     wikidata: Q18045052
     wikipedia: Seth Moulton
+    google_entity: kg:/m/0sgh587
   name:
     first: Seth
     last: Moulton
@@ -38591,6 +39089,7 @@
     maplight: 2089
     wikidata: Q4978147
     wikipedia: Bruce Poliquin
+    google_entity: kg:/m/0hrbhmw
   name:
     first: Bruce
     last: Poliquin
@@ -38620,6 +39119,7 @@
     maplight: 2090
     wikidata: Q16194212
     wikipedia: John Moolenaar
+    google_entity: kg:/m/0z6rww4
   name:
     first: John
     last: Moolenaar
@@ -38649,6 +39149,7 @@
     maplight: 2091
     wikidata: Q16196834
     wikipedia: Mike Bishop (politician)
+    google_entity: kg:/m/027qc0m
   name:
     first: Mike
     last: Bishop
@@ -38678,6 +39179,7 @@
     maplight: 2092
     wikidata: Q16982345
     wikipedia: Dave Trott (politician)
+    google_entity: kg:/m/0x0fzkk
   name:
     first: Dave
     last: Trott
@@ -38707,6 +39209,7 @@
     maplight: 2093
     wikidata: Q5248232
     wikipedia: Debbie Dingell
+    google_entity: kg:/m/03m4188
   name:
     first: Debbie
     last: Dingell
@@ -38737,6 +39240,7 @@
     maplight: 2094
     wikidata: Q4960712
     wikipedia: Brenda Lawrence
+    google_entity: kg:/m/02w_vhg
   name:
     first: Brenda
     last: Lawrence
@@ -38766,6 +39270,7 @@
     maplight: 2095
     wikidata: Q7815723
     wikipedia: Tom Emmer
+    google_entity: kg:/m/06w2w3l
   name:
     first: Tom
     last: Emmer
@@ -38795,6 +39300,7 @@
     maplight: 2096
     wikidata: Q7384672
     wikipedia: Ryan Zinke
+    google_entity: kg:/m/0gkz1jg
   name:
     first: Ryan
     last: Zinke
@@ -38824,6 +39330,7 @@
     maplight: 2097
     wikidata: Q5239255
     wikipedia: David Rouzer
+    google_entity: kg:/m/0jt1s3l
   name:
     first: David
     last: Rouzer
@@ -38853,6 +39360,7 @@
     maplight: 2098
     wikidata: Q4953782
     wikipedia: Brad Ashford
+    google_entity: kg:/m/02pys5v
   name:
     first: Brad
     last: Ashford
@@ -38882,6 +39390,7 @@
     maplight: 2099
     wikidata: Q18631218
     wikipedia: Tom MacArthur
+    google_entity: kg:/m/0127f8tk
   name:
     first: Tom
     last: MacArthur
@@ -38912,6 +39421,7 @@
     maplight: 2100
     wikidata: Q4942457
     wikipedia: Bonnie Watson Coleman
+    google_entity: kg:/m/08kj70
   name:
     first: Bonnie
     last: Watson Coleman
@@ -38941,6 +39451,7 @@
     maplight: 2101
     wikidata: Q16189291
     wikipedia: Cresent Hardy
+    google_entity: kg:/m/0yp3l3w
   name:
     first: Cresent
     last: Hardy
@@ -38970,6 +39481,7 @@
     maplight: 2102
     wikidata: Q16221257
     wikipedia: Lee Zeldin
+    google_entity: kg:/m/03h4jcq
   name:
     first: Lee
     last: Zeldin
@@ -39000,6 +39512,7 @@
     maplight: 2103
     wikidata: Q6376887
     wikipedia: Kathleen Rice
+    google_entity: kg:/m/08z1cf
   name:
     first: Kathleen
     last: Rice
@@ -39030,6 +39543,7 @@
     maplight: 2104
     wikidata: Q18211057
     wikipedia: Elise Stefanik
+    google_entity: kg:/m/0110fjsf
   name:
     first: Elise
     last: Stefanik
@@ -39059,6 +39573,7 @@
     maplight: 2105
     wikidata: Q18619043
     wikipedia: John Katko
+    google_entity: kg:/m/0127pf8s
   name:
     first: John
     last: Katko
@@ -39088,6 +39603,7 @@
     maplight: 2106
     wikidata: Q16195304
     wikipedia: Steve Russell (politician)
+    google_entity: kg:/m/0ndnv6f
   name:
     first: Steve
     last: Russell
@@ -39117,6 +39633,7 @@
     maplight: 2107
     wikidata: Q18631846
     wikipedia: Ryan Costello
+    google_entity: kg:/m/0127dxsz
   name:
     first: Ryan
     last: Costello
@@ -39146,6 +39663,7 @@
     maplight: 2108
     wikidata: Q4960876
     wikipedia: Brendan Boyle
+    google_entity: kg:/m/04f4fjk
   name:
     first: Brendan
     last: Boyle
@@ -39175,6 +39693,7 @@
     maplight: 2109
     wikidata: Q16980175
     wikipedia: John Ratcliffe (American politician)
+    google_entity: kg:/m/06kb09
   name:
     first: John
     last: Ratcliffe
@@ -39204,6 +39723,7 @@
     maplight: 2110
     wikidata: Q18639742
     wikipedia: Will Hurd
+    google_entity: kg:/m/0127jwdk
   name:
     first: Will
     last: Hurd
@@ -39232,6 +39752,7 @@
     maplight: 2111
     wikidata: Q16979824
     wikipedia: Brian Babin
+    google_entity: kg:/m/010qgj35
   name:
     first: Brian
     last: Babin
@@ -39262,6 +39783,7 @@
     maplight: 2112
     wikidata: Q11112119
     wikipedia: Mia Love
+    google_entity: kg:/m/09v75sn
   name:
     first: Mia
     last: Love
@@ -39291,6 +39813,7 @@
     maplight: 2113
     wikidata: Q3036086
     wikipedia: Don Beyer
+    google_entity: kg:/m/053g16
   name:
     first: Donald
     last: Beyer
@@ -39321,6 +39844,7 @@
     maplight: 2114
     wikidata: Q4858820
     wikipedia: Barbara Comstock
+    google_entity: kg:/m/02890yr
   name:
     first: Barbara
     last: Comstock
@@ -39351,6 +39875,7 @@
     maplight: 2115
     wikidata: Q18739104
     wikipedia: Stacey Plaskett
+    google_entity: kg:/m/012844_c
   name:
     first: Stacey
     last: Plaskett
@@ -39380,6 +39905,7 @@
     maplight: 2116
     wikidata: Q16733285
     wikipedia: Dan Newhouse
+    google_entity: kg:/m/0_s0bn3
   name:
     first: Dan
     last: Newhouse
@@ -39409,6 +39935,7 @@
     maplight: 2117
     wikidata: Q5568836
     wikipedia: Glenn Grothman
+    google_entity: kg:/m/02pnsk2
   name:
     first: Glenn
     last: Grothman
@@ -39438,6 +39965,7 @@
     maplight: 2118
     wikidata: Q4718026
     wikipedia: Alex Mooney
+    google_entity: kg:/m/02qqy78
   name:
     first: Alex
     last: Mooney
@@ -39467,6 +39995,7 @@
     maplight: 2119
     wikidata: Q5415437
     wikipedia: Evan Jenkins (politician)
+    google_entity: kg:/m/0d4_hq
   name:
     first: Evan
     last: Jenkins
@@ -39497,6 +40026,7 @@
     maplight: 2120
     wikidata: Q18684027
     wikipedia: Amata Coleman Radewagen
+    google_entity: kg:/m/012964p3
   name:
     first: Aumua
     last: Amata
@@ -39527,6 +40057,7 @@
     maplight: 2121
     wikidata: Q19996393
     wikipedia: Dan Sullivan (Arkansas politician)
+    google_entity: kg:/m/07s4r4q
   name:
     first: Dan
     last: Sullivan
@@ -39557,6 +40088,7 @@
     maplight: 2122
     wikidata: Q17402717
     wikipedia: David Perdue
+    google_entity: kg:/m/03wp8v4
   name:
     first: David
     last: Perdue
@@ -39588,6 +40120,7 @@
     maplight: 2123
     wikidata: Q13475242
     wikipedia: Joni Ernst
+    google_entity: kg:/m/0gg4wkg
   name:
     first: Joni
     last: Ernst
@@ -39618,6 +40151,7 @@
     maplight: 2124
     wikidata: Q7786750
     wikipedia: Thom Tillis
+    google_entity: kg:/m/0fq0395
   name:
     first: Thom
     last: Tillis
@@ -39648,6 +40182,7 @@
     maplight: 2125
     wikidata: Q722503
     wikipedia: Mike Rounds
+    google_entity: kg:/m/020z2p
   name:
     first: Mike
     last: Rounds
@@ -39677,6 +40212,7 @@
     maplight: 2126
     wikidata: Q17388892
     wikipedia: Mark Walker (North Carolina politician)
+    google_entity: kg:/m/0115r5gz
   name:
     first: Mark
     last: Walker
@@ -39707,6 +40243,7 @@
     maplight: 2127
     wikidata: Q16192221
     wikipedia: Ben Sasse
+    google_entity: kg:/m/0j5wk_6
   name:
     first: Benjamin
     middle: Eric
@@ -39739,6 +40276,7 @@
     maplight: 2161
     opensecrets: N00036928
     wikidata: Q5217998
+    google_entity: kg:/m/0c036qd
   name:
     first: Daniel
     middle: M.
@@ -39771,6 +40309,7 @@
     maplight: 2163
     opensecrets: N00037003
     wikidata: Q20204915
+    google_entity: kg:/m/013b9qgh
   name:
     first: Trent
     last: Kelly
@@ -39803,6 +40342,7 @@
     maplight: 2164
     opensecrets: N00037031
     wikidata: Q5222780
+    google_entity: kg:/m/0gg7rcy
   name:
     first: Darin
     last: LaHood
@@ -39832,6 +40372,7 @@
     ballotpedia: Warren Davidson
     wikidata: Q24458117
     maplight: 2165
+    google_entity: warren+davidson
   name:
     first: Warren
     last: Davidson

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40372,7 +40372,7 @@
     ballotpedia: Warren Davidson
     wikidata: Q24458117
     maplight: 2165
-    google_entity: warren+davidson
+    google_entity: 
   name:
     first: Warren
     last: Davidson

--- a/scripts/google_entities.py
+++ b/scripts/google_entities.py
@@ -3,7 +3,6 @@
 # Update current Google entity IDs using ProPublica Congress API.
 
 import json, urllib.request, urllib.parse, urllib.error
-import rtyaml
 from utils import load_data, save_data
 
 def run():

--- a/scripts/google_entities.py
+++ b/scripts/google_entities.py
@@ -8,7 +8,7 @@ from utils import load_data, save_data
 
 def run():
     # load in current members
-    y = load_data("/Users/DW-Admin/code/congress-legislators/legislators-current.yaml")
+    y = load_data("legislators-current.yaml")
     for m in y:
         response = urllib.request.urlopen("http://propublica-congress.elasticbeanstalk.com/represent/api/v1/members/%s.json" % m['id']['bioguide']).read()
         j = json.loads(response.decode("utf8"))

--- a/scripts/google_entities.py
+++ b/scripts/google_entities.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# Update current Google entity IDs using ProPublica Congress API.
+
+import json, urllib.request, urllib.parse, urllib.error
+import rtyaml
+from utils import load_data, save_data
+
+def run():
+    # load in current members
+    y = load_data("/Users/DW-Admin/code/congress-legislators/legislators-current.yaml")
+    for m in y:
+        response = urllib.request.urlopen("http://propublica-congress.elasticbeanstalk.com/represent/api/v1/members/%s.json" % m['id']['bioguide']).read()
+        j = json.loads(response.decode("utf8"))
+        google = j['results'][0]['google_entity_id']
+        if not google == '':
+            m['id']['google_entity'] = google
+    save_data(y, "legislators-current.yaml")
+
+if __name__ == '__main__':
+  run()


### PR DESCRIPTION
Google has a Knowledge Graph for its search data that, among other things, has unique entity ids for people, organizations and "things," members of congress among them. I've matched current members to their entity ids (Warren Davidson, the newest member, doesn't have a unique one yet) and added `google_entity_id` to legislators-current.yaml, as well as a script to generate them using the ProPublica API.

These IDs could be used in combination with the Google Trends API to gauge search interest in members, for example. If this seems valuable, many former members also have these and I could work on adding those, too.
