### PR TITLE
Lookup legislator properties by name and committee membership, update fax numbers

### DIFF
--- a/congress_lookup.py
+++ b/congress_lookup.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#coding: utf-8
+__author__ = 'stsmith'
+
+# congress_lookup: Look up information about congress from the congress-legislators database
+# See: https://github.com/unitedstates/congress-legislators and https://github.com/TheWalkers/congress-legislators
+
+# The project is in the public domain within the United States, and
+# copyright and related rights in the work worldwide are waived
+# through the CC0 1.0 Universal public domain dedication.
+
+# Author 2017 Steven T. Smith <steve dot t dot smith at gmail dot com>
+
+import argparse as ap, contextlib, errno, fnmatch, os, urllib2, urlparse, yaml
+
+class CongressLookup:
+    '''A class used to lookup legislator properties from the github congress-legislators YAML database.'''
+
+    def __init__(self):
+        self.args = self.parseArgs()
+        self.data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),self.args.data_dir)
+        self.properties = dict()
+        self.database_load()
+        for prop in self.args.properties: self.lookup_property(prop)
+
+    def parseArgs(self):
+        parser = ap.ArgumentParser()
+        parser.add_argument('properties', metavar='PROPS', type=str, nargs='+',
+                            help='Properties to look up')
+        parser.add_argument('-c', '--committee', help="Committee name (wildcard)", type=str, default=None)
+        parser.add_argument('-n', '--last-name', help="Last name of legislator (wildcard)", type=str, default=None)
+        parser.add_argument('-d', '--data-dir', help="Database directory", type=str, default='.')
+        parser.add_argument('-r', '--repo', help="GitHub repo URL", type=str, default='https://github.com/essandess/congress-legislators/')
+        parser.add_argument('-D', '--download', help="Download data", action='store_true', default=True)
+        parser.add_argument('-g', '--debug', help="Debug flag", action='store_true')
+        return parser.parse_args()
+
+    def lookup_property(self,property):
+        if self.args.committee is not None:
+            self.lookup_by_committee(property)
+        if self.args.last_name is not None:
+            self.lookup_by_lastname(property)
+
+    def lookup_by_committee(self,property):
+        for comm in (comm for comm in self.committees if self.inclusive_wildcard_match(comm['name'],self.args.committee)):
+            if self.args.debug: print(comm)
+            print('"{}" member properties:'.format(comm['name'].encode('utf-8')))
+            members = self.membership[comm['thomas_id']] if comm['thomas_id'] in self.membership else []
+            for member in members: self.lookup_by_member(property,member)
+
+    def inclusive_wildcard_match(self,name,pat):
+        if any(c in pat for c in '*?[]'):	# a wildcard pattern
+            # prepend or append a * for inclusiveness if not already there
+            if pat[0] is not '*': pat = '*' + pat
+            if pat[-1] is not '*': pat = pat + '*'
+        else:					# not a wildcard
+            pat = '*' + pat + '*'
+        return fnmatch.fnmatch(name,pat)
+
+    def lookup_by_member(self,property,member):
+        for leg in ( leg for leg in self.legislators if \
+                    (leg['name']['official_full'] == member['name']) \
+                    or ('bioguide' in leg['id'] and leg['id']['bioguide'] == member['bioguide']) \
+                    or ('thomas' in leg['id'] and leg['id']['thomas'] == member['thomas']) ):
+            self.lookup_legislator_properties(property,leg)
+
+    def lookup_by_lastname(self,property):
+        for leg in (leg for leg in self.legislators if fnmatch.fnmatch(leg['name']['last'],self.args.last_name)):
+            if self.args.debug: print(leg)
+            self.lookup_legislator_properties(property,leg)
+
+    def lookup_legislator_properties(self,property,legislator):
+        self.properties[property] = [term[property] for term in legislator['terms'] if property in term and len(term[property]) > 0]
+        for off in self.offices:
+            if self.args.debug: print(off)
+            if any(off['id'][db] == legislator['id'][db] for db in off['id'] if db in off['id'] and db in legislator['id']):
+                self.properties[property] += [ok[property] for ok in off['offices'] if property in ok and len(ok[property]) > 0]
+                break
+        print('Property \'{}\' for {}:'.format(property,legislator['name']['official_full'].encode('utf-8')))
+        print('\n'.join(self.properties[property]))
+
+    def database_load(self):
+        try:
+	    with self.database_access('legislators-current.yaml') as y:
+    	        self.legislators = yaml.load(y, Loader=yaml.CLoader)
+            with self.database_access('legislators-district-offices.yaml') as y:
+                self.offices = yaml.load(y, Loader=yaml.CLoader)
+            if self.args.committee is not None:
+                with self.database_access('committees-current.yaml') as y:
+                    self.committees = yaml.load(y, Loader=yaml.CLoader)
+                with self.database_access('committee-membership-current.yaml') as y:
+                    self.membership = yaml.load(y, Loader=yaml.CLoader)
+            else:
+                self.committees = None
+        except (BaseException,IOError) as e:
+            print(e)
+            raise Exception('Clone data from {} and copy it to {}.'.format(self.args.repo,self.data_path))
+
+    def database_access(self,filename):
+        if self.args.download:
+            if self.args.repo[-1] != '/': self.args.repo += '/'
+            url_base = urlparse.urljoin(urlparse.urlunparse(urlparse.urlparse(self.args.repo)._replace(netloc='raw.githubusercontent.com')),'master/')
+            # contextlib required for urlopen in with ... as for v < 3.3
+            res = contextlib.closing(urllib2.urlopen( urlparse.urljoin(url_base,filename) ))
+        else:
+            res = open(os.path.join(self.data_path,filename),'r')
+        return res        
+
+if __name__ == "__main__":
+    res = CongressLookup()

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -2647,6 +2647,7 @@
     url: http://www.tomudall.senate.gov
     address: 110 Hart Senate Office Building Washington DC 20510
     phone: 202-224-6621
+    fax: 202-228-3261
     contact_form: http://www.tomudall.senate.gov/?p=contact
     office: 110 Hart Senate Office Building
     state_rank: senior
@@ -2776,7 +2777,7 @@
     url: http://gillibrand.senate.gov
     address: 478 RUSSELL SENATE OFFICE BUILDING WASHINGTON DC 20510
     phone: 202-224-4451
-    fax: 202-225-1168
+    fax: 202-228-0282
     contact_form: http://www.gillibrand.senate.gov/contact/
     office: 478 Russell Senate Office Building
   - type: sen
@@ -2880,6 +2881,7 @@
     url: http://www.coons.senate.gov
     address: 127A Russell Senate Office Building Washington DC 20510
     phone: 202-224-5042
+    fax: 202-228-3075
     contact_form: http://www.coons.senate.gov/contact/
     office: 127a Russell Senate Office Building
     state_rank: junior
@@ -3573,7 +3575,7 @@
     url: https://www.bennet.senate.gov
     address: 261 Russell Senate Office Building Washington DC 20510
     phone: 202-224-5852
-    fax: 202-228-5036
+    fax: 202-228-5097
     contact_form: http://www.bennet.senate.gov/contact/email
     office: 261 Russell Senate Office Building
     state_rank: senior
@@ -32427,6 +32429,7 @@
     office: 401 Cannon House Office Building
     address: 401 Cannon HOB; Washington DC 20515-2801
     phone: 202-225-5965
+    fax: 202-225-3119
     rss_url: http://titus.house.gov/rss.xml
     contact_form: https://titus.house.gov/contact/email-me
   - type: rep
@@ -34159,6 +34162,7 @@
     address: 317 Hart Senate Office Building Washington DC 20510
     office: 317 Hart Senate Office Building
     phone: 202-224-4543
+    fax: 202-228-2072
     state_rank: senior
     contact_form: http://www.warren.senate.gov/?p=email_senator#thisForm
     rss_url: http://www.warren.senate.gov/rss/?p=hot_topic
@@ -40023,6 +40027,7 @@
     office: 1530 Longworth House Office Building
     address: 1530 Longworth HOB; Washington DC 20515-2901
     phone: 202-225-5456
+    fax: 202-228-6362
     rss_url: http://shea-porter.house.gov/rss.xml
     contact_form: https://shea-porter.house.gov/contact/email-me
   - type: rep


### PR DESCRIPTION
Add the ability to look up specific fields by committee membership or member last name. Wildcards are used. For example,

```
python congress_lookup.py -c 'Financ*' phone fax
```

prints the phone and fax numbers of all members of the **Senate Committee on Finance** and the **House Committee on Financial Services**.

The command

```
python congress_lookup.py -n Smith fax hours
```

prints all fax numbers and hours listed for any legislator named "Smith".

There are also updates to the current legislator database per #411.

This is a commit-specific resubmission of #405.