### PR TITLE
add twitter handles for 2 legislators and run resolvetw to fix some twitter ids

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -1100,12 +1100,12 @@
     thomas: '01910'
     govtrack: 412308
   social:
-    twitter: JaredPolis
+    twitter: RepJaredPolis
     facebook: jaredpolis
     youtube: JaredPolis31275
     facebook_id: '53481427529'
     youtube_id: UCJJ1Ye0mOzqZh1_GErFUISw
-    twitter_id: 15361570
+    twitter_id: 463132556
 - id:
     bioguide: P000597
     thomas: '01927'
@@ -4556,19 +4556,19 @@
   social:
     facebook: chrismurphyct
     facebook_id: '19437978960'
-    twitter: ChrisMurphyCT
+    twitter: senmurphyoffice
     youtube: senchrismurphy
     youtube_id: UCbcEa40PIFpLpdDe06n3F3Q
-    twitter_id: 150078976
+    twitter_id: 2853793517
 - id:
     bioguide: B001288
     govtrack: 412598
     thomas: '02194'
   social:
-    twitter: CoryBooker
+    twitter: senbookeroffice
     youtube: SenCoryBooker
     youtube_id: UC6FlymqNS1VettnVZa7goPA
-    twitter_id: 15808765
+    twitter_id: 2167097881
 - id:
     bioguide: C001101
     govtrack: 412600
@@ -4952,9 +4952,9 @@
     govtrack: 412652
     thomas: '02267'
   social:
-    twitter: RepBrendanBoyle
+    twitter: CongBoyle
     facebook: CongressmanBoyle
-    twitter_id: 231108733
+    twitter_id: 4304448314
 - id:
     bioguide: H001071
     govtrack: 412623

--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -406,7 +406,7 @@
     youtube_id: UCr9reyLip23im9SVDJ9IGAg
     instagram: pattiberi
     instagram_id: 1213878120
-    twitter_id: 3145255727
+    twitter_id: 912608010
 - id:
     bioguide: T000461
     thomas: '02085'
@@ -1067,12 +1067,14 @@
     thomas: '02082'
     govtrack: 412492
   social:
+    twitter: randpaul
     facebook: SenatorRandPaul
     youtube: SenatorRandPaul
     facebook_id: '161355253917286'
     youtube_id: UCeM9I-20oWUs8daIIpsNHoQ
     instagram: senatorrandpaul
     instagram_id: 541357095
+    twitter_id: 216881337
 - id:
     bioguide: P000601
     thomas: '02035'
@@ -1608,7 +1610,7 @@
     youtube: RepMarkey
     facebook_id: '6846731378'
     youtube_id: UCT1ujew5yQy2uMhGrjiKHoA
-    twitter_id: 3047090620
+    twitter_id: 21406834
 - id:
     bioguide: M000087
     thomas: '00729'
@@ -2387,7 +2389,7 @@
     youtube: repluisgutierrez
     facebook_id: '91052833204'
     youtube_id: UCLooufcInrRP1FQn_WY9yDA
-    twitter_id: 322013313
+    twitter_id: 36948268
 - id:
     bioguide: G000410
     thomas: '00462'
@@ -2674,6 +2676,7 @@
     facebook_id: '69862092533'
     youtube_id: UCoC_r0R2M_74UVrH4A44awQ
     twitter: RepCharlieDent
+    twitter_id: 242376736
 - id:
     bioguide: D000600
     thomas: '01717'
@@ -2769,7 +2772,7 @@
     thomas: '01984'
     govtrack: 412390
   social:
-    twitter: SenCoons
+    twitter: SenCoonsOffice
     facebook: senatorchriscoons
     youtube: senatorchriscoons
     facebook_id: '254950754518205'
@@ -3048,6 +3051,7 @@
     youtube: RepMikeCapuano
     facebook_id: '151168844937573'
     youtube_id: UCvzAdbimlJksgZjEMQn0kuw
+    twitter_id: 747806211983179776
 - id:
     bioguide: C001035
     thomas: '01541'
@@ -3438,10 +3442,12 @@
     thomas: '02029'
     govtrack: 412438
   social:
+    twitter: justinamash
     facebook: repjustinamash
     youtube: repjustinamash
     facebook_id: '173604349345646'
     youtube_id: UCeg6HhoCXrS8xpON9dxtZgA
+    twitter_id: 233842454
 - id:
     bioguide: A000360
     thomas: '01695'
@@ -4493,6 +4499,7 @@
     twitter: SenGillibrand
     facebook: KirstenGillibrand
     youtube_id: UCVEloQogVsmnkd5vxJInmYg
+    twitter_id: 72198806
 - id:
     bioguide: R000584
     govtrack: 412322
@@ -4565,7 +4572,7 @@
     twitter: CoryBooker
     youtube: SenCoryBooker
     youtube_id: UC6FlymqNS1VettnVZa7goPA
-    twitter_id: 2167097881
+    twitter_id: 15808765
 - id:
     bioguide: C001101
     govtrack: 412600
@@ -5122,10 +5129,12 @@
     govtrack: 400343
     thomas: '00979'
   social:
+    twitter: reprohrabacher
     facebook: RepRohrabacher
     youtube: RepDanaRohrabacher
     youtube_id: UCFr7qO61vGJyyBJ7B_gB1_Q
     facebook_id: '321029601363321'
+    twitter_id: 831483464
 - id:
     bioguide: D000625
     govtrack: 412672
@@ -5151,66 +5160,77 @@
   social:
     facebook: RepJimBanks
     twitter: RepJimBanks
+    twitter_id: 816131319033950208
 - id:
     bioguide: D000627
     govtrack: 412696
   social:
     facebook: RepresentativeValDemings
     twitter: RepValDemings
+    twitter_id: 798973032362606600
 - id:
     bioguide: B001303
     govtrack: 412689
   social:
     facebook: Rep.BluntRochester
     twitter: RepBRochester
+    twitter_id: 817050219007328258
 - id:
     bioguide: R000606
     govtrack: 412708
   social:
     facebook: repraskin
     twitter: repraskin
+    twitter_id: 806906355214852096
 - id:
     bioguide: P000613
     govtrack: 412685
   social:
     facebook: RepJimmyPanetta
     twitter: RepJimmyPanetta
+    twitter_id: 796736612554117120
 - id:
     bioguide: C001111
     govtrack: 412697
   social:
     facebook: RepCharlieCrist
     twitter: repcharliecrist
+    twitter_id: 816030424778543104
 - id:
     bioguide: D000628
     govtrack: 412691
   social:
     facebook: drnealdunnfl2
     twitter: drnealdunnfl2
+    twitter_id: 815952318487298048
 - id:
     bioguide: B001300
     govtrack: 412687
   social:
     facebook: CongresswomanBarragan
     twitter: RepBarragan
+    twitter_id: 816833925456789505
 - id:
     bioguide: B001302
     govtrack: 412683
   social:
     facebook: RepAndyBiggs
     twitter: RepAndyBiggsAZ
+    twitter_id: 816652616625168388
 - id:
     bioguide: M001199
     govtrack: 412698
   social:
     facebook: repbrianmast
     twitter: repbrianmast
+    twitter_id: 814103950404239360
 - id:
     bioguide: M001200
     govtrack: 412728
   social:
     facebook: RepMcEachin
     twitter: RepMcEachin
+    twitter_id: 816181091673448448
 - id:
     bioguide: D000626
     govtrack: 412675
@@ -5218,42 +5238,49 @@
   social:
     facebook: CongressmanWarrenDavidson
     twitter: WarrenDavidson
+    twitter_id: 742735530287304704
 - id:
     bioguide: F000465
     govtrack: 412700
   social:
     facebook: RepDrewFerguson
     twitter: RepDrewFerguson
+    twitter_id: 806583915012046854
 - id:
     bioguide: G000581
     govtrack: 412725
   social:
     facebook: USCongressmanVicenteGonzalez
     twitter: RepGonzalez
+    twitter_id: 818536152588238849
 - id:
     bioguide: G000583
     govtrack: 412714
   social:
     facebook: RepJoshG
     twitter: RepJoshG
+    twitter_id: 815310506596691968
 - id:
     bioguide: G000580
     govtrack: 412729
   social:
     facebook: congressman-Tom-Garrett-1835767753333490
     twitter: Rep_Tom_Garrett
+    twitter_id: 818460870573441028
 - id:
     bioguide: C001113
     govtrack: 412681
   social:
     facebook: SenatorCortezMasto
     twitter: sencortezmasto
+    twitter_id: 811313565760163844
 - id:
     bioguide: K000389
     govtrack: 412684
   social:
     facebook: RepRoKhanna
     twitter: RepRoKhanna
+    twitter_id: 816298918468259841
 - id:
     bioguide: S001170
     govtrack: 412219
@@ -5261,48 +5288,56 @@
   social:
     facebook: repsheaporter
     twitter: repsheaporter
+    twitter_id: 126171100
 - id:
     bioguide: G000582
     govtrack: 412723
   social:
     facebook: RepJennifferGonzalezColon
     twitter: repjenniffer
+    twitter_id: 819744763020775425
 - id:
     bioguide: M001202
     govtrack: 412694
   social:
     facebook: RepStephMurphy
     twitter: RepStephMurphy
+    twitter_id: 796183515998068736
 - id:
     bioguide: H001074
     govtrack: 412703
   social:
     facebook: reptrey
     twitter: reptrey
+    twitter_id: 811986281177772032
 - id:
     bioguide: A000375
     govtrack: 412726
   social:
     facebook: JodeyArrington
     twitter: RepArrington
+    twitter_id: 816284664658874368
 - id:
     bioguide: C001109
     govtrack: 412732
   social:
     facebook: replizcheney
     twitter: RepLizCheney
+    twitter_id: 816719802328715264
 - id:
     bioguide: C001112
     govtrack: 412686
   social:
     facebook: repsaludcarbajal
     twitter: RepCarbajal
+    twitter_id: 816157667882373120
 - id:
     bioguide: S001201
     govtrack: 412717
   social:
     facebook: RepTomSuozzi
     twitter: RepTomSuozzi
+    twitter_id: 816705409486618624
 - id:
     bioguide: S001190
     govtrack: 412534
@@ -5310,126 +5345,147 @@
   social:
     facebook: CongressmanBradSchneider
     twitter: repschneider
+    twitter_id: 1071840474
 - id:
     bioguide: F000464
     govtrack: 412719
   social:
     facebook: RepJohnFaso
     twitter: RepJohnFaso
+    twitter_id: 815931811348017152
 - id:
     bioguide: T000478
     govtrack: 412720
   social:
     facebook: RepClaudiaTenney
     twitter: RepTenney
+    twitter_id: 797201048490430465
 - id:
     bioguide: B001305
     govtrack: 412712
   social:
     facebook: RepTedBudd
     twitter: RepTedBudd
+    twitter_id: 817138492614524928
 - id:
     bioguide: J000298
     govtrack: 412730
   social:
     facebook: RepJayapal
     twitter: RepJayapal
+    twitter_id: 815733290955112448
 - id:
     bioguide: F000466
     govtrack: 412721
   social:
     facebook: repbrianfitzpatrick
     twitter: repbrianfitz
+    twitter_id: 816303263586914304
 - id:
     bioguide: O000171
     govtrack: 412682
   social:
     facebook: repohalleran
     twitter: repohalleran
+    twitter_id: 808416682972770304
 - id:
     bioguide: R000607
     govtrack: 412699
   social:
     facebook: RepRooney
     twitter: RepRooney
+    twitter_id: 816111677917851649
 - id:
     bioguide: K000390
     govtrack: 412716
   social:
     facebook: RepKihuen
     twitter: RepKihuen
+    twitter_id: 816282029276938240
 - id:
     bioguide: K000393
     govtrack: 412679
   social:
     facebook: JohnKennedyLouisiana
     twitter: SenJohnKennedy
+    twitter_id: 816683274076614656
 - id:
     bioguide: L000586
     govtrack: 412693
   social:
     facebook: RepAlLawsonJr
     twitter: RepAlLawsonJr
+    twitter_id: 818472418620608512
 - id:
     bioguide: M001201
     govtrack: 412710
   social:
     facebook: reppaulmitchell
     twitter: RepPaulMitchell
+    twitter_id: 811632636598910976
 - id:
     bioguide: K000391
     govtrack: 412701
   social:
     facebook: congressmanraja
     twitter: congressmanraja
+    twitter_id: 814179031956488192
 - id:
     bioguide: H001076
     govtrack: 412680
   social:
     facebook: SenatorHassan
     twitter: Senatorhassan
+    twitter_id: 946549322
 - id:
     bioguide: E000297
     govtrack: 412718
   social:
     facebook: RepEspaillat
     twitter: RepEspaillat
+    twitter_id: 817076257770835968
 - id:
     bioguide: K000392
     govtrack: 412724
   social:
     facebook: RepDavidKustoff
     twitter: repdavidkustoff
+    twitter_id: 816012124505931780
 - id:
     bioguide: L000587
     govtrack: 412711
   social:
     facebook: RepJasonLewis
     twitter: RepJasonLewis
+    twitter_id: 816047090849746945
 - id:
     bioguide: G000578
     govtrack: 412690
   social:
     facebook: CongressmanMattGaetz
     twitter: Rep_Matt_Gaetz
+    twitter_id: 818948638890217473
 - id:
     bioguide: S001200
     govtrack: 412695
   social:
     twitter: RepDarrenSoto
     facebook: CongressmanDarrenSoto
+    twitter_id: 818713465653051392
 - id:
     bioguide: B001301
     govtrack: 412709
   social:
     facebook: RepJackBergman
     twitter: RepJackBergman
+    twitter_id: 815241612154417152
 - id:
     bioguide: G000579
     govtrack: 412731
   social:
     facebook: RepMikeGallagher
     twitter: RepGallagher
+    twitter_id: 815966620300480514
 - id:
     bioguide: C001108
     govtrack: 412676
@@ -5441,45 +5497,60 @@
   social:
     facebook: rogermarshallmd
     twitter: RepMarshall
+    twitter_id: 752364246218862592
 - id:
     bioguide: E000296
     govtrack: 412677
   social:
     twitter: RepDwightEvans
+    twitter_id: 90639372
 - id:
     bioguide: R000609
     govtrack: 412692
   social:
     facebook: RepRutherfordFL
     twitter: RepRutherfordFL
+    twitter_id: 828977216595849216
 - id:
     bioguide: J000299
     govtrack: 412706
   social:
     facebook: RepMikeJohnson
     twitter: RepMikeJohnson
+    twitter_id: 827279765287559171
 - id:
     bioguide: R000608
     govtrack: 412715
   social:
     twitter: repjackyrosen
+    twitter_id: 818554054309715969
 - id:
     bioguide: C001110
     govtrack: 412688
   social:
     twitter: reploucorrea
+    twitter_id: 815985039485837312
 - id:
     bioguide: B001298
     govtrack: 412713
   social:
     twitter: repdonbacon
+    twitter_id: 818975124460335106
 - id:
     bioguide: S001199
     govtrack: 412722
   social:
     twitter: RepSmucker
+    twitter_id: 41417564
 - id:
     bioguide: S001202
     govtrack: 412734
   social:
     twitter: SenatorStrange
+    twitter_id: 829794295355940866
+- id:
+    bioguide: H001050
+    govtrack: 412418
+  social:
+    twitter: RepHanabusa
+    twitter_id: 235373000

--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -1067,14 +1067,12 @@
     thomas: '02082'
     govtrack: 412492
   social:
-    twitter: randpaul
     facebook: SenatorRandPaul
     youtube: SenatorRandPaul
     facebook_id: '161355253917286'
     youtube_id: UCeM9I-20oWUs8daIIpsNHoQ
     instagram: senatorrandpaul
     instagram_id: 541357095
-    twitter_id: 216881337
 - id:
     bioguide: P000601
     thomas: '02035'
@@ -3442,12 +3440,10 @@
     thomas: '02029'
     govtrack: 412438
   social:
-    twitter: justinamash
     facebook: repjustinamash
     youtube: repjustinamash
     facebook_id: '173604349345646'
     youtube_id: UCeg6HhoCXrS8xpON9dxtZgA
-    twitter_id: 233842454
 - id:
     bioguide: A000360
     thomas: '01695'


### PR DESCRIPTION
Adds twitter handles for Amash, Hanabusa, Rand Paul, and Rohrabacker, and run social_media.py --resolvetw.  resolvetw showed we had some incorrect twitter ids.

Amash's twitter wasn't linked from his website but the twitter account links to his facebook which links to his official website, which seemed official enough.
