### PR TITLE
Fix birthdate for Jason Lewis from MN district 2

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40873,7 +40873,7 @@
     official_full: Jason Lewis
   bio:
     gender: M
-    birthday: '1995-09-23'
+    birthday: '1955-09-23'
   terms:
   - type: rep
     start: '2017-01-03'


### PR DESCRIPTION
Birthdate for Jason Lewis was incorrect, correct birthdate can be seen here: http://bioguide.congress.gov/scripts/biodisplay.pl?index=L000587