### PR TITLE
add official full name for Warren Davidson to legislators-current

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -39721,6 +39721,7 @@
   name:
     first: Warren
     last: Davidson
+    official_full: Warren Davidson
   bio:
     gender: M
     birthday: '1970-03-01'


### PR DESCRIPTION
Warren Davidson seems to be the only current legislator missing an official full name in the YAML file