### PR TITLE
Updated Twitter and Facebook social media accounts

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -1207,6 +1207,7 @@
     youtube: RepDavidPrice
     youtube_id: UCtX7bSXBLF9ge-Q955n5Vqw
     twitter_id: 155669457
+    facebook: RepDavidEPrice
 - id:
     bioguide: P000449
     thomas: '00924'
@@ -2705,6 +2706,7 @@
     youtube: CongressmanDent
     facebook_id: '69862092533'
     youtube_id: UCoC_r0R2M_74UVrH4A44awQ
+    twitter: RepCharlieDent
 - id:
     bioguide: D000600
     thomas: '01717'
@@ -3193,6 +3195,7 @@
     youtube: SenatorCantwell
     youtube_id: UCN52UDqKgvHRk39ncySrIMw
     twitter_id: 117501995
+    facebook: senatorcantwell
 - id:
     bioguide: C000059
     thomas: '00165'
@@ -5175,3 +5178,297 @@
     facebook: replahood
     facebook_id: '1499570210366431'
     youtube_id: UCVRbtFwaBGcixZIkygtalRw
+- id:
+    bioguide: B001299
+    govtrack: 412702
+  social:
+    facebook: RepJimBanks
+    twitter: RepJimBanks
+- id:
+    bioguide: D000627
+    govtrack: 412696
+  social:
+    facebook: RepresentativeValDemings
+    twitter: RepValDemings
+- id:
+    bioguide: B001303
+    govtrack: 412689
+  social:
+    facebook: Rep.BluntRochester
+    twitter: RepBRochester
+- id:
+    bioguide: R000606
+    govtrack: 412708
+  social:
+    facebook: repraskin
+    twitter: repraskin
+- id:
+    bioguide: P000613
+    govtrack: 412685
+  social:
+    facebook: RepJimmyPanetta
+    twitter: RepJimmyPanetta
+- id:
+    bioguide: C001111
+    govtrack: 412697
+  social:
+    facebook: RepCharlieCrist
+    twitter: repcharliecrist
+- id:
+    bioguide: D000628
+    govtrack: 412691
+  social:
+    facebook: drnealdunnfl2
+    twitter: drnealdunnfl2
+- id:
+    bioguide: B001300
+    govtrack: 412687
+  social:
+    facebook: CongresswomanBarragan
+    twitter: RepBarragan
+- id:
+    bioguide: B001302
+    govtrack: 412683
+  social:
+    facebook: RepAndyBiggs
+    twitter: RepAndyBiggsAZ
+- id:
+    bioguide: M001199
+    govtrack: 412698
+  social:
+    facebook: repbrianmast
+    twitter: repbrianmast
+- id:
+    bioguide: M001200
+    govtrack: 412728
+  social:
+    facebook: RepMcEachin
+    twitter: RepMcEachin
+- id:
+    bioguide: D000626
+    govtrack: 412675
+    thomas: '02296'
+  social:
+    facebook: CongressmanWarrenDavidson
+    twitter: WarrenDavidson
+- id:
+    bioguide: F000465
+    govtrack: 412700
+  social:
+    facebook: RepDrewFerguson
+    twitter: RepDrewFerguson
+- id:
+    bioguide: G000581
+    govtrack: 412725
+  social:
+    facebook: USCongressmanVicenteGonzalez
+    twitter: RepGonzalez
+- id:
+    bioguide: G000583
+    govtrack: 412714
+  social:
+    facebook: RepJoshG
+    twitter: RepJoshG
+- id:
+    bioguide: G000580
+    govtrack: 412729
+  social:
+    facebook: congressman-Tom-Garrett-1835767753333490
+    twitter: Rep_Tom_Garrett
+- id:
+    bioguide: C001113
+    govtrack: 412681
+  social:
+    facebook: SenatorCortezMasto
+    twitter: sencortezmasto
+- id:
+    bioguide: K000389
+    govtrack: 412684
+  social:
+    facebook: RepRoKhanna
+    twitter: RepRoKhanna
+- id:
+    bioguide: S001170
+    govtrack: 412219
+    thomas: '01861'
+  social:
+    facebook: repsheaporter
+    twitter: repsheaporter
+- id:
+    bioguide: G000582
+    govtrack: 412723
+  social:
+    facebook: RepJennifferGonzalezColon
+    twitter: repjenniffer
+- id:
+    bioguide: M001202
+    govtrack: 412694
+  social:
+    facebook: RepStephMurphy
+    twitter: RepStephMurphy
+- id:
+    bioguide: H001074
+    govtrack: 412703
+  social:
+    facebook: reptrey
+    twitter: reptrey
+- id:
+    bioguide: A000375
+    govtrack: 412726
+  social:
+    facebook: JodeyArrington
+    twitter: RepArrington
+- id:
+    bioguide: C001109
+    govtrack: 412732
+  social:
+    facebook: replizcheney
+    twitter: RepLizCheney
+- id:
+    bioguide: C001112
+    govtrack: 412686
+  social:
+    facebook: repsaludcarbajal
+    twitter: RepCarbajal
+- id:
+    bioguide: S001201
+    govtrack: 412717
+  social:
+    facebook: RepTomSuozzi
+    twitter: RepTomSuozzi
+- id:
+    bioguide: S001190
+    govtrack: 412534
+    thomas: '02124'
+  social:
+    facebook: CongressmanBradSchneider
+    twitter: repschneider
+- id:
+    bioguide: F000464
+    govtrack: 412719
+  social:
+    facebook: RepJohnFaso
+    twitter: RepJohnFaso
+- id:
+    bioguide: T000478
+    govtrack: 412720
+  social:
+    facebook: RepClaudiaTenney
+    twitter: RepTenney
+- id:
+    bioguide: B001305
+    govtrack: 412712
+  social:
+    facebook: RepTedBudd
+    twitter: RepTedBudd
+- id:
+    bioguide: J000298
+    govtrack: 412730
+  social:
+    facebook: RepJayapal
+    twitter: RepJayapal
+- id:
+    bioguide: F000466
+    govtrack: 412721
+  social:
+    facebook: repbrianfitzpatrick
+    twitter: repbrianfitz
+- id:
+    bioguide: O000171
+    govtrack: 412682
+  social:
+    facebook: repohalleran
+    twitter: repohalleran
+- id:
+    bioguide: R000607
+    govtrack: 412699
+  social:
+    facebook: RepRooney
+    twitter: RepRooney
+- id:
+    bioguide: K000390
+    govtrack: 412716
+  social:
+    facebook: RepKihuen
+    twitter: RepKihuen
+- id:
+    bioguide: K000393
+    govtrack: 412679
+  social:
+    facebook: JohnKennedyLouisiana
+    twitter: SenJohnKennedy
+- id:
+    bioguide: L000586
+    govtrack: 412693
+  social:
+    facebook: RepAlLawsonJr
+    twitter: RepAlLawsonJr
+- id:
+    bioguide: M001201
+    govtrack: 412710
+  social:
+    facebook: reppaulmitchell
+    twitter: RepPaulMitchell
+- id:
+    bioguide: K000391
+    govtrack: 412701
+  social:
+    facebook: congressmanraja
+    twitter: congressmanraja
+- id:
+    bioguide: H001076
+    govtrack: 412680
+  social:
+    facebook: SenatorHassan
+    twitter: Senatorhassan
+- id:
+    bioguide: E000297
+    govtrack: 412718
+  social:
+    facebook: RepEspaillat
+    twitter: RepEspaillat
+- id:
+    bioguide: K000392
+    govtrack: 412724
+  social:
+    facebook: RepDavidKustoff
+    twitter: repdavidkustoff
+- id:
+    bioguide: L000587
+    govtrack: 412711
+  social:
+    facebook: RepJasonLewis
+    twitter: RepJasonLewis
+- id:
+    bioguide: G000578
+    govtrack: 412690
+  social:
+    facebook: CongressmanMattGaetz
+    twitter: Rep_Matt_Gaetz
+- id:
+    bioguide: S001200
+    govtrack: 412695
+  social:
+    twitter: RepDarrenSoto
+- id:
+    bioguide: B001301
+    govtrack: 412709
+  social:
+    facebook: RepJackBergman
+    twitter: RepJackBergman
+- id:
+    bioguide: G000579
+    govtrack: 412731
+  social:
+    facebook: RepMikeGallagher
+    twitter: RepGallagher
+- id:
+    bioguide: C001108
+    govtrack: 412676
+  social:
+    facebook: congressmancomer
+- id:
+    bioguide: M001198
+    govtrack: 412704
+  social:
+    facebook: rogermarshallmd

--- a/scripts/data/social_media_blacklist.csv
+++ b/scripts/data/social_media_blacklist.csv
@@ -45,6 +45,7 @@ youtube,^cp$,embed tag
 youtube,SmallBizRepublicans,shared page
 youtube,^watch$,embed tag
 youtube,housedems,embed tag
+youtube,republicanconference,embed tag
 youtube,^WSB111$,Some weird vendor thing
 youtube,^p$,embed tag
 youtube,HouseConference,shared page


### PR DESCRIPTION
This does a full sweep of Twitter and Facebook accounts. This scans MoC house.gov and senate.gov pages (for any MoC where we don't have an account for them already) and looks for links to twitter.com and facebook.com links, subject to filtering out common false positives.

I went and hand-verified that every Twitter account either links back to the house.gov/senate.gov site (or was otherwise clearly not a campaign account and positively linked to from the house.gov/senate.gov site), and hand-verified that every discovered Facebook account either has a verified checkmark for a Page set to Government Official, or that it links back to the homepage or is otherwise clearly not a campaign account. I also sanity checked every Twitter and Facebook handle to make sure it matched up with the name of the member in question.

I did remove one -- [Congressman Soto](https://soto.house.gov/)'s [Facebook account](https://www.facebook.com/people/US-Rep-Darren-Soto/100014901039474) -- which doesn't link properly through our scanner, as it's set to a personal account and not a Page like everyone else. I'll give him some time to change that before attempting to fix or otherwise blacklist the page.