### PR TITLE
Fixed the terms for TX Sens Gramm and Cornyn

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -1627,7 +1627,7 @@
     start: '2017-01-03'
   terms:
   - type: sen
-    start: '2002-01-01'
+    start: '2002-11-30'
     end: '2003-01-03'
     state: TX
     class: 2


### PR DESCRIPTION
Gramm's resignation was effective 11/30/2002, and Cornyn served in the interim - 11/30/2002 to the end of the session, 01/03/2003