### PR TITLE
prefer existing social media over first found

### DIFF
--- a/scripts/social_media.py
+++ b/scripts/social_media.py
@@ -433,7 +433,7 @@ def main():
 
       bioguide = entry['id']['bioguide']
 
-      candidate = candidate_for(bioguide)
+      candidate = candidate_for(bioguide, current)
       if not candidate:
         # if current is in whitelist, and none is on the page, that's okay
         if current.lower() in whitelist[service]:
@@ -490,7 +490,12 @@ def main():
     print("Saving historical legislators...")
     save_data(media, "legislators-social-media.yaml")
 
-  def candidate_for(bioguide):
+
+  def candidate_for(bioguide, current = None):
+    """find the most likely candidate account from the URL.
+    If current is passed, the candidate will match it if found
+    otherwise, the first candidate match is returned
+    """
     url = current_bioguide[bioguide]["terms"][-1].get("url", None)
     if not url:
       if debug:
@@ -509,6 +514,10 @@ def main():
       matches = re.findall(regex, body, re.I)
       if matches:
         all_matches.extend(matches)
+
+    if not current == None and current in all_matches:
+      return current
+
     if all_matches:
       for candidate in all_matches:
         passed = True


### PR DESCRIPTION
I noticed when running social_media.py --verify [--resolvetw], candidate_for is currently returning the first regex that passes.  This changes the logic to return the existing candidate first if its found.  This causes the output of the script to be less verbose, like so:

[W000437] mismatch on http://www.wicker.senate.gov - SenatorWicker -> AjitPaiFCC

Also, would anyone object to making lines like this debug-only?
Found redirect, downloading http://www.thune.senate.gov/public/ instead..
