### PR TITLE
WIP: joint house committee membership updates

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -10089,43 +10089,6 @@ JCSE:
   rank: 4
   bioguide: S001181
   chamber: senate
-- name: Christopher H. Smith
-  party: majority
-  rank: 1
-  title: Co-Chairman
-  bioguide: S000522
-  thomas: '01071'
-  chamber: house
-- name: Robert Aderholt
-  party: majority
-  rank: 3
-  bioguide: A000055
-  thomas: '01460'
-  chamber: house
-- name: Michael C. Burgess
-  party: majority
-  rank: 4
-  bioguide: B001248
-  thomas: '01751'
-  chamber: house
-- name: Alcee L. Hastings
-  party: minority
-  rank: 1
-  bioguide: H000324
-  thomas: '00511'
-  chamber: house
-- name: Louise McIntosh Slaughter
-  party: minority
-  rank: 2
-  bioguide: S000480
-  thomas: '01069'
-  chamber: house
-- name: Steve Cohen
-  party: minority
-  rank: 3
-  bioguide: C001068
-  thomas: '01878'
-  chamber: house
 JSEC:
 - name: Mike Lee
   party: majority
@@ -10178,48 +10141,56 @@ JSEC:
   rank: 4
   bioguide: H001076
   chamber: senate
-- name: Kevin Brady
+- name: Pat Tiberi
   party: majority
   rank: 1
-  bioguide: B000755
-  thomas: '01468'
   title: Chairman
-  chamber: house
-- name: Sean P. Duffy
-  party: majority
-  rank: 3
-  bioguide: D000614
-  thomas: '02072'
-  chamber: house
-- name: Justin Amash
-  party: majority
-  rank: 4
-  bioguide: A000367
-  thomas: '02029'
+  bioguide: T000462
   chamber: house
 - name: Erik Paulsen
   party: majority
-  rank: 5
+  rank: 2
   bioguide: P000594
-  thomas: '01930'
   chamber: house
-- name: Carolyn B. Maloney
-  party: minority
-  rank: 1
-  bioguide: M000087
-  thomas: '00729'
-  chamber: house
-- name: Elijah E. Cummings
-  party: minority
+- name: David Schweikert
+  party: majority
   rank: 3
-  bioguide: C000984
-  thomas: '00256'
+  bioguide: S001183
   chamber: house
-- name: John K. Delaney
-  party: minority
+- name: Barbara Comstock
+  party: majority
   rank: 4
+  bioguide: C001105
+  chamber: house
+- name: Darin LaHood
+  party: majority
+  rank: 5
+  bioguide: L000585
+  chamber: house
+- name: Francis Rooney
+  party: majority
+  rank: 6
+  bioguide: R000607
+  chamber: house
+- name: Carolyn Maloney
+  party: minority
+  rank: 7
+  bioguide: M000087
+  chamber: house
+- name: John Delaney
+  party: minority
+  rank: 8
   bioguide: D000620
-  thomas: '02133'
+  chamber: house
+- name: Alma Adams
+  party: minority
+  rank: 9
+  bioguide: A000370
+  chamber: house
+- name: Don Beyer
+  party: minority
+  rank: 10
+  bioguide: B001292
   chamber: house
 JSLC:
 - name: Roy Blunt
@@ -10248,31 +10219,6 @@ JSLC:
   rank: 2
   bioguide: L000174
   chamber: senate
-- name: Gregg Harper
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: H001045
-  thomas: '01933'
-  chamber: house
-- name: Tom Cole
-  party: majority
-  rank: 3
-  bioguide: C001053
-  thomas: '01742'
-  chamber: house
-- name: Robert A. Brady
-  party: minority
-  rank: 1
-  bioguide: B001227
-  thomas: '01469'
-  chamber: house
-- name: Zoe Lofgren
-  party: minority
-  rank: 2
-  bioguide: L000397
-  thomas: '00701'
-  chamber: house
 JSPR:
 - name: Roy Blunt
   party: majority
@@ -10300,25 +10246,6 @@ JSPR:
   rank: 2
   bioguide: U000039
   chamber: senate
-- name: Gregg Harper
-  party: majority
-  rank: 1
-  title: Vice Chairman
-  bioguide: H001045
-  thomas: '01933'
-  chamber: house
-- name: Robert A. Brady
-  party: minority
-  rank: 1
-  bioguide: B001227
-  thomas: '01469'
-  chamber: house
-- name: Juan Vargas
-  party: minority
-  rank: 2
-  bioguide: V000130
-  thomas: '02112'
-  chamber: house
 JSTX:
 - name: Orrin G. Hatch
   party: majority
@@ -10346,30 +10273,26 @@ JSTX:
   rank: 2
   bioguide: S000770
   chamber: senate
-- name: Paul Ryan
+- name: Kevin Brady
   party: majority
   rank: 1
-  title: Chairman
-  bioguide: R000570
-  thomas: '01560'
+  title: Vice Chairman
+  bioguide: B000755
   chamber: house
 - name: Sam Johnson
   party: majority
   rank: 2
   bioguide: J000174
-  thomas: '00603'
   chamber: house
-- name: Kevin Brady
+- name: Devin Nunes
   party: majority
   rank: 3
-  bioguide: B000755
-  thomas: '01468'
+  bioguide: N000181
   chamber: house
 - name: Sander Levin
   party: minority
-  rank: 1
+  rank: 4
   bioguide: L000263
-  thomas: '00683'
   chamber: house
 SCNC:
 - name: Chuck Grassley

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -3,428 +3,428 @@ HLIG:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01710'
   bioguide: N000181
+  thomas: '01710'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Thomas J. Rooney
   party: majority
   rank: 5
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 6
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Michael R. Turner
   party: majority
   rank: 7
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Brad R. Wenstrup
   party: majority
   rank: 8
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Chris Stewart
   party: majority
   rank: 9
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 10
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Trey Gowdy
   party: majority
   rank: 11
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Elise M. Stefanik
   party: majority
   rank: 12
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Will Hurd
   party: majority
   rank: 13
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Adam B. Schiff
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01635'
   bioguide: S001150
+  thomas: '01635'
 - name: James A. Himes
   party: minority
   rank: 2
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Terri A. Sewell
   party: minority
   rank: 3
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: André Carson
   party: minority
   rank: 4
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Jackie Speier
   party: minority
   rank: 5
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 6
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: Eric Swalwell
   party: minority
   rank: 7
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 - name: Joaquin Castro
   party: minority
   rank: 8
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 9
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 HLIG01:
 - name: Frank A. LoBiondo
   party: majority
   rank: 1
   title: Chair
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Thomas J. Rooney
   party: majority
   rank: 4
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 5
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Chris Stewart
   party: majority
   rank: 6
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: Eric Swalwell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 - name: James A. Himes
   party: minority
   rank: 2
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Joaquin Castro
   party: minority
   rank: 3
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 4
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 HLIG02:
 - name: Thomas J. Rooney
   party: majority
   rank: 1
   title: Chair
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Michael R. Turner
   party: majority
   rank: 4
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Trey Gowdy
   party: majority
   rank: 5
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Elise M. Stefanik
   party: majority
   rank: 6
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: James A. Himes
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Terri A. Sewell
   party: minority
   rank: 2
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: Jackie Speier
   party: minority
   rank: 3
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 4
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 HLIG03:
 - name: Peter T. King
   party: majority
   rank: 1
   title: Chair
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Frank A. LoBiondo
   party: majority
   rank: 2
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 4
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Trey Gowdy
   party: majority
   rank: 5
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Will Hurd
   party: majority
   rank: 6
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: André Carson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Jackie Speier
   party: minority
   rank: 2
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 3
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: Eric Swalwell
   party: minority
   rank: 4
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 HLIG04:
 - name: Chris Stewart
   party: majority
   rank: 1
   title: Chair
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: Michael R. Turner
   party: majority
   rank: 2
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 4
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Elise M. Stefanik
   party: majority
   rank: 5
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Will Hurd
   party: majority
   rank: 6
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Terri A. Sewell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: André Carson
   party: minority
   rank: 2
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Joaquin Castro
   party: minority
   rank: 3
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 4
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 HSAG:
 - name: K. Michael Conaway
   party: majority
   rank: 1
   title: Chair
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Bob Goodlatte
   party: majority
   rank: 2
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Steve King
   party: majority
   rank: 4
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Mike Rogers
   party: majority
   rank: 5
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Glenn Thompson
   party: majority
   rank: 6
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Bob Gibbs
   party: majority
   rank: 7
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Austin Scott
   party: majority
   rank: 8
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 9
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Scott DesJarlais
   party: majority
   rank: 10
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 11
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Jeff Denham
   party: majority
   rank: 12
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Doug LaMalfa
   party: majority
   rank: 13
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Rodney Davis
   party: majority
   rank: 14
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Ted S. Yoho
   party: majority
   rank: 15
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Rick W. Allen
   party: majority
   rank: 16
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 17
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: David Rouzer
   party: majority
   rank: 18
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Ralph Lee Abraham
   party: majority
   rank: 19
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 20
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: James Comer
   party: majority
   rank: 21
@@ -453,73 +453,73 @@ HSAG:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00910'
   bioguide: P000258
+  thomas: '00910'
 - name: David Scott
   party: minority
   rank: 2
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Timothy J. Walz
   party: minority
   rank: 4
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Marcia L. Fudge
   party: minority
   rank: 5
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: James P. McGovern
   party: minority
   rank: 6
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Filemon Vela
   party: minority
   rank: 7
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 8
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Ann M. Kuster
   party: minority
   rank: 9
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Richard M. Nolan
   party: minority
   rank: 10
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Cheri Bustos
   party: minority
   rank: 11
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Sean Patrick Maloney
   party: minority
   rank: 12
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Stacey E. Plaskett
   party: minority
   rank: 13
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Alma S. Adams
   party: minority
   rank: 14
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Dwight Evans
   party: minority
   rank: 15
@@ -549,43 +549,43 @@ HSAG03:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 3
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Scott DesJarlais
   party: majority
   rank: 4
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 5
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Rodney Davis
   party: majority
   rank: 6
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Ted S. Yoho
   party: majority
   rank: 7
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: David Rouzer
   party: majority
   rank: 8
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: James Comer
   party: majority
   rank: 9
@@ -606,13 +606,13 @@ HSAG03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Alma S. Adams
   party: minority
   rank: 2
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Dwight Evans
   party: minority
   rank: 3
@@ -620,13 +620,13 @@ HSAG03:
 - name: Marcia L. Fudge
   party: minority
   rank: 4
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 5
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Al Lawson, Jr.
   party: minority
   rank: 6
@@ -642,35 +642,35 @@ HSAG03:
 - name: Sean Patrick Maloney
   party: minority
   rank: 9
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 HSAG14:
 - name: Rodney Davis
   party: majority
   rank: 1
   title: Chair
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Bob Gibbs
   party: majority
   rank: 2
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Jeff Denham
   party: majority
   rank: 3
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Ted S. Yoho
   party: majority
   rank: 4
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: David Rouzer
   party: majority
   rank: 5
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Don Bacon
   party: majority
   rank: 6
@@ -687,8 +687,8 @@ HSAG14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Al Lawson, Jr.
   party: minority
   rank: 2
@@ -700,13 +700,13 @@ HSAG14:
 - name: Jim Costa
   party: minority
   rank: 4
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: James P. McGovern
   party: minority
   rank: 5
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 6
@@ -716,64 +716,64 @@ HSAG15:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Glenn Thompson
   party: majority
   rank: 2
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Jeff Denham
   party: majority
   rank: 3
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Doug LaMalfa
   party: majority
   rank: 4
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Rick W. Allen
   party: majority
   rank: 5
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 6
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Ralph Lee Abraham
   party: majority
   rank: 7
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 8
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Marcia L. Fudge
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Timothy J. Walz
   party: minority
   rank: 2
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Ann M. Kuster
   party: minority
   rank: 3
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Richard M. Nolan
   party: minority
   rank: 4
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Tom O'Halleran
   party: minority
   rank: 5
@@ -781,55 +781,55 @@ HSAG15:
 - name: Filemon Vela
   party: minority
   rank: 6
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 HSAG16:
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 1
   title: Chair
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Frank D. Lucas
   party: majority
   rank: 2
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Mike Rogers
   party: majority
   rank: 3
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Bob Gibbs
   party: majority
   rank: 4
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Austin Scott
   party: majority
   rank: 5
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Scott DesJarlais
   party: majority
   rank: 6
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Rick W. Allen
   party: majority
   rank: 7
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 8
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Ralph Lee Abraham
   party: majority
   rank: 9
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Don Bacon
   party: majority
   rank: 10
@@ -846,18 +846,18 @@ HSAG16:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Timothy J. Walz
   party: minority
   rank: 2
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Cheri Bustos
   party: minority
   rank: 3
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 4
@@ -865,18 +865,18 @@ HSAG16:
 - name: David Scott
   party: minority
   rank: 5
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Sean Patrick Maloney
   party: minority
   rank: 6
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Stacey E. Plaskett
   party: minority
   rank: 7
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Al Lawson, Jr.
   party: minority
   rank: 8
@@ -890,28 +890,28 @@ HSAG22:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Bob Goodlatte
   party: majority
   rank: 2
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: Mike Rogers
   party: majority
   rank: 3
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Doug LaMalfa
   party: majority
   rank: 4
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Rodney Davis
   party: majority
   rank: 5
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: James Comer
   party: majority
   rank: 6
@@ -928,23 +928,23 @@ HSAG22:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Sean Patrick Maloney
   party: minority
   rank: 2
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Ann M. Kuster
   party: minority
   rank: 3
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Stacey E. Plaskett
   party: minority
   rank: 4
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Tom O'Halleran
   party: minority
   rank: 5
@@ -958,38 +958,38 @@ HSAG29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Bob Goodlatte
   party: majority
   rank: 2
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: Steve King
   party: majority
   rank: 3
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Scott DesJarlais
   party: majority
   rank: 4
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 5
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Ted S. Yoho
   party: majority
   rank: 6
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Trent Kelly
   party: majority
   rank: 7
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Roger W. Marshall
   party: majority
   rank: 8
@@ -998,23 +998,23 @@ HSAG29:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Filemon Vela
   party: minority
   rank: 2
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Cheri Bustos
   party: minority
   rank: 3
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Stacey E. Plaskett
   party: minority
   rank: 4
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Dwight Evans
   party: minority
   rank: 5
@@ -1024,148 +1024,148 @@ HSAP:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00414'
   bioguide: F000372
+  thomas: '00414'
 - name: Harold Rogers
   party: majority
   rank: 2
-  thomas: '00977'
   bioguide: R000395
+  thomas: '00977'
 - name: Robert B. Aderholt
   party: majority
   rank: 3
-  thomas: '01460'
   bioguide: A000055
+  thomas: '01460'
 - name: Kay Granger
   party: majority
   rank: 4
-  thomas: '01487'
   bioguide: G000377
+  thomas: '01487'
 - name: Michael K. Simpson
   party: majority
   rank: 5
-  thomas: '01590'
   bioguide: S001148
+  thomas: '01590'
 - name: John Abney Culberson
   party: majority
   rank: 6
-  thomas: '01670'
   bioguide: C001048
+  thomas: '01670'
 - name: John R. Carter
   party: majority
   rank: 7
-  thomas: '01752'
   bioguide: C001051
+  thomas: '01752'
 - name: Ken Calvert
   party: majority
   rank: 8
-  thomas: '00165'
   bioguide: C000059
+  thomas: '00165'
 - name: Tom Cole
   party: majority
   rank: 9
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: Mario Diaz-Balart
   party: majority
   rank: 10
-  thomas: '01717'
   bioguide: D000600
+  thomas: '01717'
 - name: Charles W. Dent
   party: majority
   rank: 11
-  thomas: '01799'
   bioguide: D000604
+  thomas: '01799'
 - name: Tom Graves
   party: majority
   rank: 12
-  thomas: '01979'
   bioguide: G000560
+  thomas: '01979'
 - name: Kevin Yoder
   party: majority
   rank: 13
-  thomas: '02021'
   bioguide: Y000063
+  thomas: '02021'
 - name: Steve Womack
   party: majority
   rank: 14
-  thomas: '01991'
   bioguide: W000809
+  thomas: '01991'
 - name: Jeff Fortenberry
   party: majority
   rank: 15
-  thomas: '01793'
   bioguide: F000449
+  thomas: '01793'
 - name: Thomas J. Rooney
   party: majority
   rank: 16
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 17
-  thomas: '02061'
   bioguide: F000459
+  thomas: '02061'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 18
-  thomas: '02071'
   bioguide: H001056
+  thomas: '02071'
 - name: David P. Joyce
   party: majority
   rank: 19
-  thomas: '02154'
   bioguide: J000295
+  thomas: '02154'
 - name: David G. Valadao
   party: majority
   rank: 20
-  thomas: '02105'
   bioguide: V000129
+  thomas: '02105'
 - name: Andy Harris
   party: majority
   rank: 21
-  thomas: '02026'
   bioguide: H001052
+  thomas: '02026'
 - name: Martha Roby
   party: majority
   rank: 22
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Mark E. Amodei
   party: majority
   rank: 23
-  thomas: '02090'
   bioguide: A000369
+  thomas: '02090'
 - name: Chris Stewart
   party: majority
   rank: 24
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: David Young
   party: majority
   rank: 25
-  thomas: '02242'
   bioguide: Y000066
+  thomas: '02242'
 - name: Evan H. Jenkins
   party: majority
   rank: 26
-  thomas: '02278'
   bioguide: J000297
+  thomas: '02278'
 - name: Steven M. Palazzo
   party: majority
   rank: 27
-  thomas: '02035'
   bioguide: P000601
+  thomas: '02035'
 - name: Dan Newhouse
   party: majority
   rank: 28
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: John R. Moolenaar
   party: majority
   rank: 29
-  thomas: '02248'
   bioguide: M001194
+  thomas: '02248'
 - name: Scott Taylor
   party: majority
   rank: 30
@@ -1174,260 +1174,988 @@ HSAP:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00709'
   bioguide: L000480
+  thomas: '00709'
 - name: Marcy Kaptur
   party: minority
   rank: 2
-  thomas: '00616'
   bioguide: K000009
+  thomas: '00616'
 - name: Peter J. Visclosky
   party: minority
   rank: 3
-  thomas: '01188'
   bioguide: V000108
+  thomas: '01188'
 - name: José E. Serrano
   party: minority
   rank: 4
-  thomas: '01042'
   bioguide: S000248
+  thomas: '01042'
 - name: Rosa L. DeLauro
   party: minority
   rank: 5
-  thomas: '00281'
   bioguide: D000216
+  thomas: '00281'
 - name: David E. Price
   party: minority
   rank: 6
-  thomas: '00930'
   bioguide: P000523
+  thomas: '00930'
 - name: Lucille Roybal-Allard
   party: minority
   rank: 7
-  thomas: '00997'
   bioguide: R000486
+  thomas: '00997'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 8
-  thomas: '00091'
   bioguide: B000490
+  thomas: '00091'
 - name: Barbara Lee
   party: minority
   rank: 9
-  thomas: '01501'
   bioguide: L000551
+  thomas: '01501'
 - name: Betty McCollum
   party: minority
   rank: 10
-  thomas: '01653'
   bioguide: M001143
+  thomas: '01653'
 - name: Tim Ryan
   party: minority
   rank: 11
-  thomas: '01756'
   bioguide: R000577
+  thomas: '01756'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 12
-  thomas: '01728'
   bioguide: R000576
+  thomas: '01728'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 13
-  thomas: '01777'
   bioguide: W000797
+  thomas: '01777'
 - name: Henry Cuellar
   party: minority
   rank: 14
-  thomas: '01807'
   bioguide: C001063
+  thomas: '01807'
 - name: Chellie Pingree
   party: minority
   rank: 15
-  thomas: '01927'
   bioguide: P000597
+  thomas: '01927'
 - name: Mike Quigley
   party: minority
   rank: 16
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: Derek Kilmer
   party: minority
   rank: 17
-  thomas: '02169'
   bioguide: K000381
+  thomas: '02169'
 - name: Matt Cartwright
   party: minority
   rank: 18
-  thomas: '02159'
   bioguide: C001090
+  thomas: '02159'
 - name: Grace Meng
   party: minority
   rank: 19
-  thomas: '02148'
   bioguide: M001188
+  thomas: '02148'
 - name: Mark Pocan
   party: minority
   rank: 20
-  thomas: '02171'
   bioguide: P000607
+  thomas: '02171'
 - name: Katherine M. Clark
   party: minority
   rank: 21
-  thomas: '02196'
   bioguide: C001101
+  thomas: '02196'
 - name: Pete Aguilar
   party: minority
   rank: 22
-  thomas: '02229'
   bioguide: A000371
+  thomas: '02229'
+HSAP01:
+- name: Robert B. Aderholt
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: A000055
+  thomas: '01460'
+- name: Kevin Yoder
+  party: majority
+  rank: 2
+  bioguide: Y000063
+  thomas: '02021'
+- name: Thomas J. Rooney
+  party: majority
+  rank: 3
+  bioguide: R000583
+  thomas: '01916'
+- name: David G. Valadao
+  party: majority
+  rank: 4
+  bioguide: V000129
+  thomas: '02105'
+- name: Andy Harris
+  party: majority
+  rank: 5
+  bioguide: H001052
+  thomas: '02026'
+- name: David Young
+  party: majority
+  rank: 6
+  bioguide: Y000066
+  thomas: '02242'
+- name: Steven M. Palazzo
+  party: majority
+  rank: 7
+  bioguide: P000601
+  thomas: '02035'
+- name: Sanford D. Bishop, Jr.
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B000490
+  thomas: '00091'
+- name: Rosa L. DeLauro
+  party: minority
+  rank: 2
+  bioguide: D000216
+  thomas: '00281'
+- name: Chellie Pingree
+  party: minority
+  rank: 3
+  bioguide: P000597
+  thomas: '01927'
+- name: Mark Pocan
+  party: minority
+  rank: 4
+  bioguide: P000607
+  thomas: '02171'
+HSAP02:
+- name: Kay Granger
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: G000377
+  thomas: '01487'
+- name: Harold Rogers
+  party: majority
+  rank: 2
+  bioguide: R000395
+  thomas: '00977'
+- name: Ken Calvert
+  party: majority
+  rank: 3
+  bioguide: C000059
+  thomas: '00165'
+- name: Tom Cole
+  party: majority
+  rank: 4
+  bioguide: C001053
+  thomas: '01742'
+- name: Steve Womack
+  party: majority
+  rank: 5
+  bioguide: W000809
+  thomas: '01991'
+- name: Robert B. Aderholt
+  party: majority
+  rank: 6
+  bioguide: A000055
+  thomas: '01460'
+- name: John R. Carter
+  party: majority
+  rank: 7
+  bioguide: C001051
+  thomas: '01752'
+- name: Mario Diaz-Balart
+  party: majority
+  rank: 8
+  bioguide: D000600
+  thomas: '01717'
+- name: Tom Graves
+  party: majority
+  rank: 9
+  bioguide: G000560
+  thomas: '01979'
+- name: Martha Roby
+  party: majority
+  rank: 10
+  bioguide: R000591
+  thomas: '01986'
+- name: Peter J. Visclosky
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: V000108
+  thomas: '01188'
+- name: Betty McCollum
+  party: minority
+  rank: 2
+  bioguide: M001143
+  thomas: '01653'
+- name: Tim Ryan
+  party: minority
+  rank: 3
+  bioguide: R000577
+  thomas: '01756'
+- name: C. A. Dutch Ruppersberger
+  party: minority
+  rank: 4
+  bioguide: R000576
+  thomas: '01728'
+- name: Marcy Kaptur
+  party: minority
+  rank: 5
+  bioguide: K000009
+  thomas: '00616'
+- name: Henry Cuellar
+  party: minority
+  rank: 6
+  bioguide: C001063
+  thomas: '01807'
+HSAP04:
+- name: Harold Rogers
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000395
+  thomas: '00977'
+- name: Kay Granger
+  party: majority
+  rank: 2
+  bioguide: G000377
+  thomas: '01487'
+- name: Mario Diaz-Balart
+  party: majority
+  rank: 3
+  bioguide: D000600
+  thomas: '01717'
+- name: Charles W. Dent
+  party: majority
+  rank: 4
+  bioguide: D000604
+  thomas: '01799'
+- name: Thomas J. Rooney
+  party: majority
+  rank: 5
+  bioguide: R000583
+  thomas: '01916'
+- name: Jeff Fortenberry
+  party: majority
+  rank: 6
+  bioguide: F000449
+  thomas: '01793'
+- name: Chris Stewart
+  party: majority
+  rank: 7
+  bioguide: S001192
+  thomas: '02168'
+- name: Nita M. Lowey
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000480
+  thomas: '00709'
+- name: Barbara Lee
+  party: minority
+  rank: 2
+  bioguide: L000551
+  thomas: '01501'
+- name: C. A. Dutch Ruppersberger
+  party: minority
+  rank: 3
+  bioguide: R000576
+  thomas: '01728'
+- name: Grace Meng
+  party: minority
+  rank: 4
+  bioguide: M001188
+  thomas: '02148'
+- name: David E. Price
+  party: minority
+  rank: 5
+  bioguide: P000523
+  thomas: '00930'
+HSAP06:
+- name: Ken Calvert
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C000059
+  thomas: '00165'
+- name: Michael K. Simpson
+  party: majority
+  rank: 2
+  bioguide: S001148
+  thomas: '01590'
+- name: Tom Cole
+  party: majority
+  rank: 3
+  bioguide: C001053
+  thomas: '01742'
+- name: David P. Joyce
+  party: majority
+  rank: 4
+  bioguide: J000295
+  thomas: '02154'
+- name: Chris Stewart
+  party: majority
+  rank: 5
+  bioguide: S001192
+  thomas: '02168'
+- name: Mark E. Amodei
+  party: majority
+  rank: 6
+  bioguide: A000369
+  thomas: '02090'
+- name: Evan H. Jenkins
+  party: majority
+  rank: 7
+  bioguide: J000297
+  thomas: '02278'
+- name: Betty McCollum
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001143
+  thomas: '01653'
+- name: Chellie Pingree
+  party: minority
+  rank: 2
+  bioguide: P000597
+  thomas: '01927'
+- name: Derek Kilmer
+  party: minority
+  rank: 3
+  bioguide: K000381
+  thomas: '02169'
+- name: Marcy Kaptur
+  party: minority
+  rank: 4
+  bioguide: K000009
+  thomas: '00616'
+HSAP07:
+- name: Tom Cole
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001053
+  thomas: '01742'
+- name: Michael K. Simpson
+  party: majority
+  rank: 2
+  bioguide: S001148
+  thomas: '01590'
+- name: Steve Womack
+  party: majority
+  rank: 3
+  bioguide: W000809
+  thomas: '01991'
+- name: Charles J. "Chuck" Fleischmann
+  party: majority
+  rank: 4
+  bioguide: F000459
+  thomas: '02061'
+- name: Andy Harris
+  party: majority
+  rank: 5
+  bioguide: H001052
+  thomas: '02026'
+- name: Martha Roby
+  party: majority
+  rank: 6
+  bioguide: R000591
+  thomas: '01986'
+- name: Jaime Herrera Beutler
+  party: majority
+  rank: 7
+  bioguide: H001056
+  thomas: '02071'
+- name: John R. Moolenaar
+  party: majority
+  rank: 8
+  bioguide: M001194
+  thomas: '02248'
+- name: Rosa L. DeLauro
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000216
+  thomas: '00281'
+- name: Lucille Roybal-Allard
+  party: minority
+  rank: 2
+  bioguide: R000486
+  thomas: '00997'
+- name: Barbara Lee
+  party: minority
+  rank: 3
+  bioguide: L000551
+  thomas: '01501'
+- name: Mark Pocan
+  party: minority
+  rank: 4
+  bioguide: P000607
+  thomas: '02171'
+- name: Katherine M. Clark
+  party: minority
+  rank: 5
+  bioguide: C001101
+  thomas: '02196'
+HSAP10:
+- name: Michael K. Simpson
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: S001148
+  thomas: '01590'
+- name: Ken Calvert
+  party: majority
+  rank: 2
+  bioguide: C000059
+  thomas: '00165'
+- name: Charles J. "Chuck" Fleischmann
+  party: majority
+  rank: 3
+  bioguide: F000459
+  thomas: '02061'
+- name: Jeff Fortenberry
+  party: majority
+  rank: 4
+  bioguide: F000449
+  thomas: '01793'
+- name: Kay Granger
+  party: majority
+  rank: 5
+  bioguide: G000377
+  thomas: '01487'
+- name: Jaime Herrera Beutler
+  party: majority
+  rank: 6
+  bioguide: H001056
+  thomas: '02071'
+- name: David P. Joyce
+  party: majority
+  rank: 7
+  bioguide: J000295
+  thomas: '02154'
+- name: Dan Newhouse
+  party: majority
+  rank: 8
+  bioguide: N000189
+  thomas: '02275'
+- name: Marcy Kaptur
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: K000009
+  thomas: '00616'
+- name: Peter J. Visclosky
+  party: minority
+  rank: 2
+  bioguide: V000108
+  thomas: '01188'
+- name: Debbie Wasserman Schultz
+  party: minority
+  rank: 3
+  bioguide: W000797
+  thomas: '01777'
+- name: Pete Aguilar
+  party: minority
+  rank: 4
+  bioguide: A000371
+  thomas: '02229'
+- name: José E. Serrano
+  party: minority
+  rank: 5
+  bioguide: S000248
+  thomas: '01042'
+HSAP15:
+- name: John R. Carter
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001051
+  thomas: '01752'
+- name: John Abney Culberson
+  party: majority
+  rank: 2
+  bioguide: C001048
+  thomas: '01670'
+- name: Charles J. "Chuck" Fleischmann
+  party: majority
+  rank: 3
+  bioguide: F000459
+  thomas: '02061'
+- name: Andy Harris
+  party: majority
+  rank: 4
+  bioguide: H001052
+  thomas: '02026'
+- name: Steven M. Palazzo
+  party: majority
+  rank: 5
+  bioguide: P000601
+  thomas: '02035'
+- name: Dan Newhouse
+  party: majority
+  rank: 6
+  bioguide: N000189
+  thomas: '02275'
+- name: Scott Taylor
+  party: majority
+  rank: 7
+  bioguide: T000477
+- name: Lucille Roybal-Allard
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000486
+  thomas: '00997'
+- name: Henry Cuellar
+  party: minority
+  rank: 2
+  bioguide: C001063
+  thomas: '01807'
+- name: David E. Price
+  party: minority
+  rank: 3
+  bioguide: P000523
+  thomas: '00930'
+- name: C. A. Dutch Ruppersberger
+  party: minority
+  rank: 4
+  bioguide: R000576
+  thomas: '01728'
+HSAP18:
+- name: Charles W. Dent
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000604
+  thomas: '01799'
+- name: Jeff Fortenberry
+  party: majority
+  rank: 2
+  bioguide: F000449
+  thomas: '01793'
+- name: Thomas J. Rooney
+  party: majority
+  rank: 3
+  bioguide: R000583
+  thomas: '01916'
+- name: David G. Valadao
+  party: majority
+  rank: 4
+  bioguide: V000129
+  thomas: '02105'
+- name: Steve Womack
+  party: majority
+  rank: 5
+  bioguide: W000809
+  thomas: '01991'
+- name: Evan H. Jenkins
+  party: majority
+  rank: 6
+  bioguide: J000297
+  thomas: '02278'
+- name: Scott Taylor
+  party: majority
+  rank: 7
+  bioguide: T000477
+- name: Debbie Wasserman Schultz
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000797
+  thomas: '01777'
+- name: Sanford D. Bishop, Jr.
+  party: minority
+  rank: 2
+  bioguide: B000490
+  thomas: '00091'
+- name: Barbara Lee
+  party: minority
+  rank: 3
+  bioguide: L000551
+  thomas: '01501'
+- name: Tim Ryan
+  party: minority
+  rank: 4
+  bioguide: R000577
+  thomas: '01756'
+HSAP19:
+- name: John Abney Culberson
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001048
+  thomas: '01670'
+- name: Harold Rogers
+  party: majority
+  rank: 2
+  bioguide: R000395
+  thomas: '00977'
+- name: Robert B. Aderholt
+  party: majority
+  rank: 3
+  bioguide: A000055
+  thomas: '01460'
+- name: John R. Carter
+  party: majority
+  rank: 4
+  bioguide: C001051
+  thomas: '01752'
+- name: Martha Roby
+  party: majority
+  rank: 5
+  bioguide: R000591
+  thomas: '01986'
+- name: Steven M. Palazzo
+  party: majority
+  rank: 6
+  bioguide: P000601
+  thomas: '02035'
+- name: Evan H. Jenkins
+  party: majority
+  rank: 7
+  bioguide: J000297
+  thomas: '02278'
+- name: José E. Serrano
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S000248
+  thomas: '01042'
+- name: Derek Kilmer
+  party: minority
+  rank: 2
+  bioguide: K000381
+  thomas: '02169'
+- name: Matt Cartwright
+  party: minority
+  rank: 3
+  bioguide: C001090
+  thomas: '02159'
+- name: Grace Meng
+  party: minority
+  rank: 4
+  bioguide: M001188
+  thomas: '02148'
+HSAP20:
+- name: Mario Diaz-Balart
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000600
+  thomas: '01717'
+- name: Charles W. Dent
+  party: majority
+  rank: 2
+  bioguide: D000604
+  thomas: '01799'
+- name: David P. Joyce
+  party: majority
+  rank: 3
+  bioguide: J000295
+  thomas: '02154'
+- name: John Abney Culberson
+  party: majority
+  rank: 4
+  bioguide: C001048
+  thomas: '01670'
+- name: David Young
+  party: majority
+  rank: 5
+  bioguide: Y000066
+  thomas: '02242'
+- name: David G. Valadao
+  party: majority
+  rank: 6
+  bioguide: V000129
+  thomas: '02105'
+- name: Tom Graves
+  party: majority
+  rank: 7
+  bioguide: G000560
+  thomas: '01979'
+- name: David E. Price
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: P000523
+  thomas: '00930'
+- name: Mike Quigley
+  party: minority
+  rank: 2
+  bioguide: Q000023
+  thomas: '01967'
+- name: Katherine M. Clark
+  party: minority
+  rank: 3
+  bioguide: C001101
+  thomas: '02196'
+- name: Pete Aguilar
+  party: minority
+  rank: 4
+  bioguide: A000371
+  thomas: '02229'
+HSAP23:
+- name: Tom Graves
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: G000560
+  thomas: '01979'
+- name: Kevin Yoder
+  party: majority
+  rank: 2
+  bioguide: Y000063
+  thomas: '02021'
+- name: Jaime Herrera Beutler
+  party: majority
+  rank: 3
+  bioguide: H001056
+  thomas: '02071'
+- name: Mark E. Amodei
+  party: majority
+  rank: 4
+  bioguide: A000369
+  thomas: '02090'
+- name: Chris Stewart
+  party: majority
+  rank: 5
+  bioguide: S001192
+  thomas: '02168'
+- name: David Young
+  party: majority
+  rank: 6
+  bioguide: Y000066
+  thomas: '02242'
+- name: John R. Moolenaar
+  party: majority
+  rank: 7
+  bioguide: M001194
+  thomas: '02248'
+- name: Mike Quigley
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: Q000023
+  thomas: '01967'
+- name: José E. Serrano
+  party: minority
+  rank: 2
+  bioguide: S000248
+  thomas: '01042'
+- name: Matt Cartwright
+  party: minority
+  rank: 3
+  bioguide: C001090
+  thomas: '02159'
+- name: Sanford D. Bishop, Jr.
+  party: minority
+  rank: 4
+  bioguide: B000490
+  thomas: '00091'
+HSAP24:
+- name: Kevin Yoder
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: Y000063
+  thomas: '02021'
+- name: Mark E. Amodei
+  party: majority
+  rank: 2
+  bioguide: A000369
+  thomas: '02090'
+- name: Dan Newhouse
+  party: majority
+  rank: 3
+  bioguide: N000189
+  thomas: '02275'
+- name: John R. Moolenaar
+  party: majority
+  rank: 4
+  bioguide: M001194
+  thomas: '02248'
+- name: Scott Taylor
+  party: majority
+  rank: 5
+  bioguide: T000477
+- name: Tim Ryan
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000577
+  thomas: '01756'
+- name: Betty McCollum
+  party: minority
+  rank: 2
+  bioguide: M001143
+  thomas: '01653'
+- name: Debbie Wasserman Schultz
+  party: minority
+  rank: 3
+  bioguide: W000797
+  thomas: '01777'
 HSAS:
 - name: Mac Thornberry
   party: majority
   rank: 1
   title: Chair
-  thomas: '01155'
   bioguide: T000238
+  thomas: '01155'
 - name: Walter B. Jones
   party: majority
   rank: 2
-  thomas: '00612'
   bioguide: J000255
+  thomas: '00612'
 - name: Joe Wilson
   party: majority
   rank: 3
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Rob Bishop
   party: majority
   rank: 5
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Michael R. Turner
   party: majority
   rank: 6
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Mike Rogers
   party: majority
   rank: 7
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Trent Franks
   party: majority
   rank: 8
-  thomas: '01707'
   bioguide: F000448
+  thomas: '01707'
 - name: Bill Shuster
   party: majority
   rank: 9
-  thomas: '01681'
   bioguide: S001154
+  thomas: '01681'
 - name: K. Michael Conaway
   party: majority
   rank: 10
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Doug Lamborn
   party: majority
   rank: 11
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 12
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Duncan Hunter
   party: majority
   rank: 13
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Mike Coffman
   party: majority
   rank: 14
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Vicky Hartzler
   party: majority
   rank: 15
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Austin Scott
   party: majority
   rank: 16
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Mo Brooks
   party: majority
   rank: 17
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Paul Cook
   party: majority
   rank: 18
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Jim Bridenstine
   party: majority
   rank: 19
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Brad R. Wenstrup
   party: majority
   rank: 20
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Bradley Byrne
   party: majority
   rank: 21
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Sam Graves
   party: majority
   rank: 22
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Elise M. Stefanik
   party: majority
   rank: 23
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Martha McSally
   party: majority
   rank: 24
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: Stephen Knight
   party: majority
   rank: 25
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Steve Russell
   party: majority
   rank: 26
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Scott DesJarlais
   party: majority
   rank: 27
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Ralph Lee Abraham
   party: majority
   rank: 28
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 29
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Mike Gallagher
   party: majority
   rank: 30
@@ -1452,98 +2180,98 @@ HSAS:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01528'
   bioguide: S000510
+  thomas: '01528'
 - name: Robert A. Brady
   party: minority
   rank: 2
-  thomas: '01469'
   bioguide: B001227
+  thomas: '01469'
 - name: Susan A. Davis
   party: minority
   rank: 3
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: James R. Langevin
   party: minority
   rank: 4
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Rick Larsen
   party: minority
   rank: 5
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Jim Cooper
   party: minority
   rank: 6
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 7
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Joe Courtney
   party: minority
   rank: 8
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Niki Tsongas
   party: minority
   rank: 9
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: John Garamendi
   party: minority
   rank: 10
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Jackie Speier
   party: minority
   rank: 11
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Marc A. Veasey
   party: minority
   rank: 12
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Tulsi Gabbard
   party: minority
   rank: 13
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Beto O'Rourke
   party: minority
   rank: 14
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Donald Norcross
   party: minority
   rank: 15
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Ruben Gallego
   party: minority
   rank: 16
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Seth Moulton
   party: minority
   rank: 17
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Colleen Hanabusa
   party: minority
   rank: 18
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Carol Shea-Porter
   party: minority
   rank: 19
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Jacky Rosen
   party: minority
   rank: 20
@@ -1581,24 +2309,24 @@ HSAS02:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Walter B. Jones
   party: majority
   rank: 2
-  thomas: '00612'
   bioguide: J000255
+  thomas: '00612'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
   title: Vice Chair
 - name: Steve Russell
   party: majority
   rank: 4
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Don Bacon
   party: majority
   rank: 5
@@ -1606,44 +2334,44 @@ HSAS02:
 - name: Martha McSally
   party: majority
   rank: 6
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: Ralph Lee Abraham
   party: majority
   rank: 7
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 8
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Jackie Speier
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Robert A. Brady
   party: minority
   rank: 2
-  thomas: '01469'
   bioguide: B001227
+  thomas: '01469'
 - name: Niki Tsongas
   party: minority
   rank: 3
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Ruben Gallego
   party: minority
   rank: 4
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Carol Shea-Porter
   party: minority
   rank: 5
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Jacky Rosen
   party: minority
   rank: 6
@@ -1653,54 +2381,54 @@ HSAS03:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Rob Bishop
   party: majority
   rank: 2
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Austin Scott
   party: majority
   rank: 3
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Steve Russell
   party: majority
   rank: 4
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Mike Rogers
   party: majority
   rank: 5
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Vicky Hartzler
   party: majority
   rank: 6
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Elise M. Stefanik
   party: majority
   rank: 7
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Martha McSally
   party: majority
   rank: 8
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
   title: Vice Chair
 - name: Scott DesJarlais
   party: majority
   rank: 9
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Trent Kelly
   party: majority
   rank: 10
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Mike Gallagher
   party: majority
   rank: 11
@@ -1709,23 +2437,23 @@ HSAS03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Joe Courtney
   party: minority
   rank: 2
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Tulsi Gabbard
   party: minority
   rank: 3
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Carol Shea-Porter
   party: minority
   rank: 4
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: A. Donald McEachin
   party: minority
   rank: 5
@@ -1751,13 +2479,13 @@ HSAS06:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Matt Gaetz
   party: majority
   rank: 3
@@ -1773,14 +2501,14 @@ HSAS06:
 - name: Austin Scott
   party: majority
   rank: 6
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Seth Moulton
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Tom O'Halleran
   party: minority
   rank: 2
@@ -1794,39 +2522,39 @@ HSAS25:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Frank A. LoBiondo
   party: majority
   rank: 2
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Paul Cook
   party: majority
   rank: 3
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
   title: Vice Chair
 - name: Sam Graves
   party: majority
   rank: 4
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Martha McSally
   party: majority
   rank: 5
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: Stephen Knight
   party: majority
   rank: 6
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 7
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Matt Gaetz
   party: majority
   rank: 8
@@ -1842,49 +2570,49 @@ HSAS25:
 - name: Walter B. Jones
   party: majority
   rank: 11
-  thomas: '00612'
   bioguide: J000255
+  thomas: '00612'
 - name: Rob Bishop
   party: majority
   rank: 12
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Robert J. Wittman
   party: majority
   rank: 13
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Mo Brooks
   party: majority
   rank: 14
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Niki Tsongas
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: James R. Langevin
   party: minority
   rank: 2
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Jim Cooper
   party: minority
   rank: 3
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Marc A. Veasey
   party: minority
   rank: 4
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Ruben Gallego
   party: minority
   rank: 5
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Jacky Rosen
   party: minority
   rank: 6
@@ -1910,23 +2638,23 @@ HSAS26:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Bill Shuster
   party: majority
   rank: 2
-  thomas: '01681'
   bioguide: S001154
+  thomas: '01681'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Ralph Lee Abraham
   party: majority
   rank: 4
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Liz Cheney
   party: majority
   rank: 5
@@ -1935,64 +2663,64 @@ HSAS26:
 - name: Joe Wilson
   party: majority
   rank: 6
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Frank A. LoBiondo
   party: majority
   rank: 7
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Trent Franks
   party: majority
   rank: 8
-  thomas: '01707'
   bioguide: F000448
+  thomas: '01707'
 - name: Doug Lamborn
   party: majority
   rank: 9
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Austin Scott
   party: majority
   rank: 10
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: James R. Langevin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Rick Larsen
   party: minority
   rank: 2
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Jim Cooper
   party: minority
   rank: 3
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Jackie Speier
   party: minority
   rank: 4
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Marc A. Veasey
   party: minority
   rank: 5
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Beto O'Rourke
   party: minority
   rank: 7
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Stephanie N. Murphy
   party: minority
   rank: 8
@@ -2002,29 +2730,29 @@ HSAS28:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Vicky Hartzler
   party: majority
   rank: 3
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Bradley Byrne
   party: majority
   rank: 4
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
   title: Vice Chair
 - name: Scott DesJarlais
   party: majority
   rank: 5
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Mike Gallagher
   party: majority
   rank: 6
@@ -2032,69 +2760,69 @@ HSAS28:
 - name: Duncan Hunter
   party: majority
   rank: 7
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Paul Cook
   party: majority
   rank: 8
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Jim Bridenstine
   party: majority
   rank: 9
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 10
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Ralph Lee Abraham
   party: majority
   rank: 11
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Joe Courtney
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Susan A. Davis
   party: minority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: James R. Langevin
   party: minority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 4
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: John Garamendi
   party: minority
   rank: 5
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Donald Norcross
   party: minority
   rank: 6
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Seth Moulton
   party: minority
   rank: 7
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Colleen Hanabusa
   party: minority
   rank: 8
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: A. Donald McEachin
   party: minority
   rank: 9
@@ -2104,90 +2832,90 @@ HSAS29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Trent Franks
   party: majority
   rank: 2
-  thomas: '01707'
   bioguide: F000448
+  thomas: '01707'
   title: Vice Chair
 - name: Doug Lamborn
   party: majority
   rank: 3
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Duncan Hunter
   party: majority
   rank: 4
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Mo Brooks
   party: majority
   rank: 5
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Jim Bridenstine
   party: majority
   rank: 6
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Michael R. Turner
   party: majority
   rank: 7
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Mike Coffman
   party: majority
   rank: 8
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Bradley Byrne
   party: majority
   rank: 9
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Sam Graves
   party: majority
   rank: 10
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Jim Cooper
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Susan A. Davis
   party: minority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Rick Larsen
   party: minority
   rank: 3
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: John Garamendi
   party: minority
   rank: 4
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Beto O'Rourke
   party: minority
   rank: 5
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Donald Norcross
   party: minority
   rank: 6
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Colleen Hanabusa
   party: minority
   rank: 7
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Ro Khanna
   party: minority
   rank: 8
@@ -2197,153 +2925,153 @@ HSBA:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
 - name: Peter T. King
   party: majority
   rank: 2
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Edward R. Royce
   party: majority
   rank: 3
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Frank D. Lucas
   party: majority
   rank: 4
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Patrick T. McHenry
   party: majority
   rank: 5
-  thomas: '01792'
   bioguide: M001156
+  thomas: '01792'
 - name: Stevan Pearce
   party: majority
   rank: 6
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Bill Posey
   party: majority
   rank: 7
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 8
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Bill Huizenga
   party: majority
   rank: 9
-  thomas: '02028'
   bioguide: H001058
+  thomas: '02028'
 - name: Sean P. Duffy
   party: majority
   rank: 10
-  thomas: '02072'
   bioguide: D000614
+  thomas: '02072'
 - name: Steve Stivers
   party: majority
   rank: 11
-  thomas: '02047'
   bioguide: S001187
+  thomas: '02047'
 - name: Randy Hultgren
   party: majority
   rank: 12
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Dennis A. Ross
   party: majority
   rank: 13
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Robert Pittenger
   party: majority
   rank: 14
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
 - name: Ann Wagner
   party: majority
   rank: 15
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Andy Barr
   party: majority
   rank: 16
-  thomas: '02131'
   bioguide: B001282
+  thomas: '02131'
 - name: Keith J. Rothfus
   party: majority
   rank: 17
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
 - name: Luke Messer
   party: majority
   rank: 18
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Scott R. Tipton
   party: majority
   rank: 19
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 20
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
 - name: Bruce Poliquin
   party: majority
   rank: 21
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Mia B. Love
   party: majority
   rank: 22
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 23
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 24
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Lee M. Zeldin
   party: majority
   rank: 25
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 26
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 27
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Alexander X. Mooney
   party: majority
   rank: 28
-  thomas: '02277'
   bioguide: M001195
+  thomas: '02277'
 - name: Thomas MacArthur
   party: majority
   rank: 29
-  thomas: '02258'
   bioguide: M001193
+  thomas: '02258'
 - name: Warren Davidson
   party: majority
   rank: 30
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 31
@@ -2364,113 +3092,113 @@ HSBA:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Nydia M. Velázquez
   party: minority
   rank: 3
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Brad Sherman
   party: minority
   rank: 4
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Gregory W. Meeks
   party: minority
   rank: 5
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Michael E. Capuano
   party: minority
   rank: 6
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Wm. Lacy Clay
   party: minority
   rank: 7
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Stephen F. Lynch
   party: minority
   rank: 8
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: David Scott
   party: minority
   rank: 9
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Al Green
   party: minority
   rank: 10
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Emanuel Cleaver
   party: minority
   rank: 11
-  thomas: '01790'
   bioguide: C001061
+  thomas: '01790'
 - name: Gwen Moore
   party: minority
   rank: 12
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Keith Ellison
   party: minority
   rank: 13
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Ed Perlmutter
   party: minority
   rank: 14
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: James A. Himes
   party: minority
   rank: 15
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Bill Foster
   party: minority
   rank: 16
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Daniel T. Kildee
   party: minority
   rank: 17
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 18
-  thomas: '02133'
   bioguide: D000620
+  thomas: '02133'
 - name: Kyrsten Sinema
   party: minority
   rank: 19
-  thomas: '02099'
   bioguide: S001191
+  thomas: '02099'
 - name: Joyce Beatty
   party: minority
   rank: 20
-  thomas: '02153'
   bioguide: B001281
+  thomas: '02153'
 - name: Denny Heck
   party: minority
   rank: 21
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 - name: Juan Vargas
   party: minority
   rank: 22
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 23
@@ -2492,64 +3220,64 @@ HSBA01:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Robert Pittenger
   party: majority
   rank: 2
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
   title: Vice Chair
 - name: Keith J. Rothfus
   party: majority
   rank: 3
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
 - name: Luke Messer
   party: majority
   rank: 4
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Scott R. Tipton
   party: majority
   rank: 5
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 6
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
 - name: Bruce Poliquin
   party: majority
   rank: 7
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Mia B. Love
   party: majority
   rank: 8
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 9
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 10
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Lee M. Zeldin
   party: majority
   rank: 11
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: Warren Davidson
   party: majority
   rank: 12
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 13
@@ -2561,50 +3289,50 @@ HSBA01:
 - name: Jeb Hensarling
   party: majority
   rank: 15
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Ed Perlmutter
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: James A. Himes
   party: minority
   rank: 3
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Bill Foster
   party: minority
   rank: 4
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Daniel T. Kildee
   party: minority
   rank: 5
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 6
-  thomas: '02133'
   bioguide: D000620
+  thomas: '02133'
 - name: Kyrsten Sinema
   party: minority
   rank: 7
-  thomas: '02099'
   bioguide: S001191
+  thomas: '02099'
 - name: Juan Vargas
   party: minority
   rank: 8
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 9
@@ -2620,72 +3348,72 @@ HSBA01:
 - name: Maxine Waters
   party: minority
   rank: 12
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA04:
 - name: Sean P. Duffy
   party: majority
   rank: 1
   title: Chair
-  thomas: '02072'
   bioguide: D000614
+  thomas: '02072'
 - name: Dennis A. Ross
   party: majority
   rank: 2
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
   title: Vice Chair
 - name: Edward R. Royce
   party: majority
   rank: 3
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Stevan Pearce
   party: majority
   rank: 4
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Bill Posey
   party: majority
   rank: 5
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 6
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Steve Stivers
   party: majority
   rank: 7
-  thomas: '02047'
   bioguide: S001187
+  thomas: '02047'
 - name: Randy Hultgren
   party: majority
   rank: 8
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Keith J. Rothfus
   party: majority
   rank: 9
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
 - name: Lee M. Zeldin
   party: majority
   rank: 10
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 11
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Thomas MacArthur
   party: majority
   rank: 12
-  thomas: '02258'
   bioguide: M001193
+  thomas: '02258'
 - name: Ted Budd
   party: majority
   rank: 13
@@ -2693,55 +3421,55 @@ HSBA04:
 - name: Jeb Hensarling
   party: majority
   rank: 14
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Emanuel Cleaver
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01790'
   bioguide: C001061
+  thomas: '01790'
 - name: Nydia M. Velázquez
   party: minority
   rank: 2
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Michael E. Capuano
   party: minority
   rank: 3
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Brad Sherman
   party: minority
   rank: 5
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Stephen F. Lynch
   party: minority
   rank: 6
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Joyce Beatty
   party: minority
   rank: 7
-  thomas: '02153'
   bioguide: B001281
+  thomas: '02153'
 - name: Daniel T. Kildee
   party: minority
   rank: 8
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 9
-  thomas: '02133'
   bioguide: D000620
+  thomas: '02133'
 - name: Ruben Kihuen
   party: minority
   rank: 10
@@ -2749,57 +3477,57 @@ HSBA04:
 - name: Maxine Waters
   party: minority
   rank: 11
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA09:
 - name: Ann Wagner
   party: majority
   rank: 1
   title: Chair
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Scott R. Tipton
   party: majority
   rank: 2
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
   title: Vice Chair
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Patrick T. McHenry
   party: majority
   rank: 4
-  thomas: '01792'
   bioguide: M001156
+  thomas: '01792'
 - name: Dennis A. Ross
   party: majority
   rank: 5
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Luke Messer
   party: majority
   rank: 6
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Lee M. Zeldin
   party: majority
   rank: 7
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 8
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 9
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: David Kustoff
   party: majority
   rank: 10
@@ -2815,40 +3543,40 @@ HSBA09:
 - name: Jeb Hensarling
   party: majority
   rank: 13
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Al Green
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Keith Ellison
   party: minority
   rank: 2
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Emanuel Cleaver
   party: minority
   rank: 3
-  thomas: '01790'
   bioguide: C001061
+  thomas: '01790'
 - name: Joyce Beatty
   party: minority
   rank: 4
-  thomas: '02153'
   bioguide: B001281
+  thomas: '02153'
 - name: Michael E. Capuano
   party: minority
   rank: 5
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Gwen Moore
   party: minority
   rank: 6
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Josh Gottheimer
   party: minority
   rank: 7
@@ -2864,77 +3592,77 @@ HSBA09:
 - name: Maxine Waters
   party: minority
   rank: 10
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA15:
 - name: Blaine Luetkemeyer
   party: majority
   rank: 1
   title: Chair
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Keith J. Rothfus
   party: majority
   rank: 2
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
   title: Vice Chair
 - name: Edward R. Royce
   party: majority
   rank: 3
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Frank D. Lucas
   party: majority
   rank: 4
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Bill Posey
   party: majority
   rank: 5
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Dennis A. Ross
   party: majority
   rank: 6
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Robert Pittenger
   party: majority
   rank: 7
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
 - name: Andy Barr
   party: majority
   rank: 8
-  thomas: '02131'
   bioguide: B001282
+  thomas: '02131'
 - name: Scott R. Tipton
   party: majority
   rank: 9
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 10
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
 - name: Mia B. Love
   party: majority
   rank: 11
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: David A. Trott
   party: majority
   rank: 12
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 13
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: David Kustoff
   party: majority
   rank: 14
@@ -2946,60 +3674,60 @@ HSBA15:
 - name: Jeb Hensarling
   party: majority
   rank: 16
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Wm. Lacy Clay
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Gregory W. Meeks
   party: minority
   rank: 3
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: David Scott
   party: minority
   rank: 4
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Nydia M. Velázquez
   party: minority
   rank: 5
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Al Green
   party: minority
   rank: 6
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Keith Ellison
   party: minority
   rank: 7
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Michael E. Capuano
   party: minority
   rank: 8
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Denny Heck
   party: minority
   rank: 9
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 - name: Gwen Moore
   party: minority
   rank: 10
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Charlie Crist
   party: minority
   rank: 11
@@ -3007,82 +3735,82 @@ HSBA15:
 - name: Maxine Waters
   party: minority
   rank: 12
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA16:
 - name: Bill Huizenga
   party: majority
   rank: 1
   title: Chair
-  thomas: '02028'
   bioguide: H001058
+  thomas: '02028'
 - name: Randy Hultgren
   party: majority
   rank: 2
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
   title: Vice Chair
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Patrick T. McHenry
   party: majority
   rank: 4
-  thomas: '01792'
   bioguide: M001156
+  thomas: '01792'
 - name: Sean P. Duffy
   party: majority
   rank: 5
-  thomas: '02072'
   bioguide: D000614
+  thomas: '02072'
 - name: Steve Stivers
   party: majority
   rank: 6
-  thomas: '02047'
   bioguide: S001187
+  thomas: '02047'
 - name: Ann Wagner
   party: majority
   rank: 7
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Luke Messer
   party: majority
   rank: 8
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Bruce Poliquin
   party: majority
   rank: 9
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: J. French Hill
   party: majority
   rank: 10
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 11
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Alexander X. Mooney
   party: majority
   rank: 12
-  thomas: '02277'
   bioguide: M001195
+  thomas: '02277'
 - name: Thomas MacArthur
   party: majority
   rank: 13
-  thomas: '02258'
   bioguide: M001193
+  thomas: '02258'
 - name: Warren Davidson
   party: majority
   rank: 14
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 15
@@ -3094,60 +3822,60 @@ HSBA16:
 - name: Jeb Hensarling
   party: majority
   rank: 17
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Carolyn B. Maloney
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Brad Sherman
   party: minority
   rank: 2
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Stephen F. Lynch
   party: minority
   rank: 3
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: David Scott
   party: minority
   rank: 4
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: James A. Himes
   party: minority
   rank: 5
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Keith Ellison
   party: minority
   rank: 6
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Bill Foster
   party: minority
   rank: 7
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Gregory W. Meeks
   party: minority
   rank: 8
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Kyrsten Sinema
   party: minority
   rank: 9
-  thomas: '02099'
   bioguide: S001191
+  thomas: '02099'
 - name: Juan Vargas
   party: minority
   rank: 10
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 11
@@ -3159,62 +3887,62 @@ HSBA16:
 - name: Maxine Waters
   party: minority
   rank: 13
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA20:
 - name: Andy Barr
   party: majority
   rank: 1
   title: Chair
-  thomas: '02131'
   bioguide: B001282
+  thomas: '02131'
 - name: Roger Williams
   party: majority
   rank: 2
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
   title: Vice Chair
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Bill Huizenga
   party: majority
   rank: 4
-  thomas: '02028'
   bioguide: H001058
+  thomas: '02028'
 - name: Robert Pittenger
   party: majority
   rank: 5
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
 - name: Mia B. Love
   party: majority
   rank: 6
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 7
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 8
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Alexander X. Mooney
   party: majority
   rank: 9
-  thomas: '02277'
   bioguide: M001195
+  thomas: '02277'
 - name: Warren Davidson
   party: majority
   rank: 10
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Claudia Tenney
   party: majority
   rank: 11
@@ -3226,50 +3954,50 @@ HSBA20:
 - name: Jeb Hensarling
   party: majority
   rank: 13
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Gwen Moore
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Gregory W. Meeks
   party: minority
   rank: 2
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Bill Foster
   party: minority
   rank: 3
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Brad Sherman
   party: minority
   rank: 4
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Al Green
   party: minority
   rank: 5
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Denny Heck
   party: minority
   rank: 6
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 - name: Daniel T. Kildee
   party: minority
   rank: 7
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: Juan Vargas
   party: minority
   rank: 8
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Charlie Crist
   party: minority
   rank: 9
@@ -3277,86 +4005,86 @@ HSBA20:
 - name: Maxine Waters
   party: minority
   rank: 10
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBU:
 - name: Diane Black
   party: majority
   rank: 1
   title: Chair
-  thomas: '02063'
   bioguide: B001273
+  thomas: '02063'
 - name: Mario Diaz-Balart
   party: majority
   rank: 2
-  thomas: '01717'
   bioguide: D000600
+  thomas: '01717'
 - name: Tom Cole
   party: majority
   rank: 3
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: Tom McClintock
   party: majority
   rank: 4
-  thomas: '01908'
   bioguide: M001177
+  thomas: '01908'
 - name: Todd Rokita
   party: majority
   rank: 5
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Rob Woodall
   party: majority
   rank: 6
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Mark Sanford
   party: majority
   rank: 7
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Steve Womack
   party: majority
   rank: 8
-  thomas: '01991'
   bioguide: W000809
+  thomas: '01991'
 - name: Dave Brat
   party: majority
   rank: 9
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 10
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Gary J. Palmer
   party: majority
   rank: 11
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: Bruce Westerman
   party: majority
   rank: 12
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: James B. Renacci
   party: majority
   rank: 13
-  thomas: '02048'
   bioguide: R000586
+  thomas: '02048'
 - name: Bill Johnson
   party: majority
   rank: 14
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Jason Smith
   party: majority
   rank: 15
-  thomas: '02191'
   bioguide: S001195
+  thomas: '02191'
 - name: Jason Lewis
   party: majority
   rank: 16
@@ -3389,48 +4117,48 @@ HSBU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01853'
   bioguide: Y000062
+  thomas: '01853'
 - name: Barbara Lee
   party: minority
   rank: 2
-  thomas: '01501'
   bioguide: L000551
+  thomas: '01501'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 3
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Seth Moulton
   party: minority
   rank: 4
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
-  thomas: '02149'
   bioguide: J000294
+  thomas: '02149'
 - name: Brian Higgins
   party: minority
   rank: 6
-  thomas: '01794'
   bioguide: H001038
+  thomas: '01794'
 - name: Suzan K. DelBene
   party: minority
   rank: 7
-  thomas: '02096'
   bioguide: D000617
+  thomas: '02096'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 8
-  thomas: '01777'
   bioguide: W000797
+  thomas: '01777'
 - name: Brendan F. Boyle
   party: minority
   rank: 9
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Ro Khanna
   party: minority
   rank: 10
@@ -3446,96 +4174,96 @@ HSBU:
 - name: Sheila Jackson Lee
   party: minority
   rank: 13
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: Janice D. Schakowsky
   party: minority
   rank: 14
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 HSED:
 - name: Virginia Foxx
   party: majority
   rank: 1
   title: Chair
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
   title: Vice Chair
 - name: Duncan Hunter
   party: majority
   rank: 3
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: David P. Roe
   party: majority
   rank: 4
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Glenn Thompson
   party: majority
   rank: 5
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Tim Walberg
   party: majority
   rank: 6
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Brett Guthrie
   party: majority
   rank: 7
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Todd Rokita
   party: majority
   rank: 8
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Lou Barletta
   party: majority
   rank: 9
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Luke Messer
   party: majority
   rank: 10
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Bradley Byrne
   party: majority
   rank: 11
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Dave Brat
   party: majority
   rank: 12
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 13
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Steve Russell
   party: majority
   rank: 14
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Elise M. Stefanik
   party: majority
   rank: 15
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Rick W. Allen
   party: majority
   rank: 16
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 17
@@ -3564,68 +4292,68 @@ HSED:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01037'
   bioguide: S000185
+  thomas: '01037'
 - name: Susan A. Davis
   party: minority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Raúl M. Grijalva
   party: minority
   rank: 3
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Joe Courtney
   party: minority
   rank: 4
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Marcia L. Fudge
   party: minority
   rank: 5
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Jared Polis
   party: minority
   rank: 6
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
   rank: 8
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Suzanne Bonamici
   party: minority
   rank: 9
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Mark Takano
   party: minority
   rank: 10
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Alma S. Adams
   party: minority
   rank: 11
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 12
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Donald Norcross
   party: minority
   rank: 13
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 14
@@ -3637,8 +4365,8 @@ HSED:
 - name: Carol Shea-Porter
   party: minority
   rank: 16
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Adriano Espaillat
   party: minority
   rank: 17
@@ -3648,33 +4376,33 @@ HSED02:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: David P. Roe
   party: majority
   rank: 3
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Todd Rokita
   party: majority
   rank: 4
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Lou Barletta
   party: majority
   rank: 5
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Rick W. Allen
   party: majority
   rank: 6
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 7
@@ -3699,18 +4427,18 @@ HSED02:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
   rank: 2
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Donald Norcross
   party: minority
   rank: 3
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 4
@@ -3718,8 +4446,8 @@ HSED02:
 - name: Carol Shea-Porter
   party: minority
   rank: 5
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Adriano Espaillat
   party: minority
   rank: 6
@@ -3727,50 +4455,50 @@ HSED02:
 - name: Joe Courtney
   party: minority
   rank: 7
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Marcia L. Fudge
   party: minority
   rank: 8
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Suzanne Bonamici
   party: minority
   rank: 9
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 HSED10:
 - name: Bradley Byrne
   party: majority
   rank: 1
   title: Chair
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Duncan Hunter
   party: majority
   rank: 3
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Dave Brat
   party: majority
   rank: 4
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 5
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Elise M. Stefanik
   party: majority
   rank: 6
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Francis Rooney
   party: majority
   rank: 7
@@ -3783,28 +4511,28 @@ HSED10:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Raúl M. Grijalva
   party: minority
   rank: 2
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Alma S. Adams
   party: minority
   rank: 3
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 4
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Donald Norcross
   party: minority
   rank: 5
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 6
@@ -3812,50 +4540,50 @@ HSED10:
 - name: Carol Shea-Porter
   party: minority
   rank: 7
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 HSED13:
 - name: Brett Guthrie
   party: majority
   rank: 1
   title: Chair
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Glenn Thompson
   party: majority
   rank: 2
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Lou Barletta
   party: majority
   rank: 3
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Luke Messer
   party: majority
   rank: 4
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Bradley Byrne
   party: majority
   rank: 5
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Glenn Grothman
   party: majority
   rank: 6
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Elise M. Stefanik
   party: majority
   rank: 7
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Rick W. Allen
   party: majority
   rank: 8
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 9
@@ -3876,23 +4604,23 @@ HSED13:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Joe Courtney
   party: minority
   rank: 2
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Alma S. Adams
   party: minority
   rank: 3
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 4
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 5
@@ -3900,18 +4628,18 @@ HSED13:
 - name: Jared Polis
   party: minority
   rank: 6
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Mark Takano
   party: minority
   rank: 8
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 9
@@ -3925,33 +4653,33 @@ HSED14:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Duncan Hunter
   party: majority
   rank: 2
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: David P. Roe
   party: majority
   rank: 3
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Glenn Thompson
   party: majority
   rank: 4
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Luke Messer
   party: majority
   rank: 5
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Dave Brat
   party: majority
   rank: 6
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Thomas A. Garrett, Jr.
   party: majority
   rank: 7
@@ -3960,145 +4688,145 @@ HSED14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Raúl M. Grijalva
   party: minority
   rank: 2
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Marcia L. Fudge
   party: minority
   rank: 3
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Susan A. Davis
   party: minority
   rank: 5
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Frederica S. Wilson
   party: minority
   rank: 6
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 HSFA:
 - name: Edward R. Royce
   party: majority
   rank: 1
   title: Chair
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Christopher H. Smith
   party: majority
   rank: 2
-  thomas: '01071'
   bioguide: S000522
+  thomas: '01071'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Dana Rohrabacher
   party: majority
   rank: 4
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Steve Chabot
   party: majority
   rank: 5
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Joe Wilson
   party: majority
   rank: 6
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Michael T. McCaul
   party: majority
   rank: 7
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
 - name: Ted Poe
   party: majority
   rank: 8
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Darrell E. Issa
   party: majority
   rank: 9
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Tom Marino
   party: majority
   rank: 10
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Jeff Duncan
   party: majority
   rank: 11
-  thomas: '02057'
   bioguide: D000615
+  thomas: '02057'
 - name: Mo Brooks
   party: majority
   rank: 12
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Paul Cook
   party: majority
   rank: 13
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Scott Perry
   party: majority
   rank: 14
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Ron DeSantis
   party: majority
   rank: 15
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Mark Meadows
   party: majority
   rank: 16
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Ted S. Yoho
   party: majority
   rank: 17
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Adam Kinzinger
   party: majority
   rank: 18
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: Lee M. Zeldin
   party: majority
   rank: 19
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 20
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 21
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Ann Wagner
   party: majority
   rank: 22
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Brian J. Mast
   party: majority
   rank: 23
@@ -4119,93 +4847,93 @@ HSFA:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: Brad Sherman
   party: minority
   rank: 2
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Gregory W. Meeks
   party: minority
   rank: 3
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Albio Sires
   party: minority
   rank: 4
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: Gerald E. Connolly
   party: minority
   rank: 5
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Theodore E. Deutch
   party: minority
   rank: 6
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Karen Bass
   party: minority
   rank: 7
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: William R. Keating
   party: minority
   rank: 8
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: David N. Cicilline
   party: minority
   rank: 9
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Ami Bera
   party: minority
   rank: 10
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Lois Frankel
   party: minority
   rank: 11
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Tulsi Gabbard
   party: minority
   rank: 12
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Joaquin Castro
   party: minority
   rank: 13
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Robin L. Kelly
   party: minority
   rank: 14
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Brendan F. Boyle
   party: minority
   rank: 15
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Dina Titus
   party: minority
   rank: 16
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Norma J. Torres
   party: minority
   rank: 17
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Bradley Scott Schneider
   party: minority
   rank: 18
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 - name: Thomas R. Suozzi
   party: minority
   rank: 19
@@ -4217,62 +4945,143 @@ HSFA:
 - name: Ted Lieu
   party: minority
   rank: 21
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 HSFA05:
+- name: Ted S. Yoho
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: Y000065
+  thomas: '02115'
+- name: Dana Rohrabacher
+  party: majority
+  rank: 2
+  bioguide: R000409
+  thomas: '00979'
+- name: Steve Chabot
+  party: majority
+  rank: 3
+  bioguide: C000266
+  thomas: '00186'
+- name: Tom Marino
+  party: majority
+  rank: 4
+  bioguide: M001179
+  thomas: '02053'
+- name: Mo Brooks
+  party: majority
+  rank: 5
+  bioguide: B001274
+  thomas: '01987'
+- name: Scott Perry
+  party: majority
+  rank: 6
+  bioguide: P000605
+  thomas: '02157'
+- name: Adam Kinzinger
+  party: majority
+  rank: 7
+  bioguide: K000378
+  thomas: '02014'
+- name: Ann Wagner
+  party: majority
+  rank: 8
+  bioguide: W000812
+  thomas: '02137'
 - name: Brad Sherman
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Ami Bera
   party: minority
   rank: 2
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Dina Titus
   party: minority
   rank: 3
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Gerald E. Connolly
   party: minority
   rank: 4
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Theodore E. Deutch
   party: minority
   rank: 5
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 HSFA07:
+- name: Jeff Duncan
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000615
+  thomas: '02057'
+- name: Christopher H. Smith
+  party: majority
+  rank: 2
+  bioguide: S000522
+  thomas: '01071'
+- name: Ileana Ros-Lehtinen
+  party: majority
+  rank: 3
+  bioguide: R000435
+  thomas: '00985'
+- name: Michael T. McCaul
+  party: majority
+  rank: 4
+  bioguide: M001157
+  thomas: '01804'
+- name: Mo Brooks
+  party: majority
+  rank: 5
+  bioguide: B001274
+  thomas: '01987'
+- name: Ron DeSantis
+  party: majority
+  rank: 6
+  bioguide: D000621
+  thomas: '02116'
+- name: Ted S. Yoho
+  party: majority
+  rank: 7
+  bioguide: Y000065
+  thomas: '02115'
+- name: Francis Rooney
+  party: majority
+  rank: 8
+  bioguide: R000607
 - name: Albio Sires
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: Joaquin Castro
   party: minority
   rank: 2
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Robin L. Kelly
   party: minority
   rank: 3
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Norma J. Torres
   party: minority
   rank: 4
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Adriano Espaillat
   party: minority
   rank: 5
@@ -4280,45 +5089,104 @@ HSFA07:
 - name: Gregory W. Meeks
   party: minority
   rank: 6
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 HSFA13:
+- name: Ileana Ros-Lehtinen
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000435
+  thomas: '00985'
+- name: Steve Chabot
+  party: majority
+  rank: 2
+  bioguide: C000266
+  thomas: '00186'
+- name: Darrell E. Issa
+  party: majority
+  rank: 3
+  bioguide: I000056
+  thomas: '01640'
+- name: Ron DeSantis
+  party: majority
+  rank: 4
+  bioguide: D000621
+  thomas: '02116'
+- name: Mark Meadows
+  party: majority
+  rank: 5
+  bioguide: M001187
+  thomas: '02142'
+- name: Paul Cook
+  party: majority
+  rank: 6
+  bioguide: C001094
+  thomas: '02103'
+- name: Adam Kinzinger
+  party: majority
+  rank: 7
+  bioguide: K000378
+  thomas: '02014'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 8
+  bioguide: Z000017
+  thomas: '02261'
+- name: Daniel M. Donovan, Jr.
+  party: majority
+  rank: 9
+  bioguide: D000625
+  thomas: '02293'
+- name: Ann Wagner
+  party: majority
+  rank: 10
+  bioguide: W000812
+  thomas: '02137'
+- name: Brian J. Mast
+  party: majority
+  rank: 11
+  bioguide: M001199
+- name: Brian K. Fitzpatrick
+  party: majority
+  rank: 12
+  bioguide: F000466
 - name: Theodore E. Deutch
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Gerald E. Connolly
   party: minority
   rank: 2
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: David N. Cicilline
   party: minority
   rank: 3
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Lois Frankel
   party: minority
   rank: 4
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Brendan F. Boyle
   party: minority
   rank: 5
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Bradley Scott Schneider
   party: minority
   rank: 7
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 - name: Thomas R. Suozzi
   party: minority
   rank: 8
@@ -4326,205 +5194,308 @@ HSFA13:
 - name: Ted Lieu
   party: minority
   rank: 9
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 HSFA14:
+- name: Dana Rohrabacher
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000409
+  thomas: '00979'
+- name: Joe Wilson
+  party: majority
+  rank: 2
+  bioguide: W000795
+  thomas: '01688'
+- name: Ted Poe
+  party: majority
+  rank: 3
+  bioguide: P000592
+  thomas: '01802'
+- name: Tom Marino
+  party: majority
+  rank: 4
+  bioguide: M001179
+  thomas: '02053'
+- name: Jeff Duncan
+  party: majority
+  rank: 5
+  bioguide: D000615
+  thomas: '02057'
+- name: F. James Sensenbrenner, Jr.
+  party: majority
+  rank: 6
+  bioguide: S000244
+  thomas: '01041'
+- name: Francis Rooney
+  party: majority
+  rank: 7
+  bioguide: R000607
+- name: Brian K. Fitzpatrick
+  party: majority
+  rank: 8
+  bioguide: F000466
 - name: Gregory W. Meeks
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Brad Sherman
   party: minority
   rank: 2
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Albio Sires
   party: minority
   rank: 3
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: William R. Keating
   party: minority
   rank: 4
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: David N. Cicilline
   party: minority
   rank: 5
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Robin L. Kelly
   party: minority
   rank: 6
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 HSFA16:
+- name: Christopher H. Smith
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: S000522
+  thomas: '01071'
+- name: Mark Meadows
+  party: majority
+  rank: 2
+  bioguide: M001187
+  thomas: '02142'
+- name: Daniel M. Donovan, Jr.
+  party: majority
+  rank: 3
+  bioguide: D000625
+  thomas: '02293'
+- name: F. James Sensenbrenner, Jr.
+  party: majority
+  rank: 4
+  bioguide: S000244
+  thomas: '01041'
+- name: Thomas A. Garrett, Jr.
+  party: majority
+  rank: 5
+  bioguide: G000580
 - name: Karen Bass
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: Ami Bera
   party: minority
   rank: 2
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Joaquin Castro
   party: minority
   rank: 3
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Thomas R. Suozzi
   party: minority
   rank: 4
   bioguide: S001201
 HSFA18:
+- name: Ted Poe
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: P000592
+  thomas: '01802'
+- name: Joe Wilson
+  party: majority
+  rank: 2
+  bioguide: W000795
+  thomas: '01688'
+- name: Darrell E. Issa
+  party: majority
+  rank: 3
+  bioguide: I000056
+  thomas: '01640'
+- name: Paul Cook
+  party: majority
+  rank: 4
+  bioguide: C001094
+  thomas: '02103'
+- name: Scott Perry
+  party: majority
+  rank: 5
+  bioguide: P000605
+  thomas: '02157'
+- name: Lee M. Zeldin
+  party: majority
+  rank: 6
+  bioguide: Z000017
+  thomas: '02261'
+- name: Brian J. Mast
+  party: majority
+  rank: 7
+  bioguide: M001199
+- name: Thomas A. Garrett, Jr.
+  party: majority
+  rank: 8
+  bioguide: G000580
 - name: William R. Keating
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Lois Frankel
   party: minority
   rank: 2
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Brendan F. Boyle
   party: minority
   rank: 3
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Dina Titus
   party: minority
   rank: 4
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Norma J. Torres
   party: minority
   rank: 5
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Bradley Scott Schneider
   party: minority
   rank: 6
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 HSGO:
 - name: Jason Chaffetz
   party: majority
   rank: 1
   title: Chair
-  thomas: '01956'
   bioguide: C001076
+  thomas: '01956'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 2
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Jim Jordan
   party: majority
   rank: 4
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Mark Sanford
   party: majority
   rank: 5
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Justin Amash
   party: majority
   rank: 6
-  thomas: '02029'
   bioguide: A000367
+  thomas: '02029'
 - name: Paul A. Gosar
   party: majority
   rank: 7
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Scott DesJarlais
   party: majority
   rank: 8
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Trey Gowdy
   party: majority
   rank: 9
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Blake Farenthold
   party: majority
   rank: 10
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Virginia Foxx
   party: majority
   rank: 11
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Thomas Massie
   party: majority
   rank: 12
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 13
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Ron DeSantis
   party: majority
   rank: 14
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Dennis A. Ross
   party: majority
   rank: 15
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Mark Walker
   party: majority
   rank: 16
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
 - name: Rod Blum
   party: majority
   rank: 17
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: Jody B. Hice
   party: majority
   rank: 18
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: Steve Russell
   party: majority
   rank: 19
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Glenn Grothman
   party: majority
   rank: 20
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Will Hurd
   party: majority
   rank: 21
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Gary J. Palmer
   party: majority
   rank: 22
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: James Comer
   party: majority
   rank: 23
@@ -4537,58 +5508,58 @@ HSGO:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00256'
   bioguide: C000984
+  thomas: '00256'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Stephen F. Lynch
   party: minority
   rank: 5
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Jim Cooper
   party: minority
   rank: 6
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Gerald E. Connolly
   party: minority
   rank: 7
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Robin L. Kelly
   party: minority
   rank: 8
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Brenda L. Lawrence
   party: minority
   rank: 9
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 10
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Stacey E. Plaskett
   party: minority
   rank: 11
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Val Butler Demings
   party: minority
   rank: 12
@@ -4604,61 +5575,61 @@ HSGO:
 - name: Peter Welch
   party: minority
   rank: 15
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Matt Cartwright
   party: minority
   rank: 16
-  thomas: '02159'
   bioguide: C001090
+  thomas: '02159'
 - name: Mark DeSaulnier
   party: minority
   rank: 17
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: John P. Sarbanes
   party: minority
   rank: 18
-  thomas: '01854'
   bioguide: S001168
+  thomas: '01854'
 HSGO06:
 - name: Ron DeSantis
   party: majority
   rank: 1
   title: Chair
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Steve Russell
   party: majority
   rank: 2
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
   title: Vice Chair
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Justin Amash
   party: majority
   rank: 4
-  thomas: '02029'
   bioguide: A000367
+  thomas: '02029'
 - name: Paul A. Gosar
   party: majority
   rank: 5
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Virginia Foxx
   party: majority
   rank: 6
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Jody B. Hice
   party: majority
   rank: 7
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: James Comer
   party: majority
   rank: 8
@@ -4667,94 +5638,94 @@ HSGO06:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Peter Welch
   party: minority
   rank: 2
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 HSGO24:
 - name: Mark Meadows
   party: majority
   rank: 1
   title: Chair
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Jody B. Hice
   party: majority
   rank: 2
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
   title: Vice Chair
 - name: Jim Jordan
   party: majority
   rank: 3
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Mark Sanford
   party: majority
   rank: 4
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Thomas Massie
   party: majority
   rank: 5
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Ron DeSantis
   party: majority
   rank: 6
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Dennis A. Ross
   party: majority
   rank: 7
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Rod Blum
   party: majority
   rank: 8
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: Gerald E. Connolly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Brenda L. Lawrence
   party: minority
   rank: 5
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 6
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 HSGO25:
 - name: Will Hurd
   party: majority
   rank: 1
   title: Chair
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Paul Mitchell
   party: majority
   rank: 2
@@ -4763,29 +5734,29 @@ HSGO25:
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Justin Amash
   party: majority
   rank: 4
-  thomas: '02029'
   bioguide: A000367
+  thomas: '02029'
 - name: Blake Farenthold
   party: majority
   rank: 5
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Steve Russell
   party: majority
   rank: 6
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Robin L. Kelly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -4793,13 +5764,13 @@ HSGO25:
 - name: Stephen F. Lynch
   party: minority
   rank: 3
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Gerald E. Connolly
   party: minority
   rank: 4
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 5
@@ -4809,39 +5780,39 @@ HSGO27:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Mark Walker
   party: majority
   rank: 2
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
   title: Vice Chair
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Mark Sanford
   party: majority
   rank: 4
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Scott DesJarlais
   party: majority
   rank: 5
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Mark Meadows
   party: majority
   rank: 6
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Glenn Grothman
   party: majority
   rank: 7
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Paul Mitchell
   party: majority
   rank: 8
@@ -4854,51 +5825,51 @@ HSGO27:
 - name: Jim Cooper
   party: minority
   rank: 2
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Robin L. Kelly
   party: minority
   rank: 4
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 5
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Stacey E. Plaskett
   party: minority
   rank: 6
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 HSGO28:
 - name: Blake Farenthold
   party: majority
   rank: 1
   title: Chair
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Paul A. Gosar
   party: majority
   rank: 2
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
   title: Vice Chair
 - name: Dennis A. Ross
   party: majority
   rank: 3
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Gary J. Palmer
   party: majority
   rank: 4
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: James Comer
   party: majority
   rank: 5
@@ -4907,8 +5878,8 @@ HSGO28:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -4918,39 +5889,39 @@ HSGO29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: Glenn Grothman
   party: majority
   rank: 2
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
   title: Vice Chair
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Trey Gowdy
   party: majority
   rank: 4
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Virginia Foxx
   party: majority
   rank: 5
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Thomas Massie
   party: majority
   rank: 6
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Walker
   party: majority
   rank: 7
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
 - name: Val Butler Demings
   party: minority
   rank: 1
@@ -4961,44 +5932,44 @@ HSHA:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: Rodney Davis
   party: majority
   rank: 2
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Barbara Comstock
   party: majority
   rank: 3
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Mark Walker
   party: majority
   rank: 4
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
 - name: Adrian Smith
   party: majority
   rank: 5
-  thomas: '01860'
   bioguide: S001172
+  thomas: '01860'
 - name: Barry Loudermilk
   party: majority
   rank: 6
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Robert A. Brady
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01469'
   bioguide: B001227
+  thomas: '01469'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Jamie Raskin
   party: minority
   rank: 3
@@ -5008,68 +5979,68 @@ HSHM:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
 - name: Lamar Smith
   party: majority
   rank: 2
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Mike Rogers
   party: majority
   rank: 4
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Jeff Duncan
   party: majority
   rank: 5
-  thomas: '02057'
   bioguide: D000615
+  thomas: '02057'
 - name: Tom Marino
   party: majority
   rank: 6
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Lou Barletta
   party: majority
   rank: 7
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Scott Perry
   party: majority
   rank: 8
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: John Katko
   party: majority
   rank: 9
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Will Hurd
   party: majority
   rank: 10
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Martha McSally
   party: majority
   rank: 11
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: John Ratcliffe
   party: majority
   rank: 12
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 13
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: Mike Gallagher
   party: majority
   rank: 14
@@ -5094,48 +6065,48 @@ HSHM:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: James R. Langevin
   party: minority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Cedric L. Richmond
   party: minority
   rank: 4
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: William R. Keating
   party: minority
   rank: 5
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 6
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Filemon Vela
   party: minority
   rank: 7
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 8
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Kathleen M. Rice
   party: minority
   rank: 9
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: J. Luis Correa
   party: minority
   rank: 10
@@ -5153,23 +6124,23 @@ HSHM05:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Lou Barletta
   party: majority
   rank: 2
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Scott Perry
   party: majority
   rank: 3
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Will Hurd
   party: majority
   rank: 4
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Mike Gallagher
   party: majority
   rank: 5
@@ -5177,48 +6148,48 @@ HSHM05:
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Kathleen M. Rice
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: William R. Keating
   party: minority
   rank: 3
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM07:
 - name: John Katko
   party: majority
   rank: 1
   title: Chair
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Peter T. King
   party: majority
   rank: 2
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Mike Rogers
   party: majority
   rank: 3
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Clay Higgins
   party: majority
   rank: 4
@@ -5230,48 +6201,48 @@ HSHM07:
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Bonnie Watson Coleman
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: William R. Keating
   party: minority
   rank: 2
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 3
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM08:
 - name: John Ratcliffe
   party: majority
   rank: 1
   title: Chair
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: John Katko
   party: majority
   rank: 2
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 3
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: Mike Gallagher
   party: majority
   rank: 4
@@ -5291,25 +6262,25 @@ HSHM08:
 - name: Michael T. McCaul
   party: majority
   rank: 8
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Cedric L. Richmond
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: James R. Langevin
   party: minority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Val Butler Demings
   party: minority
   rank: 4
@@ -5317,31 +6288,31 @@ HSHM08:
 - name: Bennie G. Thompson
   party: minority
   rank: 5
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM09:
 - name: Scott Perry
   party: majority
   rank: 1
   title: Chair
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Jeff Duncan
   party: majority
   rank: 2
-  thomas: '02057'
   bioguide: D000615
+  thomas: '02057'
 - name: Tom Marino
   party: majority
   rank: 3
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: John Ratcliffe
   party: majority
   rank: 4
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Clay Higgins
   party: majority
   rank: 5
@@ -5349,8 +6320,8 @@ HSHM09:
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: J. Luis Correa
   party: minority
@@ -5360,8 +6331,8 @@ HSHM09:
 - name: Kathleen M. Rice
   party: minority
   rank: 2
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 3
@@ -5369,41 +6340,41 @@ HSHM09:
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM11:
 - name: Martha McSally
   party: majority
   rank: 1
   title: Chair
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: Lamar Smith
   party: majority
   rank: 2
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Mike Rogers
   party: majority
   rank: 3
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Jeff Duncan
   party: majority
   rank: 4
-  thomas: '02057'
   bioguide: D000615
+  thomas: '02057'
 - name: Lou Barletta
   party: majority
   rank: 5
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Will Hurd
   party: majority
   rank: 6
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: John H. Rutherford
   party: majority
   rank: 7
@@ -5411,20 +6382,20 @@ HSHM11:
 - name: Michael T. McCaul
   party: majority
   rank: 8
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Filemon Vela
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Cedric L. Richmond
   party: minority
   rank: 2
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: J. Luis Correa
   party: minority
   rank: 3
@@ -5440,26 +6411,26 @@ HSHM11:
 - name: Bennie G. Thompson
   party: minority
   rank: 6
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM12:
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 1
   title: Chair
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: Tom Marino
   party: majority
   rank: 2
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Martha McSally
   party: majority
   rank: 3
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: John H. Rutherford
   party: majority
   rank: 4
@@ -5471,1272 +6442,1272 @@ HSHM12:
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: James R. Langevin
   party: minority
   rank: 2
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 3
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSIF:
 - name: Greg Walden
   party: majority
   rank: 1
   title: Chair
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
 - name: Joe Barton
   party: majority
   rank: 2
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Fred Upton
   party: majority
   rank: 3
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: John Shimkus
   party: majority
   rank: 4
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Tim Murphy
   party: majority
   rank: 5
-  thomas: '01744'
   bioguide: M001151
+  thomas: '01744'
 - name: Michael C. Burgess
   party: majority
   rank: 6
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Marsha Blackburn
   party: majority
   rank: 7
-  thomas: '01748'
   bioguide: B001243
+  thomas: '01748'
 - name: Steve Scalise
   party: majority
   rank: 8
-  thomas: '01892'
   bioguide: S001176
+  thomas: '01892'
 - name: Robert E. Latta
   party: majority
   rank: 9
-  thomas: '01885'
   bioguide: L000566
+  thomas: '01885'
 - name: Cathy McMorris Rodgers
   party: majority
   rank: 10
-  thomas: '01809'
   bioguide: M001159
+  thomas: '01809'
 - name: Gregg Harper
   party: majority
   rank: 11
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: Leonard Lance
   party: majority
   rank: 12
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
 - name: Brett Guthrie
   party: majority
   rank: 13
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Pete Olson
   party: majority
   rank: 14
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
 - name: David B. McKinley
   party: majority
   rank: 15
-  thomas: '02074'
   bioguide: M001180
+  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 16
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
   rank: 17
-  thomas: '02070'
   bioguide: G000568
+  thomas: '02070'
 - name: Gus M. Bilirakis
   party: majority
   rank: 18
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Bill Johnson
   party: majority
   rank: 19
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 20
-  thomas: '02033'
   bioguide: L000576
+  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 21
-  thomas: '02018'
   bioguide: B001275
+  thomas: '02018'
 - name: Bill Flores
   party: majority
   rank: 22
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Susan W. Brooks
   party: majority
   rank: 23
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Markwayne Mullin
   party: majority
   rank: 24
-  thomas: '02156'
   bioguide: M001190
+  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 25
-  thomas: '02140'
   bioguide: H001067
+  thomas: '02140'
 - name: Chris Collins
   party: majority
   rank: 26
-  thomas: '02151'
   bioguide: C001092
+  thomas: '02151'
 - name: Kevin Cramer
   party: majority
   rank: 27
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 28
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Mimi Walters
   party: majority
   rank: 29
-  thomas: '02232'
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 30
-  thomas: '02266'
   bioguide: C001106
+  thomas: '02266'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 31
-  thomas: '02236'
   bioguide: C001103
+  thomas: '02236'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
 - name: Bobby L. Rush
   party: minority
   rank: 2
-  thomas: '01003'
   bioguide: R000515
+  thomas: '01003'
 - name: Anna G. Eshoo
   party: minority
   rank: 3
-  thomas: '00355'
   bioguide: E000215
+  thomas: '00355'
 - name: Eliot L. Engel
   party: minority
   rank: 4
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: Gene Green
   party: minority
   rank: 5
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Diana DeGette
   party: minority
   rank: 6
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Michael F. Doyle
   party: minority
   rank: 7
-  thomas: '00316'
   bioguide: D000482
+  thomas: '00316'
 - name: Janice D. Schakowsky
   party: minority
   rank: 8
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: G. K. Butterfield
   party: minority
   rank: 9
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 10
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Kathy Castor
   party: minority
   rank: 11
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 12
-  thomas: '01854'
   bioguide: S001168
+  thomas: '01854'
 - name: Jerry McNerney
   party: minority
   rank: 13
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Peter Welch
   party: minority
   rank: 14
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Ben Ray Luján
   party: minority
   rank: 15
-  thomas: '01939'
   bioguide: L000570
+  thomas: '01939'
 - name: Paul Tonko
   party: minority
   rank: 16
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Yvette D. Clarke
   party: minority
   rank: 17
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: David Loebsack
   party: minority
   rank: 18
-  thomas: '01846'
   bioguide: L000565
+  thomas: '01846'
 - name: Kurt Schrader
   party: minority
   rank: 19
-  thomas: '01950'
   bioguide: S001180
+  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 20
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: Tony Cárdenas
   party: minority
   rank: 21
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Raul Ruiz
   party: minority
   rank: 22
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 23
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Debbie Dingell
   party: minority
   rank: 24
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 HSIF02:
 - name: Tim Murphy
   party: majority
   rank: 1
   title: Chair
-  thomas: '01744'
   bioguide: M001151
+  thomas: '01744'
 - name: H. Morgan Griffith
   party: majority
   rank: 2
-  thomas: '02070'
   bioguide: G000568
+  thomas: '02070'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Michael C. Burgess
   party: majority
   rank: 4
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Susan W. Brooks
   party: majority
   rank: 5
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Chris Collins
   party: majority
   rank: 6
-  thomas: '02151'
   bioguide: C001092
+  thomas: '02151'
 - name: Tim Walberg
   party: majority
   rank: 7
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Mimi Walters
   party: majority
   rank: 8
-  thomas: '02232'
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 9
-  thomas: '02266'
   bioguide: C001106
+  thomas: '02266'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 10
-  thomas: '02236'
   bioguide: C001103
+  thomas: '02236'
 - name: Greg Walden
   party: majority
-  rank: 12
-  thomas: '01596'
+  rank: 11
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Diana DeGette
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Janice D. Schakowsky
   party: minority
   rank: 2
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: Kathy Castor
   party: minority
   rank: 3
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: Paul Tonko
   party: minority
   rank: 4
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Yvette D. Clarke
   party: minority
   rank: 5
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Raul Ruiz
   party: minority
   rank: 6
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 7
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Frank Pallone, Jr.
   party: minority
-  rank: 9
-  thomas: '00887'
+  rank: 8
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF03:
 - name: Fred Upton
   party: majority
   rank: 1
   title: Chair
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: Pete Olson
   party: majority
   rank: 2
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: John Shimkus
   party: majority
   rank: 4
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Tim Murphy
   party: majority
   rank: 5
-  thomas: '01744'
   bioguide: M001151
+  thomas: '01744'
 - name: Robert E. Latta
   party: majority
   rank: 6
-  thomas: '01885'
   bioguide: L000566
+  thomas: '01885'
 - name: Gregg Harper
   party: majority
   rank: 7
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: David B. McKinley
   party: majority
   rank: 8
-  thomas: '02074'
   bioguide: M001180
+  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 9
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
   rank: 10
-  thomas: '02070'
   bioguide: G000568
+  thomas: '02070'
 - name: Bill Johnson
   party: majority
   rank: 11
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 12
-  thomas: '02033'
   bioguide: L000576
+  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 13
-  thomas: '02018'
   bioguide: B001275
+  thomas: '02018'
 - name: Bill Flores
   party: majority
   rank: 14
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Markwayne Mullin
   party: majority
   rank: 15
-  thomas: '02156'
   bioguide: M001190
+  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 16
-  thomas: '02140'
   bioguide: H001067
+  thomas: '02140'
 - name: Kevin Cramer
   party: majority
   rank: 17
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 18
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Greg Walden
   party: majority
-  rank: 20
-  thomas: '01596'
+  rank: 19
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Bobby L. Rush
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01003'
   bioguide: R000515
+  thomas: '01003'
 - name: Jerry McNerney
   party: minority
   rank: 2
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Scott H. Peters
   party: minority
   rank: 3
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Gene Green
   party: minority
   rank: 4
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Michael F. Doyle
   party: minority
   rank: 5
-  thomas: '00316'
   bioguide: D000482
+  thomas: '00316'
 - name: Kathy Castor
   party: minority
   rank: 6
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 7
-  thomas: '01854'
   bioguide: S001168
+  thomas: '01854'
 - name: Peter Welch
   party: minority
   rank: 8
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Paul Tonko
   party: minority
   rank: 9
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: David Loebsack
   party: minority
   rank: 10
-  thomas: '01846'
   bioguide: L000565
+  thomas: '01846'
 - name: Kurt Schrader
   party: minority
   rank: 11
-  thomas: '01950'
   bioguide: S001180
+  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 12
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: G. K. Butterfield
   party: minority
   rank: 13
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Frank Pallone, Jr.
   party: minority
-  rank: 15
-  thomas: '00887'
+  rank: 14
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF14:
 - name: Michael C. Burgess
   party: majority
   rank: 1
   title: Chair
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Brett Guthrie
   party: majority
   rank: 2
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Fred Upton
   party: majority
   rank: 4
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: John Shimkus
   party: majority
   rank: 5
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Tim Murphy
   party: majority
   rank: 6
-  thomas: '01744'
   bioguide: M001151
+  thomas: '01744'
 - name: Marsha Blackburn
   party: majority
   rank: 7
-  thomas: '01748'
   bioguide: B001243
+  thomas: '01748'
 - name: Cathy McMorris Rodgers
   party: majority
   rank: 8
-  thomas: '01809'
   bioguide: M001159
+  thomas: '01809'
 - name: Leonard Lance
   party: majority
   rank: 9
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
 - name: H. Morgan Griffith
   party: majority
   rank: 10
-  thomas: '02070'
   bioguide: G000568
+  thomas: '02070'
 - name: Gus M. Bilirakis
   party: majority
   rank: 11
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Billy Long
   party: majority
   rank: 12
-  thomas: '02033'
   bioguide: L000576
+  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 13
-  thomas: '02018'
   bioguide: B001275
+  thomas: '02018'
 - name: Susan W. Brooks
   party: majority
   rank: 14
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Markwayne Mullin
   party: majority
   rank: 15
-  thomas: '02156'
   bioguide: M001190
+  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 16
-  thomas: '02140'
   bioguide: H001067
+  thomas: '02140'
 - name: Chris Collins
   party: majority
   rank: 17
-  thomas: '02151'
   bioguide: C001092
+  thomas: '02151'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 18
-  thomas: '02236'
   bioguide: C001103
+  thomas: '02236'
 - name: Greg Walden
   party: majority
-  rank: 20
-  thomas: '01596'
+  rank: 19
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Gene Green
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Eliot L. Engel
   party: minority
   rank: 2
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: Janice D. Schakowsky
   party: minority
   rank: 3
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: G. K. Butterfield
   party: minority
   rank: 4
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 5
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Kathy Castor
   party: minority
   rank: 6
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 7
-  thomas: '01854'
   bioguide: S001168
+  thomas: '01854'
 - name: Ben Ray Luján
   party: minority
   rank: 8
-  thomas: '01939'
   bioguide: L000570
+  thomas: '01939'
 - name: Kurt Schrader
   party: minority
   rank: 9
-  thomas: '01950'
   bioguide: S001180
+  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 10
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: Tony Cárdenas
   party: minority
   rank: 11
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Anna G. Eshoo
   party: minority
   rank: 12
-  thomas: '00355'
   bioguide: E000215
+  thomas: '00355'
 - name: Diana DeGette
   party: minority
   rank: 13
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Frank Pallone, Jr.
   party: minority
-  rank: 15
-  thomas: '00887'
+  rank: 14
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF16:
 - name: Marsha Blackburn
   party: majority
   rank: 1
   title: Chair
-  thomas: '01748'
   bioguide: B001243
+  thomas: '01748'
 - name: Leonard Lance
   party: majority
   rank: 2
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
   title: Vice Chair
 - name: John Shimkus
   party: majority
   rank: 3
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Steve Scalise
   party: majority
   rank: 4
-  thomas: '01892'
   bioguide: S001176
+  thomas: '01892'
 - name: Robert E. Latta
   party: majority
   rank: 5
-  thomas: '01885'
   bioguide: L000566
+  thomas: '01885'
 - name: Brett Guthrie
   party: majority
   rank: 6
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Pete Olson
   party: majority
   rank: 7
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
 - name: Adam Kinzinger
   party: majority
   rank: 8
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: Gus M. Bilirakis
   party: majority
   rank: 9
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Bill Johnson
   party: majority
   rank: 10
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 11
-  thomas: '02033'
   bioguide: L000576
+  thomas: '02033'
 - name: Bill Flores
   party: majority
   rank: 12
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Susan W. Brooks
   party: majority
   rank: 13
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Chris Collins
   party: majority
   rank: 14
-  thomas: '02151'
   bioguide: C001092
+  thomas: '02151'
 - name: Kevin Cramer
   party: majority
   rank: 15
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Mimi Walters
   party: majority
   rank: 16
-  thomas: '02232'
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 17
-  thomas: '02266'
   bioguide: C001106
+  thomas: '02266'
 - name: Greg Walden
   party: majority
-  rank: 19
-  thomas: '01596'
+  rank: 18
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Michael F. Doyle
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00316'
   bioguide: D000482
+  thomas: '00316'
 - name: Peter Welch
   party: minority
   rank: 2
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Yvette D. Clarke
   party: minority
   rank: 3
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: David Loebsack
   party: minority
   rank: 4
-  thomas: '01846'
   bioguide: L000565
+  thomas: '01846'
 - name: Raul Ruiz
   party: minority
   rank: 5
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Debbie Dingell
   party: minority
   rank: 6
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 - name: Bobby L. Rush
   party: minority
   rank: 7
-  thomas: '01003'
   bioguide: R000515
+  thomas: '01003'
 - name: Anna G. Eshoo
   party: minority
   rank: 8
-  thomas: '00355'
   bioguide: E000215
+  thomas: '00355'
 - name: Eliot L. Engel
   party: minority
   rank: 9
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: G. K. Butterfield
   party: minority
   rank: 10
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 11
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Jerry McNerney
   party: minority
   rank: 12
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Frank Pallone, Jr.
   party: minority
-  rank: 14
-  thomas: '00887'
+  rank: 13
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF17:
 - name: Robert E. Latta
   party: majority
   rank: 1
   title: Chair
-  thomas: '01885'
   bioguide: L000566
+  thomas: '01885'
 - name: Gregg Harper
   party: majority
   rank: 2
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
   title: Vice Chair
 - name: Fred Upton
   party: majority
   rank: 3
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: Michael C. Burgess
   party: majority
   rank: 4
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Leonard Lance
   party: majority
   rank: 5
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
 - name: Brett Guthrie
   party: majority
   rank: 6
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: David B. McKinley
   party: majority
   rank: 7
-  thomas: '02074'
   bioguide: M001180
+  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 8
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: Gus M. Bilirakis
   party: majority
   rank: 9
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Larry Bucshon
   party: majority
   rank: 10
-  thomas: '02018'
   bioguide: B001275
+  thomas: '02018'
 - name: Markwayne Mullin
   party: majority
   rank: 11
-  thomas: '02156'
   bioguide: M001190
+  thomas: '02156'
 - name: Mimi Walters
   party: majority
   rank: 12
-  thomas: '02232'
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 13
-  thomas: '02266'
   bioguide: C001106
+  thomas: '02266'
 - name: Greg Walden
   party: majority
-  rank: 15
-  thomas: '01596'
+  rank: 14
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Janice D. Schakowsky
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: Ben Ray Luján
   party: minority
   rank: 2
-  thomas: '01939'
   bioguide: L000570
+  thomas: '01939'
 - name: Yvette D. Clarke
   party: minority
   rank: 3
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Tony Cárdenas
   party: minority
   rank: 4
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Debbie Dingell
   party: minority
   rank: 5
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 - name: Doris O. Matsui
   party: minority
   rank: 6
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Peter Welch
   party: minority
   rank: 7
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 8
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: Gene Green
   party: minority
   rank: 9
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Frank Pallone, Jr.
   party: minority
-  rank: 11
-  thomas: '00887'
+  rank: 10
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF18:
 - name: John Shimkus
   party: majority
   rank: 1
   title: Chair
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: David B. McKinley
   party: majority
   rank: 2
-  thomas: '02074'
   bioguide: M001180
+  thomas: '02074'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Tim Murphy
   party: majority
   rank: 4
-  thomas: '01744'
   bioguide: M001151
+  thomas: '01744'
 - name: Marsha Blackburn
   party: majority
   rank: 5
-  thomas: '01748'
   bioguide: B001243
+  thomas: '01748'
 - name: Gregg Harper
   party: majority
   rank: 6
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: Pete Olson
   party: majority
   rank: 7
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
 - name: Bill Johnson
   party: majority
   rank: 8
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Bill Flores
   party: majority
   rank: 9
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Richard Hudson
   party: majority
   rank: 10
-  thomas: '02140'
   bioguide: H001067
+  thomas: '02140'
 - name: Kevin Cramer
   party: majority
   rank: 11
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 12
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 13
-  thomas: '02236'
   bioguide: C001103
+  thomas: '02236'
 - name: Greg Walden
   party: majority
-  rank: 15
-  thomas: '01596'
+  rank: 14
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Paul Tonko
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Raul Ruiz
   party: minority
   rank: 2
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 3
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Gene Green
   party: minority
   rank: 4
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Diana DeGette
   party: minority
   rank: 5
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Jerry McNerney
   party: minority
   rank: 6
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Tony Cárdenas
   party: minority
   rank: 7
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Debbie Dingell
   party: minority
   rank: 8
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 - name: Doris O. Matsui
   party: minority
   rank: 9
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Frank Pallone, Jr.
   party: minority
-  rank: 11
-  thomas: '00887'
+  rank: 10
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSII:
 - name: Rob Bishop
   party: majority
   rank: 1
   title: Chair
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Louie Gohmert
   party: majority
   rank: 3
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Doug Lamborn
   party: majority
   rank: 4
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 5
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Tom McClintock
   party: majority
   rank: 6
-  thomas: '01908'
   bioguide: M001177
+  thomas: '01908'
 - name: Stevan Pearce
   party: majority
   rank: 7
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 8
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Paul A. Gosar
   party: majority
   rank: 9
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Raúl R. Labrador
   party: majority
   rank: 10
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Scott R. Tipton
   party: majority
   rank: 11
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Doug LaMalfa
   party: majority
   rank: 12
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Jeff Denham
   party: majority
   rank: 13
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Paul Cook
   party: majority
   rank: 14
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Bruce Westerman
   party: majority
   rank: 15
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Garret Graves
   party: majority
   rank: 16
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 17
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 18
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Darin LaHood
   party: majority
   rank: 19
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 20
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: David Rouzer
   party: majority
   rank: 21
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Jack Bergman
   party: majority
   rank: 22
@@ -6757,63 +7728,63 @@ HSII:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Grace F. Napolitano
   party: minority
   rank: 2
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 3
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Jim Costa
   party: minority
   rank: 4
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 5
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Niki Tsongas
   party: minority
   rank: 6
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Jared Huffman
   party: minority
   rank: 7
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 8
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 9
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Norma J. Torres
   party: minority
   rank: 10
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Ruben Gallego
   party: minority
   rank: 11
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Colleen Hanabusa
   party: minority
   rank: 12
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 13
@@ -6837,70 +7808,70 @@ HSII:
 - name: Wm. Lacy Clay
   party: minority
   rank: 18
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 HSII06:
 - name: Paul A. Gosar
   party: majority
   rank: 1
   title: Chair
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Doug Lamborn
   party: majority
   rank: 3
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 4
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Stevan Pearce
   party: majority
   rank: 5
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 6
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Scott R. Tipton
   party: majority
   rank: 7
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Paul Cook
   party: majority
   rank: 8
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Bruce Westerman
   party: majority
   rank: 9
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Garret Graves
   party: majority
   rank: 10
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 11
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: Darin LaHood
   party: majority
   rank: 12
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Liz Cheney
   party: majority
   rank: 13
@@ -6908,15 +7879,15 @@ HSII06:
 - name: Rob Bishop
   party: majority
   rank: 14
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Alan S. Lowenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Anthony G. Brown
   party: minority
   rank: 2
@@ -6924,23 +7895,23 @@ HSII06:
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Niki Tsongas
   party: minority
   rank: 4
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Jared Huffman
   party: minority
   rank: 5
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Darren Soto
   party: minority
   rank: 7
@@ -6952,61 +7923,61 @@ HSII06:
 - name: Raúl M. Grijalva
   party: minority
   rank: 11
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII10:
 - name: Tom McClintock
   party: majority
   rank: 1
   title: Chair
-  thomas: '01908'
   bioguide: M001177
+  thomas: '01908'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Stevan Pearce
   party: majority
   rank: 3
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 4
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Raúl R. Labrador
   party: majority
   rank: 5
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Scott R. Tipton
   party: majority
   rank: 6
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Bruce Westerman
   party: majority
   rank: 7
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Darin LaHood
   party: majority
   rank: 8
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 9
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: David Rouzer
   party: majority
   rank: 10
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Jack Bergman
   party: majority
   rank: 11
@@ -7018,35 +7989,35 @@ HSII10:
 - name: Rob Bishop
   party: majority
   rank: 13
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Colleen Hanabusa
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Niki Tsongas
   party: minority
   rank: 2
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Alan S. Lowenthal
   party: minority
   rank: 3
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Norma J. Torres
   party: minority
   rank: 4
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Ruben Gallego
   party: minority
   rank: 5
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Jimmy Panetta
   party: minority
   rank: 6
@@ -7062,61 +8033,61 @@ HSII10:
 - name: Raúl M. Grijalva
   party: minority
   rank: 10
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII13:
 - name: Doug Lamborn
   party: majority
   rank: 1
   title: Chair
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 2
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Tom McClintock
   party: majority
   rank: 3
-  thomas: '01908'
   bioguide: M001177
+  thomas: '01908'
 - name: Paul A. Gosar
   party: majority
   rank: 4
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Doug LaMalfa
   party: majority
   rank: 5
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Jeff Denham
   party: majority
   rank: 6
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Garret Graves
   party: majority
   rank: 7
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 8
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: Daniel Webster
   party: majority
   rank: 9
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: David Rouzer
   party: majority
   rank: 10
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Mike Johnson
   party: majority
   rank: 11
@@ -7124,30 +8095,30 @@ HSII13:
 - name: Rob Bishop
   party: majority
   rank: 12
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Jared Huffman
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Grace F. Napolitano
   party: minority
   rank: 2
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 4
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 5
@@ -7159,36 +8130,36 @@ HSII13:
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 7
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 8
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Raúl M. Grijalva
   party: minority
   rank: 9
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII15:
 - name: Raúl R. Labrador
   party: majority
   rank: 1
   title: Chair
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Jack Bergman
   party: majority
   rank: 4
@@ -7204,8 +8175,8 @@ HSII15:
 - name: Rob Bishop
   party: majority
   rank: 7
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: A. Donald McEachin
   party: minority
@@ -7215,13 +8186,13 @@ HSII15:
 - name: Ruben Gallego
   party: minority
   rank: 2
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Jared Huffman
   party: minority
   rank: 3
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Darren Soto
   party: minority
   rank: 4
@@ -7229,46 +8200,46 @@ HSII15:
 - name: Wm. Lacy Clay
   party: minority
   rank: 5
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Raúl M. Grijalva
   party: minority
   rank: 6
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII24:
 - name: Doug LaMalfa
   party: majority
   rank: 1
   title: Chair
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Jeff Denham
   party: majority
   rank: 3
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Paul Cook
   party: majority
   rank: 4
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Darin LaHood
   party: majority
   rank: 6
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Jack Bergman
   party: majority
   rank: 7
@@ -7280,30 +8251,30 @@ HSII24:
 - name: Rob Bishop
   party: majority
   rank: 9
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Norma J. Torres
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 2
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 3
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Ruben Gallego
   party: minority
   rank: 4
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Darren Soto
   party: minority
   rank: 5
@@ -7311,116 +8282,116 @@ HSII24:
 - name: Colleen Hanabusa
   party: minority
   rank: 6
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Raúl M. Grijalva
   party: minority
   rank: 7
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSJU:
 - name: Bob Goodlatte
   party: majority
   rank: 1
   title: Chair
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 2
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Lamar Smith
   party: majority
   rank: 3
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Steve Chabot
   party: majority
   rank: 4
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Darrell E. Issa
   party: majority
   rank: 5
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Steve King
   party: majority
   rank: 6
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Trent Franks
   party: majority
   rank: 7
-  thomas: '01707'
   bioguide: F000448
+  thomas: '01707'
 - name: Louie Gohmert
   party: majority
   rank: 8
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Jim Jordan
   party: majority
   rank: 9
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Ted Poe
   party: majority
   rank: 10
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Jason Chaffetz
   party: majority
   rank: 11
-  thomas: '01956'
   bioguide: C001076
+  thomas: '01956'
 - name: Tom Marino
   party: majority
   rank: 12
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Trey Gowdy
   party: majority
   rank: 13
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Raúl R. Labrador
   party: majority
   rank: 14
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Blake Farenthold
   party: majority
   rank: 15
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Doug Collins
   party: majority
   rank: 16
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
 - name: Ron DeSantis
   party: majority
   rank: 17
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Ken Buck
   party: majority
   rank: 18
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: John Ratcliffe
   party: majority
   rank: 19
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Martha Roby
   party: majority
   rank: 20
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Matt Gaetz
   party: majority
   rank: 21
@@ -7437,73 +8408,73 @@ HSJU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00229'
   bioguide: C000714
+  thomas: '00229'
 - name: Jerrold Nadler
   party: minority
   rank: 2
-  thomas: '00850'
   bioguide: N000002
+  thomas: '00850'
 - name: Zoe Lofgren
   party: minority
   rank: 3
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Sheila Jackson Lee
   party: minority
   rank: 4
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: Steve Cohen
   party: minority
   rank: 5
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 6
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Theodore E. Deutch
   party: minority
   rank: 7
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Luis V. Gutiérrez
   party: minority
   rank: 8
-  thomas: '00478'
   bioguide: G000535
+  thomas: '00478'
 - name: Karen Bass
   party: minority
   rank: 9
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
   rank: 10
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 11
-  thomas: '02149'
   bioguide: J000294
+  thomas: '02149'
 - name: David N. Cicilline
   party: minority
   rank: 12
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Eric Swalwell
   party: minority
   rank: 13
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 - name: Ted Lieu
   party: minority
   rank: 14
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 - name: Jamie Raskin
   party: minority
   rank: 15
@@ -7515,41 +8486,41 @@ HSJU:
 - name: Bradley Scott Schneider
   party: minority
   rank: 17
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 HSJU01:
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 1
   title: Chair
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Raúl R. Labrador
   party: majority
   rank: 2
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
   title: Vice Chair
 - name: Lamar Smith
   party: majority
   rank: 3
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Steve King
   party: majority
   rank: 4
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Jim Jordan
   party: majority
   rank: 5
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Ken Buck
   party: majority
   rank: 6
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: Mike Johnson
   party: majority
   rank: 7
@@ -7562,13 +8533,13 @@ HSJU01:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Luis V. Gutiérrez
   party: minority
   rank: 2
-  thomas: '00478'
   bioguide: G000535
+  thomas: '00478'
 - name: Pramila Jayapal
   party: minority
   rank: 3
@@ -7576,71 +8547,71 @@ HSJU01:
 - name: Sheila Jackson Lee
   party: minority
   rank: 4
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 HSJU03:
 - name: Darrell E. Issa
   party: majority
   rank: 1
   title: Chair
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Doug Collins
   party: majority
   rank: 2
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
   title: Vice Chair
 - name: Lamar Smith
   party: majority
   rank: 3
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Steve Chabot
   party: majority
   rank: 4
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Trent Franks
   party: majority
   rank: 5
-  thomas: '01707'
   bioguide: F000448
+  thomas: '01707'
 - name: Jim Jordan
   party: majority
   rank: 6
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Ted Poe
   party: majority
   rank: 7
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Jason Chaffetz
   party: majority
   rank: 8
-  thomas: '01956'
   bioguide: C001076
+  thomas: '01956'
 - name: Tom Marino
   party: majority
   rank: 9
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Raúl R. Labrador
   party: majority
   rank: 10
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Blake Farenthold
   party: majority
   rank: 11
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Ron DeSantis
   party: majority
   rank: 12
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Matt Gaetz
   party: majority
   rank: 13
@@ -7653,91 +8624,91 @@ HSJU03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00850'
   bioguide: N000002
+  thomas: '00850'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 2
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Theodore E. Deutch
   party: minority
   rank: 3
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Karen Bass
   party: minority
   rank: 4
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
   rank: 5
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 6
-  thomas: '02149'
   bioguide: J000294
+  thomas: '02149'
 - name: Eric Swalwell
   party: minority
   rank: 7
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 - name: Ted Lieu
   party: minority
   rank: 8
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 - name: Zoe Lofgren
   party: minority
   rank: 9
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Steve Cohen
   party: minority
   rank: 10
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Luis V. Gutiérrez
   party: minority
   rank: 11
-  thomas: '00478'
   bioguide: G000535
+  thomas: '00478'
 HSJU05:
 - name: Tom Marino
   party: majority
   rank: 1
   title: Chair
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Blake Farenthold
   party: majority
   rank: 2
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
   title: Vice Chair
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Doug Collins
   party: majority
   rank: 4
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
 - name: Ken Buck
   party: majority
   rank: 5
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: John Ratcliffe
   party: majority
   rank: 6
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Matt Gaetz
   party: majority
   rank: 7
@@ -7746,18 +8717,18 @@ HSJU05:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 2
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Eric Swalwell
   party: minority
   rank: 3
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 - name: Jamie Raskin
   party: minority
   rank: 4
@@ -7771,44 +8742,44 @@ HSJU08:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
   title: Vice Chair
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 3
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Steve Chabot
   party: majority
   rank: 4
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Ted Poe
   party: majority
   rank: 5
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Jason Chaffetz
   party: majority
   rank: 6
-  thomas: '01956'
   bioguide: C001076
+  thomas: '01956'
 - name: John Ratcliffe
   party: majority
   rank: 7
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Martha Roby
   party: majority
   rank: 8
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Mike Johnson
   party: majority
   rank: 9
@@ -7817,72 +8788,72 @@ HSJU08:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: Theodore E. Deutch
   party: minority
   rank: 2
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Karen Bass
   party: minority
   rank: 3
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
   rank: 4
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
-  thomas: '02149'
   bioguide: J000294
+  thomas: '02149'
 - name: David N. Cicilline
   party: minority
   rank: 6
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Ted Lieu
   party: minority
   rank: 7
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 HSJU10:
 - name: Steve King
   party: majority
   rank: 1
   title: Chair
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Ron DeSantis
   party: majority
   rank: 2
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
   title: Vice Chair
 - name: Trent Franks
   party: majority
   rank: 3
-  thomas: '01707'
   bioguide: F000448
+  thomas: '01707'
 - name: Louie Gohmert
   party: majority
   rank: 4
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Trey Gowdy
   party: majority
   rank: 5
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Steve Cohen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -7890,151 +8861,151 @@ HSJU10:
 - name: Jerrold Nadler
   party: minority
   rank: 3
-  thomas: '00850'
   bioguide: N000002
+  thomas: '00850'
 HSPW:
 - name: Bill Shuster
   party: majority
   rank: 1
   title: Chair
-  thomas: '01681'
   bioguide: S001154
+  thomas: '01681'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
   title: Vice Chair
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Sam Graves
   party: majority
   rank: 5
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Duncan Hunter
   party: majority
   rank: 6
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 7
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Lou Barletta
   party: majority
   rank: 8
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 9
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 10
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 11
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jeff Denham
   party: majority
   rank: 12
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 13
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 14
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 15
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 16
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 17
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 18
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 19
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 20
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 21
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Garret Graves
   party: majority
   rank: 22
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Barbara Comstock
   party: majority
   rank: 23
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: David Rouzer
   party: majority
   rank: 24
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 25
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 26
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Doug LaMalfa
   party: majority
   rank: 27
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 28
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 29
@@ -8063,215 +9034,215 @@ HSPW:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00279'
   bioguide: D000191
+  thomas: '00279'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 2
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Jerrold Nadler
   party: minority
   rank: 3
-  thomas: '00850'
   bioguide: N000002
+  thomas: '00850'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 4
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: Elijah E. Cummings
   party: minority
   rank: 5
-  thomas: '00256'
   bioguide: C000984
+  thomas: '00256'
 - name: Rick Larsen
   party: minority
   rank: 6
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Michael E. Capuano
   party: minority
   rank: 7
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
   rank: 8
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Daniel Lipinski
   party: minority
   rank: 9
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Steve Cohen
   party: minority
   rank: 10
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Albio Sires
   party: minority
   rank: 11
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: John Garamendi
   party: minority
   rank: 12
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 13
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: André Carson
   party: minority
   rank: 14
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Richard M. Nolan
   party: minority
   rank: 15
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Dina Titus
   party: minority
   rank: 16
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 17
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
   rank: 18
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Lois Frankel
   party: minority
   rank: 19
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Cheri Bustos
   party: minority
   rank: 20
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Jared Huffman
   party: minority
   rank: 21
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Julia Brownley
   party: minority
   rank: 22
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Frederica S. Wilson
   party: minority
   rank: 23
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 24
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Alan S. Lowenthal
   party: minority
   rank: 25
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Brenda L. Lawrence
   party: minority
   rank: 26
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Mark DeSaulnier
   party: minority
   rank: 27
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 HSPW02:
 - name: Garret Graves
   party: majority
   rank: 1
   title: Chair
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Bob Gibbs
   party: majority
   rank: 3
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 4
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Thomas Massie
   party: majority
   rank: 5
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Rodney Davis
   party: majority
   rank: 6
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 7
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 8
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 9
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 10
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 11
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: David Rouzer
   party: majority
   rank: 12
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 13
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 14
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Doug LaMalfa
   party: majority
   rank: 15
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: A. Drew Ferguson IV
   party: majority
   rank: 16
@@ -8284,165 +9255,165 @@ HSPW02:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Lois Frankel
   party: minority
   rank: 2
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Frederica S. Wilson
   party: minority
   rank: 3
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Jared Huffman
   party: minority
   rank: 4
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: John Garamendi
   party: minority
   rank: 7
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Dina Titus
   party: minority
   rank: 8
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 9
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
   rank: 10
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Cheri Bustos
   party: minority
   rank: 11
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Julia Brownley
   party: minority
   rank: 12
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Brenda L. Lawrence
   party: minority
   rank: 13
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 HSPW05:
 - name: Frank A. LoBiondo
   party: majority
   rank: 1
   title: Chair
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Sam Graves
   party: majority
   rank: 4
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Duncan Hunter
   party: majority
   rank: 5
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Blake Farenthold
   party: majority
   rank: 6
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 7
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 8
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jeff Denham
   party: majority
   rank: 9
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 10
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 11
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 12
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 13
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 14
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 15
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 16
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Barbara Comstock
   party: majority
   rank: 17
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Doug LaMalfa
   party: majority
   rank: 18
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 19
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Paul Mitchell
   party: majority
   rank: 20
@@ -8455,115 +9426,115 @@ HSPW05:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 2
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: André Carson
   party: minority
   rank: 4
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Cheri Bustos
   party: minority
   rank: 5
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 6
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Dina Titus
   party: minority
   rank: 7
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 8
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Julia Brownley
   party: minority
   rank: 9
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 10
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Brenda L. Lawrence
   party: minority
   rank: 11
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Michael E. Capuano
   party: minority
   rank: 12
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
   rank: 13
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Steve Cohen
   party: minority
   rank: 14
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 15
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Richard M. Nolan
   party: minority
   rank: 16
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 HSPW07:
 - name: Duncan Hunter
   party: majority
   rank: 1
   title: Chair
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Frank A. LoBiondo
   party: majority
   rank: 3
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Garret Graves
   party: majority
   rank: 4
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: David Rouzer
   party: majority
   rank: 5
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 6
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Brian J. Mast
   party: majority
   rank: 7
@@ -8576,150 +9547,150 @@ HSPW07:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Elijah E. Cummings
   party: minority
   rank: 2
-  thomas: '00256'
   bioguide: C000984
+  thomas: '00256'
 - name: Rick Larsen
   party: minority
   rank: 3
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Jared Huffman
   party: minority
   rank: 4
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 6
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 HSPW12:
 - name: Sam Graves
   party: majority
   rank: 1
   title: Chair
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Duncan Hunter
   party: majority
   rank: 5
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 6
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Lou Barletta
   party: majority
   rank: 7
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 8
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 9
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Jeff Denham
   party: majority
   rank: 10
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 11
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 12
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 13
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 14
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Rob Woodall
   party: majority
   rank: 15
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: John Katko
   party: majority
   rank: 16
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 17
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Garret Graves
   party: majority
   rank: 18
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Barbara Comstock
   party: majority
   rank: 19
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: David Rouzer
   party: majority
   rank: 20
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 21
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Doug LaMalfa
   party: majority
   rank: 22
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 23
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 24
@@ -8740,130 +9711,130 @@ HSPW12:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Jerrold Nadler
   party: minority
   rank: 2
-  thomas: '00850'
   bioguide: N000002
+  thomas: '00850'
 - name: Steve Cohen
   party: minority
   rank: 3
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Albio Sires
   party: minority
   rank: 4
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: Richard M. Nolan
   party: minority
   rank: 5
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Dina Titus
   party: minority
   rank: 6
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 7
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
   rank: 8
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Jared Huffman
   party: minority
   rank: 9
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Julia Brownley
   party: minority
   rank: 10
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Alan S. Lowenthal
   party: minority
   rank: 11
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Brenda L. Lawrence
   party: minority
   rank: 12
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Mark DeSaulnier
   party: minority
   rank: 13
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 14
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: Michael E. Capuano
   party: minority
   rank: 15
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
   rank: 16
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Daniel Lipinski
   party: minority
   rank: 17
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 18
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Lois Frankel
   party: minority
   rank: 19
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Cheri Bustos
   party: minority
   rank: 20
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Frederica S. Wilson
   party: minority
   rank: 21
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 HSPW13:
 - name: Lou Barletta
   party: majority
   rank: 1
   title: Chair
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Barbara Comstock
   party: majority
   rank: 3
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Mike Bost
   party: majority
   rank: 4
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Lloyd Smucker
   party: majority
   rank: 5
@@ -8884,100 +9855,100 @@ HSPW13:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 2
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Albio Sires
   party: minority
   rank: 3
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: Grace F. Napolitano
   party: minority
   rank: 4
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Michael E. Capuano
   party: minority
   rank: 5
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 HSPW14:
 - name: Jeff Denham
   party: majority
   rank: 1
   title: Chair
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 2
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Sam Graves
   party: majority
   rank: 3
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Lou Barletta
   party: majority
   rank: 4
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 5
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Daniel Webster
   party: majority
   rank: 6
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Mark Meadows
   party: majority
   rank: 7
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 8
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Mark Sanford
   party: majority
   rank: 9
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Todd Rokita
   party: majority
   rank: 10
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 11
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 12
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 13
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Bruce Westerman
   party: majority
   rank: 14
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 15
@@ -8998,115 +9969,115 @@ HSPW14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 2
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Jerrold Nadler
   party: minority
   rank: 3
-  thomas: '00850'
   bioguide: N000002
+  thomas: '00850'
 - name: Elijah E. Cummings
   party: minority
   rank: 4
-  thomas: '00256'
   bioguide: C000984
+  thomas: '00256'
 - name: Steve Cohen
   party: minority
   rank: 5
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Albio Sires
   party: minority
   rank: 6
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: John Garamendi
   party: minority
   rank: 7
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: André Carson
   party: minority
   rank: 8
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Richard M. Nolan
   party: minority
   rank: 9
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Elizabeth H. Esty
   party: minority
   rank: 10
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Cheri Bustos
   party: minority
   rank: 11
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Frederica S. Wilson
   party: minority
   rank: 12
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Mark DeSaulnier
   party: minority
   rank: 13
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Daniel Lipinski
   party: minority
   rank: 14
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 HSRU:
 - name: Pete Sessions
   party: majority
   rank: 1
   title: Chair
-  thomas: '01525'
   bioguide: S000250
+  thomas: '01525'
 - name: Tom Cole
   party: majority
   rank: 2
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: Rob Woodall
   party: majority
   rank: 3
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Michael C. Burgess
   party: majority
   rank: 4
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Doug Collins
   party: majority
   rank: 5
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
 - name: Bradley Byrne
   party: majority
   rank: 6
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Dan Newhouse
   party: majority
   rank: 7
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: Ken Buck
   party: majority
   rank: 8
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: Liz Cheney
   party: majority
   rank: 9
@@ -9115,65 +10086,140 @@ HSRU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01069'
   bioguide: S000480
+  thomas: '01069'
 - name: James P. McGovern
   party: minority
   rank: 2
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Alcee L. Hastings
   party: minority
   rank: 3
-  thomas: '00511'
   bioguide: H000324
+  thomas: '00511'
 - name: Jared Polis
   party: minority
   rank: 4
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
+HSRU02:
+- name: Rob Woodall
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: W000810
+  thomas: '02008'
+- name: Michael C. Burgess
+  party: majority
+  rank: 2
+  bioguide: B001248
+  thomas: '01751'
+- name: Bradley Byrne
+  party: majority
+  rank: 3
+  bioguide: B001289
+  thomas: '02197'
+- name: Dan Newhouse
+  party: majority
+  rank: 4
+  bioguide: N000189
+  thomas: '02275'
+- name: Ken Buck
+  party: majority
+  rank: 5
+  bioguide: B001297
+  thomas: '02233'
+- name: Alcee L. Hastings
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H000324
+  thomas: '00511'
+- name: Jared Polis
+  party: minority
+  rank: 2
+  bioguide: P000598
+  thomas: '01910'
+HSRU04:
+- name: Doug Collins
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001093
+  thomas: '02121'
+- name: Bradley Byrne
+  party: majority
+  rank: 2
+  bioguide: B001289
+  thomas: '02197'
+- name: Dan Newhouse
+  party: majority
+  rank: 3
+  bioguide: N000189
+  thomas: '02275'
+- name: Liz Cheney
+  party: majority
+  rank: 4
+  bioguide: C001109
+- name: Pete Sessions
+  party: majority
+  rank: 5
+  bioguide: S000250
+  thomas: '01525'
+- name: Louise McIntosh Slaughter
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S000480
+  thomas: '01069'
+- name: James P. McGovern
+  party: minority
+  rank: 2
+  bioguide: M000312
+  thomas: '01504'
 HSSM:
 - name: Steve Chabot
   party: majority
   rank: 1
   title: Chair
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Dave Brat
   party: majority
   rank: 4
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Stephen Knight
   party: majority
   rank: 6
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 7
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Rod Blum
   party: majority
   rank: 8
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: James Comer
   party: majority
   rank: 9
@@ -9198,8 +10244,8 @@ HSSM:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Dwight Evans
   party: minority
   rank: 2
@@ -9215,18 +10261,18 @@ HSSM:
 - name: Yvette D. Clarke
   party: minority
   rank: 5
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Judy Chu
   party: minority
   rank: 6
-  thomas: '01970'
   bioguide: C001080
+  thomas: '01970'
 - name: Alma S. Adams
   party: minority
   rank: 7
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Adriano Espaillat
   party: minority
   rank: 8
@@ -9234,36 +10280,54 @@ HSSM:
 - name: Bradley Scott Schneider
   party: minority
   rank: 9
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 HSSM23:
 - name: Stephen Knight
   party: majority
   rank: 1
   title: Chair
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: James Comer
   party: majority
   rank: 3
   bioguide: C001108
+- name: Stephanie N. Murphy
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001202
+- name: Yvette D. Clarke
+  party: minority
+  rank: 2
+  bioguide: C001067
+  thomas: '01864'
+- name: Dwight Evans
+  party: minority
+  rank: 3
+  bioguide: E000296
+- name: Al Lawson, Jr.
+  party: minority
+  rank: 4
+  bioguide: L000586
 HSSM24:
 - name: Trent Kelly
   party: majority
   rank: 1
   title: Chair
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Rod Blum
   party: majority
   rank: 2
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: Don Bacon
   party: majority
   rank: 3
@@ -9272,28 +10336,34 @@ HSSM24:
   party: majority
   rank: 4
   bioguide: M001198
+- name: Alma S. Adams
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: A000370
+  thomas: '02201'
 HSSM25:
 - name: Rod Blum
   party: majority
   rank: 1
   title: Chair
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 4
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: James Comer
   party: majority
   rank: 5
@@ -9302,23 +10372,33 @@ HSSM25:
   party: majority
   rank: 6
   bioguide: B001298
+- name: Bradley Scott Schneider
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001190
+  thomas: '02124'
+- name: Al Lawson, Jr.
+  party: minority
+  rank: 2
+  bioguide: L000586
 HSSM26:
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 1
   title: Chair
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 2
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Dave Brat
   party: majority
   rank: 3
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Jenniffer González-Colón
   party: majority
   rank: 4
@@ -9331,23 +10411,32 @@ HSSM26:
   party: majority
   rank: 6
   bioguide: M001198
+- name: Al Lawson, Jr.
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000586
+- name: Adriano Espaillat
+  party: minority
+  rank: 2
+  bioguide: E000297
 HSSM27:
 - name: Dave Brat
   party: majority
   rank: 1
   title: Chair
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Stephen Knight
   party: majority
   rank: 2
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 3
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Jenniffer González-Colón
   party: majority
   rank: 4
@@ -9356,49 +10445,68 @@ HSSM27:
   party: majority
   rank: 5
   bioguide: F000466
+- name: Dwight Evans
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: E000296
+- name: Judy Chu
+  party: minority
+  rank: 2
+  bioguide: C001080
+  thomas: '01970'
+- name: Stephanie N. Murphy
+  party: minority
+  rank: 3
+  bioguide: M001202
+- name: Yvette D. Clarke
+  party: minority
+  rank: 4
+  bioguide: C001067
+  thomas: '01864'
 HSSO:
 - name: Susan W. Brooks
   party: majority
   rank: 1
   title: Chair
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Patrick Meehan
   party: majority
   rank: 2
-  thomas: '02052'
   bioguide: M001181
+  thomas: '02052'
 - name: Trey Gowdy
   party: majority
   rank: 3
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Kenny Marchant
   party: majority
   rank: 4
-  thomas: '01806'
   bioguide: M001158
+  thomas: '01806'
 - name: Leonard Lance
   party: majority
   rank: 5
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
 - name: Theodore E. Deutch
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Yvette D. Clarke
   party: minority
   rank: 2
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Jared Polis
   party: minority
   rank: 3
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Anthony G. Brown
   party: minority
   rank: 4
@@ -9406,95 +10514,95 @@ HSSO:
 - name: Steve Cohen
   party: minority
   rank: 5
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 HSSY:
 - name: Lamar Smith
   party: majority
   rank: 1
   title: Chair
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Randy Hultgren
   party: majority
   rank: 5
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Bill Posey
   party: majority
   rank: 6
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Thomas Massie
   party: majority
   rank: 7
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Jim Bridenstine
   party: majority
   rank: 8
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 9
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Stephen Knight
   party: majority
   rank: 10
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Brian Babin
   party: majority
   rank: 11
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Barbara Comstock
   party: majority
   rank: 12
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Gary J. Palmer
   party: majority
   rank: 13
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: Barry Loudermilk
   party: majority
   rank: 14
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Ralph Lee Abraham
   party: majority
   rank: 15
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Darin LaHood
   party: majority
   rank: 16
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 17
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jim Banks
   party: majority
   rank: 18
@@ -9519,43 +10627,43 @@ HSSY:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Ami Bera
   party: minority
   rank: 5
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Elizabeth H. Esty
   party: minority
   rank: 6
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Marc A. Veasey
   party: minority
   rank: 7
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 8
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Jacky Rosen
   party: minority
   rank: 9
@@ -9563,33 +10671,33 @@ HSSY:
 - name: Jerry McNerney
   party: minority
   rank: 10
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Ed Perlmutter
   party: minority
   rank: 11
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Paul Tonko
   party: minority
   rank: 12
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Bill Foster
   party: minority
   rank: 13
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Mark Takano
   party: minority
   rank: 14
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Colleen Hanabusa
   party: minority
   rank: 15
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Charlie Crist
   party: minority
   rank: 16
@@ -9599,39 +10707,39 @@ HSSY15:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Frank D. Lucas
   party: majority
   rank: 2
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Randy Hultgren
   party: majority
   rank: 3
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Stephen Knight
   party: majority
   rank: 4
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Darin LaHood
   party: majority
   rank: 5
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Ralph Lee Abraham
   party: majority
   rank: 6
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
   title: Vice Chair
 - name: Daniel Webster
   party: majority
   rank: 7
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jim Banks
   party: majority
   rank: 8
@@ -9643,20 +10751,20 @@ HSSY15:
 - name: Lamar Smith
   party: majority
   rank: 10
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Daniel Lipinski
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Elizabeth H. Esty
   party: minority
   rank: 2
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Jacky Rosen
   party: minority
   rank: 3
@@ -9664,77 +10772,77 @@ HSSY15:
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Ami Bera
   party: minority
   rank: 5
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 7
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY16:
 - name: Brian Babin
   party: majority
   rank: 1
   title: Chair
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
   title: Vice Chair
 - name: Bill Posey
   party: majority
   rank: 5
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Jim Bridenstine
   party: majority
   rank: 6
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 7
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Barbara Comstock
   party: majority
   rank: 8
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Ralph Lee Abraham
   party: majority
   rank: 9
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Daniel Webster
   party: majority
   rank: 10
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jim Banks
   party: majority
   rank: 11
@@ -9754,40 +10862,40 @@ HSSY16:
 - name: Lamar Smith
   party: majority
   rank: 15
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Ami Bera
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 3
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Marc A. Veasey
   party: minority
   rank: 4
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Daniel Lipinski
   party: minority
   rank: 5
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Ed Perlmutter
   party: minority
   rank: 6
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Charlie Crist
   party: minority
   rank: 7
@@ -9795,13 +10903,13 @@ HSSY16:
 - name: Bill Foster
   party: minority
   rank: 8
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 11
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY18:
 - name: Andy Biggs
@@ -9812,38 +10920,38 @@ HSSY18:
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Bill Posey
   party: majority
   rank: 3
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 5
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Brian Babin
   party: majority
   rank: 6
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Gary J. Palmer
   party: majority
   rank: 7
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: Barry Loudermilk
   party: majority
   rank: 8
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Jim Banks
   party: majority
   rank: 9
@@ -9856,20 +10964,20 @@ HSSY18:
 - name: Lamar Smith
   party: majority
   rank: 11
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Suzanne Bonamici
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Colleen Hanabusa
   party: minority
   rank: 2
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Charlie Crist
   party: minority
   rank: 3
@@ -9877,62 +10985,62 @@ HSSY18:
 - name: Eddie Bernice Johnson
   party: minority
   rank: 8
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY20:
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 1
   title: Chair
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Randy Hultgren
   party: majority
   rank: 5
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Thomas Massie
   party: majority
   rank: 6
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Jim Bridenstine
   party: majority
   rank: 7
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 8
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
   title: Vice Chair
 - name: Darin LaHood
   party: majority
   rank: 9
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 10
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Neal P. Dunn
   party: majority
   rank: 11
@@ -9940,25 +11048,25 @@ HSSY20:
 - name: Lamar Smith
   party: majority
   rank: 12
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Marc A. Veasey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Jacky Rosen
   party: minority
   rank: 4
@@ -9966,56 +11074,56 @@ HSSY20:
 - name: Jerry McNerney
   party: minority
   rank: 5
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Paul Tonko
   party: minority
   rank: 6
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Bill Foster
   party: minority
   rank: 7
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Mark Takano
   party: minority
   rank: 8
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 9
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY21:
 - name: Darin LaHood
   party: majority
   rank: 1
   title: Chair
-  thomas: '02295'
   bioguide: L000585
+  thomas: '02295'
 - name: Bill Posey
   party: majority
   rank: 2
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Thomas Massie
   party: majority
   rank: 3
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Gary J. Palmer
   party: majority
   rank: 4
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: Barry Loudermilk
   party: majority
   rank: 5
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Roger W. Marshall
   party: majority
   rank: 6
@@ -10028,68 +11136,68 @@ HSSY21:
 - name: Lamar Smith
   party: majority
   rank: 8
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Jerry McNerney
   party: minority
   rank: 2
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Ed Perlmutter
   party: minority
   rank: 3
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSVR:
 - name: David P. Roe
   party: majority
   rank: 1
   title: Chair
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Mike Coffman
   party: majority
   rank: 3
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Brad R. Wenstrup
   party: majority
   rank: 4
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Mike Bost
   party: majority
   rank: 6
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Bruce Poliquin
   party: majority
   rank: 7
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Neal P. Dunn
   party: majority
   rank: 8
@@ -10122,33 +11230,33 @@ HSVR:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Julia Brownley
   party: minority
   rank: 3
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Ann M. Kuster
   party: minority
   rank: 4
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Beto O'Rourke
   party: minority
   rank: 5
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Kathleen M. Rice
   party: minority
   rank: 6
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: J. Luis Correa
   party: minority
   rank: 7
@@ -10156,35 +11264,35 @@ HSVR:
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 8
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Elizabeth H. Esty
   party: minority
   rank: 9
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Scott H. Peters
   party: minority
   rank: 10
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 HSVR03:
 - name: Brad R. Wenstrup
   party: majority
   rank: 1
   title: Chair
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Neal P. Dunn
   party: majority
   rank: 4
@@ -10205,23 +11313,23 @@ HSVR03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Ann M. Kuster
   party: minority
   rank: 3
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Beto O'Rourke
   party: minority
   rank: 4
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: J. Luis Correa
   party: minority
   rank: 5
@@ -10235,13 +11343,13 @@ HSVR08:
 - name: Mike Bost
   party: majority
   rank: 2
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Bruce Poliquin
   party: majority
   rank: 3
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Neal P. Dunn
   party: majority
   rank: 4
@@ -10258,40 +11366,40 @@ HSVR08:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Kathleen M. Rice
   party: minority
   rank: 2
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: Scott H. Peters
   party: minority
   rank: 3
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 4
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 HSVR09:
 - name: Mike Bost
   party: majority
   rank: 1
   title: Chair
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Mike Coffman
   party: majority
   rank: 2
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Jack Bergman
   party: majority
   rank: 4
@@ -10304,18 +11412,18 @@ HSVR09:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Elizabeth H. Esty
   party: minority
   rank: 2
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 3
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 HSVR10:
 - name: Jodey C. Arrington
   party: majority
@@ -10325,13 +11433,13 @@ HSVR10:
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: John H. Rutherford
   party: majority
   rank: 4
@@ -10344,13 +11452,13 @@ HSVR10:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: J. Luis Correa
   party: minority
   rank: 3
@@ -10358,677 +11466,682 @@ HSVR10:
 - name: Kathleen M. Rice
   party: minority
   rank: 4
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 HSWM:
 - name: Kevin Brady
   party: majority
   rank: 1
   title: Chair
-  thomas: '01468'
   bioguide: B000755
+  thomas: '01468'
 - name: Sam Johnson
   party: majority
   rank: 2
-  thomas: '00603'
   bioguide: J000174
+  thomas: '00603'
 - name: Devin Nunes
   party: majority
   rank: 3
-  thomas: '01710'
   bioguide: N000181
+  thomas: '01710'
 - name: Patrick J. Tiberi
   party: majority
   rank: 4
-  thomas: '01664'
   bioguide: T000462
+  thomas: '01664'
 - name: David G. Reichert
   party: majority
   rank: 5
-  thomas: '01810'
   bioguide: R000578
+  thomas: '01810'
 - name: Peter J. Roskam
   party: majority
   rank: 6
-  thomas: '01848'
   bioguide: R000580
+  thomas: '01848'
 - name: Vern Buchanan
   party: majority
   rank: 7
-  thomas: '01840'
   bioguide: B001260
+  thomas: '01840'
 - name: Adrian Smith
   party: majority
   rank: 8
-  thomas: '01860'
   bioguide: S001172
+  thomas: '01860'
 - name: Lynn Jenkins
   party: majority
   rank: 9
-  thomas: '01921'
   bioguide: J000290
+  thomas: '01921'
 - name: Erik Paulsen
   party: majority
   rank: 10
-  thomas: '01930'
   bioguide: P000594
+  thomas: '01930'
 - name: Kenny Marchant
   party: majority
   rank: 11
-  thomas: '01806'
   bioguide: M001158
+  thomas: '01806'
 - name: Diane Black
   party: majority
   rank: 12
-  thomas: '02063'
   bioguide: B001273
+  thomas: '02063'
 - name: Tom Reed
   party: majority
   rank: 13
-  thomas: '01982'
   bioguide: R000585
+  thomas: '01982'
 - name: Mike Kelly
   party: majority
   rank: 14
-  thomas: '02051'
   bioguide: K000376
+  thomas: '02051'
 - name: James B. Renacci
   party: majority
   rank: 15
-  thomas: '02048'
   bioguide: R000586
+  thomas: '02048'
 - name: Patrick Meehan
   party: majority
   rank: 16
-  thomas: '02052'
   bioguide: M001181
+  thomas: '02052'
 - name: Kristi L. Noem
   party: majority
   rank: 17
-  thomas: '02060'
   bioguide: N000184
+  thomas: '02060'
 - name: George Holding
   party: majority
   rank: 18
-  thomas: '02143'
   bioguide: H001065
+  thomas: '02143'
 - name: Jason Smith
   party: majority
   rank: 19
-  thomas: '02191'
   bioguide: S001195
+  thomas: '02191'
 - name: Tom Rice
   party: majority
   rank: 20
-  thomas: '02160'
   bioguide: R000597
+  thomas: '02160'
 - name: David Schweikert
   party: majority
   rank: 21
-  thomas: '01994'
   bioguide: S001183
+  thomas: '01994'
 - name: Jackie Walorski
   party: majority
   rank: 22
-  thomas: '02128'
   bioguide: W000813
+  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
   rank: 23
-  thomas: '02235'
   bioguide: C001107
+  thomas: '02235'
 - name: Mike Bishop
   party: majority
   rank: 24
-  thomas: '02249'
   bioguide: B001293
+  thomas: '02249'
 - name: Richard E. Neal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00854'
   bioguide: N000015
+  thomas: '00854'
 - name: Sander M. Levin
   party: minority
   rank: 2
-  thomas: '00683'
   bioguide: L000263
+  thomas: '00683'
 - name: John Lewis
   party: minority
   rank: 3
-  thomas: '00688'
   bioguide: L000287
+  thomas: '00688'
 - name: Lloyd Doggett
   party: minority
   rank: 4
-  thomas: '00303'
   bioguide: D000399
+  thomas: '00303'
 - name: Mike Thompson
   party: minority
   rank: 5
-  thomas: '01593'
   bioguide: T000460
+  thomas: '01593'
 - name: John B. Larson
   party: minority
   rank: 6
-  thomas: '01583'
   bioguide: L000557
+  thomas: '01583'
 - name: Earl Blumenauer
   party: minority
   rank: 7
-  thomas: '00099'
   bioguide: B000574
+  thomas: '00099'
 - name: Ron Kind
   party: minority
   rank: 8
-  thomas: '01498'
   bioguide: K000188
+  thomas: '01498'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 9
-  thomas: '01510'
   bioguide: P000096
+  thomas: '01510'
 - name: Joseph Crowley
   party: minority
   rank: 10
-  thomas: '01604'
   bioguide: C001038
+  thomas: '01604'
 - name: Danny K. Davis
   party: minority
   rank: 11
-  thomas: '01477'
   bioguide: D000096
+  thomas: '01477'
 - name: Linda T. Sánchez
   party: minority
   rank: 12
-  thomas: '01757'
   bioguide: S001156
+  thomas: '01757'
 - name: Brian Higgins
   party: minority
   rank: 13
-  thomas: '01794'
   bioguide: H001038
+  thomas: '01794'
 - name: Terri A. Sewell
   party: minority
   rank: 14
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: Suzan K. DelBene
   party: minority
   rank: 15
-  thomas: '02096'
   bioguide: D000617
+  thomas: '02096'
 - name: Judy Chu
   party: minority
   rank: 16
-  thomas: '01970'
   bioguide: C001080
+  thomas: '01970'
 HSWM01:
 - name: Sam Johnson
   party: majority
   rank: 1
   title: Chair
-  thomas: '00603'
   bioguide: J000174
+  thomas: '00603'
 - name: Tom Rice
   party: majority
   rank: 2
-  thomas: '02160'
   bioguide: R000597
+  thomas: '02160'
 - name: David Schweikert
   party: majority
   rank: 3
-  thomas: '01994'
   bioguide: S001183
+  thomas: '01994'
 - name: Vern Buchanan
   party: majority
   rank: 4
-  thomas: '01840'
   bioguide: B001260
+  thomas: '01840'
 - name: Mike Kelly
   party: majority
   rank: 5
-  thomas: '02051'
   bioguide: K000376
+  thomas: '02051'
 - name: James B. Renacci
   party: majority
   rank: 6
-  thomas: '02048'
   bioguide: R000586
-- name: Jackie Walorski
+  thomas: '02048'
+- name: Jason Smith
   party: majority
   rank: 7
-  thomas: '02128'
-  bioguide: W000813
+  bioguide: S001195
+  thomas: '02191'
 - name: John B. Larson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01583'
   bioguide: L000557
+  thomas: '01583'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 2
-  thomas: '01510'
   bioguide: P000096
+  thomas: '01510'
 - name: Joseph Crowley
   party: minority
   rank: 3
-  thomas: '01604'
   bioguide: C001038
-- name: Brian Higgins
+  thomas: '01604'
+- name: Linda T. Sánchez
   party: minority
   rank: 4
-  thomas: '01794'
-  bioguide: H001038
+  bioguide: S001156
+  thomas: '01757'
 HSWM02:
 - name: Patrick J. Tiberi
   party: majority
   rank: 1
   title: Chair
-  thomas: '01664'
   bioguide: T000462
+  thomas: '01664'
 - name: Sam Johnson
   party: majority
   rank: 2
-  thomas: '00603'
   bioguide: J000174
+  thomas: '00603'
 - name: Devin Nunes
   party: majority
   rank: 3
-  thomas: '01710'
   bioguide: N000181
+  thomas: '01710'
 - name: Peter J. Roskam
   party: majority
   rank: 4
-  thomas: '01848'
   bioguide: R000580
+  thomas: '01848'
 - name: Vern Buchanan
   party: majority
   rank: 5
-  thomas: '01840'
   bioguide: B001260
+  thomas: '01840'
 - name: Adrian Smith
   party: majority
   rank: 6
-  thomas: '01860'
   bioguide: S001172
+  thomas: '01860'
 - name: Lynn Jenkins
   party: majority
   rank: 7
-  thomas: '01921'
   bioguide: J000290
+  thomas: '01921'
 - name: Kenny Marchant
   party: majority
   rank: 8
-  thomas: '01806'
   bioguide: M001158
+  thomas: '01806'
 - name: Diane Black
   party: majority
   rank: 9
-  thomas: '02063'
   bioguide: B001273
+  thomas: '02063'
 - name: Erik Paulsen
   party: majority
   rank: 10
-  thomas: '01930'
   bioguide: P000594
+  thomas: '01930'
+- name: Tom Reed
+  party: majority
+  rank: 11
+  bioguide: R000585
+  thomas: '01982'
 - name: Sander M. Levin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00683'
   bioguide: L000263
+  thomas: '00683'
 - name: Mike Thompson
   party: minority
   rank: 2
-  thomas: '01593'
   bioguide: T000460
+  thomas: '01593'
 - name: Ron Kind
   party: minority
   rank: 3
-  thomas: '01498'
   bioguide: K000188
+  thomas: '01498'
 - name: Earl Blumenauer
   party: minority
   rank: 4
-  thomas: '00099'
   bioguide: B000574
-- name: John Lewis
-  party: minority
-  rank: 5
-  thomas: '00688'
-  bioguide: L000287
+  thomas: '00099'
 - name: Brian Higgins
   party: minority
-  rank: 6
-  thomas: '01794'
+  rank: 5
   bioguide: H001038
+  thomas: '01794'
 - name: Terri A. Sewell
   party: minority
-  rank: 7
-  thomas: '01988'
+  rank: 6
   bioguide: S001185
+  thomas: '01988'
+- name: Judy Chu
+  party: minority
+  rank: 7
+  bioguide: C001080
+  thomas: '01970'
 HSWM03:
 - name: Adrian Smith
   party: majority
   rank: 1
   title: Chair
-  thomas: '01860'
   bioguide: S001172
+  thomas: '01860'
 - name: Jason Smith
   party: majority
   rank: 2
-  thomas: '02191'
   bioguide: S001195
+  thomas: '02191'
 - name: Jackie Walorski
   party: majority
   rank: 3
-  thomas: '02128'
   bioguide: W000813
+  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
   rank: 4
-  thomas: '02235'
   bioguide: C001107
-- name: David G. Reichert
+  thomas: '02235'
+- name: Mike Bishop
   party: majority
   rank: 5
-  thomas: '01810'
-  bioguide: R000578
-- name: Tom Reed
+  bioguide: B001293
+  thomas: '02249'
+- name: David G. Reichert
   party: majority
   rank: 6
-  thomas: '01982'
-  bioguide: R000585
-- name: Tom Rice
+  bioguide: R000578
+  thomas: '01810'
+- name: Tom Reed
   party: majority
   rank: 7
-  thomas: '02160'
-  bioguide: R000597
+  bioguide: R000585
+  thomas: '01982'
 - name: Danny K. Davis
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01477'
   bioguide: D000096
+  thomas: '01477'
 - name: Lloyd Doggett
   party: minority
   rank: 2
-  thomas: '00303'
   bioguide: D000399
-- name: Linda T. Sánchez
-  party: minority
-  rank: 3
-  thomas: '01757'
-  bioguide: S001156
+  thomas: '00303'
 - name: Terri A. Sewell
   party: minority
-  rank: 4
-  thomas: '01988'
+  rank: 3
   bioguide: S001185
+  thomas: '01988'
+- name: Judy Chu
+  party: minority
+  rank: 4
+  bioguide: C001080
+  thomas: '01970'
 HSWM04:
 - name: David G. Reichert
   party: majority
   rank: 1
   title: Chair
-  thomas: '01810'
   bioguide: R000578
+  thomas: '01810'
 - name: Devin Nunes
   party: majority
   rank: 2
-  thomas: '01710'
   bioguide: N000181
+  thomas: '01710'
 - name: Lynn Jenkins
   party: majority
   rank: 3
-  thomas: '01921'
   bioguide: J000290
+  thomas: '01921'
 - name: Erik Paulsen
   party: majority
   rank: 4
-  thomas: '01930'
   bioguide: P000594
+  thomas: '01930'
 - name: Mike Kelly
   party: majority
   rank: 5
-  thomas: '02051'
   bioguide: K000376
+  thomas: '02051'
 - name: Patrick Meehan
   party: majority
   rank: 6
-  thomas: '02052'
   bioguide: M001181
+  thomas: '02052'
 - name: Tom Reed
   party: majority
   rank: 7
-  thomas: '01982'
   bioguide: R000585
+  thomas: '01982'
 - name: Kristi L. Noem
   party: majority
   rank: 8
-  thomas: '02060'
   bioguide: N000184
+  thomas: '02060'
 - name: George Holding
   party: majority
   rank: 9
-  thomas: '02143'
   bioguide: H001065
+  thomas: '02143'
 - name: Tom Rice
   party: majority
   rank: 10
-  thomas: '02160'
   bioguide: R000597
+  thomas: '02160'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01510'
   bioguide: P000096
+  thomas: '01510'
 - name: Ron Kind
   party: minority
   rank: 2
-  thomas: '01498'
   bioguide: K000188
+  thomas: '01498'
 - name: Lloyd Doggett
   party: minority
   rank: 3
-  thomas: '00303'
   bioguide: D000399
+  thomas: '00303'
 - name: Sander M. Levin
   party: minority
   rank: 4
-  thomas: '00683'
   bioguide: L000263
+  thomas: '00683'
 - name: Danny K. Davis
   party: minority
   rank: 5
-  thomas: '01477'
   bioguide: D000096
+  thomas: '01477'
 - name: Suzan K. DelBene
   party: minority
   rank: 6
-  thomas: '02096'
   bioguide: D000617
+  thomas: '02096'
 HSWM05:
 - name: Peter J. Roskam
   party: majority
   rank: 1
   title: Chair
-  thomas: '01848'
   bioguide: R000580
+  thomas: '01848'
 - name: David G. Reichert
   party: majority
   rank: 2
-  thomas: '01810'
   bioguide: R000578
+  thomas: '01810'
 - name: Patrick J. Tiberi
   party: majority
   rank: 3
-  thomas: '01664'
   bioguide: T000462
-- name: Tom Reed
-  party: majority
-  rank: 4
-  thomas: '01982'
-  bioguide: R000585
+  thomas: '01664'
 - name: Mike Kelly
   party: majority
-  rank: 5
-  thomas: '02051'
+  rank: 4
   bioguide: K000376
+  thomas: '02051'
 - name: James B. Renacci
   party: majority
-  rank: 6
-  thomas: '02048'
+  rank: 5
   bioguide: R000586
+  thomas: '02048'
 - name: Kristi L. Noem
   party: majority
-  rank: 7
-  thomas: '02060'
+  rank: 6
   bioguide: N000184
+  thomas: '02060'
 - name: George Holding
   party: majority
-  rank: 8
-  thomas: '02143'
+  rank: 7
   bioguide: H001065
+  thomas: '02143'
 - name: Kenny Marchant
   party: majority
-  rank: 9
-  thomas: '01806'
+  rank: 8
   bioguide: M001158
+  thomas: '01806'
+- name: Patrick Meehan
+  party: majority
+  rank: 9
+  bioguide: M001181
+  thomas: '02052'
 - name: Lloyd Doggett
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00303'
   bioguide: D000399
+  thomas: '00303'
 - name: John B. Larson
   party: minority
   rank: 2
-  thomas: '01583'
   bioguide: L000557
+  thomas: '01583'
 - name: Linda T. Sánchez
   party: minority
   rank: 3
-  thomas: '01757'
   bioguide: S001156
+  thomas: '01757'
 - name: Mike Thompson
   party: minority
   rank: 4
-  thomas: '01593'
   bioguide: T000460
+  thomas: '01593'
 - name: Suzan K. DelBene
   party: minority
   rank: 5
-  thomas: '02096'
   bioguide: D000617
+  thomas: '02096'
 - name: Earl Blumenauer
   party: minority
   rank: 6
-  thomas: '00099'
   bioguide: B000574
+  thomas: '00099'
 HSWM06:
 - name: Vern Buchanan
   party: majority
   rank: 1
   title: Chair
-  thomas: '01840'
   bioguide: B001260
-- name: Patrick Meehan
-  party: majority
-  rank: 2
-  thomas: '02052'
-  bioguide: M001181
-- name: Jason Smith
-  party: majority
-  rank: 3
-  thomas: '02191'
-  bioguide: S001195
+  thomas: '01840'
 - name: David Schweikert
   party: majority
-  rank: 4
-  thomas: '01994'
+  rank: 2
   bioguide: S001183
+  thomas: '01994'
 - name: Jackie Walorski
   party: majority
-  rank: 5
-  thomas: '02128'
+  rank: 3
   bioguide: W000813
+  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
-  rank: 6
-  thomas: '02235'
+  rank: 4
   bioguide: C001107
+  thomas: '02235'
+- name: Mike Bishop
+  party: majority
+  rank: 5
+  bioguide: B001293
+  thomas: '02249'
+- name: Patrick Meehan
+  party: majority
+  rank: 6
+  bioguide: M001181
+  thomas: '02052'
 - name: George Holding
   party: majority
   rank: 7
-  thomas: '02143'
   bioguide: H001065
+  thomas: '02143'
 - name: John Lewis
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00688'
   bioguide: L000287
+  thomas: '00688'
 - name: Joseph Crowley
   party: minority
   rank: 2
-  thomas: '01604'
   bioguide: C001038
-- name: Danny K. Davis
+  thomas: '01604'
+- name: Suzan K. DelBene
   party: minority
   rank: 3
-  thomas: '01477'
-  bioguide: D000096
+  bioguide: D000617
+  thomas: '02096'
 - name: Earl Blumenauer
   party: minority
   rank: 4
-  thomas: '00099'
   bioguide: B000574
+  thomas: '00099'
 JCSE:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Cochairman
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
   chamber: senate
 - name: Richard Burr
   party: majority
   rank: 2
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
   chamber: senate
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
   chamber: senate
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
   chamber: senate
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
   chamber: senate
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
   chamber: senate
 - name: Christopher H. Smith
   party: majority
@@ -11072,56 +12185,56 @@ JSEC:
   party: majority
   rank: 1
   title: Vice Chairman
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
   chamber: senate
 - name: Tom Cotton
   party: majority
   rank: 2
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
   chamber: senate
 - name: Ben Sasse
   party: majority
   rank: 3
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
   chamber: senate
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
   chamber: senate
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
   chamber: senate
 - name: Bill Cassidy
   party: majority
   rank: 6
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
   chamber: senate
 - name: Martin Heinrich
   party: minority
   rank: 1
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
   chamber: senate
 - name: Gary C. Peters
   party: minority
   rank: 3
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
   chamber: senate
 - name: Margaret Wood Hassan
   party: minority
@@ -11176,32 +12289,32 @@ JSLC:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
   chamber: senate
 - name: Shelley Moore Capito
   party: majority
   rank: 3
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
   chamber: senate
 - name: Charles E. Schumer
   party: minority
   rank: 1
-  thomas: '01036'
   bioguide: S000148
+  thomas: '01036'
   chamber: senate
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -11233,32 +12346,32 @@ JSPR:
   party: majority
   rank: 1
   title: Vice Chairman
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
   chamber: senate
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
   chamber: senate
 - name: Charles E. Schumer
   party: minority
   rank: 1
-  thomas: '01036'
   bioguide: S000148
+  thomas: '01036'
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -11284,32 +12397,32 @@ JSTX:
   party: majority
   rank: 1
   title: Vice Chairman
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
   chamber: senate
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
   chamber: senate
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
   chamber: senate
 - name: Ron Wyden
   party: minority
   rank: 1
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
   chamber: senate
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
   chamber: senate
 - name: Paul Ryan
   party: majority
@@ -11341,139 +12454,139 @@ SCNC:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Cornyn
   party: majority
   rank: 2
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Dianne Feinstein
   party: minority
   rank: 1
-  thomas: '01332'
   bioguide: F000062
-- name: Charles E. Schumer
-  party: minority
-  rank: 2
-  thomas: '01036'
-  bioguide: S000148
+  thomas: '01332'
 - name: Sheldon Whitehouse
   party: minority
-  rank: 3
-  thomas: '01823'
+  rank: 2
   bioguide: W000802
+  thomas: '01823'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 3
+  bioguide: H001069
+  thomas: '02174'
 SLET:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 2
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 SLIA:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: John McCain
   party: majority
   rank: 3
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Lisa Murkowski
   party: majority
   rank: 4
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: James Lankford
   party: majority
   rank: 5
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Mike Crapo
   party: majority
   rank: 7
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Jerry Moran
   party: majority
   rank: 8
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Tom Udall
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Al Franken
   party: minority
   rank: 4
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Brian Schatz
   party: minority
   rank: 5
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Heidi Heitkamp
   party: minority
   rank: 6
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
@@ -11483,86 +12596,86 @@ SLIN:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Roy Blunt
   party: majority
   rank: 5
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Tom Cotton
   party: majority
   rank: 7
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: John Cornyn
   party: majority
   rank: 8
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Mitch McConnell
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: John McCain
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Ron Wyden
   party: minority
   rank: 3
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Joe Manchin, III
   party: minority
   rank: 6
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Kamala D. Harris
   party: minority
   rank: 7
@@ -11571,97 +12684,97 @@ SLIN:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '01036'
   bioguide: S000148
+  thomas: '01036'
 - name: Jack Reed
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SPAG:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Jeff Flake
   party: majority
   rank: 3
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Tim Scott
   party: majority
   rank: 4
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Bob Corker
   party: majority
   rank: 6
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Richard Burr
   party: majority
   rank: 7
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Deb Fischer
   party: majority
   rank: 9
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Bill Nelson
   party: minority
   rank: 2
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 5
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 6
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Elizabeth Warren
   party: minority
   rank: 7
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
@@ -11671,53 +12784,53 @@ SSAF:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 5
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Joni Ernst
   party: majority
   rank: 6
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Chuck Grassley
   party: majority
   rank: 7
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 8
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 9
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: David Perdue
   party: majority
   rank: 10
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Luther Strange
   party: majority
   rank: 11
@@ -11726,160 +12839,160 @@ SSAF:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sherrod Brown
   party: minority
   rank: 3
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Michael F. Bennet
   party: minority
   rank: 5
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Joe Donnelly
   party: minority
   rank: 7
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Heidi Heitkamp
   party: minority
   rank: 8
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 9
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAF13:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: John Hoeven
   party: majority
   rank: 3
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: David Perdue
   party: majority
   rank: 7
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Pat Roberts
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Sherrod Brown
   party: minority
   rank: 2
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Michael F. Bennet
   party: minority
   rank: 3
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Joe Donnelly
   party: minority
   rank: 5
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Chris Van Hollen
   party: minority
   rank: 6
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Debbie Stabenow
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAF14:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Chuck Grassley
   party: majority
   rank: 5
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Luther Strange
   party: majority
   rank: 6
@@ -11888,72 +13001,72 @@ SSAF14:
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Joe Donnelly
   party: minority
   rank: 4
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAF15:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Luther Strange
   party: majority
   rank: 7
@@ -11962,45 +13075,45 @@ SSAF15:
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Chris Van Hollen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Sherrod Brown
   party: minority
   rank: 2
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Michael F. Bennet
   party: minority
   rank: 4
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Joe Donnelly
   party: minority
   rank: 5
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Heidi Heitkamp
   party: minority
   rank: 6
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Debbie Stabenow
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAF16:
 - name: Luther Strange
   party: majority
@@ -12010,208 +13123,208 @@ SSAF16:
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Joni Ernst
   party: majority
   rank: 5
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: David Perdue
   party: majority
   rank: 6
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Pat Roberts
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sherrod Brown
   party: minority
   rank: 3
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Chris Van Hollen
   party: minority
   rank: 5
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAF17:
 - name: David Perdue
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Pat Roberts
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAP:
 - name: Thad Cochran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Roy Blunt
   party: majority
   rank: 8
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Jerry Moran
   party: majority
   rank: 9
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: John Hoeven
   party: majority
   rank: 10
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Boozman
   party: majority
   rank: 11
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 12
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 13
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 14
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: John Kennedy
   party: majority
   rank: 15
@@ -12219,256 +13332,256 @@ SSAP:
 - name: Marco Rubio
   party: majority
   rank: 16
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Patrick J. Leahy
   party: minority
   rank: 1
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Jack Reed
   party: minority
   rank: 5
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 6
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 8
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 9
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher A. Coons
   party: minority
   rank: 10
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 11
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 12
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 13
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 14
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 15
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP01:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Roy Blunt
   party: majority
   rank: 5
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Marco Rubio
   party: majority
   rank: 7
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 4
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Patrick J. Leahy
   party: minority
   rank: 5
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 SSAP02:
 - name: Thad Cochran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Roy Blunt
   party: majority
   rank: 8
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Steve Daines
   party: majority
   rank: 9
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Jerry Moran
   party: majority
   rank: 10
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patty Murray
   party: minority
   rank: 4
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Jack Reed
   party: minority
   rank: 5
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 6
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Brian Schatz
   party: minority
   rank: 8
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 9
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 SSAP08:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 2
@@ -12476,63 +13589,63 @@ SSAP08:
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 4
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Chris Van Hollen
   party: minority
   rank: 2
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP14:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lisa Murkowski
   party: majority
   rank: 4
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: John Hoeven
   party: majority
   rank: 5
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 7
@@ -12541,75 +13654,75 @@ SSAP14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Patty Murray
   party: minority
   rank: 4
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Tammy Baldwin
   party: minority
   rank: 5
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Joe Manchin, III
   party: minority
   rank: 6
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 SSAP16:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 2
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Boozman
   party: majority
   rank: 6
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 8
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -12618,169 +13731,169 @@ SSAP16:
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Joe Manchin, III
   party: minority
   rank: 7
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 8
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP17:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Roy Blunt
   party: majority
   rank: 4
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: John Hoeven
   party: majority
   rank: 5
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Mitch McConnell
   party: majority
   rank: 6
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Tom Udall
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 5
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Jeff Merkley
   party: minority
   rank: 6
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP18:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 8
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -12788,276 +13901,276 @@ SSAP18:
 - name: Marco Rubio
   party: majority
   rank: 10
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Jack Reed
   party: minority
   rank: 3
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 7
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 8
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 9
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Patrick J. Leahy
   party: minority
   rank: 10
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP19:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: John Boozman
   party: majority
   rank: 6
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Jon Tester
   party: minority
   rank: 2
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Patty Murray
   party: minority
   rank: 3
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 7
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Patrick J. Leahy
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP20:
 - name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Patrick J. Leahy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher Murphy
   party: minority
   rank: 6
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP22:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 4
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Hoeven
   party: majority
   rank: 8
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -13066,276 +14179,276 @@ SSAP22:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 6
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 7
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher A. Coons
   party: minority
   rank: 8
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP23:
 - name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: James Lankford
   party: majority
   rank: 4
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Thad Cochran
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Joe Manchin, III
   party: minority
   rank: 3
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 4
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Patrick J. Leahy
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP24:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Roy Blunt
   party: majority
   rank: 4
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: John Boozman
   party: majority
   rank: 5
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Lindsey Graham
   party: majority
   rank: 8
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Hoeven
   party: majority
   rank: 9
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Thad Cochran
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Dianne Feinstein
   party: minority
   rank: 4
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Christopher Murphy
   party: minority
   rank: 7
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 8
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAS:
 - name: John McCain
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Roger F. Wicker
   party: majority
   rank: 3
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Tom Cotton
   party: majority
   rank: 5
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 6
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 7
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 9
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: David Perdue
   party: majority
   rank: 10
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Ted Cruz
   party: majority
   rank: 11
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Lindsey Graham
   party: majority
   rank: 12
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 13
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Luther Strange
   party: majority
   rank: 14
@@ -13344,95 +14457,95 @@ SSAS:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Bill Nelson
   party: minority
   rank: 2
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 3
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 6
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 7
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Tim Kaine
   party: minority
   rank: 9
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 10
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Martin Heinrich
   party: minority
   rank: 11
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Elizabeth Warren
   party: minority
   rank: 12
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 13
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 SSAS13:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Tom Cotton
   party: majority
   rank: 2
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 3
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 5
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Luther Strange
   party: majority
   rank: 6
@@ -13441,142 +14554,142 @@ SSAS13:
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Jack Reed
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS14:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Roger F. Wicker
   party: majority
   rank: 3
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 5
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Ted Cruz
   party: majority
   rank: 6
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Claire McCaskill
   party: minority
   rank: 2
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 4
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Elizabeth Warren
   party: minority
   rank: 5
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 6
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS15:
 - name: James M. Inhofe
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Rounds
   party: majority
   rank: 2
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: David Perdue
   party: majority
   rank: 4
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Luther Strange
   party: majority
   rank: 5
@@ -13585,322 +14698,322 @@ SSAS15:
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Mazie K. Hirono
   party: minority
   rank: 3
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS16:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Tom Cotton
   party: majority
   rank: 3
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Dan Sullivan
   party: majority
   rank: 4
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Lindsey Graham
   party: majority
   rank: 6
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John McCain
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Joe Donnelly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Martin Heinrich
   party: minority
   rank: 2
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS17:
 - name: Thom Tillis
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Joni Ernst
   party: majority
   rank: 2
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Lindsey Graham
   party: majority
   rank: 3
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 4
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Claire McCaskill
   party: minority
   rank: 2
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS20:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 3
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: David Perdue
   party: majority
   rank: 4
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: John McCain
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Martin Heinrich
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Bill Nelson
   party: minority
   rank: 2
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS21:
 - name: Mike Rounds
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Deb Fischer
   party: majority
   rank: 2
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: David Perdue
   party: majority
   rank: 3
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 5
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Bill Nelson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 2
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 3
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSBK:
 - name: Mike Crapo
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Dean Heller
   party: majority
   rank: 5
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 6
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Tom Cotton
   party: majority
   rank: 8
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 9
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: David Perdue
   party: majority
   rank: 10
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Thom Tillis
   party: majority
   rank: 11
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 12
@@ -13909,53 +15022,53 @@ SSBK:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Robert Menendez
   party: minority
   rank: 3
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jon Tester
   party: minority
   rank: 4
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Mark R. Warner
   party: minority
   rank: 5
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Elizabeth Warren
   party: minority
   rank: 6
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Heidi Heitkamp
   party: minority
   rank: 7
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Joe Donnelly
   party: minority
   rank: 8
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Brian Schatz
   party: minority
   rank: 9
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 11
@@ -13965,80 +15078,80 @@ SSBK04:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Tim Scott
   party: majority
   rank: 5
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Mike Rounds
   party: majority
   rank: 7
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Mike Crapo
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Robert Menendez
   party: minority
   rank: 3
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jon Tester
   party: minority
   rank: 4
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Elizabeth Warren
   party: minority
   rank: 5
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Chris Van Hollen
   party: minority
   rank: 6
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
@@ -14047,110 +15160,110 @@ SSBK04:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK05:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Bob Corker
   party: majority
   rank: 2
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Tom Cotton
   party: majority
   rank: 3
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 4
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: David Perdue
   party: majority
   rank: 5
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Mike Crapo
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Joe Donnelly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Mark R. Warner
   party: minority
   rank: 2
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK08:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Dean Heller
   party: majority
   rank: 4
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 5
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Tom Cotton
   party: majority
   rank: 7
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: David Perdue
   party: majority
   rank: 8
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -14159,44 +15272,44 @@ SSBK08:
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Elizabeth Warren
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Mark R. Warner
   party: minority
   rank: 4
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Joe Donnelly
   party: minority
   rank: 5
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
@@ -14205,35 +15318,35 @@ SSBK08:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK09:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Dean Heller
   party: majority
   rank: 3
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Mike Rounds
   party: majority
   rank: 4
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 6
@@ -14242,62 +15355,62 @@ SSBK09:
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 5
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Sherrod Brown
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK12:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Patrick J. Toomey
   party: majority
   rank: 2
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: David Perdue
   party: majority
   rank: 3
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 5
@@ -14306,82 +15419,82 @@ SSBK12:
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Joe Donnelly
   party: minority
   rank: 4
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBU:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Patrick J. Toomey
   party: majority
   rank: 5
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Bob Corker
   party: majority
   rank: 7
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: David Perdue
   party: majority
   rank: 8
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Cory Gardner
   party: majority
   rank: 9
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: John Kennedy
   party: majority
   rank: 10
@@ -14389,8 +15502,8 @@ SSBU:
 - name: John Boozman
   party: majority
   rank: 11
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Luther Strange
   party: majority
   rank: 12
@@ -14399,53 +15512,53 @@ SSBU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Ron Wyden
   party: minority
   rank: 3
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 4
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Sheldon Whitehouse
   party: minority
   rank: 5
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Jeff Merkley
   party: minority
   rank: 7
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Tim Kaine
   party: minority
   rank: 8
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 9
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Kamala D. Harris
   party: minority
   rank: 11
@@ -14455,129 +15568,129 @@ SSCM:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 4
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 7
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 8
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 9
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 10
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 11
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 12
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 13
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 14
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Bill Nelson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 5
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 7
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 8
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 9
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 10
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 11
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 12
@@ -14591,120 +15704,120 @@ SSCM01:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 6
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 7
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 8
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 9
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Shelley Moore Capito
   party: majority
   rank: 10
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 11
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 12
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 13
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 8
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 9
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 10
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 11
@@ -14713,92 +15826,92 @@ SSCM01:
   party: minority
   rank: 12
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM20:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Roy Blunt
   party: majority
   rank: 2
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Dean Heller
   party: majority
   rank: 5
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 6
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 7
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Todd Young
   party: majority
   rank: 9
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Edward J. Markey
   party: minority
   rank: 3
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 4
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Tammy Duckworth
   party: minority
   rank: 6
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 7
@@ -14811,167 +15924,167 @@ SSCM20:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM22:
 - name: Dan Sullivan
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 3
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: James M. Inhofe
   party: majority
   rank: 4
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 5
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 8
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Tammy Baldwin
   party: minority
   rank: 7
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Bill Nelson
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM24:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 3
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 5
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: John Thune
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Brian Schatz
   party: minority
   rank: 2
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 5
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Margaret Wood Hassan
   party: minority
   rank: 6
@@ -14980,97 +16093,97 @@ SSCM24:
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM25:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Dean Heller
   party: majority
   rank: 4
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 5
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 8
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 9
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Cory A. Booker
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 8
@@ -15079,132 +16192,132 @@ SSCM25:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM26:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 2
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 6
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 7
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 8
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 9
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 10
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 11
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 12
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 13
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 14
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 8
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 9
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 10
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 11
@@ -15217,65 +16330,65 @@ SSCM26:
   party: minority
   rank: 13
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSEG:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Jeff Flake
   party: majority
   rank: 5
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 8
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 9
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 10
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 11
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Luther Strange
   party: majority
   rank: 12
@@ -15284,53 +16397,53 @@ SSEG:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Debbie Stabenow
   party: minority
   rank: 4
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Al Franken
   party: minority
   rank: 5
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Joe Manchin, III
   party: minority
   rank: 6
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Martin Heinrich
   party: minority
   rank: 7
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Angus S. King, Jr.
   party: minority
   rank: 9
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Tammy Duckworth
   party: minority
   rank: 10
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Catherine Cortez Masto
   party: minority
   rank: 11
@@ -15340,85 +16453,85 @@ SSEG01:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Jeff Flake
   party: majority
   rank: 3
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 4
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Lamar Alexander
   party: majority
   rank: 5
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 6
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 7
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 8
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Lisa Murkowski
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Joe Manchin, III
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Al Franken
   party: minority
   rank: 4
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Martin Heinrich
   party: minority
   rank: 5
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
   rank: 6
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
@@ -15427,92 +16540,92 @@ SSEG01:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEG03:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Jeff Flake
   party: majority
   rank: 4
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Cory Gardner
   party: majority
   rank: 6
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 7
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 8
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 9
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Lisa Murkowski
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Al Franken
   party: minority
   rank: 3
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Joe Manchin, III
   party: minority
   rank: 4
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Martin Heinrich
   party: minority
   rank: 5
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Mazie K. Hirono
   party: minority
   rank: 6
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
@@ -15521,260 +16634,260 @@ SSEG03:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEG04:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Mike Lee
   party: majority
   rank: 3
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Cory Gardner
   party: majority
   rank: 4
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 5
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 6
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Rob Portman
   party: majority
   rank: 7
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Debbie Stabenow
   party: minority
   rank: 3
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Maria Cantwell
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEG07:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Bill Cassidy
   party: majority
   rank: 5
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 6
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Lisa Murkowski
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Al Franken
   party: minority
   rank: 4
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Joe Manchin, III
   party: minority
   rank: 5
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Tammy Duckworth
   party: minority
   rank: 6
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Maria Cantwell
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEV:
 - name: John Barrasso
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Shelley Moore Capito
   party: majority
   rank: 3
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Roger F. Wicker
   party: majority
   rank: 5
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 6
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 7
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Mike Rounds
   party: majority
   rank: 8
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 9
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Dan Sullivan
   party: majority
   rank: 10
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Richard C. Shelby
   party: majority
   rank: 11
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Thomas R. Carper
   party: minority
   rank: 1
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Cory A. Booker
   party: minority
   rank: 7
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Edward J. Markey
   party: minority
   rank: 8
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Kamala D. Harris
   party: minority
   rank: 10
@@ -15788,1148 +16901,1148 @@ SSFI:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Pat Roberts
   party: majority
   rank: 4
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 5
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 6
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: John Thune
   party: majority
   rank: 7
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 8
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 9
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 10
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Patrick J. Toomey
   party: majority
   rank: 11
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Dean Heller
   party: majority
   rank: 12
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 13
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Bill Cassidy
   party: majority
   rank: 14
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Maria Cantwell
   party: minority
   rank: 3
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Bill Nelson
   party: minority
   rank: 4
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Robert Menendez
   party: minority
   rank: 5
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Thomas R. Carper
   party: minority
   rank: 6
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 7
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Sherrod Brown
   party: minority
   rank: 8
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Michael F. Bennet
   party: minority
   rank: 9
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 10
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Mark R. Warner
   party: minority
   rank: 11
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Claire McCaskill
   party: minority
   rank: 12
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 SSFI02:
 - name: Bill Cassidy
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 2
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Orrin G. Hatch
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Ron Wyden
   party: minority
   rank: 3
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI10:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 6
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 7
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 8
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Dean Heller
   party: majority
   rank: 9
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Bill Cassidy
   party: majority
   rank: 10
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Orrin G. Hatch
   party: majority
   rank: 11
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Maria Cantwell
   party: minority
   rank: 3
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Thomas R. Carper
   party: minority
   rank: 4
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Sherrod Brown
   party: minority
   rank: 6
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Mark R. Warner
   party: minority
   rank: 7
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Ron Wyden
   party: minority
   rank: 8
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI11:
 - name: Rob Portman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Mike Crapo
   party: majority
   rank: 2
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 5
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: John Thune
   party: majority
   rank: 6
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 7
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 8
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Patrick J. Toomey
   party: majority
   rank: 9
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Tim Scott
   party: majority
   rank: 10
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Orrin G. Hatch
   party: majority
   rank: 11
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 3
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Claire McCaskill
   party: minority
   rank: 4
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Robert Menendez
   party: minority
   rank: 5
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Michael F. Bennet
   party: minority
   rank: 6
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 7
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Maria Cantwell
   party: minority
   rank: 8
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Ron Wyden
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI12:
 - name: Dean Heller
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 5
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Richard Burr
   party: majority
   rank: 6
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Tim Scott
   party: majority
   rank: 7
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Bill Cassidy
   party: majority
   rank: 8
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Orrin G. Hatch
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Bill Nelson
   party: minority
   rank: 3
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Robert Menendez
   party: minority
   rank: 4
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Thomas R. Carper
   party: minority
   rank: 5
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Ron Wyden
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI13:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Dean Heller
   party: majority
   rank: 6
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Orrin G. Hatch
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Bill Nelson
   party: minority
   rank: 3
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 4
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Ron Wyden
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI14:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFR:
 - name: Bob Corker
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 4
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Jeff Flake
   party: majority
   rank: 5
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 6
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Barrasso
   party: majority
   rank: 8
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 9
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 10
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 11
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Christopher Murphy
   party: minority
   rank: 6
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Tim Kaine
   party: minority
   rank: 7
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Edward J. Markey
   party: minority
   rank: 8
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Jeff Merkley
   party: minority
   rank: 9
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Cory A. Booker
   party: minority
   rank: 10
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 SSFR01:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: John Barrasso
   party: majority
   rank: 3
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Edward J. Markey
   party: minority
   rank: 2
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Robert Menendez
   party: minority
   rank: 3
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 SSFR02:
 - name: Cory Gardner
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: John Barrasso
   party: majority
   rank: 4
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 5
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Jeff Merkley
   party: minority
   rank: 2
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher Murphy
   party: minority
   rank: 3
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 SSFR06:
 - name: Marco Rubio
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 2
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Jeff Flake
   party: majority
   rank: 3
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 4
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Johnny Isakson
   party: majority
   rank: 5
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 SSFR07:
 - name: James E. Risch
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 2
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 3
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Todd Young
   party: majority
   rank: 4
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Rob Portman
   party: majority
   rank: 5
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Christopher Murphy
   party: minority
   rank: 3
   title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Cory A. Booker
   party: minority
   rank: 4
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 SSFR09:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Todd Young
   party: majority
   rank: 2
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Barrasso
   party: majority
   rank: 3
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Cory A. Booker
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Christopher A. Coons
   party: minority
   rank: 2
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 SSFR14:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 2
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Cory A. Booker
   party: minority
   rank: 3
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 4
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 SSFR15:
 - name: Todd Young
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Jeff Flake
   party: majority
   rank: 2
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 3
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: John Barrasso
   party: majority
   rank: 4
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Rob Portman
   party: majority
   rank: 5
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Christopher A. Coons
   party: minority
   rank: 3
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Edward J. Markey
   party: minority
   rank: 4
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 SSGA:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: John McCain
   party: majority
   rank: 2
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Rob Portman
   party: majority
   rank: 3
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 4
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: James Lankford
   party: majority
   rank: 5
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Michael B. Enzi
   party: majority
   rank: 6
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Hoeven
   party: majority
   rank: 7
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Steve Daines
   party: majority
   rank: 8
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Claire McCaskill
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Gary C. Peters
   party: minority
   rank: 5
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Margaret Wood Hassan
   party: minority
   rank: 6
@@ -16943,95 +18056,95 @@ SSGA01:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: James Lankford
   party: majority
   rank: 2
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John McCain
   party: majority
   rank: 3
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Rand Paul
   party: majority
   rank: 4
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Ron Johnson
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Jon Tester
   party: minority
   rank: 2
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Claire McCaskill
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 SSGA18:
 - name: Rand Paul
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: James Lankford
   party: majority
   rank: 2
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Michael B. Enzi
   party: majority
   rank: 3
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Ron Johnson
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Margaret Wood Hassan
   party: minority
   rank: 2
@@ -17044,52 +18157,52 @@ SSGA18:
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 SSGA19:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John McCain
   party: majority
   rank: 2
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Rob Portman
   party: majority
   rank: 3
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Ron Johnson
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Margaret Wood Hassan
   party: minority
   rank: 3
@@ -17102,121 +18215,121 @@ SSGA19:
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 SSHR:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Michael B. Enzi
   party: majority
   rank: 2
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Richard Burr
   party: majority
   rank: 3
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Susan M. Collins
   party: majority
   rank: 6
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Bill Cassidy
   party: majority
   rank: 7
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 8
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 9
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 10
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Lisa Murkowski
   party: majority
   rank: 11
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Tim Scott
   party: majority
   rank: 12
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 3
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Al Franken
   party: minority
   rank: 4
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Michael F. Bennet
   party: minority
   rank: 5
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Sheldon Whitehouse
   party: minority
   rank: 6
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Tammy Baldwin
   party: minority
   rank: 7
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 8
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
   rank: 9
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Tim Kaine
   party: minority
   rank: 10
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
   rank: 11
@@ -17226,70 +18339,70 @@ SSHR09:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Lisa Murkowski
   party: majority
   rank: 2
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Richard Burr
   party: majority
   rank: 3
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Bill Cassidy
   party: majority
   rank: 4
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 5
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 6
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 7
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Al Franken
   party: minority
   rank: 3
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Michael F. Bennet
   party: minority
   rank: 4
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Tim Kaine
   party: minority
   rank: 5
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
   rank: 6
@@ -17298,177 +18411,177 @@ SSHR09:
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 SSHR11:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Tim Scott
   party: majority
   rank: 3
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Richard Burr
   party: majority
   rank: 4
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bill Cassidy
   party: majority
   rank: 6
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Al Franken
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Tammy Baldwin
   party: minority
   rank: 4
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 5
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
   rank: 6
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Patty Murray
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 SSHR12:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Richard Burr
   party: majority
   rank: 2
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Susan M. Collins
   party: majority
   rank: 3
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Bill Cassidy
   party: majority
   rank: 4
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 5
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 6
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 7
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Tim Scott
   party: majority
   rank: 8
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Lisa Murkowski
   party: majority
   rank: 9
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lamar Alexander
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Michael F. Bennet
   party: minority
   rank: 2
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Tammy Baldwin
   party: minority
   rank: 4
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 5
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
   rank: 6
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Tim Kaine
   party: minority
   rank: 7
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
   rank: 8
@@ -17477,60 +18590,60 @@ SSHR12:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 SSJU:
 - name: Chuck Grassley
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Lindsey Graham
   party: majority
   rank: 3
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Cornyn
   party: majority
   rank: 4
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Mike Lee
   party: majority
   rank: 5
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ted Cruz
   party: majority
   rank: 6
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Jeff Flake
   party: majority
   rank: 8
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Mike Crapo
   party: majority
   rank: 9
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Thom Tillis
   party: majority
   rank: 10
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 11
@@ -17539,108 +18652,108 @@ SSJU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Amy Klobuchar
   party: minority
   rank: 5
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Al Franken
   party: minority
   rank: 6
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Christopher A. Coons
   party: minority
   rank: 7
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Richard Blumenthal
   party: minority
   rank: 8
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 9
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 SSJU01:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Orrin G. Hatch
   party: majority
   rank: 3
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Al Franken
   party: minority
   rank: 3
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 SSJU04:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Thom Tillis
   party: majority
   rank: 2
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 3
@@ -17648,134 +18761,134 @@ SSJU04:
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Jeff Flake
   party: majority
   rank: 6
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Mike Crapo
   party: majority
   rank: 7
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Mike Lee
   party: majority
   rank: 8
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Al Franken
   party: minority
   rank: 5
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Richard Blumenthal
   party: minority
   rank: 6
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 7
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 SSJU21:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: John Cornyn
   party: majority
   rank: 2
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Ben Sasse
   party: majority
   rank: 4
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Al Franken
   party: minority
   rank: 3
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 SSJU22:
 - name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Cornyn
   party: majority
   rank: 2
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 4
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: John Kennedy
   party: majority
   rank: 5
@@ -17784,50 +18897,50 @@ SSJU22:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 SSJU23:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Mike Lee
   party: majority
   rank: 3
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Mike Crapo
   party: majority
   rank: 5
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: John Kennedy
   party: majority
   rank: 6
@@ -17836,45 +18949,45 @@ SSJU23:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 SSJU25:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: John Kennedy
   party: majority
   rank: 4
@@ -17882,153 +18995,153 @@ SSJU25:
 - name: Orrin G. Hatch
   party: majority
   rank: 5
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Mike Lee
   party: majority
   rank: 6
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Jeff Flake
   party: majority
   rank: 7
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Al Franken
   party: minority
   rank: 5
-  thomas: '01969'
   bioguide: F000457
+  thomas: '01969'
 - name: Richard Blumenthal
   party: minority
   rank: 6
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 7
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 SSRA:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Thad Cochran
   party: majority
   rank: 3
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Pat Roberts
   party: majority
   rank: 5
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Roy Blunt
   party: majority
   rank: 6
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 7
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Roger F. Wicker
   party: majority
   rank: 9
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 10
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Charles E. Schumer
   party: minority
   rank: 3
-  thomas: '01036'
   bioguide: S000148
+  thomas: '01036'
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Patrick J. Leahy
   party: minority
   rank: 7
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Angus S. King, Jr.
   party: minority
   rank: 8
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Catherine Cortez Masto
   party: minority
   rank: 9
@@ -18038,48 +19151,48 @@ SSSB:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 2
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Rand Paul
   party: majority
   rank: 3
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Tim Scott
   party: majority
   rank: 4
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Joni Ernst
   party: majority
   rank: 5
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: James M. Inhofe
   party: majority
   rank: 6
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Michael B. Enzi
   party: majority
   rank: 8
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Mike Rounds
   party: majority
   rank: 9
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: John Kennedy
   party: majority
   rank: 10
@@ -18088,123 +19201,123 @@ SSSB:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Benjamin L. Cardin
   party: minority
   rank: 3
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Christopher A. Coons
   party: minority
   rank: 7
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 SSVA:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Dean Heller
   party: majority
   rank: 4
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Bill Cassidy
   party: majority
   rank: 5
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Mike Rounds
   party: majority
   rank: 6
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 7
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 8
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Jon Tester
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Sherrod Brown
   party: minority
   rank: 4
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Richard Blumenthal
   party: minority
   rank: 5
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 6
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Joe Manchin, III
   party: minority
   rank: 7
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -4,427 +4,345 @@ HLIG:
   rank: 1
   title: Chair
   bioguide: N000181
-  thomas: '01710'
 - name: K. Michael Conaway
   party: majority
   rank: 2
   bioguide: C001062
-  thomas: '01805'
 - name: Peter T. King
   party: majority
   rank: 3
   bioguide: K000210
-  thomas: '00635'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
   bioguide: L000554
-  thomas: '00699'
 - name: Thomas J. Rooney
   party: majority
   rank: 5
   bioguide: R000583
-  thomas: '01916'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 6
   bioguide: R000435
-  thomas: '00985'
 - name: Michael R. Turner
   party: majority
   rank: 7
   bioguide: T000463
-  thomas: '01741'
 - name: Brad R. Wenstrup
   party: majority
   rank: 8
   bioguide: W000815
-  thomas: '02152'
 - name: Chris Stewart
   party: majority
   rank: 9
   bioguide: S001192
-  thomas: '02168'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 10
   bioguide: C001087
-  thomas: '01989'
 - name: Trey Gowdy
   party: majority
   rank: 11
   bioguide: G000566
-  thomas: '02058'
 - name: Elise M. Stefanik
   party: majority
   rank: 12
   bioguide: S001196
-  thomas: '02263'
 - name: Will Hurd
   party: majority
   rank: 13
   bioguide: H001073
-  thomas: '02269'
 - name: Adam B. Schiff
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001150
-  thomas: '01635'
 - name: James A. Himes
   party: minority
   rank: 2
   bioguide: H001047
-  thomas: '01913'
 - name: Terri A. Sewell
   party: minority
   rank: 3
   bioguide: S001185
-  thomas: '01988'
 - name: André Carson
   party: minority
   rank: 4
   bioguide: C001072
-  thomas: '01889'
 - name: Jackie Speier
   party: minority
   rank: 5
   bioguide: S001175
-  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 6
   bioguide: Q000023
-  thomas: '01967'
 - name: Eric Swalwell
   party: minority
   rank: 7
   bioguide: S001193
-  thomas: '02104'
 - name: Joaquin Castro
   party: minority
   rank: 8
   bioguide: C001091
-  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 9
   bioguide: H001064
-  thomas: '02170'
 HLIG01:
 - name: Frank A. LoBiondo
   party: majority
   rank: 1
   title: Chair
   bioguide: L000554
-  thomas: '00699'
 - name: K. Michael Conaway
   party: majority
   rank: 2
   bioguide: C001062
-  thomas: '01805'
 - name: Peter T. King
   party: majority
   rank: 3
   bioguide: K000210
-  thomas: '00635'
 - name: Thomas J. Rooney
   party: majority
   rank: 4
   bioguide: R000583
-  thomas: '01916'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 5
   bioguide: R000435
-  thomas: '00985'
 - name: Chris Stewart
   party: majority
   rank: 6
   bioguide: S001192
-  thomas: '02168'
 - name: Eric Swalwell
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001193
-  thomas: '02104'
 - name: James A. Himes
   party: minority
   rank: 2
   bioguide: H001047
-  thomas: '01913'
 - name: Joaquin Castro
   party: minority
   rank: 3
   bioguide: C001091
-  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 4
   bioguide: H001064
-  thomas: '02170'
 HLIG02:
 - name: Thomas J. Rooney
   party: majority
   rank: 1
   title: Chair
   bioguide: R000583
-  thomas: '01916'
 - name: K. Michael Conaway
   party: majority
   rank: 2
   bioguide: C001062
-  thomas: '01805'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
   bioguide: R000435
-  thomas: '00985'
 - name: Michael R. Turner
   party: majority
   rank: 4
   bioguide: T000463
-  thomas: '01741'
 - name: Trey Gowdy
   party: majority
   rank: 5
   bioguide: G000566
-  thomas: '02058'
 - name: Elise M. Stefanik
   party: majority
   rank: 6
   bioguide: S001196
-  thomas: '02263'
 - name: James A. Himes
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001047
-  thomas: '01913'
 - name: Terri A. Sewell
   party: minority
   rank: 2
   bioguide: S001185
-  thomas: '01988'
 - name: Jackie Speier
   party: minority
   rank: 3
   bioguide: S001175
-  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 4
   bioguide: Q000023
-  thomas: '01967'
 HLIG03:
 - name: Peter T. King
   party: majority
   rank: 1
   title: Chair
   bioguide: K000210
-  thomas: '00635'
 - name: Frank A. LoBiondo
   party: majority
   rank: 2
   bioguide: L000554
-  thomas: '00699'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
   bioguide: W000815
-  thomas: '02152'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 4
   bioguide: C001087
-  thomas: '01989'
 - name: Trey Gowdy
   party: majority
   rank: 5
   bioguide: G000566
-  thomas: '02058'
 - name: Will Hurd
   party: majority
   rank: 6
   bioguide: H001073
-  thomas: '02269'
 - name: André Carson
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001072
-  thomas: '01889'
 - name: Jackie Speier
   party: minority
   rank: 2
   bioguide: S001175
-  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 3
   bioguide: Q000023
-  thomas: '01967'
 - name: Eric Swalwell
   party: minority
   rank: 4
   bioguide: S001193
-  thomas: '02104'
 HLIG04:
 - name: Chris Stewart
   party: majority
   rank: 1
   title: Chair
   bioguide: S001192
-  thomas: '02168'
 - name: Michael R. Turner
   party: majority
   rank: 2
   bioguide: T000463
-  thomas: '01741'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
   bioguide: W000815
-  thomas: '02152'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 4
   bioguide: C001087
-  thomas: '01989'
 - name: Elise M. Stefanik
   party: majority
   rank: 5
   bioguide: S001196
-  thomas: '02263'
 - name: Will Hurd
   party: majority
   rank: 6
   bioguide: H001073
-  thomas: '02269'
 - name: Terri A. Sewell
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001185
-  thomas: '01988'
 - name: André Carson
   party: minority
   rank: 2
   bioguide: C001072
-  thomas: '01889'
 - name: Joaquin Castro
   party: minority
   rank: 3
   bioguide: C001091
-  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 4
   bioguide: H001064
-  thomas: '02170'
 HSAG:
 - name: K. Michael Conaway
   party: majority
   rank: 1
   title: Chair
   bioguide: C001062
-  thomas: '01805'
 - name: Bob Goodlatte
   party: majority
   rank: 2
   bioguide: G000289
-  thomas: '00446'
 - name: Frank D. Lucas
   party: majority
   rank: 3
   bioguide: L000491
-  thomas: '00711'
 - name: Steve King
   party: majority
   rank: 4
   bioguide: K000362
-  thomas: '01724'
 - name: Mike Rogers
   party: majority
   rank: 5
   bioguide: R000575
-  thomas: '01704'
 - name: Glenn Thompson
   party: majority
   rank: 6
   bioguide: T000467
-  thomas: '01952'
 - name: Bob Gibbs
   party: majority
   rank: 7
   bioguide: G000563
-  thomas: '02049'
 - name: Austin Scott
   party: majority
   rank: 8
   bioguide: S001189
-  thomas: '02009'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 9
   bioguide: C001087
-  thomas: '01989'
 - name: Scott DesJarlais
   party: majority
   rank: 10
   bioguide: D000616
-  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 11
   bioguide: H001053
-  thomas: '02032'
 - name: Jeff Denham
   party: majority
   rank: 12
   bioguide: D000612
-  thomas: '01995'
 - name: Doug LaMalfa
   party: majority
   rank: 13
   bioguide: L000578
-  thomas: '02100'
 - name: Rodney Davis
   party: majority
   rank: 14
   bioguide: D000619
-  thomas: '02126'
 - name: Ted S. Yoho
   party: majority
   rank: 15
   bioguide: Y000065
-  thomas: '02115'
 - name: Rick W. Allen
   party: majority
   rank: 16
   bioguide: A000372
-  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 17
   bioguide: B001295
-  thomas: '02243'
 - name: David Rouzer
   party: majority
   rank: 18
   bioguide: R000603
-  thomas: '02256'
 - name: Ralph Lee Abraham
   party: majority
   rank: 19
   bioguide: A000374
-  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 20
   bioguide: K000388
-  thomas: '02294'
 - name: James Comer
   party: majority
   rank: 21
@@ -454,72 +372,58 @@ HSAG:
   rank: 1
   title: Ranking Member
   bioguide: P000258
-  thomas: '00910'
 - name: David Scott
   party: minority
   rank: 2
   bioguide: S001157
-  thomas: '01722'
 - name: Jim Costa
   party: minority
   rank: 3
   bioguide: C001059
-  thomas: '01774'
 - name: Timothy J. Walz
   party: minority
   rank: 4
   bioguide: W000799
-  thomas: '01856'
 - name: Marcia L. Fudge
   party: minority
   rank: 5
   bioguide: F000455
-  thomas: '01895'
 - name: James P. McGovern
   party: minority
   rank: 6
   bioguide: M000312
-  thomas: '01504'
 - name: Filemon Vela
   party: minority
   rank: 7
   bioguide: V000132
-  thomas: '02167'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 8
   bioguide: L000580
-  thomas: '02146'
 - name: Ann M. Kuster
   party: minority
   rank: 9
   bioguide: K000382
-  thomas: '02145'
 - name: Richard M. Nolan
   party: minority
   rank: 10
   bioguide: N000127
-  thomas: '00867'
 - name: Cheri Bustos
   party: minority
   rank: 11
   bioguide: B001286
-  thomas: '02127'
 - name: Sean Patrick Maloney
   party: minority
   rank: 12
   bioguide: M001185
-  thomas: '02150'
 - name: Stacey E. Plaskett
   party: minority
   rank: 13
   bioguide: P000610
-  thomas: '02274'
 - name: Alma S. Adams
   party: minority
   rank: 14
   bioguide: A000370
-  thomas: '02201'
 - name: Dwight Evans
   party: minority
   rank: 15
@@ -550,42 +454,34 @@ HSAG03:
   rank: 1
   title: Chair
   bioguide: T000467
-  thomas: '01952'
 - name: Steve King
   party: majority
   rank: 2
   bioguide: K000362
-  thomas: '01724'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 3
   bioguide: C001087
-  thomas: '01989'
 - name: Scott DesJarlais
   party: majority
   rank: 4
   bioguide: D000616
-  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 5
   bioguide: H001053
-  thomas: '02032'
 - name: Rodney Davis
   party: majority
   rank: 6
   bioguide: D000619
-  thomas: '02126'
 - name: Ted S. Yoho
   party: majority
   rank: 7
   bioguide: Y000065
-  thomas: '02115'
 - name: David Rouzer
   party: majority
   rank: 8
   bioguide: R000603
-  thomas: '02256'
 - name: James Comer
   party: majority
   rank: 9
@@ -607,12 +503,10 @@ HSAG03:
   rank: 1
   title: Ranking Member
   bioguide: M000312
-  thomas: '01504'
 - name: Alma S. Adams
   party: minority
   rank: 2
   bioguide: A000370
-  thomas: '02201'
 - name: Dwight Evans
   party: minority
   rank: 3
@@ -621,12 +515,10 @@ HSAG03:
   party: minority
   rank: 4
   bioguide: F000455
-  thomas: '01895'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 5
   bioguide: L000580
-  thomas: '02146'
 - name: Al Lawson, Jr.
   party: minority
   rank: 6
@@ -643,34 +535,28 @@ HSAG03:
   party: minority
   rank: 9
   bioguide: M001185
-  thomas: '02150'
 HSAG14:
 - name: Rodney Davis
   party: majority
   rank: 1
   title: Chair
   bioguide: D000619
-  thomas: '02126'
 - name: Bob Gibbs
   party: majority
   rank: 2
   bioguide: G000563
-  thomas: '02049'
 - name: Jeff Denham
   party: majority
   rank: 3
   bioguide: D000612
-  thomas: '01995'
 - name: Ted S. Yoho
   party: majority
   rank: 4
   bioguide: Y000065
-  thomas: '02115'
 - name: David Rouzer
   party: majority
   rank: 5
   bioguide: R000603
-  thomas: '02256'
 - name: Don Bacon
   party: majority
   rank: 6
@@ -688,7 +574,6 @@ HSAG14:
   rank: 1
   title: Ranking Member
   bioguide: L000580
-  thomas: '02146'
 - name: Al Lawson, Jr.
   party: minority
   rank: 2
@@ -701,12 +586,10 @@ HSAG14:
   party: minority
   rank: 4
   bioguide: C001059
-  thomas: '01774'
 - name: James P. McGovern
   party: minority
   rank: 5
   bioguide: M000312
-  thomas: '01504'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 6
@@ -717,63 +600,51 @@ HSAG15:
   rank: 1
   title: Chair
   bioguide: L000491
-  thomas: '00711'
 - name: Glenn Thompson
   party: majority
   rank: 2
   bioguide: T000467
-  thomas: '01952'
 - name: Jeff Denham
   party: majority
   rank: 3
   bioguide: D000612
-  thomas: '01995'
 - name: Doug LaMalfa
   party: majority
   rank: 4
   bioguide: L000578
-  thomas: '02100'
 - name: Rick W. Allen
   party: majority
   rank: 5
   bioguide: A000372
-  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 6
   bioguide: B001295
-  thomas: '02243'
 - name: Ralph Lee Abraham
   party: majority
   rank: 7
   bioguide: A000374
-  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 8
   bioguide: K000388
-  thomas: '02294'
 - name: Marcia L. Fudge
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: F000455
-  thomas: '01895'
 - name: Timothy J. Walz
   party: minority
   rank: 2
   bioguide: W000799
-  thomas: '01856'
 - name: Ann M. Kuster
   party: minority
   rank: 3
   bioguide: K000382
-  thomas: '02145'
 - name: Richard M. Nolan
   party: minority
   rank: 4
   bioguide: N000127
-  thomas: '00867'
 - name: Tom O'Halleran
   party: minority
   rank: 5
@@ -782,54 +653,44 @@ HSAG15:
   party: minority
   rank: 6
   bioguide: V000132
-  thomas: '02167'
 HSAG16:
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 1
   title: Chair
   bioguide: C001087
-  thomas: '01989'
 - name: Frank D. Lucas
   party: majority
   rank: 2
   bioguide: L000491
-  thomas: '00711'
 - name: Mike Rogers
   party: majority
   rank: 3
   bioguide: R000575
-  thomas: '01704'
 - name: Bob Gibbs
   party: majority
   rank: 4
   bioguide: G000563
-  thomas: '02049'
 - name: Austin Scott
   party: majority
   rank: 5
   bioguide: S001189
-  thomas: '02009'
 - name: Scott DesJarlais
   party: majority
   rank: 6
   bioguide: D000616
-  thomas: '02062'
 - name: Rick W. Allen
   party: majority
   rank: 7
   bioguide: A000372
-  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 8
   bioguide: B001295
-  thomas: '02243'
 - name: Ralph Lee Abraham
   party: majority
   rank: 9
   bioguide: A000374
-  thomas: '02244'
 - name: Don Bacon
   party: majority
   rank: 10
@@ -847,17 +708,14 @@ HSAG16:
   rank: 1
   title: Ranking Member
   bioguide: N000127
-  thomas: '00867'
 - name: Timothy J. Walz
   party: minority
   rank: 2
   bioguide: W000799
-  thomas: '01856'
 - name: Cheri Bustos
   party: minority
   rank: 3
   bioguide: B001286
-  thomas: '02127'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 4
@@ -866,17 +724,14 @@ HSAG16:
   party: minority
   rank: 5
   bioguide: S001157
-  thomas: '01722'
 - name: Sean Patrick Maloney
   party: minority
   rank: 6
   bioguide: M001185
-  thomas: '02150'
 - name: Stacey E. Plaskett
   party: minority
   rank: 7
   bioguide: P000610
-  thomas: '02274'
 - name: Al Lawson, Jr.
   party: minority
   rank: 8
@@ -891,27 +746,22 @@ HSAG22:
   rank: 1
   title: Chair
   bioguide: S001189
-  thomas: '02009'
 - name: Bob Goodlatte
   party: majority
   rank: 2
   bioguide: G000289
-  thomas: '00446'
 - name: Mike Rogers
   party: majority
   rank: 3
   bioguide: R000575
-  thomas: '01704'
 - name: Doug LaMalfa
   party: majority
   rank: 4
   bioguide: L000578
-  thomas: '02100'
 - name: Rodney Davis
   party: majority
   rank: 5
   bioguide: D000619
-  thomas: '02126'
 - name: James Comer
   party: majority
   rank: 6
@@ -929,22 +779,18 @@ HSAG22:
   rank: 1
   title: Ranking Member
   bioguide: S001157
-  thomas: '01722'
 - name: Sean Patrick Maloney
   party: minority
   rank: 2
   bioguide: M001185
-  thomas: '02150'
 - name: Ann M. Kuster
   party: minority
   rank: 3
   bioguide: K000382
-  thomas: '02145'
 - name: Stacey E. Plaskett
   party: minority
   rank: 4
   bioguide: P000610
-  thomas: '02274'
 - name: Tom O'Halleran
   party: minority
   rank: 5
@@ -959,37 +805,30 @@ HSAG29:
   rank: 1
   title: Chair
   bioguide: R000603
-  thomas: '02256'
 - name: Bob Goodlatte
   party: majority
   rank: 2
   bioguide: G000289
-  thomas: '00446'
 - name: Steve King
   party: majority
   rank: 3
   bioguide: K000362
-  thomas: '01724'
 - name: Scott DesJarlais
   party: majority
   rank: 4
   bioguide: D000616
-  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 5
   bioguide: H001053
-  thomas: '02032'
 - name: Ted S. Yoho
   party: majority
   rank: 6
   bioguide: Y000065
-  thomas: '02115'
 - name: Trent Kelly
   party: majority
   rank: 7
   bioguide: K000388
-  thomas: '02294'
 - name: Roger W. Marshall
   party: majority
   rank: 8
@@ -999,22 +838,18 @@ HSAG29:
   rank: 1
   title: Ranking Member
   bioguide: C001059
-  thomas: '01774'
 - name: Filemon Vela
   party: minority
   rank: 2
   bioguide: V000132
-  thomas: '02167'
 - name: Cheri Bustos
   party: minority
   rank: 3
   bioguide: B001286
-  thomas: '02127'
 - name: Stacey E. Plaskett
   party: minority
   rank: 4
   bioguide: P000610
-  thomas: '02274'
 - name: Dwight Evans
   party: minority
   rank: 5
@@ -1025,147 +860,118 @@ HSAP:
   rank: 1
   title: Chair
   bioguide: F000372
-  thomas: '00414'
 - name: Harold Rogers
   party: majority
   rank: 2
   bioguide: R000395
-  thomas: '00977'
 - name: Robert B. Aderholt
   party: majority
   rank: 3
   bioguide: A000055
-  thomas: '01460'
 - name: Kay Granger
   party: majority
   rank: 4
   bioguide: G000377
-  thomas: '01487'
 - name: Michael K. Simpson
   party: majority
   rank: 5
   bioguide: S001148
-  thomas: '01590'
 - name: John Abney Culberson
   party: majority
   rank: 6
   bioguide: C001048
-  thomas: '01670'
 - name: John R. Carter
   party: majority
   rank: 7
   bioguide: C001051
-  thomas: '01752'
 - name: Ken Calvert
   party: majority
   rank: 8
   bioguide: C000059
-  thomas: '00165'
 - name: Tom Cole
   party: majority
   rank: 9
   bioguide: C001053
-  thomas: '01742'
 - name: Mario Diaz-Balart
   party: majority
   rank: 10
   bioguide: D000600
-  thomas: '01717'
 - name: Charles W. Dent
   party: majority
   rank: 11
   bioguide: D000604
-  thomas: '01799'
 - name: Tom Graves
   party: majority
   rank: 12
   bioguide: G000560
-  thomas: '01979'
 - name: Kevin Yoder
   party: majority
   rank: 13
   bioguide: Y000063
-  thomas: '02021'
 - name: Steve Womack
   party: majority
   rank: 14
   bioguide: W000809
-  thomas: '01991'
 - name: Jeff Fortenberry
   party: majority
   rank: 15
   bioguide: F000449
-  thomas: '01793'
 - name: Thomas J. Rooney
   party: majority
   rank: 16
   bioguide: R000583
-  thomas: '01916'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 17
   bioguide: F000459
-  thomas: '02061'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 18
   bioguide: H001056
-  thomas: '02071'
 - name: David P. Joyce
   party: majority
   rank: 19
   bioguide: J000295
-  thomas: '02154'
 - name: David G. Valadao
   party: majority
   rank: 20
   bioguide: V000129
-  thomas: '02105'
 - name: Andy Harris
   party: majority
   rank: 21
   bioguide: H001052
-  thomas: '02026'
 - name: Martha Roby
   party: majority
   rank: 22
   bioguide: R000591
-  thomas: '01986'
 - name: Mark E. Amodei
   party: majority
   rank: 23
   bioguide: A000369
-  thomas: '02090'
 - name: Chris Stewart
   party: majority
   rank: 24
   bioguide: S001192
-  thomas: '02168'
 - name: David Young
   party: majority
   rank: 25
   bioguide: Y000066
-  thomas: '02242'
 - name: Evan H. Jenkins
   party: majority
   rank: 26
   bioguide: J000297
-  thomas: '02278'
 - name: Steven M. Palazzo
   party: majority
   rank: 27
   bioguide: P000601
-  thomas: '02035'
 - name: Dan Newhouse
   party: majority
   rank: 28
   bioguide: N000189
-  thomas: '02275'
 - name: John R. Moolenaar
   party: majority
   rank: 29
   bioguide: M001194
-  thomas: '02248'
 - name: Scott Taylor
   party: majority
   rank: 30
@@ -1175,542 +981,438 @@ HSAP:
   rank: 1
   title: Ranking Member
   bioguide: L000480
-  thomas: '00709'
 - name: Marcy Kaptur
   party: minority
   rank: 2
   bioguide: K000009
-  thomas: '00616'
 - name: Peter J. Visclosky
   party: minority
   rank: 3
   bioguide: V000108
-  thomas: '01188'
 - name: José E. Serrano
   party: minority
   rank: 4
   bioguide: S000248
-  thomas: '01042'
 - name: Rosa L. DeLauro
   party: minority
   rank: 5
   bioguide: D000216
-  thomas: '00281'
 - name: David E. Price
   party: minority
   rank: 6
   bioguide: P000523
-  thomas: '00930'
 - name: Lucille Roybal-Allard
   party: minority
   rank: 7
   bioguide: R000486
-  thomas: '00997'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 8
   bioguide: B000490
-  thomas: '00091'
 - name: Barbara Lee
   party: minority
   rank: 9
   bioguide: L000551
-  thomas: '01501'
 - name: Betty McCollum
   party: minority
   rank: 10
   bioguide: M001143
-  thomas: '01653'
 - name: Tim Ryan
   party: minority
   rank: 11
   bioguide: R000577
-  thomas: '01756'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 12
   bioguide: R000576
-  thomas: '01728'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 13
   bioguide: W000797
-  thomas: '01777'
 - name: Henry Cuellar
   party: minority
   rank: 14
   bioguide: C001063
-  thomas: '01807'
 - name: Chellie Pingree
   party: minority
   rank: 15
   bioguide: P000597
-  thomas: '01927'
 - name: Mike Quigley
   party: minority
   rank: 16
   bioguide: Q000023
-  thomas: '01967'
 - name: Derek Kilmer
   party: minority
   rank: 17
   bioguide: K000381
-  thomas: '02169'
 - name: Matt Cartwright
   party: minority
   rank: 18
   bioguide: C001090
-  thomas: '02159'
 - name: Grace Meng
   party: minority
   rank: 19
   bioguide: M001188
-  thomas: '02148'
 - name: Mark Pocan
   party: minority
   rank: 20
   bioguide: P000607
-  thomas: '02171'
 - name: Katherine M. Clark
   party: minority
   rank: 21
   bioguide: C001101
-  thomas: '02196'
 - name: Pete Aguilar
   party: minority
   rank: 22
   bioguide: A000371
-  thomas: '02229'
 HSAP01:
 - name: Robert B. Aderholt
   party: majority
   rank: 1
   title: Chair
   bioguide: A000055
-  thomas: '01460'
 - name: Kevin Yoder
   party: majority
   rank: 2
   bioguide: Y000063
-  thomas: '02021'
 - name: Thomas J. Rooney
   party: majority
   rank: 3
   bioguide: R000583
-  thomas: '01916'
 - name: David G. Valadao
   party: majority
   rank: 4
   bioguide: V000129
-  thomas: '02105'
 - name: Andy Harris
   party: majority
   rank: 5
   bioguide: H001052
-  thomas: '02026'
 - name: David Young
   party: majority
   rank: 6
   bioguide: Y000066
-  thomas: '02242'
 - name: Steven M. Palazzo
   party: majority
   rank: 7
   bioguide: P000601
-  thomas: '02035'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B000490
-  thomas: '00091'
 - name: Rosa L. DeLauro
   party: minority
   rank: 2
   bioguide: D000216
-  thomas: '00281'
 - name: Chellie Pingree
   party: minority
   rank: 3
   bioguide: P000597
-  thomas: '01927'
 - name: Mark Pocan
   party: minority
   rank: 4
   bioguide: P000607
-  thomas: '02171'
 HSAP02:
 - name: Kay Granger
   party: majority
   rank: 1
   title: Chair
   bioguide: G000377
-  thomas: '01487'
 - name: Harold Rogers
   party: majority
   rank: 2
   bioguide: R000395
-  thomas: '00977'
 - name: Ken Calvert
   party: majority
   rank: 3
   bioguide: C000059
-  thomas: '00165'
 - name: Tom Cole
   party: majority
   rank: 4
   bioguide: C001053
-  thomas: '01742'
 - name: Steve Womack
   party: majority
   rank: 5
   bioguide: W000809
-  thomas: '01991'
 - name: Robert B. Aderholt
   party: majority
   rank: 6
   bioguide: A000055
-  thomas: '01460'
 - name: John R. Carter
   party: majority
   rank: 7
   bioguide: C001051
-  thomas: '01752'
 - name: Mario Diaz-Balart
   party: majority
   rank: 8
   bioguide: D000600
-  thomas: '01717'
 - name: Tom Graves
   party: majority
   rank: 9
   bioguide: G000560
-  thomas: '01979'
 - name: Martha Roby
   party: majority
   rank: 10
   bioguide: R000591
-  thomas: '01986'
 - name: Peter J. Visclosky
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: V000108
-  thomas: '01188'
 - name: Betty McCollum
   party: minority
   rank: 2
   bioguide: M001143
-  thomas: '01653'
 - name: Tim Ryan
   party: minority
   rank: 3
   bioguide: R000577
-  thomas: '01756'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 4
   bioguide: R000576
-  thomas: '01728'
 - name: Marcy Kaptur
   party: minority
   rank: 5
   bioguide: K000009
-  thomas: '00616'
 - name: Henry Cuellar
   party: minority
   rank: 6
   bioguide: C001063
-  thomas: '01807'
 HSAP04:
 - name: Harold Rogers
   party: majority
   rank: 1
   title: Chair
   bioguide: R000395
-  thomas: '00977'
 - name: Kay Granger
   party: majority
   rank: 2
   bioguide: G000377
-  thomas: '01487'
 - name: Mario Diaz-Balart
   party: majority
   rank: 3
   bioguide: D000600
-  thomas: '01717'
 - name: Charles W. Dent
   party: majority
   rank: 4
   bioguide: D000604
-  thomas: '01799'
 - name: Thomas J. Rooney
   party: majority
   rank: 5
   bioguide: R000583
-  thomas: '01916'
 - name: Jeff Fortenberry
   party: majority
   rank: 6
   bioguide: F000449
-  thomas: '01793'
 - name: Chris Stewart
   party: majority
   rank: 7
   bioguide: S001192
-  thomas: '02168'
 - name: Nita M. Lowey
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000480
-  thomas: '00709'
 - name: Barbara Lee
   party: minority
   rank: 2
   bioguide: L000551
-  thomas: '01501'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 3
   bioguide: R000576
-  thomas: '01728'
 - name: Grace Meng
   party: minority
   rank: 4
   bioguide: M001188
-  thomas: '02148'
 - name: David E. Price
   party: minority
   rank: 5
   bioguide: P000523
-  thomas: '00930'
 HSAP06:
 - name: Ken Calvert
   party: majority
   rank: 1
   title: Chair
   bioguide: C000059
-  thomas: '00165'
 - name: Michael K. Simpson
   party: majority
   rank: 2
   bioguide: S001148
-  thomas: '01590'
 - name: Tom Cole
   party: majority
   rank: 3
   bioguide: C001053
-  thomas: '01742'
 - name: David P. Joyce
   party: majority
   rank: 4
   bioguide: J000295
-  thomas: '02154'
 - name: Chris Stewart
   party: majority
   rank: 5
   bioguide: S001192
-  thomas: '02168'
 - name: Mark E. Amodei
   party: majority
   rank: 6
   bioguide: A000369
-  thomas: '02090'
 - name: Evan H. Jenkins
   party: majority
   rank: 7
   bioguide: J000297
-  thomas: '02278'
 - name: Betty McCollum
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001143
-  thomas: '01653'
 - name: Chellie Pingree
   party: minority
   rank: 2
   bioguide: P000597
-  thomas: '01927'
 - name: Derek Kilmer
   party: minority
   rank: 3
   bioguide: K000381
-  thomas: '02169'
 - name: Marcy Kaptur
   party: minority
   rank: 4
   bioguide: K000009
-  thomas: '00616'
 HSAP07:
 - name: Tom Cole
   party: majority
   rank: 1
   title: Chair
   bioguide: C001053
-  thomas: '01742'
 - name: Michael K. Simpson
   party: majority
   rank: 2
   bioguide: S001148
-  thomas: '01590'
 - name: Steve Womack
   party: majority
   rank: 3
   bioguide: W000809
-  thomas: '01991'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 4
   bioguide: F000459
-  thomas: '02061'
 - name: Andy Harris
   party: majority
   rank: 5
   bioguide: H001052
-  thomas: '02026'
 - name: Martha Roby
   party: majority
   rank: 6
   bioguide: R000591
-  thomas: '01986'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 7
   bioguide: H001056
-  thomas: '02071'
 - name: John R. Moolenaar
   party: majority
   rank: 8
   bioguide: M001194
-  thomas: '02248'
 - name: Rosa L. DeLauro
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000216
-  thomas: '00281'
 - name: Lucille Roybal-Allard
   party: minority
   rank: 2
   bioguide: R000486
-  thomas: '00997'
 - name: Barbara Lee
   party: minority
   rank: 3
   bioguide: L000551
-  thomas: '01501'
 - name: Mark Pocan
   party: minority
   rank: 4
   bioguide: P000607
-  thomas: '02171'
 - name: Katherine M. Clark
   party: minority
   rank: 5
   bioguide: C001101
-  thomas: '02196'
 HSAP10:
 - name: Michael K. Simpson
   party: majority
   rank: 1
   title: Chair
   bioguide: S001148
-  thomas: '01590'
 - name: Ken Calvert
   party: majority
   rank: 2
   bioguide: C000059
-  thomas: '00165'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 3
   bioguide: F000459
-  thomas: '02061'
 - name: Jeff Fortenberry
   party: majority
   rank: 4
   bioguide: F000449
-  thomas: '01793'
 - name: Kay Granger
   party: majority
   rank: 5
   bioguide: G000377
-  thomas: '01487'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 6
   bioguide: H001056
-  thomas: '02071'
 - name: David P. Joyce
   party: majority
   rank: 7
   bioguide: J000295
-  thomas: '02154'
 - name: Dan Newhouse
   party: majority
   rank: 8
   bioguide: N000189
-  thomas: '02275'
 - name: Marcy Kaptur
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000009
-  thomas: '00616'
 - name: Peter J. Visclosky
   party: minority
   rank: 2
   bioguide: V000108
-  thomas: '01188'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 3
   bioguide: W000797
-  thomas: '01777'
 - name: Pete Aguilar
   party: minority
   rank: 4
   bioguide: A000371
-  thomas: '02229'
 - name: José E. Serrano
   party: minority
   rank: 5
   bioguide: S000248
-  thomas: '01042'
 HSAP15:
 - name: John R. Carter
   party: majority
   rank: 1
   title: Chair
   bioguide: C001051
-  thomas: '01752'
 - name: John Abney Culberson
   party: majority
   rank: 2
   bioguide: C001048
-  thomas: '01670'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 3
   bioguide: F000459
-  thomas: '02061'
 - name: Andy Harris
   party: majority
   rank: 4
   bioguide: H001052
-  thomas: '02026'
 - name: Steven M. Palazzo
   party: majority
   rank: 5
   bioguide: P000601
-  thomas: '02035'
 - name: Dan Newhouse
   party: majority
   rank: 6
   bioguide: N000189
-  thomas: '02275'
 - name: Scott Taylor
   party: majority
   rank: 7
@@ -1720,54 +1422,44 @@ HSAP15:
   rank: 1
   title: Ranking Member
   bioguide: R000486
-  thomas: '00997'
 - name: Henry Cuellar
   party: minority
   rank: 2
   bioguide: C001063
-  thomas: '01807'
 - name: David E. Price
   party: minority
   rank: 3
   bioguide: P000523
-  thomas: '00930'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 4
   bioguide: R000576
-  thomas: '01728'
 HSAP18:
 - name: Charles W. Dent
   party: majority
   rank: 1
   title: Chair
   bioguide: D000604
-  thomas: '01799'
 - name: Jeff Fortenberry
   party: majority
   rank: 2
   bioguide: F000449
-  thomas: '01793'
 - name: Thomas J. Rooney
   party: majority
   rank: 3
   bioguide: R000583
-  thomas: '01916'
 - name: David G. Valadao
   party: majority
   rank: 4
   bioguide: V000129
-  thomas: '02105'
 - name: Steve Womack
   party: majority
   rank: 5
   bioguide: W000809
-  thomas: '01991'
 - name: Evan H. Jenkins
   party: majority
   rank: 6
   bioguide: J000297
-  thomas: '02278'
 - name: Scott Taylor
   party: majority
   rank: 7
@@ -1777,218 +1469,177 @@ HSAP18:
   rank: 1
   title: Ranking Member
   bioguide: W000797
-  thomas: '01777'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 2
   bioguide: B000490
-  thomas: '00091'
 - name: Barbara Lee
   party: minority
   rank: 3
   bioguide: L000551
-  thomas: '01501'
 - name: Tim Ryan
   party: minority
   rank: 4
   bioguide: R000577
-  thomas: '01756'
 HSAP19:
 - name: John Abney Culberson
   party: majority
   rank: 1
   title: Chair
   bioguide: C001048
-  thomas: '01670'
 - name: Harold Rogers
   party: majority
   rank: 2
   bioguide: R000395
-  thomas: '00977'
 - name: Robert B. Aderholt
   party: majority
   rank: 3
   bioguide: A000055
-  thomas: '01460'
 - name: John R. Carter
   party: majority
   rank: 4
   bioguide: C001051
-  thomas: '01752'
 - name: Martha Roby
   party: majority
   rank: 5
   bioguide: R000591
-  thomas: '01986'
 - name: Steven M. Palazzo
   party: majority
   rank: 6
   bioguide: P000601
-  thomas: '02035'
 - name: Evan H. Jenkins
   party: majority
   rank: 7
   bioguide: J000297
-  thomas: '02278'
 - name: José E. Serrano
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000248
-  thomas: '01042'
 - name: Derek Kilmer
   party: minority
   rank: 2
   bioguide: K000381
-  thomas: '02169'
 - name: Matt Cartwright
   party: minority
   rank: 3
   bioguide: C001090
-  thomas: '02159'
 - name: Grace Meng
   party: minority
   rank: 4
   bioguide: M001188
-  thomas: '02148'
 HSAP20:
 - name: Mario Diaz-Balart
   party: majority
   rank: 1
   title: Chair
   bioguide: D000600
-  thomas: '01717'
 - name: Charles W. Dent
   party: majority
   rank: 2
   bioguide: D000604
-  thomas: '01799'
 - name: David P. Joyce
   party: majority
   rank: 3
   bioguide: J000295
-  thomas: '02154'
 - name: John Abney Culberson
   party: majority
   rank: 4
   bioguide: C001048
-  thomas: '01670'
 - name: David Young
   party: majority
   rank: 5
   bioguide: Y000066
-  thomas: '02242'
 - name: David G. Valadao
   party: majority
   rank: 6
   bioguide: V000129
-  thomas: '02105'
 - name: Tom Graves
   party: majority
   rank: 7
   bioguide: G000560
-  thomas: '01979'
 - name: David E. Price
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000523
-  thomas: '00930'
 - name: Mike Quigley
   party: minority
   rank: 2
   bioguide: Q000023
-  thomas: '01967'
 - name: Katherine M. Clark
   party: minority
   rank: 3
   bioguide: C001101
-  thomas: '02196'
 - name: Pete Aguilar
   party: minority
   rank: 4
   bioguide: A000371
-  thomas: '02229'
 HSAP23:
 - name: Tom Graves
   party: majority
   rank: 1
   title: Chair
   bioguide: G000560
-  thomas: '01979'
 - name: Kevin Yoder
   party: majority
   rank: 2
   bioguide: Y000063
-  thomas: '02021'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 3
   bioguide: H001056
-  thomas: '02071'
 - name: Mark E. Amodei
   party: majority
   rank: 4
   bioguide: A000369
-  thomas: '02090'
 - name: Chris Stewart
   party: majority
   rank: 5
   bioguide: S001192
-  thomas: '02168'
 - name: David Young
   party: majority
   rank: 6
   bioguide: Y000066
-  thomas: '02242'
 - name: John R. Moolenaar
   party: majority
   rank: 7
   bioguide: M001194
-  thomas: '02248'
 - name: Mike Quigley
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: Q000023
-  thomas: '01967'
 - name: José E. Serrano
   party: minority
   rank: 2
   bioguide: S000248
-  thomas: '01042'
 - name: Matt Cartwright
   party: minority
   rank: 3
   bioguide: C001090
-  thomas: '02159'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 4
   bioguide: B000490
-  thomas: '00091'
 HSAP24:
 - name: Kevin Yoder
   party: majority
   rank: 1
   title: Chair
   bioguide: Y000063
-  thomas: '02021'
 - name: Mark E. Amodei
   party: majority
   rank: 2
   bioguide: A000369
-  thomas: '02090'
 - name: Dan Newhouse
   party: majority
   rank: 3
   bioguide: N000189
-  thomas: '02275'
 - name: John R. Moolenaar
   party: majority
   rank: 4
   bioguide: M001194
-  thomas: '02248'
 - name: Scott Taylor
   party: majority
   rank: 5
@@ -1998,164 +1649,132 @@ HSAP24:
   rank: 1
   title: Ranking Member
   bioguide: R000577
-  thomas: '01756'
 - name: Betty McCollum
   party: minority
   rank: 2
   bioguide: M001143
-  thomas: '01653'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 3
   bioguide: W000797
-  thomas: '01777'
 HSAS:
 - name: Mac Thornberry
   party: majority
   rank: 1
   title: Chair
   bioguide: T000238
-  thomas: '01155'
 - name: Walter B. Jones
   party: majority
   rank: 2
   bioguide: J000255
-  thomas: '00612'
 - name: Joe Wilson
   party: majority
   rank: 3
   bioguide: W000795
-  thomas: '01688'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
   bioguide: L000554
-  thomas: '00699'
 - name: Rob Bishop
   party: majority
   rank: 5
   bioguide: B001250
-  thomas: '01753'
 - name: Michael R. Turner
   party: majority
   rank: 6
   bioguide: T000463
-  thomas: '01741'
 - name: Mike Rogers
   party: majority
   rank: 7
   bioguide: R000575
-  thomas: '01704'
 - name: Trent Franks
   party: majority
   rank: 8
   bioguide: F000448
-  thomas: '01707'
 - name: Bill Shuster
   party: majority
   rank: 9
   bioguide: S001154
-  thomas: '01681'
 - name: K. Michael Conaway
   party: majority
   rank: 10
   bioguide: C001062
-  thomas: '01805'
 - name: Doug Lamborn
   party: majority
   rank: 11
   bioguide: L000564
-  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 12
   bioguide: W000804
-  thomas: '01886'
 - name: Duncan Hunter
   party: majority
   rank: 13
   bioguide: H001048
-  thomas: '01909'
 - name: Mike Coffman
   party: majority
   rank: 14
   bioguide: C001077
-  thomas: '01912'
 - name: Vicky Hartzler
   party: majority
   rank: 15
   bioguide: H001053
-  thomas: '02032'
 - name: Austin Scott
   party: majority
   rank: 16
   bioguide: S001189
-  thomas: '02009'
 - name: Mo Brooks
   party: majority
   rank: 17
   bioguide: B001274
-  thomas: '01987'
 - name: Paul Cook
   party: majority
   rank: 18
   bioguide: C001094
-  thomas: '02103'
 - name: Jim Bridenstine
   party: majority
   rank: 19
   bioguide: B001283
-  thomas: '02155'
 - name: Brad R. Wenstrup
   party: majority
   rank: 20
   bioguide: W000815
-  thomas: '02152'
 - name: Bradley Byrne
   party: majority
   rank: 21
   bioguide: B001289
-  thomas: '02197'
 - name: Sam Graves
   party: majority
   rank: 22
   bioguide: G000546
-  thomas: '01656'
 - name: Elise M. Stefanik
   party: majority
   rank: 23
   bioguide: S001196
-  thomas: '02263'
 - name: Martha McSally
   party: majority
   rank: 24
   bioguide: M001197
-  thomas: '02225'
 - name: Stephen Knight
   party: majority
   rank: 25
   bioguide: K000387
-  thomas: '02228'
 - name: Steve Russell
   party: majority
   rank: 26
   bioguide: R000604
-  thomas: '02265'
 - name: Scott DesJarlais
   party: majority
   rank: 27
   bioguide: D000616
-  thomas: '02062'
 - name: Ralph Lee Abraham
   party: majority
   rank: 28
   bioguide: A000374
-  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 29
   bioguide: K000388
-  thomas: '02294'
 - name: Mike Gallagher
   party: majority
   rank: 30
@@ -2181,97 +1800,78 @@ HSAS:
   rank: 1
   title: Ranking Member
   bioguide: S000510
-  thomas: '01528'
 - name: Robert A. Brady
   party: minority
   rank: 2
   bioguide: B001227
-  thomas: '01469'
 - name: Susan A. Davis
   party: minority
   rank: 3
   bioguide: D000598
-  thomas: '01641'
 - name: James R. Langevin
   party: minority
   rank: 4
   bioguide: L000559
-  thomas: '01668'
 - name: Rick Larsen
   party: minority
   rank: 5
   bioguide: L000560
-  thomas: '01675'
 - name: Jim Cooper
   party: minority
   rank: 6
   bioguide: C000754
-  thomas: '00231'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 7
   bioguide: B001245
-  thomas: '01723'
 - name: Joe Courtney
   party: minority
   rank: 8
   bioguide: C001069
-  thomas: '01836'
 - name: Niki Tsongas
   party: minority
   rank: 9
   bioguide: T000465
-  thomas: '01884'
 - name: John Garamendi
   party: minority
   rank: 10
   bioguide: G000559
-  thomas: '01973'
 - name: Jackie Speier
   party: minority
   rank: 11
   bioguide: S001175
-  thomas: '01890'
 - name: Marc A. Veasey
   party: minority
   rank: 12
   bioguide: V000131
-  thomas: '02166'
 - name: Tulsi Gabbard
   party: minority
   rank: 13
   bioguide: G000571
-  thomas: '02122'
 - name: Beto O'Rourke
   party: minority
   rank: 14
   bioguide: O000170
-  thomas: '02162'
 - name: Donald Norcross
   party: minority
   rank: 15
   bioguide: N000188
-  thomas: '02202'
 - name: Ruben Gallego
   party: minority
   rank: 16
   bioguide: G000574
-  thomas: '02226'
 - name: Seth Moulton
   party: minority
   rank: 17
   bioguide: M001196
-  thomas: '02246'
 - name: Colleen Hanabusa
   party: minority
   rank: 18
   bioguide: H001050
-  thomas: '02010'
 - name: Carol Shea-Porter
   party: minority
   rank: 19
   bioguide: S001170
-  thomas: '01861'
 - name: Jacky Rosen
   party: minority
   rank: 20
@@ -2310,23 +1910,19 @@ HSAS02:
   rank: 1
   title: Chair
   bioguide: C001077
-  thomas: '01912'
 - name: Walter B. Jones
   party: majority
   rank: 2
   bioguide: J000255
-  thomas: '00612'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
   bioguide: W000815
-  thomas: '02152'
   title: Vice Chair
 - name: Steve Russell
   party: majority
   rank: 4
   bioguide: R000604
-  thomas: '02265'
 - name: Don Bacon
   party: majority
   rank: 5
@@ -2335,43 +1931,35 @@ HSAS02:
   party: majority
   rank: 6
   bioguide: M001197
-  thomas: '02225'
 - name: Ralph Lee Abraham
   party: majority
   rank: 7
   bioguide: A000374
-  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 8
   bioguide: K000388
-  thomas: '02294'
 - name: Jackie Speier
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001175
-  thomas: '01890'
 - name: Robert A. Brady
   party: minority
   rank: 2
   bioguide: B001227
-  thomas: '01469'
 - name: Niki Tsongas
   party: minority
   rank: 3
   bioguide: T000465
-  thomas: '01884'
 - name: Ruben Gallego
   party: minority
   rank: 4
   bioguide: G000574
-  thomas: '02226'
 - name: Carol Shea-Porter
   party: minority
   rank: 5
   bioguide: S001170
-  thomas: '01861'
 - name: Jacky Rosen
   party: minority
   rank: 6
@@ -2382,53 +1970,43 @@ HSAS03:
   rank: 1
   title: Chair
   bioguide: W000795
-  thomas: '01688'
 - name: Rob Bishop
   party: majority
   rank: 2
   bioguide: B001250
-  thomas: '01753'
 - name: Austin Scott
   party: majority
   rank: 3
   bioguide: S001189
-  thomas: '02009'
 - name: Steve Russell
   party: majority
   rank: 4
   bioguide: R000604
-  thomas: '02265'
 - name: Mike Rogers
   party: majority
   rank: 5
   bioguide: R000575
-  thomas: '01704'
 - name: Vicky Hartzler
   party: majority
   rank: 6
   bioguide: H001053
-  thomas: '02032'
 - name: Elise M. Stefanik
   party: majority
   rank: 7
   bioguide: S001196
-  thomas: '02263'
 - name: Martha McSally
   party: majority
   rank: 8
   bioguide: M001197
-  thomas: '02225'
   title: Vice Chair
 - name: Scott DesJarlais
   party: majority
   rank: 9
   bioguide: D000616
-  thomas: '02062'
 - name: Trent Kelly
   party: majority
   rank: 10
   bioguide: K000388
-  thomas: '02294'
 - name: Mike Gallagher
   party: majority
   rank: 11
@@ -2438,22 +2016,18 @@ HSAS03:
   rank: 1
   title: Ranking Member
   bioguide: B001245
-  thomas: '01723'
 - name: Joe Courtney
   party: minority
   rank: 2
   bioguide: C001069
-  thomas: '01836'
 - name: Tulsi Gabbard
   party: minority
   rank: 3
   bioguide: G000571
-  thomas: '02122'
 - name: Carol Shea-Porter
   party: minority
   rank: 4
   bioguide: S001170
-  thomas: '01861'
 - name: A. Donald McEachin
   party: minority
   rank: 5
@@ -2480,12 +2054,10 @@ HSAS06:
   rank: 1
   title: Chair
   bioguide: H001053
-  thomas: '02032'
 - name: K. Michael Conaway
   party: majority
   rank: 2
   bioguide: C001062
-  thomas: '01805'
 - name: Matt Gaetz
   party: majority
   rank: 3
@@ -2502,13 +2074,11 @@ HSAS06:
   party: majority
   rank: 6
   bioguide: S001189
-  thomas: '02009'
 - name: Seth Moulton
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001196
-  thomas: '02246'
 - name: Tom O'Halleran
   party: minority
   rank: 2
@@ -2523,38 +2093,31 @@ HSAS25:
   rank: 1
   title: Chair
   bioguide: T000463
-  thomas: '01741'
 - name: Frank A. LoBiondo
   party: majority
   rank: 2
   bioguide: L000554
-  thomas: '00699'
 - name: Paul Cook
   party: majority
   rank: 3
   bioguide: C001094
-  thomas: '02103'
   title: Vice Chair
 - name: Sam Graves
   party: majority
   rank: 4
   bioguide: G000546
-  thomas: '01656'
 - name: Martha McSally
   party: majority
   rank: 5
   bioguide: M001197
-  thomas: '02225'
 - name: Stephen Knight
   party: majority
   rank: 6
   bioguide: K000387
-  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 7
   bioguide: K000388
-  thomas: '02294'
 - name: Matt Gaetz
   party: majority
   rank: 8
@@ -2571,48 +2134,39 @@ HSAS25:
   party: majority
   rank: 11
   bioguide: J000255
-  thomas: '00612'
 - name: Rob Bishop
   party: majority
   rank: 12
   bioguide: B001250
-  thomas: '01753'
 - name: Robert J. Wittman
   party: majority
   rank: 13
   bioguide: W000804
-  thomas: '01886'
 - name: Mo Brooks
   party: majority
   rank: 14
   bioguide: B001274
-  thomas: '01987'
 - name: Niki Tsongas
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: T000465
-  thomas: '01884'
 - name: James R. Langevin
   party: minority
   rank: 2
   bioguide: L000559
-  thomas: '01668'
 - name: Jim Cooper
   party: minority
   rank: 3
   bioguide: C000754
-  thomas: '00231'
 - name: Marc A. Veasey
   party: minority
   rank: 4
   bioguide: V000131
-  thomas: '02166'
 - name: Ruben Gallego
   party: minority
   rank: 5
   bioguide: G000574
-  thomas: '02226'
 - name: Jacky Rosen
   party: minority
   rank: 6
@@ -2639,22 +2193,18 @@ HSAS26:
   rank: 1
   title: Chair
   bioguide: S001196
-  thomas: '02263'
 - name: Bill Shuster
   party: majority
   rank: 2
   bioguide: S001154
-  thomas: '01681'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
   bioguide: W000815
-  thomas: '02152'
 - name: Ralph Lee Abraham
   party: majority
   rank: 4
   bioguide: A000374
-  thomas: '02244'
 - name: Liz Cheney
   party: majority
   rank: 5
@@ -2664,63 +2214,51 @@ HSAS26:
   party: majority
   rank: 6
   bioguide: W000795
-  thomas: '01688'
 - name: Frank A. LoBiondo
   party: majority
   rank: 7
   bioguide: L000554
-  thomas: '00699'
 - name: Trent Franks
   party: majority
   rank: 8
   bioguide: F000448
-  thomas: '01707'
 - name: Doug Lamborn
   party: majority
   rank: 9
   bioguide: L000564
-  thomas: '01834'
 - name: Austin Scott
   party: majority
   rank: 10
   bioguide: S001189
-  thomas: '02009'
 - name: James R. Langevin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000559
-  thomas: '01668'
 - name: Rick Larsen
   party: minority
   rank: 2
   bioguide: L000560
-  thomas: '01675'
 - name: Jim Cooper
   party: minority
   rank: 3
   bioguide: C000754
-  thomas: '00231'
 - name: Jackie Speier
   party: minority
   rank: 4
   bioguide: S001175
-  thomas: '01890'
 - name: Marc A. Veasey
   party: minority
   rank: 5
   bioguide: V000131
-  thomas: '02166'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
   bioguide: G000571
-  thomas: '02122'
 - name: Beto O'Rourke
   party: minority
   rank: 7
   bioguide: O000170
-  thomas: '02162'
 - name: Stephanie N. Murphy
   party: minority
   rank: 8
@@ -2731,28 +2269,23 @@ HSAS28:
   rank: 1
   title: Chair
   bioguide: W000804
-  thomas: '01886'
 - name: K. Michael Conaway
   party: majority
   rank: 2
   bioguide: C001062
-  thomas: '01805'
 - name: Vicky Hartzler
   party: majority
   rank: 3
   bioguide: H001053
-  thomas: '02032'
 - name: Bradley Byrne
   party: majority
   rank: 4
   bioguide: B001289
-  thomas: '02197'
   title: Vice Chair
 - name: Scott DesJarlais
   party: majority
   rank: 5
   bioguide: D000616
-  thomas: '02062'
 - name: Mike Gallagher
   party: majority
   rank: 6
@@ -2761,68 +2294,55 @@ HSAS28:
   party: majority
   rank: 7
   bioguide: H001048
-  thomas: '01909'
 - name: Paul Cook
   party: majority
   rank: 8
   bioguide: C001094
-  thomas: '02103'
 - name: Jim Bridenstine
   party: majority
   rank: 9
   bioguide: B001283
-  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 10
   bioguide: K000387
-  thomas: '02228'
 - name: Ralph Lee Abraham
   party: majority
   rank: 11
   bioguide: A000374
-  thomas: '02244'
 - name: Joe Courtney
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001069
-  thomas: '01836'
 - name: Susan A. Davis
   party: minority
   rank: 2
   bioguide: D000598
-  thomas: '01641'
 - name: James R. Langevin
   party: minority
   rank: 3
   bioguide: L000559
-  thomas: '01668'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 4
   bioguide: B001245
-  thomas: '01723'
 - name: John Garamendi
   party: minority
   rank: 5
   bioguide: G000559
-  thomas: '01973'
 - name: Donald Norcross
   party: minority
   rank: 6
   bioguide: N000188
-  thomas: '02202'
 - name: Seth Moulton
   party: minority
   rank: 7
   bioguide: M001196
-  thomas: '02246'
 - name: Colleen Hanabusa
   party: minority
   rank: 8
   bioguide: H001050
-  thomas: '02010'
 - name: A. Donald McEachin
   party: minority
   rank: 9
@@ -2833,89 +2353,72 @@ HSAS29:
   rank: 1
   title: Chair
   bioguide: R000575
-  thomas: '01704'
 - name: Trent Franks
   party: majority
   rank: 2
   bioguide: F000448
-  thomas: '01707'
   title: Vice Chair
 - name: Doug Lamborn
   party: majority
   rank: 3
   bioguide: L000564
-  thomas: '01834'
 - name: Duncan Hunter
   party: majority
   rank: 4
   bioguide: H001048
-  thomas: '01909'
 - name: Mo Brooks
   party: majority
   rank: 5
   bioguide: B001274
-  thomas: '01987'
 - name: Jim Bridenstine
   party: majority
   rank: 6
   bioguide: B001283
-  thomas: '02155'
 - name: Michael R. Turner
   party: majority
   rank: 7
   bioguide: T000463
-  thomas: '01741'
 - name: Mike Coffman
   party: majority
   rank: 8
   bioguide: C001077
-  thomas: '01912'
 - name: Bradley Byrne
   party: majority
   rank: 9
   bioguide: B001289
-  thomas: '02197'
 - name: Sam Graves
   party: majority
   rank: 10
   bioguide: G000546
-  thomas: '01656'
 - name: Jim Cooper
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000754
-  thomas: '00231'
 - name: Susan A. Davis
   party: minority
   rank: 2
   bioguide: D000598
-  thomas: '01641'
 - name: Rick Larsen
   party: minority
   rank: 3
   bioguide: L000560
-  thomas: '01675'
 - name: John Garamendi
   party: minority
   rank: 4
   bioguide: G000559
-  thomas: '01973'
 - name: Beto O'Rourke
   party: minority
   rank: 5
   bioguide: O000170
-  thomas: '02162'
 - name: Donald Norcross
   party: minority
   rank: 6
   bioguide: N000188
-  thomas: '02202'
 - name: Colleen Hanabusa
   party: minority
   rank: 7
   bioguide: H001050
-  thomas: '02010'
 - name: Ro Khanna
   party: minority
   rank: 8
@@ -2926,152 +2429,122 @@ HSBA:
   rank: 1
   title: Chair
   bioguide: H001036
-  thomas: '01749'
 - name: Peter T. King
   party: majority
   rank: 2
   bioguide: K000210
-  thomas: '00635'
 - name: Edward R. Royce
   party: majority
   rank: 3
   bioguide: R000487
-  thomas: '00998'
 - name: Frank D. Lucas
   party: majority
   rank: 4
   bioguide: L000491
-  thomas: '00711'
 - name: Patrick T. McHenry
   party: majority
   rank: 5
   bioguide: M001156
-  thomas: '01792'
 - name: Stevan Pearce
   party: majority
   rank: 6
   bioguide: P000588
-  thomas: '01738'
 - name: Bill Posey
   party: majority
   rank: 7
   bioguide: P000599
-  thomas: '01915'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 8
   bioguide: L000569
-  thomas: '01931'
 - name: Bill Huizenga
   party: majority
   rank: 9
   bioguide: H001058
-  thomas: '02028'
 - name: Sean P. Duffy
   party: majority
   rank: 10
   bioguide: D000614
-  thomas: '02072'
 - name: Steve Stivers
   party: majority
   rank: 11
   bioguide: S001187
-  thomas: '02047'
 - name: Randy Hultgren
   party: majority
   rank: 12
   bioguide: H001059
-  thomas: '02015'
 - name: Dennis A. Ross
   party: majority
   rank: 13
   bioguide: R000593
-  thomas: '02003'
 - name: Robert Pittenger
   party: majority
   rank: 14
   bioguide: P000606
-  thomas: '02141'
 - name: Ann Wagner
   party: majority
   rank: 15
   bioguide: W000812
-  thomas: '02137'
 - name: Andy Barr
   party: majority
   rank: 16
   bioguide: B001282
-  thomas: '02131'
 - name: Keith J. Rothfus
   party: majority
   rank: 17
   bioguide: R000598
-  thomas: '02158'
 - name: Luke Messer
   party: majority
   rank: 18
   bioguide: M001189
-  thomas: '02130'
 - name: Scott R. Tipton
   party: majority
   rank: 19
   bioguide: T000470
-  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 20
   bioguide: W000816
-  thomas: '02165'
 - name: Bruce Poliquin
   party: majority
   rank: 21
   bioguide: P000611
-  thomas: '02247'
 - name: Mia B. Love
   party: majority
   rank: 22
   bioguide: L000584
-  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 23
   bioguide: H001072
-  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 24
   bioguide: E000294
-  thomas: '02253'
 - name: Lee M. Zeldin
   party: majority
   rank: 25
   bioguide: Z000017
-  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 26
   bioguide: T000475
-  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 27
   bioguide: L000583
-  thomas: '02238'
 - name: Alexander X. Mooney
   party: majority
   rank: 28
   bioguide: M001195
-  thomas: '02277'
 - name: Thomas MacArthur
   party: majority
   rank: 29
   bioguide: M001193
-  thomas: '02258'
 - name: Warren Davidson
   party: majority
   rank: 30
   bioguide: D000626
-  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 31
@@ -3093,112 +2566,90 @@ HSBA:
   rank: 1
   title: Ranking Member
   bioguide: W000187
-  thomas: '01205'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
   bioguide: M000087
-  thomas: '00729'
 - name: Nydia M. Velázquez
   party: minority
   rank: 3
   bioguide: V000081
-  thomas: '01184'
 - name: Brad Sherman
   party: minority
   rank: 4
   bioguide: S000344
-  thomas: '01526'
 - name: Gregory W. Meeks
   party: minority
   rank: 5
   bioguide: M001137
-  thomas: '01506'
 - name: Michael E. Capuano
   party: minority
   rank: 6
   bioguide: C001037
-  thomas: '01564'
 - name: Wm. Lacy Clay
   party: minority
   rank: 7
   bioguide: C001049
-  thomas: '01654'
 - name: Stephen F. Lynch
   party: minority
   rank: 8
   bioguide: L000562
-  thomas: '01686'
 - name: David Scott
   party: minority
   rank: 9
   bioguide: S001157
-  thomas: '01722'
 - name: Al Green
   party: minority
   rank: 10
   bioguide: G000553
-  thomas: '01803'
 - name: Emanuel Cleaver
   party: minority
   rank: 11
   bioguide: C001061
-  thomas: '01790'
 - name: Gwen Moore
   party: minority
   rank: 12
   bioguide: M001160
-  thomas: '01811'
 - name: Keith Ellison
   party: minority
   rank: 13
   bioguide: E000288
-  thomas: '01857'
 - name: Ed Perlmutter
   party: minority
   rank: 14
   bioguide: P000593
-  thomas: '01835'
 - name: James A. Himes
   party: minority
   rank: 15
   bioguide: H001047
-  thomas: '01913'
 - name: Bill Foster
   party: minority
   rank: 16
   bioguide: F000454
-  thomas: '01888'
 - name: Daniel T. Kildee
   party: minority
   rank: 17
   bioguide: K000380
-  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 18
   bioguide: D000620
-  thomas: '02133'
 - name: Kyrsten Sinema
   party: minority
   rank: 19
   bioguide: S001191
-  thomas: '02099'
 - name: Joyce Beatty
   party: minority
   rank: 20
   bioguide: B001281
-  thomas: '02153'
 - name: Denny Heck
   party: minority
   rank: 21
   bioguide: H001064
-  thomas: '02170'
 - name: Juan Vargas
   party: minority
   rank: 22
   bioguide: V000130
-  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 23
@@ -3221,63 +2672,51 @@ HSBA01:
   rank: 1
   title: Chair
   bioguide: P000588
-  thomas: '01738'
 - name: Robert Pittenger
   party: majority
   rank: 2
   bioguide: P000606
-  thomas: '02141'
   title: Vice Chair
 - name: Keith J. Rothfus
   party: majority
   rank: 3
   bioguide: R000598
-  thomas: '02158'
 - name: Luke Messer
   party: majority
   rank: 4
   bioguide: M001189
-  thomas: '02130'
 - name: Scott R. Tipton
   party: majority
   rank: 5
   bioguide: T000470
-  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 6
   bioguide: W000816
-  thomas: '02165'
 - name: Bruce Poliquin
   party: majority
   rank: 7
   bioguide: P000611
-  thomas: '02247'
 - name: Mia B. Love
   party: majority
   rank: 8
   bioguide: L000584
-  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 9
   bioguide: H001072
-  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 10
   bioguide: E000294
-  thomas: '02253'
 - name: Lee M. Zeldin
   party: majority
   rank: 11
   bioguide: Z000017
-  thomas: '02261'
 - name: Warren Davidson
   party: majority
   rank: 12
   bioguide: D000626
-  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 13
@@ -3290,49 +2729,40 @@ HSBA01:
   party: majority
   rank: 15
   bioguide: H001036
-  thomas: '01749'
   title: Ex Officio
 - name: Ed Perlmutter
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000593
-  thomas: '01835'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
   bioguide: M000087
-  thomas: '00729'
 - name: James A. Himes
   party: minority
   rank: 3
   bioguide: H001047
-  thomas: '01913'
 - name: Bill Foster
   party: minority
   rank: 4
   bioguide: F000454
-  thomas: '01888'
 - name: Daniel T. Kildee
   party: minority
   rank: 5
   bioguide: K000380
-  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 6
   bioguide: D000620
-  thomas: '02133'
 - name: Kyrsten Sinema
   party: minority
   rank: 7
   bioguide: S001191
-  thomas: '02099'
 - name: Juan Vargas
   party: minority
   rank: 8
   bioguide: V000130
-  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 9
@@ -3349,7 +2779,6 @@ HSBA01:
   party: minority
   rank: 12
   bioguide: W000187
-  thomas: '01205'
   title: Ex Officio
 HSBA04:
 - name: Sean P. Duffy
@@ -3357,63 +2786,51 @@ HSBA04:
   rank: 1
   title: Chair
   bioguide: D000614
-  thomas: '02072'
 - name: Dennis A. Ross
   party: majority
   rank: 2
   bioguide: R000593
-  thomas: '02003'
   title: Vice Chair
 - name: Edward R. Royce
   party: majority
   rank: 3
   bioguide: R000487
-  thomas: '00998'
 - name: Stevan Pearce
   party: majority
   rank: 4
   bioguide: P000588
-  thomas: '01738'
 - name: Bill Posey
   party: majority
   rank: 5
   bioguide: P000599
-  thomas: '01915'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 6
   bioguide: L000569
-  thomas: '01931'
 - name: Steve Stivers
   party: majority
   rank: 7
   bioguide: S001187
-  thomas: '02047'
 - name: Randy Hultgren
   party: majority
   rank: 8
   bioguide: H001059
-  thomas: '02015'
 - name: Keith J. Rothfus
   party: majority
   rank: 9
   bioguide: R000598
-  thomas: '02158'
 - name: Lee M. Zeldin
   party: majority
   rank: 10
   bioguide: Z000017
-  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 11
   bioguide: T000475
-  thomas: '02250'
 - name: Thomas MacArthur
   party: majority
   rank: 12
   bioguide: M001193
-  thomas: '02258'
 - name: Ted Budd
   party: majority
   rank: 13
@@ -3422,54 +2839,44 @@ HSBA04:
   party: majority
   rank: 14
   bioguide: H001036
-  thomas: '01749'
   title: Ex Officio
 - name: Emanuel Cleaver
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001061
-  thomas: '01790'
 - name: Nydia M. Velázquez
   party: minority
   rank: 2
   bioguide: V000081
-  thomas: '01184'
 - name: Michael E. Capuano
   party: minority
   rank: 3
   bioguide: C001037
-  thomas: '01564'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
   bioguide: C001049
-  thomas: '01654'
 - name: Brad Sherman
   party: minority
   rank: 5
   bioguide: S000344
-  thomas: '01526'
 - name: Stephen F. Lynch
   party: minority
   rank: 6
   bioguide: L000562
-  thomas: '01686'
 - name: Joyce Beatty
   party: minority
   rank: 7
   bioguide: B001281
-  thomas: '02153'
 - name: Daniel T. Kildee
   party: minority
   rank: 8
   bioguide: K000380
-  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 9
   bioguide: D000620
-  thomas: '02133'
 - name: Ruben Kihuen
   party: minority
   rank: 10
@@ -3478,7 +2885,6 @@ HSBA04:
   party: minority
   rank: 11
   bioguide: W000187
-  thomas: '01205'
   title: Ex Officio
 HSBA09:
 - name: Ann Wagner
@@ -3486,48 +2892,39 @@ HSBA09:
   rank: 1
   title: Chair
   bioguide: W000812
-  thomas: '02137'
 - name: Scott R. Tipton
   party: majority
   rank: 2
   bioguide: T000470
-  thomas: '01997'
   title: Vice Chair
 - name: Peter T. King
   party: majority
   rank: 3
   bioguide: K000210
-  thomas: '00635'
 - name: Patrick T. McHenry
   party: majority
   rank: 4
   bioguide: M001156
-  thomas: '01792'
 - name: Dennis A. Ross
   party: majority
   rank: 5
   bioguide: R000593
-  thomas: '02003'
 - name: Luke Messer
   party: majority
   rank: 6
   bioguide: M001189
-  thomas: '02130'
 - name: Lee M. Zeldin
   party: majority
   rank: 7
   bioguide: Z000017
-  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 8
   bioguide: T000475
-  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 9
   bioguide: L000583
-  thomas: '02238'
 - name: David Kustoff
   party: majority
   rank: 10
@@ -3544,39 +2941,32 @@ HSBA09:
   party: majority
   rank: 13
   bioguide: H001036
-  thomas: '01749'
   title: Ex Officio
 - name: Al Green
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: G000553
-  thomas: '01803'
 - name: Keith Ellison
   party: minority
   rank: 2
   bioguide: E000288
-  thomas: '01857'
 - name: Emanuel Cleaver
   party: minority
   rank: 3
   bioguide: C001061
-  thomas: '01790'
 - name: Joyce Beatty
   party: minority
   rank: 4
   bioguide: B001281
-  thomas: '02153'
 - name: Michael E. Capuano
   party: minority
   rank: 5
   bioguide: C001037
-  thomas: '01564'
 - name: Gwen Moore
   party: minority
   rank: 6
   bioguide: M001160
-  thomas: '01811'
 - name: Josh Gottheimer
   party: minority
   rank: 7
@@ -3593,7 +2983,6 @@ HSBA09:
   party: minority
   rank: 10
   bioguide: W000187
-  thomas: '01205'
   title: Ex Officio
 HSBA15:
 - name: Blaine Luetkemeyer
@@ -3601,68 +2990,55 @@ HSBA15:
   rank: 1
   title: Chair
   bioguide: L000569
-  thomas: '01931'
 - name: Keith J. Rothfus
   party: majority
   rank: 2
   bioguide: R000598
-  thomas: '02158'
   title: Vice Chair
 - name: Edward R. Royce
   party: majority
   rank: 3
   bioguide: R000487
-  thomas: '00998'
 - name: Frank D. Lucas
   party: majority
   rank: 4
   bioguide: L000491
-  thomas: '00711'
 - name: Bill Posey
   party: majority
   rank: 5
   bioguide: P000599
-  thomas: '01915'
 - name: Dennis A. Ross
   party: majority
   rank: 6
   bioguide: R000593
-  thomas: '02003'
 - name: Robert Pittenger
   party: majority
   rank: 7
   bioguide: P000606
-  thomas: '02141'
 - name: Andy Barr
   party: majority
   rank: 8
   bioguide: B001282
-  thomas: '02131'
 - name: Scott R. Tipton
   party: majority
   rank: 9
   bioguide: T000470
-  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 10
   bioguide: W000816
-  thomas: '02165'
 - name: Mia B. Love
   party: majority
   rank: 11
   bioguide: L000584
-  thomas: '02271'
 - name: David A. Trott
   party: majority
   rank: 12
   bioguide: T000475
-  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 13
   bioguide: L000583
-  thomas: '02238'
 - name: David Kustoff
   party: majority
   rank: 14
@@ -3675,59 +3051,48 @@ HSBA15:
   party: majority
   rank: 16
   bioguide: H001036
-  thomas: '01749'
   title: Ex Officio
 - name: Wm. Lacy Clay
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001049
-  thomas: '01654'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
   bioguide: M000087
-  thomas: '00729'
 - name: Gregory W. Meeks
   party: minority
   rank: 3
   bioguide: M001137
-  thomas: '01506'
 - name: David Scott
   party: minority
   rank: 4
   bioguide: S001157
-  thomas: '01722'
 - name: Nydia M. Velázquez
   party: minority
   rank: 5
   bioguide: V000081
-  thomas: '01184'
 - name: Al Green
   party: minority
   rank: 6
   bioguide: G000553
-  thomas: '01803'
 - name: Keith Ellison
   party: minority
   rank: 7
   bioguide: E000288
-  thomas: '01857'
 - name: Michael E. Capuano
   party: minority
   rank: 8
   bioguide: C001037
-  thomas: '01564'
 - name: Denny Heck
   party: minority
   rank: 9
   bioguide: H001064
-  thomas: '02170'
 - name: Gwen Moore
   party: minority
   rank: 10
   bioguide: M001160
-  thomas: '01811'
 - name: Charlie Crist
   party: minority
   rank: 11
@@ -3736,7 +3101,6 @@ HSBA15:
   party: minority
   rank: 12
   bioguide: W000187
-  thomas: '01205'
   title: Ex Officio
 HSBA16:
 - name: Bill Huizenga
@@ -3744,73 +3108,59 @@ HSBA16:
   rank: 1
   title: Chair
   bioguide: H001058
-  thomas: '02028'
 - name: Randy Hultgren
   party: majority
   rank: 2
   bioguide: H001059
-  thomas: '02015'
   title: Vice Chair
 - name: Peter T. King
   party: majority
   rank: 3
   bioguide: K000210
-  thomas: '00635'
 - name: Patrick T. McHenry
   party: majority
   rank: 4
   bioguide: M001156
-  thomas: '01792'
 - name: Sean P. Duffy
   party: majority
   rank: 5
   bioguide: D000614
-  thomas: '02072'
 - name: Steve Stivers
   party: majority
   rank: 6
   bioguide: S001187
-  thomas: '02047'
 - name: Ann Wagner
   party: majority
   rank: 7
   bioguide: W000812
-  thomas: '02137'
 - name: Luke Messer
   party: majority
   rank: 8
   bioguide: M001189
-  thomas: '02130'
 - name: Bruce Poliquin
   party: majority
   rank: 9
   bioguide: P000611
-  thomas: '02247'
 - name: J. French Hill
   party: majority
   rank: 10
   bioguide: H001072
-  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 11
   bioguide: E000294
-  thomas: '02253'
 - name: Alexander X. Mooney
   party: majority
   rank: 12
   bioguide: M001195
-  thomas: '02277'
 - name: Thomas MacArthur
   party: majority
   rank: 13
   bioguide: M001193
-  thomas: '02258'
 - name: Warren Davidson
   party: majority
   rank: 14
   bioguide: D000626
-  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 15
@@ -3823,59 +3173,48 @@ HSBA16:
   party: majority
   rank: 17
   bioguide: H001036
-  thomas: '01749'
   title: Ex Officio
 - name: Carolyn B. Maloney
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M000087
-  thomas: '00729'
 - name: Brad Sherman
   party: minority
   rank: 2
   bioguide: S000344
-  thomas: '01526'
 - name: Stephen F. Lynch
   party: minority
   rank: 3
   bioguide: L000562
-  thomas: '01686'
 - name: David Scott
   party: minority
   rank: 4
   bioguide: S001157
-  thomas: '01722'
 - name: James A. Himes
   party: minority
   rank: 5
   bioguide: H001047
-  thomas: '01913'
 - name: Keith Ellison
   party: minority
   rank: 6
   bioguide: E000288
-  thomas: '01857'
 - name: Bill Foster
   party: minority
   rank: 7
   bioguide: F000454
-  thomas: '01888'
 - name: Gregory W. Meeks
   party: minority
   rank: 8
   bioguide: M001137
-  thomas: '01506'
 - name: Kyrsten Sinema
   party: minority
   rank: 9
   bioguide: S001191
-  thomas: '02099'
 - name: Juan Vargas
   party: minority
   rank: 10
   bioguide: V000130
-  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 11
@@ -3888,7 +3227,6 @@ HSBA16:
   party: minority
   rank: 13
   bioguide: W000187
-  thomas: '01205'
   title: Ex Officio
 HSBA20:
 - name: Andy Barr
@@ -3896,53 +3234,43 @@ HSBA20:
   rank: 1
   title: Chair
   bioguide: B001282
-  thomas: '02131'
 - name: Roger Williams
   party: majority
   rank: 2
   bioguide: W000816
-  thomas: '02165'
   title: Vice Chair
 - name: Frank D. Lucas
   party: majority
   rank: 3
   bioguide: L000491
-  thomas: '00711'
 - name: Bill Huizenga
   party: majority
   rank: 4
   bioguide: H001058
-  thomas: '02028'
 - name: Robert Pittenger
   party: majority
   rank: 5
   bioguide: P000606
-  thomas: '02141'
 - name: Mia B. Love
   party: majority
   rank: 6
   bioguide: L000584
-  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 7
   bioguide: H001072
-  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 8
   bioguide: E000294
-  thomas: '02253'
 - name: Alexander X. Mooney
   party: majority
   rank: 9
   bioguide: M001195
-  thomas: '02277'
 - name: Warren Davidson
   party: majority
   rank: 10
   bioguide: D000626
-  thomas: '02296'
 - name: Claudia Tenney
   party: majority
   rank: 11
@@ -3955,49 +3283,40 @@ HSBA20:
   party: majority
   rank: 13
   bioguide: H001036
-  thomas: '01749'
   title: Ex Officio
 - name: Gwen Moore
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001160
-  thomas: '01811'
 - name: Gregory W. Meeks
   party: minority
   rank: 2
   bioguide: M001137
-  thomas: '01506'
 - name: Bill Foster
   party: minority
   rank: 3
   bioguide: F000454
-  thomas: '01888'
 - name: Brad Sherman
   party: minority
   rank: 4
   bioguide: S000344
-  thomas: '01526'
 - name: Al Green
   party: minority
   rank: 5
   bioguide: G000553
-  thomas: '01803'
 - name: Denny Heck
   party: minority
   rank: 6
   bioguide: H001064
-  thomas: '02170'
 - name: Daniel T. Kildee
   party: minority
   rank: 7
   bioguide: K000380
-  thomas: '02134'
 - name: Juan Vargas
   party: minority
   rank: 8
   bioguide: V000130
-  thomas: '02112'
 - name: Charlie Crist
   party: minority
   rank: 9
@@ -4006,7 +3325,6 @@ HSBA20:
   party: minority
   rank: 10
   bioguide: W000187
-  thomas: '01205'
   title: Ex Officio
 HSBU:
 - name: Diane Black
@@ -4014,77 +3332,62 @@ HSBU:
   rank: 1
   title: Chair
   bioguide: B001273
-  thomas: '02063'
 - name: Mario Diaz-Balart
   party: majority
   rank: 2
   bioguide: D000600
-  thomas: '01717'
 - name: Tom Cole
   party: majority
   rank: 3
   bioguide: C001053
-  thomas: '01742'
 - name: Tom McClintock
   party: majority
   rank: 4
   bioguide: M001177
-  thomas: '01908'
 - name: Todd Rokita
   party: majority
   rank: 5
   bioguide: R000592
-  thomas: '02017'
 - name: Rob Woodall
   party: majority
   rank: 6
   bioguide: W000810
-  thomas: '02008'
 - name: Mark Sanford
   party: majority
   rank: 7
   bioguide: S000051
-  thomas: '01012'
 - name: Steve Womack
   party: majority
   rank: 8
   bioguide: W000809
-  thomas: '01991'
 - name: Dave Brat
   party: majority
   rank: 9
   bioguide: B001290
-  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 10
   bioguide: G000576
-  thomas: '02276'
 - name: Gary J. Palmer
   party: majority
   rank: 11
   bioguide: P000609
-  thomas: '02221'
 - name: Bruce Westerman
   party: majority
   rank: 12
   bioguide: W000821
-  thomas: '02224'
 - name: James B. Renacci
   party: majority
   rank: 13
   bioguide: R000586
-  thomas: '02048'
 - name: Bill Johnson
   party: majority
   rank: 14
   bioguide: J000292
-  thomas: '02046'
 - name: Jason Smith
   party: majority
   rank: 15
   bioguide: S001195
-  thomas: '02191'
 - name: Jason Lewis
   party: majority
   rank: 16
@@ -4118,47 +3421,38 @@ HSBU:
   rank: 1
   title: Ranking Member
   bioguide: Y000062
-  thomas: '01853'
 - name: Barbara Lee
   party: minority
   rank: 2
   bioguide: L000551
-  thomas: '01501'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 3
   bioguide: L000580
-  thomas: '02146'
 - name: Seth Moulton
   party: minority
   rank: 4
   bioguide: M001196
-  thomas: '02246'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
   bioguide: J000294
-  thomas: '02149'
 - name: Brian Higgins
   party: minority
   rank: 6
   bioguide: H001038
-  thomas: '01794'
 - name: Suzan K. DelBene
   party: minority
   rank: 7
   bioguide: D000617
-  thomas: '02096'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 8
   bioguide: W000797
-  thomas: '01777'
 - name: Brendan F. Boyle
   party: minority
   rank: 9
   bioguide: B001296
-  thomas: '02267'
 - name: Ro Khanna
   party: minority
   rank: 10
@@ -4175,95 +3469,77 @@ HSBU:
   party: minority
   rank: 13
   bioguide: J000032
-  thomas: '00588'
 - name: Janice D. Schakowsky
   party: minority
   rank: 14
   bioguide: S001145
-  thomas: '01588'
 HSED:
 - name: Virginia Foxx
   party: majority
   rank: 1
   title: Chair
   bioguide: F000450
-  thomas: '01791'
 - name: Joe Wilson
   party: majority
   rank: 2
   bioguide: W000795
-  thomas: '01688'
   title: Vice Chair
 - name: Duncan Hunter
   party: majority
   rank: 3
   bioguide: H001048
-  thomas: '01909'
 - name: David P. Roe
   party: majority
   rank: 4
   bioguide: R000582
-  thomas: '01954'
 - name: Glenn Thompson
   party: majority
   rank: 5
   bioguide: T000467
-  thomas: '01952'
 - name: Tim Walberg
   party: majority
   rank: 6
   bioguide: W000798
-  thomas: '01855'
 - name: Brett Guthrie
   party: majority
   rank: 7
   bioguide: G000558
-  thomas: '01922'
 - name: Todd Rokita
   party: majority
   rank: 8
   bioguide: R000592
-  thomas: '02017'
 - name: Lou Barletta
   party: majority
   rank: 9
   bioguide: B001269
-  thomas: '02054'
 - name: Luke Messer
   party: majority
   rank: 10
   bioguide: M001189
-  thomas: '02130'
 - name: Bradley Byrne
   party: majority
   rank: 11
   bioguide: B001289
-  thomas: '02197'
 - name: Dave Brat
   party: majority
   rank: 12
   bioguide: B001290
-  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 13
   bioguide: G000576
-  thomas: '02276'
 - name: Steve Russell
   party: majority
   rank: 14
   bioguide: R000604
-  thomas: '02265'
 - name: Elise M. Stefanik
   party: majority
   rank: 15
   bioguide: S001196
-  thomas: '02263'
 - name: Rick W. Allen
   party: majority
   rank: 16
   bioguide: A000372
-  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 17
@@ -4293,67 +3569,54 @@ HSED:
   rank: 1
   title: Ranking Member
   bioguide: S000185
-  thomas: '01037'
 - name: Susan A. Davis
   party: minority
   rank: 2
   bioguide: D000598
-  thomas: '01641'
 - name: Raúl M. Grijalva
   party: minority
   rank: 3
   bioguide: G000551
-  thomas: '01708'
 - name: Joe Courtney
   party: minority
   rank: 4
   bioguide: C001069
-  thomas: '01836'
 - name: Marcia L. Fudge
   party: minority
   rank: 5
   bioguide: F000455
-  thomas: '01895'
 - name: Jared Polis
   party: minority
   rank: 6
   bioguide: P000598
-  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
   bioguide: S001177
-  thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
   rank: 8
   bioguide: W000808
-  thomas: '02004'
 - name: Suzanne Bonamici
   party: minority
   rank: 9
   bioguide: B001278
-  thomas: '02092'
 - name: Mark Takano
   party: minority
   rank: 10
   bioguide: T000472
-  thomas: '02110'
 - name: Alma S. Adams
   party: minority
   rank: 11
   bioguide: A000370
-  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 12
   bioguide: D000623
-  thomas: '02227'
 - name: Donald Norcross
   party: minority
   rank: 13
   bioguide: N000188
-  thomas: '02202'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 14
@@ -4366,7 +3629,6 @@ HSED:
   party: minority
   rank: 16
   bioguide: S001170
-  thomas: '01861'
 - name: Adriano Espaillat
   party: minority
   rank: 17
@@ -4377,32 +3639,26 @@ HSED02:
   rank: 1
   title: Chair
   bioguide: W000798
-  thomas: '01855'
 - name: Joe Wilson
   party: majority
   rank: 2
   bioguide: W000795
-  thomas: '01688'
 - name: David P. Roe
   party: majority
   rank: 3
   bioguide: R000582
-  thomas: '01954'
 - name: Todd Rokita
   party: majority
   rank: 4
   bioguide: R000592
-  thomas: '02017'
 - name: Lou Barletta
   party: majority
   rank: 5
   bioguide: B001269
-  thomas: '02054'
 - name: Rick W. Allen
   party: majority
   rank: 6
   bioguide: A000372
-  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 7
@@ -4428,17 +3684,14 @@ HSED02:
   rank: 1
   title: Ranking Member
   bioguide: S001177
-  thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
   rank: 2
   bioguide: W000808
-  thomas: '02004'
 - name: Donald Norcross
   party: minority
   rank: 3
   bioguide: N000188
-  thomas: '02202'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 4
@@ -4447,7 +3700,6 @@ HSED02:
   party: minority
   rank: 5
   bioguide: S001170
-  thomas: '01861'
 - name: Adriano Espaillat
   party: minority
   rank: 6
@@ -4456,49 +3708,40 @@ HSED02:
   party: minority
   rank: 7
   bioguide: C001069
-  thomas: '01836'
 - name: Marcia L. Fudge
   party: minority
   rank: 8
   bioguide: F000455
-  thomas: '01895'
 - name: Suzanne Bonamici
   party: minority
   rank: 9
   bioguide: B001278
-  thomas: '02092'
 HSED10:
 - name: Bradley Byrne
   party: majority
   rank: 1
   title: Chair
   bioguide: B001289
-  thomas: '02197'
 - name: Joe Wilson
   party: majority
   rank: 2
   bioguide: W000795
-  thomas: '01688'
 - name: Duncan Hunter
   party: majority
   rank: 3
   bioguide: H001048
-  thomas: '01909'
 - name: Dave Brat
   party: majority
   rank: 4
   bioguide: B001290
-  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 5
   bioguide: G000576
-  thomas: '02276'
 - name: Elise M. Stefanik
   party: majority
   rank: 6
   bioguide: S001196
-  thomas: '02263'
 - name: Francis Rooney
   party: majority
   rank: 7
@@ -4512,27 +3755,22 @@ HSED10:
   rank: 1
   title: Ranking Member
   bioguide: T000472
-  thomas: '02110'
 - name: Raúl M. Grijalva
   party: minority
   rank: 2
   bioguide: G000551
-  thomas: '01708'
 - name: Alma S. Adams
   party: minority
   rank: 3
   bioguide: A000370
-  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 4
   bioguide: D000623
-  thomas: '02227'
 - name: Donald Norcross
   party: minority
   rank: 5
   bioguide: N000188
-  thomas: '02202'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 6
@@ -4541,49 +3779,40 @@ HSED10:
   party: minority
   rank: 7
   bioguide: S001170
-  thomas: '01861'
 HSED13:
 - name: Brett Guthrie
   party: majority
   rank: 1
   title: Chair
   bioguide: G000558
-  thomas: '01922'
 - name: Glenn Thompson
   party: majority
   rank: 2
   bioguide: T000467
-  thomas: '01952'
 - name: Lou Barletta
   party: majority
   rank: 3
   bioguide: B001269
-  thomas: '02054'
 - name: Luke Messer
   party: majority
   rank: 4
   bioguide: M001189
-  thomas: '02130'
 - name: Bradley Byrne
   party: majority
   rank: 5
   bioguide: B001289
-  thomas: '02197'
 - name: Glenn Grothman
   party: majority
   rank: 6
   bioguide: G000576
-  thomas: '02276'
 - name: Elise M. Stefanik
   party: majority
   rank: 7
   bioguide: S001196
-  thomas: '02263'
 - name: Rick W. Allen
   party: majority
   rank: 8
   bioguide: A000372
-  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 9
@@ -4605,22 +3834,18 @@ HSED13:
   rank: 1
   title: Ranking Member
   bioguide: D000598
-  thomas: '01641'
 - name: Joe Courtney
   party: minority
   rank: 2
   bioguide: C001069
-  thomas: '01836'
 - name: Alma S. Adams
   party: minority
   rank: 3
   bioguide: A000370
-  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 4
   bioguide: D000623
-  thomas: '02227'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 5
@@ -4629,17 +3854,14 @@ HSED13:
   party: minority
   rank: 6
   bioguide: P000598
-  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
   bioguide: S001177
-  thomas: '01962'
 - name: Mark Takano
   party: minority
   rank: 8
   bioguide: T000472
-  thomas: '02110'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 9
@@ -4654,32 +3876,26 @@ HSED14:
   rank: 1
   title: Chair
   bioguide: R000592
-  thomas: '02017'
 - name: Duncan Hunter
   party: majority
   rank: 2
   bioguide: H001048
-  thomas: '01909'
 - name: David P. Roe
   party: majority
   rank: 3
   bioguide: R000582
-  thomas: '01954'
 - name: Glenn Thompson
   party: majority
   rank: 4
   bioguide: T000467
-  thomas: '01952'
 - name: Luke Messer
   party: majority
   rank: 5
   bioguide: M001189
-  thomas: '02130'
 - name: Dave Brat
   party: majority
   rank: 6
   bioguide: B001290
-  thomas: '02203'
 - name: Thomas A. Garrett, Jr.
   party: majority
   rank: 7
@@ -4689,144 +3905,116 @@ HSED14:
   rank: 1
   title: Ranking Member
   bioguide: P000598
-  thomas: '01910'
 - name: Raúl M. Grijalva
   party: minority
   rank: 2
   bioguide: G000551
-  thomas: '01708'
 - name: Marcia L. Fudge
   party: minority
   rank: 3
   bioguide: F000455
-  thomas: '01895'
 - name: Suzanne Bonamici
   party: minority
   rank: 4
   bioguide: B001278
-  thomas: '02092'
 - name: Susan A. Davis
   party: minority
   rank: 5
   bioguide: D000598
-  thomas: '01641'
 - name: Frederica S. Wilson
   party: minority
   rank: 6
   bioguide: W000808
-  thomas: '02004'
 HSFA:
 - name: Edward R. Royce
   party: majority
   rank: 1
   title: Chair
   bioguide: R000487
-  thomas: '00998'
 - name: Christopher H. Smith
   party: majority
   rank: 2
   bioguide: S000522
-  thomas: '01071'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
   bioguide: R000435
-  thomas: '00985'
 - name: Dana Rohrabacher
   party: majority
   rank: 4
   bioguide: R000409
-  thomas: '00979'
 - name: Steve Chabot
   party: majority
   rank: 5
   bioguide: C000266
-  thomas: '00186'
 - name: Joe Wilson
   party: majority
   rank: 6
   bioguide: W000795
-  thomas: '01688'
 - name: Michael T. McCaul
   party: majority
   rank: 7
   bioguide: M001157
-  thomas: '01804'
 - name: Ted Poe
   party: majority
   rank: 8
   bioguide: P000592
-  thomas: '01802'
 - name: Darrell E. Issa
   party: majority
   rank: 9
   bioguide: I000056
-  thomas: '01640'
 - name: Tom Marino
   party: majority
   rank: 10
   bioguide: M001179
-  thomas: '02053'
 - name: Jeff Duncan
   party: majority
   rank: 11
   bioguide: D000615
-  thomas: '02057'
 - name: Mo Brooks
   party: majority
   rank: 12
   bioguide: B001274
-  thomas: '01987'
 - name: Paul Cook
   party: majority
   rank: 13
   bioguide: C001094
-  thomas: '02103'
 - name: Scott Perry
   party: majority
   rank: 14
   bioguide: P000605
-  thomas: '02157'
 - name: Ron DeSantis
   party: majority
   rank: 15
   bioguide: D000621
-  thomas: '02116'
 - name: Mark Meadows
   party: majority
   rank: 16
   bioguide: M001187
-  thomas: '02142'
 - name: Ted S. Yoho
   party: majority
   rank: 17
   bioguide: Y000065
-  thomas: '02115'
 - name: Adam Kinzinger
   party: majority
   rank: 18
   bioguide: K000378
-  thomas: '02014'
 - name: Lee M. Zeldin
   party: majority
   rank: 19
   bioguide: Z000017
-  thomas: '02261'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 20
   bioguide: D000625
-  thomas: '02293'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 21
   bioguide: S000244
-  thomas: '01041'
 - name: Ann Wagner
   party: majority
   rank: 22
   bioguide: W000812
-  thomas: '02137'
 - name: Brian J. Mast
   party: majority
   rank: 23
@@ -4848,92 +4036,74 @@ HSFA:
   rank: 1
   title: Ranking Member
   bioguide: E000179
-  thomas: '00344'
 - name: Brad Sherman
   party: minority
   rank: 2
   bioguide: S000344
-  thomas: '01526'
 - name: Gregory W. Meeks
   party: minority
   rank: 3
   bioguide: M001137
-  thomas: '01506'
 - name: Albio Sires
   party: minority
   rank: 4
   bioguide: S001165
-  thomas: '01818'
 - name: Gerald E. Connolly
   party: minority
   rank: 5
   bioguide: C001078
-  thomas: '01959'
 - name: Theodore E. Deutch
   party: minority
   rank: 6
   bioguide: D000610
-  thomas: '01976'
 - name: Karen Bass
   party: minority
   rank: 7
   bioguide: B001270
-  thomas: '01996'
 - name: William R. Keating
   party: minority
   rank: 8
   bioguide: K000375
-  thomas: '02025'
 - name: David N. Cicilline
   party: minority
   rank: 9
   bioguide: C001084
-  thomas: '02055'
 - name: Ami Bera
   party: minority
   rank: 10
   bioguide: B001287
-  thomas: '02102'
 - name: Lois Frankel
   party: minority
   rank: 11
   bioguide: F000462
-  thomas: '02119'
 - name: Tulsi Gabbard
   party: minority
   rank: 12
   bioguide: G000571
-  thomas: '02122'
 - name: Joaquin Castro
   party: minority
   rank: 13
   bioguide: C001091
-  thomas: '02163'
 - name: Robin L. Kelly
   party: minority
   rank: 14
   bioguide: K000385
-  thomas: '02190'
 - name: Brendan F. Boyle
   party: minority
   rank: 15
   bioguide: B001296
-  thomas: '02267'
 - name: Dina Titus
   party: minority
   rank: 16
   bioguide: T000468
-  thomas: '01940'
 - name: Norma J. Torres
   party: minority
   rank: 17
   bioguide: T000474
-  thomas: '02231'
 - name: Bradley Scott Schneider
   party: minority
   rank: 18
   bioguide: S001190
-  thomas: '02124'
 - name: Thomas R. Suozzi
   party: minority
   rank: 19
@@ -4946,117 +4116,95 @@ HSFA:
   party: minority
   rank: 21
   bioguide: L000582
-  thomas: '02230'
 HSFA05:
 - name: Ted S. Yoho
   party: majority
   rank: 1
   title: Chair
   bioguide: Y000065
-  thomas: '02115'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
   bioguide: R000409
-  thomas: '00979'
 - name: Steve Chabot
   party: majority
   rank: 3
   bioguide: C000266
-  thomas: '00186'
 - name: Tom Marino
   party: majority
   rank: 4
   bioguide: M001179
-  thomas: '02053'
 - name: Mo Brooks
   party: majority
   rank: 5
   bioguide: B001274
-  thomas: '01987'
 - name: Scott Perry
   party: majority
   rank: 6
   bioguide: P000605
-  thomas: '02157'
 - name: Adam Kinzinger
   party: majority
   rank: 7
   bioguide: K000378
-  thomas: '02014'
 - name: Ann Wagner
   party: majority
   rank: 8
   bioguide: W000812
-  thomas: '02137'
 - name: Brad Sherman
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000344
-  thomas: '01526'
 - name: Ami Bera
   party: minority
   rank: 2
   bioguide: B001287
-  thomas: '02102'
 - name: Dina Titus
   party: minority
   rank: 3
   bioguide: T000468
-  thomas: '01940'
 - name: Gerald E. Connolly
   party: minority
   rank: 4
   bioguide: C001078
-  thomas: '01959'
 - name: Theodore E. Deutch
   party: minority
   rank: 5
   bioguide: D000610
-  thomas: '01976'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
   bioguide: G000571
-  thomas: '02122'
 HSFA07:
 - name: Jeff Duncan
   party: majority
   rank: 1
   title: Chair
   bioguide: D000615
-  thomas: '02057'
 - name: Christopher H. Smith
   party: majority
   rank: 2
   bioguide: S000522
-  thomas: '01071'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
   bioguide: R000435
-  thomas: '00985'
 - name: Michael T. McCaul
   party: majority
   rank: 4
   bioguide: M001157
-  thomas: '01804'
 - name: Mo Brooks
   party: majority
   rank: 5
   bioguide: B001274
-  thomas: '01987'
 - name: Ron DeSantis
   party: majority
   rank: 6
   bioguide: D000621
-  thomas: '02116'
 - name: Ted S. Yoho
   party: majority
   rank: 7
   bioguide: Y000065
-  thomas: '02115'
 - name: Francis Rooney
   party: majority
   rank: 8
@@ -5066,22 +4214,18 @@ HSFA07:
   rank: 1
   title: Ranking Member
   bioguide: S001165
-  thomas: '01818'
 - name: Joaquin Castro
   party: minority
   rank: 2
   bioguide: C001091
-  thomas: '02163'
 - name: Robin L. Kelly
   party: minority
   rank: 3
   bioguide: K000385
-  thomas: '02190'
 - name: Norma J. Torres
   party: minority
   rank: 4
   bioguide: T000474
-  thomas: '02231'
 - name: Adriano Espaillat
   party: minority
   rank: 5
@@ -5090,59 +4234,48 @@ HSFA07:
   party: minority
   rank: 6
   bioguide: M001137
-  thomas: '01506'
 HSFA13:
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 1
   title: Chair
   bioguide: R000435
-  thomas: '00985'
 - name: Steve Chabot
   party: majority
   rank: 2
   bioguide: C000266
-  thomas: '00186'
 - name: Darrell E. Issa
   party: majority
   rank: 3
   bioguide: I000056
-  thomas: '01640'
 - name: Ron DeSantis
   party: majority
   rank: 4
   bioguide: D000621
-  thomas: '02116'
 - name: Mark Meadows
   party: majority
   rank: 5
   bioguide: M001187
-  thomas: '02142'
 - name: Paul Cook
   party: majority
   rank: 6
   bioguide: C001094
-  thomas: '02103'
 - name: Adam Kinzinger
   party: majority
   rank: 7
   bioguide: K000378
-  thomas: '02014'
 - name: Lee M. Zeldin
   party: majority
   rank: 8
   bioguide: Z000017
-  thomas: '02261'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 9
   bioguide: D000625
-  thomas: '02293'
 - name: Ann Wagner
   party: majority
   rank: 10
   bioguide: W000812
-  thomas: '02137'
 - name: Brian J. Mast
   party: majority
   rank: 11
@@ -5156,37 +4289,30 @@ HSFA13:
   rank: 1
   title: Ranking Member
   bioguide: D000610
-  thomas: '01976'
 - name: Gerald E. Connolly
   party: minority
   rank: 2
   bioguide: C001078
-  thomas: '01959'
 - name: David N. Cicilline
   party: minority
   rank: 3
   bioguide: C001084
-  thomas: '02055'
 - name: Lois Frankel
   party: minority
   rank: 4
   bioguide: F000462
-  thomas: '02119'
 - name: Brendan F. Boyle
   party: minority
   rank: 5
   bioguide: B001296
-  thomas: '02267'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
   bioguide: G000571
-  thomas: '02122'
 - name: Bradley Scott Schneider
   party: minority
   rank: 7
   bioguide: S001190
-  thomas: '02124'
 - name: Thomas R. Suozzi
   party: minority
   rank: 8
@@ -5195,39 +4321,32 @@ HSFA13:
   party: minority
   rank: 9
   bioguide: L000582
-  thomas: '02230'
 HSFA14:
 - name: Dana Rohrabacher
   party: majority
   rank: 1
   title: Chair
   bioguide: R000409
-  thomas: '00979'
 - name: Joe Wilson
   party: majority
   rank: 2
   bioguide: W000795
-  thomas: '01688'
 - name: Ted Poe
   party: majority
   rank: 3
   bioguide: P000592
-  thomas: '01802'
 - name: Tom Marino
   party: majority
   rank: 4
   bioguide: M001179
-  thomas: '02053'
 - name: Jeff Duncan
   party: majority
   rank: 5
   bioguide: D000615
-  thomas: '02057'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 6
   bioguide: S000244
-  thomas: '01041'
 - name: Francis Rooney
   party: majority
   rank: 7
@@ -5241,54 +4360,44 @@ HSFA14:
   rank: 1
   title: Ranking Member
   bioguide: M001137
-  thomas: '01506'
 - name: Brad Sherman
   party: minority
   rank: 2
   bioguide: S000344
-  thomas: '01526'
 - name: Albio Sires
   party: minority
   rank: 3
   bioguide: S001165
-  thomas: '01818'
 - name: William R. Keating
   party: minority
   rank: 4
   bioguide: K000375
-  thomas: '02025'
 - name: David N. Cicilline
   party: minority
   rank: 5
   bioguide: C001084
-  thomas: '02055'
 - name: Robin L. Kelly
   party: minority
   rank: 6
   bioguide: K000385
-  thomas: '02190'
 HSFA16:
 - name: Christopher H. Smith
   party: majority
   rank: 1
   title: Chair
   bioguide: S000522
-  thomas: '01071'
 - name: Mark Meadows
   party: majority
   rank: 2
   bioguide: M001187
-  thomas: '02142'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 3
   bioguide: D000625
-  thomas: '02293'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 4
   bioguide: S000244
-  thomas: '01041'
 - name: Thomas A. Garrett, Jr.
   party: majority
   rank: 5
@@ -5298,17 +4407,14 @@ HSFA16:
   rank: 1
   title: Ranking Member
   bioguide: B001270
-  thomas: '01996'
 - name: Ami Bera
   party: minority
   rank: 2
   bioguide: B001287
-  thomas: '02102'
 - name: Joaquin Castro
   party: minority
   rank: 3
   bioguide: C001091
-  thomas: '02163'
 - name: Thomas R. Suozzi
   party: minority
   rank: 4
@@ -5319,32 +4425,26 @@ HSFA18:
   rank: 1
   title: Chair
   bioguide: P000592
-  thomas: '01802'
 - name: Joe Wilson
   party: majority
   rank: 2
   bioguide: W000795
-  thomas: '01688'
 - name: Darrell E. Issa
   party: majority
   rank: 3
   bioguide: I000056
-  thomas: '01640'
 - name: Paul Cook
   party: majority
   rank: 4
   bioguide: C001094
-  thomas: '02103'
 - name: Scott Perry
   party: majority
   rank: 5
   bioguide: P000605
-  thomas: '02157'
 - name: Lee M. Zeldin
   party: majority
   rank: 6
   bioguide: Z000017
-  thomas: '02261'
 - name: Brian J. Mast
   party: majority
   rank: 7
@@ -5358,144 +4458,116 @@ HSFA18:
   rank: 1
   title: Ranking Member
   bioguide: K000375
-  thomas: '02025'
 - name: Lois Frankel
   party: minority
   rank: 2
   bioguide: F000462
-  thomas: '02119'
 - name: Brendan F. Boyle
   party: minority
   rank: 3
   bioguide: B001296
-  thomas: '02267'
 - name: Dina Titus
   party: minority
   rank: 4
   bioguide: T000468
-  thomas: '01940'
 - name: Norma J. Torres
   party: minority
   rank: 5
   bioguide: T000474
-  thomas: '02231'
 - name: Bradley Scott Schneider
   party: minority
   rank: 6
   bioguide: S001190
-  thomas: '02124'
 HSGO:
 - name: Jason Chaffetz
   party: majority
   rank: 1
   title: Chair
   bioguide: C001076
-  thomas: '01956'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 2
   bioguide: D000533
-  thomas: '00322'
 - name: Darrell E. Issa
   party: majority
   rank: 3
   bioguide: I000056
-  thomas: '01640'
 - name: Jim Jordan
   party: majority
   rank: 4
   bioguide: J000289
-  thomas: '01868'
 - name: Mark Sanford
   party: majority
   rank: 5
   bioguide: S000051
-  thomas: '01012'
 - name: Justin Amash
   party: majority
   rank: 6
   bioguide: A000367
-  thomas: '02029'
 - name: Paul A. Gosar
   party: majority
   rank: 7
   bioguide: G000565
-  thomas: '01992'
 - name: Scott DesJarlais
   party: majority
   rank: 8
   bioguide: D000616
-  thomas: '02062'
 - name: Trey Gowdy
   party: majority
   rank: 9
   bioguide: G000566
-  thomas: '02058'
 - name: Blake Farenthold
   party: majority
   rank: 10
   bioguide: F000460
-  thomas: '02067'
 - name: Virginia Foxx
   party: majority
   rank: 11
   bioguide: F000450
-  thomas: '01791'
 - name: Thomas Massie
   party: majority
   rank: 12
   bioguide: M001184
-  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 13
   bioguide: M001187
-  thomas: '02142'
 - name: Ron DeSantis
   party: majority
   rank: 14
   bioguide: D000621
-  thomas: '02116'
 - name: Dennis A. Ross
   party: majority
   rank: 15
   bioguide: R000593
-  thomas: '02003'
 - name: Mark Walker
   party: majority
   rank: 16
   bioguide: W000819
-  thomas: '02255'
 - name: Rod Blum
   party: majority
   rank: 17
   bioguide: B001294
-  thomas: '02241'
 - name: Jody B. Hice
   party: majority
   rank: 18
   bioguide: H001071
-  thomas: '02237'
 - name: Steve Russell
   party: majority
   rank: 19
   bioguide: R000604
-  thomas: '02265'
 - name: Glenn Grothman
   party: majority
   rank: 20
   bioguide: G000576
-  thomas: '02276'
 - name: Will Hurd
   party: majority
   rank: 21
   bioguide: H001073
-  thomas: '02269'
 - name: Gary J. Palmer
   party: majority
   rank: 22
   bioguide: P000609
-  thomas: '02221'
 - name: James Comer
   party: majority
   rank: 23
@@ -5509,57 +4581,46 @@ HSGO:
   rank: 1
   title: Ranking Member
   bioguide: C000984
-  thomas: '00256'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
   bioguide: M000087
-  thomas: '00729'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
   bioguide: N000147
-  thomas: '00868'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
   bioguide: C001049
-  thomas: '01654'
 - name: Stephen F. Lynch
   party: minority
   rank: 5
   bioguide: L000562
-  thomas: '01686'
 - name: Jim Cooper
   party: minority
   rank: 6
   bioguide: C000754
-  thomas: '00231'
 - name: Gerald E. Connolly
   party: minority
   rank: 7
   bioguide: C001078
-  thomas: '01959'
 - name: Robin L. Kelly
   party: minority
   rank: 8
   bioguide: K000385
-  thomas: '02190'
 - name: Brenda L. Lawrence
   party: minority
   rank: 9
   bioguide: L000581
-  thomas: '02252'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 10
   bioguide: W000822
-  thomas: '02259'
 - name: Stacey E. Plaskett
   party: minority
   rank: 11
   bioguide: P000610
-  thomas: '02274'
 - name: Val Butler Demings
   party: minority
   rank: 12
@@ -5576,60 +4637,49 @@ HSGO:
   party: minority
   rank: 15
   bioguide: W000800
-  thomas: '01879'
 - name: Matt Cartwright
   party: minority
   rank: 16
   bioguide: C001090
-  thomas: '02159'
 - name: Mark DeSaulnier
   party: minority
   rank: 17
   bioguide: D000623
-  thomas: '02227'
 - name: John P. Sarbanes
   party: minority
   rank: 18
   bioguide: S001168
-  thomas: '01854'
 HSGO06:
 - name: Ron DeSantis
   party: majority
   rank: 1
   title: Chair
   bioguide: D000621
-  thomas: '02116'
 - name: Steve Russell
   party: majority
   rank: 2
   bioguide: R000604
-  thomas: '02265'
   title: Vice Chair
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
   bioguide: D000533
-  thomas: '00322'
 - name: Justin Amash
   party: majority
   rank: 4
   bioguide: A000367
-  thomas: '02029'
 - name: Paul A. Gosar
   party: majority
   rank: 5
   bioguide: G000565
-  thomas: '01992'
 - name: Virginia Foxx
   party: majority
   rank: 6
   bioguide: F000450
-  thomas: '01791'
 - name: Jody B. Hice
   party: majority
   rank: 7
   bioguide: H001071
-  thomas: '02237'
 - name: James Comer
   party: majority
   rank: 8
@@ -5639,93 +4689,76 @@ HSGO06:
   rank: 1
   title: Ranking Member
   bioguide: L000562
-  thomas: '01686'
 - name: Peter Welch
   party: minority
   rank: 2
   bioguide: W000800
-  thomas: '01879'
 HSGO24:
 - name: Mark Meadows
   party: majority
   rank: 1
   title: Chair
   bioguide: M001187
-  thomas: '02142'
 - name: Jody B. Hice
   party: majority
   rank: 2
   bioguide: H001071
-  thomas: '02237'
   title: Vice Chair
 - name: Jim Jordan
   party: majority
   rank: 3
   bioguide: J000289
-  thomas: '01868'
 - name: Mark Sanford
   party: majority
   rank: 4
   bioguide: S000051
-  thomas: '01012'
 - name: Thomas Massie
   party: majority
   rank: 5
   bioguide: M001184
-  thomas: '02094'
 - name: Ron DeSantis
   party: majority
   rank: 6
   bioguide: D000621
-  thomas: '02116'
 - name: Dennis A. Ross
   party: majority
   rank: 7
   bioguide: R000593
-  thomas: '02003'
 - name: Rod Blum
   party: majority
   rank: 8
   bioguide: B001294
-  thomas: '02241'
 - name: Gerald E. Connolly
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001078
-  thomas: '01959'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
   bioguide: M000087
-  thomas: '00729'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
   bioguide: N000147
-  thomas: '00868'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
   bioguide: C001049
-  thomas: '01654'
 - name: Brenda L. Lawrence
   party: minority
   rank: 5
   bioguide: L000581
-  thomas: '02252'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 6
   bioguide: W000822
-  thomas: '02259'
 HSGO25:
 - name: Will Hurd
   party: majority
   rank: 1
   title: Chair
   bioguide: H001073
-  thomas: '02269'
 - name: Paul Mitchell
   party: majority
   rank: 2
@@ -5735,28 +4768,23 @@ HSGO25:
   party: majority
   rank: 3
   bioguide: I000056
-  thomas: '01640'
 - name: Justin Amash
   party: majority
   rank: 4
   bioguide: A000367
-  thomas: '02029'
 - name: Blake Farenthold
   party: majority
   rank: 5
   bioguide: F000460
-  thomas: '02067'
 - name: Steve Russell
   party: majority
   rank: 6
   bioguide: R000604
-  thomas: '02265'
 - name: Robin L. Kelly
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000385
-  thomas: '02190'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -5765,12 +4793,10 @@ HSGO25:
   party: minority
   rank: 3
   bioguide: L000562
-  thomas: '01686'
 - name: Gerald E. Connolly
   party: minority
   rank: 4
   bioguide: C001078
-  thomas: '01959'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 5
@@ -5781,38 +4807,31 @@ HSGO27:
   rank: 1
   title: Chair
   bioguide: J000289
-  thomas: '01868'
 - name: Mark Walker
   party: majority
   rank: 2
   bioguide: W000819
-  thomas: '02255'
   title: Vice Chair
 - name: Darrell E. Issa
   party: majority
   rank: 3
   bioguide: I000056
-  thomas: '01640'
 - name: Mark Sanford
   party: majority
   rank: 4
   bioguide: S000051
-  thomas: '01012'
 - name: Scott DesJarlais
   party: majority
   rank: 5
   bioguide: D000616
-  thomas: '02062'
 - name: Mark Meadows
   party: majority
   rank: 6
   bioguide: M001187
-  thomas: '02142'
 - name: Glenn Grothman
   party: majority
   rank: 7
   bioguide: G000576
-  thomas: '02276'
 - name: Paul Mitchell
   party: majority
   rank: 8
@@ -5826,50 +4845,41 @@ HSGO27:
   party: minority
   rank: 2
   bioguide: C000754
-  thomas: '00231'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
   bioguide: N000147
-  thomas: '00868'
 - name: Robin L. Kelly
   party: minority
   rank: 4
   bioguide: K000385
-  thomas: '02190'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 5
   bioguide: W000822
-  thomas: '02259'
 - name: Stacey E. Plaskett
   party: minority
   rank: 6
   bioguide: P000610
-  thomas: '02274'
 HSGO28:
 - name: Blake Farenthold
   party: majority
   rank: 1
   title: Chair
   bioguide: F000460
-  thomas: '02067'
 - name: Paul A. Gosar
   party: majority
   rank: 2
   bioguide: G000565
-  thomas: '01992'
   title: Vice Chair
 - name: Dennis A. Ross
   party: majority
   rank: 3
   bioguide: R000593
-  thomas: '02003'
 - name: Gary J. Palmer
   party: majority
   rank: 4
   bioguide: P000609
-  thomas: '02221'
 - name: James Comer
   party: majority
   rank: 5
@@ -5879,7 +4889,6 @@ HSGO28:
   rank: 1
   title: Ranking Member
   bioguide: P000610
-  thomas: '02274'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -5890,38 +4899,31 @@ HSGO29:
   rank: 1
   title: Chair
   bioguide: P000609
-  thomas: '02221'
 - name: Glenn Grothman
   party: majority
   rank: 2
   bioguide: G000576
-  thomas: '02276'
   title: Vice Chair
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
   bioguide: D000533
-  thomas: '00322'
 - name: Trey Gowdy
   party: majority
   rank: 4
   bioguide: G000566
-  thomas: '02058'
 - name: Virginia Foxx
   party: majority
   rank: 5
   bioguide: F000450
-  thomas: '01791'
 - name: Thomas Massie
   party: majority
   rank: 6
   bioguide: M001184
-  thomas: '02094'
 - name: Mark Walker
   party: majority
   rank: 7
   bioguide: W000819
-  thomas: '02255'
 - name: Val Butler Demings
   party: minority
   rank: 1
@@ -5933,43 +4935,35 @@ HSHA:
   rank: 1
   title: Chair
   bioguide: H001045
-  thomas: '01933'
 - name: Rodney Davis
   party: majority
   rank: 2
   bioguide: D000619
-  thomas: '02126'
 - name: Barbara Comstock
   party: majority
   rank: 3
   bioguide: C001105
-  thomas: '02273'
 - name: Mark Walker
   party: majority
   rank: 4
   bioguide: W000819
-  thomas: '02255'
 - name: Adrian Smith
   party: majority
   rank: 5
   bioguide: S001172
-  thomas: '01860'
 - name: Barry Loudermilk
   party: majority
   rank: 6
   bioguide: L000583
-  thomas: '02238'
 - name: Robert A. Brady
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001227
-  thomas: '01469'
 - name: Zoe Lofgren
   party: minority
   rank: 2
   bioguide: L000397
-  thomas: '00701'
 - name: Jamie Raskin
   party: minority
   rank: 3
@@ -5980,67 +4974,54 @@ HSHM:
   rank: 1
   title: Chair
   bioguide: M001157
-  thomas: '01804'
 - name: Lamar Smith
   party: majority
   rank: 2
   bioguide: S000583
-  thomas: '01075'
 - name: Peter T. King
   party: majority
   rank: 3
   bioguide: K000210
-  thomas: '00635'
 - name: Mike Rogers
   party: majority
   rank: 4
   bioguide: R000575
-  thomas: '01704'
 - name: Jeff Duncan
   party: majority
   rank: 5
   bioguide: D000615
-  thomas: '02057'
 - name: Tom Marino
   party: majority
   rank: 6
   bioguide: M001179
-  thomas: '02053'
 - name: Lou Barletta
   party: majority
   rank: 7
   bioguide: B001269
-  thomas: '02054'
 - name: Scott Perry
   party: majority
   rank: 8
   bioguide: P000605
-  thomas: '02157'
 - name: John Katko
   party: majority
   rank: 9
   bioguide: K000386
-  thomas: '02264'
 - name: Will Hurd
   party: majority
   rank: 10
   bioguide: H001073
-  thomas: '02269'
 - name: Martha McSally
   party: majority
   rank: 11
   bioguide: M001197
-  thomas: '02225'
 - name: John Ratcliffe
   party: majority
   rank: 12
   bioguide: R000601
-  thomas: '02268'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 13
   bioguide: D000625
-  thomas: '02293'
 - name: Mike Gallagher
   party: majority
   rank: 14
@@ -6066,47 +5047,38 @@ HSHM:
   rank: 1
   title: Ranking Member
   bioguide: T000193
-  thomas: '01151'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
   bioguide: J000032
-  thomas: '00588'
 - name: James R. Langevin
   party: minority
   rank: 3
   bioguide: L000559
-  thomas: '01668'
 - name: Cedric L. Richmond
   party: minority
   rank: 4
   bioguide: R000588
-  thomas: '02023'
 - name: William R. Keating
   party: minority
   rank: 5
   bioguide: K000375
-  thomas: '02025'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 6
   bioguide: P000604
-  thomas: '02097'
 - name: Filemon Vela
   party: minority
   rank: 7
   bioguide: V000132
-  thomas: '02167'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 8
   bioguide: W000822
-  thomas: '02259'
 - name: Kathleen M. Rice
   party: minority
   rank: 9
   bioguide: R000602
-  thomas: '02262'
 - name: J. Luis Correa
   party: minority
   rank: 10
@@ -6125,22 +5097,18 @@ HSHM05:
   rank: 1
   title: Chair
   bioguide: K000210
-  thomas: '00635'
 - name: Lou Barletta
   party: majority
   rank: 2
   bioguide: B001269
-  thomas: '02054'
 - name: Scott Perry
   party: majority
   rank: 3
   bioguide: P000605
-  thomas: '02157'
 - name: Will Hurd
   party: majority
   rank: 4
   bioguide: H001073
-  thomas: '02269'
 - name: Mike Gallagher
   party: majority
   rank: 5
@@ -6149,29 +5117,24 @@ HSHM05:
   party: majority
   rank: 6
   bioguide: M001157
-  thomas: '01804'
   title: Ex Officio
 - name: Kathleen M. Rice
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: R000602
-  thomas: '02262'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
   bioguide: J000032
-  thomas: '00588'
 - name: William R. Keating
   party: minority
   rank: 3
   bioguide: K000375
-  thomas: '02025'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
   bioguide: T000193
-  thomas: '01151'
   title: Ex Officio
 HSHM07:
 - name: John Katko
@@ -6179,17 +5142,14 @@ HSHM07:
   rank: 1
   title: Chair
   bioguide: K000386
-  thomas: '02264'
 - name: Peter T. King
   party: majority
   rank: 2
   bioguide: K000210
-  thomas: '00635'
 - name: Mike Rogers
   party: majority
   rank: 3
   bioguide: R000575
-  thomas: '01704'
 - name: Clay Higgins
   party: majority
   rank: 4
@@ -6202,29 +5162,24 @@ HSHM07:
   party: majority
   rank: 6
   bioguide: M001157
-  thomas: '01804'
   title: Ex Officio
 - name: Bonnie Watson Coleman
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000822
-  thomas: '02259'
 - name: William R. Keating
   party: minority
   rank: 2
   bioguide: K000375
-  thomas: '02025'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 3
   bioguide: P000604
-  thomas: '02097'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
   bioguide: T000193
-  thomas: '01151'
   title: Ex Officio
 HSHM08:
 - name: John Ratcliffe
@@ -6232,17 +5187,14 @@ HSHM08:
   rank: 1
   title: Chair
   bioguide: R000601
-  thomas: '02268'
 - name: John Katko
   party: majority
   rank: 2
   bioguide: K000386
-  thomas: '02264'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 3
   bioguide: D000625
-  thomas: '02293'
 - name: Mike Gallagher
   party: majority
   rank: 4
@@ -6263,24 +5215,20 @@ HSHM08:
   party: majority
   rank: 8
   bioguide: M001157
-  thomas: '01804'
   title: Ex Officio
 - name: Cedric L. Richmond
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: R000588
-  thomas: '02023'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
   bioguide: J000032
-  thomas: '00588'
 - name: James R. Langevin
   party: minority
   rank: 3
   bioguide: L000559
-  thomas: '01668'
 - name: Val Butler Demings
   party: minority
   rank: 4
@@ -6289,7 +5237,6 @@ HSHM08:
   party: minority
   rank: 5
   bioguide: T000193
-  thomas: '01151'
   title: Ex Officio
 HSHM09:
 - name: Scott Perry
@@ -6297,22 +5244,18 @@ HSHM09:
   rank: 1
   title: Chair
   bioguide: P000605
-  thomas: '02157'
 - name: Jeff Duncan
   party: majority
   rank: 2
   bioguide: D000615
-  thomas: '02057'
 - name: Tom Marino
   party: majority
   rank: 3
   bioguide: M001179
-  thomas: '02053'
 - name: John Ratcliffe
   party: majority
   rank: 4
   bioguide: R000601
-  thomas: '02268'
 - name: Clay Higgins
   party: majority
   rank: 5
@@ -6321,7 +5264,6 @@ HSHM09:
   party: majority
   rank: 6
   bioguide: M001157
-  thomas: '01804'
   title: Ex Officio
 - name: J. Luis Correa
   party: minority
@@ -6332,7 +5274,6 @@ HSHM09:
   party: minority
   rank: 2
   bioguide: R000602
-  thomas: '02262'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 3
@@ -6341,7 +5282,6 @@ HSHM09:
   party: minority
   rank: 4
   bioguide: T000193
-  thomas: '01151'
   title: Ex Officio
 HSHM11:
 - name: Martha McSally
@@ -6349,32 +5289,26 @@ HSHM11:
   rank: 1
   title: Chair
   bioguide: M001197
-  thomas: '02225'
 - name: Lamar Smith
   party: majority
   rank: 2
   bioguide: S000583
-  thomas: '01075'
 - name: Mike Rogers
   party: majority
   rank: 3
   bioguide: R000575
-  thomas: '01704'
 - name: Jeff Duncan
   party: majority
   rank: 4
   bioguide: D000615
-  thomas: '02057'
 - name: Lou Barletta
   party: majority
   rank: 5
   bioguide: B001269
-  thomas: '02054'
 - name: Will Hurd
   party: majority
   rank: 6
   bioguide: H001073
-  thomas: '02269'
 - name: John H. Rutherford
   party: majority
   rank: 7
@@ -6383,19 +5317,16 @@ HSHM11:
   party: majority
   rank: 8
   bioguide: M001157
-  thomas: '01804'
   title: Ex Officio
 - name: Filemon Vela
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: V000132
-  thomas: '02167'
 - name: Cedric L. Richmond
   party: minority
   rank: 2
   bioguide: R000588
-  thomas: '02023'
 - name: J. Luis Correa
   party: minority
   rank: 3
@@ -6412,7 +5343,6 @@ HSHM11:
   party: minority
   rank: 6
   bioguide: T000193
-  thomas: '01151'
   title: Ex Officio
 HSHM12:
 - name: Daniel M. Donovan, Jr.
@@ -6420,17 +5350,14 @@ HSHM12:
   rank: 1
   title: Chair
   bioguide: D000625
-  thomas: '02293'
 - name: Tom Marino
   party: majority
   rank: 2
   bioguide: M001179
-  thomas: '02053'
 - name: Martha McSally
   party: majority
   rank: 3
   bioguide: M001197
-  thomas: '02225'
 - name: John H. Rutherford
   party: majority
   rank: 4
@@ -6443,29 +5370,24 @@ HSHM12:
   party: majority
   rank: 6
   bioguide: M001157
-  thomas: '01804'
   title: Ex Officio
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000604
-  thomas: '02097'
 - name: James R. Langevin
   party: minority
   rank: 2
   bioguide: L000559
-  thomas: '01668'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 3
   bioguide: W000822
-  thomas: '02259'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
   bioguide: T000193
-  thomas: '01151'
   title: Ex Officio
 HSIF:
 - name: Greg Walden
@@ -6473,378 +5395,304 @@ HSIF:
   rank: 1
   title: Chair
   bioguide: W000791
-  thomas: '01596'
 - name: Joe Barton
   party: majority
   rank: 2
   bioguide: B000213
-  thomas: '00062'
 - name: Fred Upton
   party: majority
   rank: 3
   bioguide: U000031
-  thomas: '01177'
 - name: John Shimkus
   party: majority
   rank: 4
   bioguide: S000364
-  thomas: '01527'
 - name: Tim Murphy
   party: majority
   rank: 5
   bioguide: M001151
-  thomas: '01744'
 - name: Michael C. Burgess
   party: majority
   rank: 6
   bioguide: B001248
-  thomas: '01751'
 - name: Marsha Blackburn
   party: majority
   rank: 7
   bioguide: B001243
-  thomas: '01748'
 - name: Steve Scalise
   party: majority
   rank: 8
   bioguide: S001176
-  thomas: '01892'
 - name: Robert E. Latta
   party: majority
   rank: 9
   bioguide: L000566
-  thomas: '01885'
 - name: Cathy McMorris Rodgers
   party: majority
   rank: 10
   bioguide: M001159
-  thomas: '01809'
 - name: Gregg Harper
   party: majority
   rank: 11
   bioguide: H001045
-  thomas: '01933'
 - name: Leonard Lance
   party: majority
   rank: 12
   bioguide: L000567
-  thomas: '01936'
 - name: Brett Guthrie
   party: majority
   rank: 13
   bioguide: G000558
-  thomas: '01922'
 - name: Pete Olson
   party: majority
   rank: 14
   bioguide: O000168
-  thomas: '01955'
 - name: David B. McKinley
   party: majority
   rank: 15
   bioguide: M001180
-  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 16
   bioguide: K000378
-  thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
   rank: 17
   bioguide: G000568
-  thomas: '02070'
 - name: Gus M. Bilirakis
   party: majority
   rank: 18
   bioguide: B001257
-  thomas: '01838'
 - name: Bill Johnson
   party: majority
   rank: 19
   bioguide: J000292
-  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 20
   bioguide: L000576
-  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 21
   bioguide: B001275
-  thomas: '02018'
 - name: Bill Flores
   party: majority
   rank: 22
   bioguide: F000461
-  thomas: '02065'
 - name: Susan W. Brooks
   party: majority
   rank: 23
   bioguide: B001284
-  thomas: '02129'
 - name: Markwayne Mullin
   party: majority
   rank: 24
   bioguide: M001190
-  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 25
   bioguide: H001067
-  thomas: '02140'
 - name: Chris Collins
   party: majority
   rank: 26
   bioguide: C001092
-  thomas: '02151'
 - name: Kevin Cramer
   party: majority
   rank: 27
   bioguide: C001096
-  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 28
   bioguide: W000798
-  thomas: '01855'
 - name: Mimi Walters
   party: majority
   rank: 29
   bioguide: W000820
-  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 30
   bioguide: C001106
-  thomas: '02266'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 31
   bioguide: C001103
-  thomas: '02236'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000034
-  thomas: '00887'
 - name: Bobby L. Rush
   party: minority
   rank: 2
   bioguide: R000515
-  thomas: '01003'
 - name: Anna G. Eshoo
   party: minority
   rank: 3
   bioguide: E000215
-  thomas: '00355'
 - name: Eliot L. Engel
   party: minority
   rank: 4
   bioguide: E000179
-  thomas: '00344'
 - name: Gene Green
   party: minority
   rank: 5
   bioguide: G000410
-  thomas: '00462'
 - name: Diana DeGette
   party: minority
   rank: 6
   bioguide: D000197
-  thomas: '01479'
 - name: Michael F. Doyle
   party: minority
   rank: 7
   bioguide: D000482
-  thomas: '00316'
 - name: Janice D. Schakowsky
   party: minority
   rank: 8
   bioguide: S001145
-  thomas: '01588'
 - name: G. K. Butterfield
   party: minority
   rank: 9
   bioguide: B001251
-  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 10
   bioguide: M001163
-  thomas: '01814'
 - name: Kathy Castor
   party: minority
   rank: 11
   bioguide: C001066
-  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 12
   bioguide: S001168
-  thomas: '01854'
 - name: Jerry McNerney
   party: minority
   rank: 13
   bioguide: M001166
-  thomas: '01832'
 - name: Peter Welch
   party: minority
   rank: 14
   bioguide: W000800
-  thomas: '01879'
 - name: Ben Ray Luján
   party: minority
   rank: 15
   bioguide: L000570
-  thomas: '01939'
 - name: Paul Tonko
   party: minority
   rank: 16
   bioguide: T000469
-  thomas: '01942'
 - name: Yvette D. Clarke
   party: minority
   rank: 17
   bioguide: C001067
-  thomas: '01864'
 - name: David Loebsack
   party: minority
   rank: 18
   bioguide: L000565
-  thomas: '01846'
 - name: Kurt Schrader
   party: minority
   rank: 19
   bioguide: S001180
-  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 20
   bioguide: K000379
-  thomas: '02172'
 - name: Tony Cárdenas
   party: minority
   rank: 21
   bioguide: C001097
-  thomas: '02107'
 - name: Raul Ruiz
   party: minority
   rank: 22
   bioguide: R000599
-  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 23
   bioguide: P000608
-  thomas: '02113'
 - name: Debbie Dingell
   party: minority
   rank: 24
   bioguide: D000624
-  thomas: '02251'
 HSIF02:
 - name: Tim Murphy
   party: majority
   rank: 1
   title: Chair
   bioguide: M001151
-  thomas: '01744'
 - name: H. Morgan Griffith
   party: majority
   rank: 2
   bioguide: G000568
-  thomas: '02070'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
   bioguide: B000213
-  thomas: '00062'
 - name: Michael C. Burgess
   party: majority
   rank: 4
   bioguide: B001248
-  thomas: '01751'
 - name: Susan W. Brooks
   party: majority
   rank: 5
   bioguide: B001284
-  thomas: '02129'
 - name: Chris Collins
   party: majority
   rank: 6
   bioguide: C001092
-  thomas: '02151'
 - name: Tim Walberg
   party: majority
   rank: 7
   bioguide: W000798
-  thomas: '01855'
 - name: Mimi Walters
   party: majority
   rank: 8
   bioguide: W000820
-  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 9
   bioguide: C001106
-  thomas: '02266'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 10
   bioguide: C001103
-  thomas: '02236'
 - name: Greg Walden
   party: majority
   rank: 11
   bioguide: W000791
-  thomas: '01596'
   title: Ex Officio
 - name: Diana DeGette
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000197
-  thomas: '01479'
 - name: Janice D. Schakowsky
   party: minority
   rank: 2
   bioguide: S001145
-  thomas: '01588'
 - name: Kathy Castor
   party: minority
   rank: 3
   bioguide: C001066
-  thomas: '01839'
 - name: Paul Tonko
   party: minority
   rank: 4
   bioguide: T000469
-  thomas: '01942'
 - name: Yvette D. Clarke
   party: minority
   rank: 5
   bioguide: C001067
-  thomas: '01864'
 - name: Raul Ruiz
   party: minority
   rank: 6
   bioguide: R000599
-  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 7
   bioguide: P000608
-  thomas: '02113'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 8
   bioguide: P000034
-  thomas: '00887'
   title: Ex Officio
 HSIF03:
 - name: Fred Upton
@@ -6852,170 +5700,137 @@ HSIF03:
   rank: 1
   title: Chair
   bioguide: U000031
-  thomas: '01177'
 - name: Pete Olson
   party: majority
   rank: 2
   bioguide: O000168
-  thomas: '01955'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
   bioguide: B000213
-  thomas: '00062'
 - name: John Shimkus
   party: majority
   rank: 4
   bioguide: S000364
-  thomas: '01527'
 - name: Tim Murphy
   party: majority
   rank: 5
   bioguide: M001151
-  thomas: '01744'
 - name: Robert E. Latta
   party: majority
   rank: 6
   bioguide: L000566
-  thomas: '01885'
 - name: Gregg Harper
   party: majority
   rank: 7
   bioguide: H001045
-  thomas: '01933'
 - name: David B. McKinley
   party: majority
   rank: 8
   bioguide: M001180
-  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 9
   bioguide: K000378
-  thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
   rank: 10
   bioguide: G000568
-  thomas: '02070'
 - name: Bill Johnson
   party: majority
   rank: 11
   bioguide: J000292
-  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 12
   bioguide: L000576
-  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 13
   bioguide: B001275
-  thomas: '02018'
 - name: Bill Flores
   party: majority
   rank: 14
   bioguide: F000461
-  thomas: '02065'
 - name: Markwayne Mullin
   party: majority
   rank: 15
   bioguide: M001190
-  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 16
   bioguide: H001067
-  thomas: '02140'
 - name: Kevin Cramer
   party: majority
   rank: 17
   bioguide: C001096
-  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 18
   bioguide: W000798
-  thomas: '01855'
 - name: Greg Walden
   party: majority
   rank: 19
   bioguide: W000791
-  thomas: '01596'
   title: Ex Officio
 - name: Bobby L. Rush
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: R000515
-  thomas: '01003'
 - name: Jerry McNerney
   party: minority
   rank: 2
   bioguide: M001166
-  thomas: '01832'
 - name: Scott H. Peters
   party: minority
   rank: 3
   bioguide: P000608
-  thomas: '02113'
 - name: Gene Green
   party: minority
   rank: 4
   bioguide: G000410
-  thomas: '00462'
 - name: Michael F. Doyle
   party: minority
   rank: 5
   bioguide: D000482
-  thomas: '00316'
 - name: Kathy Castor
   party: minority
   rank: 6
   bioguide: C001066
-  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 7
   bioguide: S001168
-  thomas: '01854'
 - name: Peter Welch
   party: minority
   rank: 8
   bioguide: W000800
-  thomas: '01879'
 - name: Paul Tonko
   party: minority
   rank: 9
   bioguide: T000469
-  thomas: '01942'
 - name: David Loebsack
   party: minority
   rank: 10
   bioguide: L000565
-  thomas: '01846'
 - name: Kurt Schrader
   party: minority
   rank: 11
   bioguide: S001180
-  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 12
   bioguide: K000379
-  thomas: '02172'
 - name: G. K. Butterfield
   party: minority
   rank: 13
   bioguide: B001251
-  thomas: '01761'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 14
   bioguide: P000034
-  thomas: '00887'
   title: Ex Officio
 HSIF14:
 - name: Michael C. Burgess
@@ -7023,170 +5838,137 @@ HSIF14:
   rank: 1
   title: Chair
   bioguide: B001248
-  thomas: '01751'
 - name: Brett Guthrie
   party: majority
   rank: 2
   bioguide: G000558
-  thomas: '01922'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
   bioguide: B000213
-  thomas: '00062'
 - name: Fred Upton
   party: majority
   rank: 4
   bioguide: U000031
-  thomas: '01177'
 - name: John Shimkus
   party: majority
   rank: 5
   bioguide: S000364
-  thomas: '01527'
 - name: Tim Murphy
   party: majority
   rank: 6
   bioguide: M001151
-  thomas: '01744'
 - name: Marsha Blackburn
   party: majority
   rank: 7
   bioguide: B001243
-  thomas: '01748'
 - name: Cathy McMorris Rodgers
   party: majority
   rank: 8
   bioguide: M001159
-  thomas: '01809'
 - name: Leonard Lance
   party: majority
   rank: 9
   bioguide: L000567
-  thomas: '01936'
 - name: H. Morgan Griffith
   party: majority
   rank: 10
   bioguide: G000568
-  thomas: '02070'
 - name: Gus M. Bilirakis
   party: majority
   rank: 11
   bioguide: B001257
-  thomas: '01838'
 - name: Billy Long
   party: majority
   rank: 12
   bioguide: L000576
-  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 13
   bioguide: B001275
-  thomas: '02018'
 - name: Susan W. Brooks
   party: majority
   rank: 14
   bioguide: B001284
-  thomas: '02129'
 - name: Markwayne Mullin
   party: majority
   rank: 15
   bioguide: M001190
-  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 16
   bioguide: H001067
-  thomas: '02140'
 - name: Chris Collins
   party: majority
   rank: 17
   bioguide: C001092
-  thomas: '02151'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 18
   bioguide: C001103
-  thomas: '02236'
 - name: Greg Walden
   party: majority
   rank: 19
   bioguide: W000791
-  thomas: '01596'
   title: Ex Officio
 - name: Gene Green
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: G000410
-  thomas: '00462'
 - name: Eliot L. Engel
   party: minority
   rank: 2
   bioguide: E000179
-  thomas: '00344'
 - name: Janice D. Schakowsky
   party: minority
   rank: 3
   bioguide: S001145
-  thomas: '01588'
 - name: G. K. Butterfield
   party: minority
   rank: 4
   bioguide: B001251
-  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 5
   bioguide: M001163
-  thomas: '01814'
 - name: Kathy Castor
   party: minority
   rank: 6
   bioguide: C001066
-  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 7
   bioguide: S001168
-  thomas: '01854'
 - name: Ben Ray Luján
   party: minority
   rank: 8
   bioguide: L000570
-  thomas: '01939'
 - name: Kurt Schrader
   party: minority
   rank: 9
   bioguide: S001180
-  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 10
   bioguide: K000379
-  thomas: '02172'
 - name: Tony Cárdenas
   party: minority
   rank: 11
   bioguide: C001097
-  thomas: '02107'
 - name: Anna G. Eshoo
   party: minority
   rank: 12
   bioguide: E000215
-  thomas: '00355'
 - name: Diana DeGette
   party: minority
   rank: 13
   bioguide: D000197
-  thomas: '01479'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 14
   bioguide: P000034
-  thomas: '00887'
   title: Ex Officio
 HSIF16:
 - name: Marsha Blackburn
@@ -7194,160 +5976,129 @@ HSIF16:
   rank: 1
   title: Chair
   bioguide: B001243
-  thomas: '01748'
 - name: Leonard Lance
   party: majority
   rank: 2
   bioguide: L000567
-  thomas: '01936'
   title: Vice Chair
 - name: John Shimkus
   party: majority
   rank: 3
   bioguide: S000364
-  thomas: '01527'
 - name: Steve Scalise
   party: majority
   rank: 4
   bioguide: S001176
-  thomas: '01892'
 - name: Robert E. Latta
   party: majority
   rank: 5
   bioguide: L000566
-  thomas: '01885'
 - name: Brett Guthrie
   party: majority
   rank: 6
   bioguide: G000558
-  thomas: '01922'
 - name: Pete Olson
   party: majority
   rank: 7
   bioguide: O000168
-  thomas: '01955'
 - name: Adam Kinzinger
   party: majority
   rank: 8
   bioguide: K000378
-  thomas: '02014'
 - name: Gus M. Bilirakis
   party: majority
   rank: 9
   bioguide: B001257
-  thomas: '01838'
 - name: Bill Johnson
   party: majority
   rank: 10
   bioguide: J000292
-  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 11
   bioguide: L000576
-  thomas: '02033'
 - name: Bill Flores
   party: majority
   rank: 12
   bioguide: F000461
-  thomas: '02065'
 - name: Susan W. Brooks
   party: majority
   rank: 13
   bioguide: B001284
-  thomas: '02129'
 - name: Chris Collins
   party: majority
   rank: 14
   bioguide: C001092
-  thomas: '02151'
 - name: Kevin Cramer
   party: majority
   rank: 15
   bioguide: C001096
-  thomas: '02144'
 - name: Mimi Walters
   party: majority
   rank: 16
   bioguide: W000820
-  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 17
   bioguide: C001106
-  thomas: '02266'
 - name: Greg Walden
   party: majority
   rank: 18
   bioguide: W000791
-  thomas: '01596'
   title: Ex Officio
 - name: Michael F. Doyle
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000482
-  thomas: '00316'
 - name: Peter Welch
   party: minority
   rank: 2
   bioguide: W000800
-  thomas: '01879'
 - name: Yvette D. Clarke
   party: minority
   rank: 3
   bioguide: C001067
-  thomas: '01864'
 - name: David Loebsack
   party: minority
   rank: 4
   bioguide: L000565
-  thomas: '01846'
 - name: Raul Ruiz
   party: minority
   rank: 5
   bioguide: R000599
-  thomas: '02109'
 - name: Debbie Dingell
   party: minority
   rank: 6
   bioguide: D000624
-  thomas: '02251'
 - name: Bobby L. Rush
   party: minority
   rank: 7
   bioguide: R000515
-  thomas: '01003'
 - name: Anna G. Eshoo
   party: minority
   rank: 8
   bioguide: E000215
-  thomas: '00355'
 - name: Eliot L. Engel
   party: minority
   rank: 9
   bioguide: E000179
-  thomas: '00344'
 - name: G. K. Butterfield
   party: minority
   rank: 10
   bioguide: B001251
-  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 11
   bioguide: M001163
-  thomas: '01814'
 - name: Jerry McNerney
   party: minority
   rank: 12
   bioguide: M001166
-  thomas: '01832'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 13
   bioguide: P000034
-  thomas: '00887'
   title: Ex Officio
 HSIF17:
 - name: Robert E. Latta
@@ -7355,125 +6106,101 @@ HSIF17:
   rank: 1
   title: Chair
   bioguide: L000566
-  thomas: '01885'
 - name: Gregg Harper
   party: majority
   rank: 2
   bioguide: H001045
-  thomas: '01933'
   title: Vice Chair
 - name: Fred Upton
   party: majority
   rank: 3
   bioguide: U000031
-  thomas: '01177'
 - name: Michael C. Burgess
   party: majority
   rank: 4
   bioguide: B001248
-  thomas: '01751'
 - name: Leonard Lance
   party: majority
   rank: 5
   bioguide: L000567
-  thomas: '01936'
 - name: Brett Guthrie
   party: majority
   rank: 6
   bioguide: G000558
-  thomas: '01922'
 - name: David B. McKinley
   party: majority
   rank: 7
   bioguide: M001180
-  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 8
   bioguide: K000378
-  thomas: '02014'
 - name: Gus M. Bilirakis
   party: majority
   rank: 9
   bioguide: B001257
-  thomas: '01838'
 - name: Larry Bucshon
   party: majority
   rank: 10
   bioguide: B001275
-  thomas: '02018'
 - name: Markwayne Mullin
   party: majority
   rank: 11
   bioguide: M001190
-  thomas: '02156'
 - name: Mimi Walters
   party: majority
   rank: 12
   bioguide: W000820
-  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 13
   bioguide: C001106
-  thomas: '02266'
 - name: Greg Walden
   party: majority
   rank: 14
   bioguide: W000791
-  thomas: '01596'
   title: Ex Officio
 - name: Janice D. Schakowsky
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001145
-  thomas: '01588'
 - name: Ben Ray Luján
   party: minority
   rank: 2
   bioguide: L000570
-  thomas: '01939'
 - name: Yvette D. Clarke
   party: minority
   rank: 3
   bioguide: C001067
-  thomas: '01864'
 - name: Tony Cárdenas
   party: minority
   rank: 4
   bioguide: C001097
-  thomas: '02107'
 - name: Debbie Dingell
   party: minority
   rank: 5
   bioguide: D000624
-  thomas: '02251'
 - name: Doris O. Matsui
   party: minority
   rank: 6
   bioguide: M001163
-  thomas: '01814'
 - name: Peter Welch
   party: minority
   rank: 7
   bioguide: W000800
-  thomas: '01879'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 8
   bioguide: K000379
-  thomas: '02172'
 - name: Gene Green
   party: minority
   rank: 9
   bioguide: G000410
-  thomas: '00462'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 10
   bioguide: P000034
-  thomas: '00887'
   title: Ex Officio
 HSIF18:
 - name: John Shimkus
@@ -7481,125 +6208,101 @@ HSIF18:
   rank: 1
   title: Chair
   bioguide: S000364
-  thomas: '01527'
 - name: David B. McKinley
   party: majority
   rank: 2
   bioguide: M001180
-  thomas: '02074'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
   bioguide: B000213
-  thomas: '00062'
 - name: Tim Murphy
   party: majority
   rank: 4
   bioguide: M001151
-  thomas: '01744'
 - name: Marsha Blackburn
   party: majority
   rank: 5
   bioguide: B001243
-  thomas: '01748'
 - name: Gregg Harper
   party: majority
   rank: 6
   bioguide: H001045
-  thomas: '01933'
 - name: Pete Olson
   party: majority
   rank: 7
   bioguide: O000168
-  thomas: '01955'
 - name: Bill Johnson
   party: majority
   rank: 8
   bioguide: J000292
-  thomas: '02046'
 - name: Bill Flores
   party: majority
   rank: 9
   bioguide: F000461
-  thomas: '02065'
 - name: Richard Hudson
   party: majority
   rank: 10
   bioguide: H001067
-  thomas: '02140'
 - name: Kevin Cramer
   party: majority
   rank: 11
   bioguide: C001096
-  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 12
   bioguide: W000798
-  thomas: '01855'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 13
   bioguide: C001103
-  thomas: '02236'
 - name: Greg Walden
   party: majority
   rank: 14
   bioguide: W000791
-  thomas: '01596'
   title: Ex Officio
 - name: Paul Tonko
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: T000469
-  thomas: '01942'
 - name: Raul Ruiz
   party: minority
   rank: 2
   bioguide: R000599
-  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 3
   bioguide: P000608
-  thomas: '02113'
 - name: Gene Green
   party: minority
   rank: 4
   bioguide: G000410
-  thomas: '00462'
 - name: Diana DeGette
   party: minority
   rank: 5
   bioguide: D000197
-  thomas: '01479'
 - name: Jerry McNerney
   party: minority
   rank: 6
   bioguide: M001166
-  thomas: '01832'
 - name: Tony Cárdenas
   party: minority
   rank: 7
   bioguide: C001097
-  thomas: '02107'
 - name: Debbie Dingell
   party: minority
   rank: 8
   bioguide: D000624
-  thomas: '02251'
 - name: Doris O. Matsui
   party: minority
   rank: 9
   bioguide: M001163
-  thomas: '01814'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 10
   bioguide: P000034
-  thomas: '00887'
   title: Ex Officio
 HSII:
 - name: Rob Bishop
@@ -7607,107 +6310,86 @@ HSII:
   rank: 1
   title: Chair
   bioguide: B001250
-  thomas: '01753'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
-  thomas: '01256'
 - name: Louie Gohmert
   party: majority
   rank: 3
   bioguide: G000552
-  thomas: '01801'
 - name: Doug Lamborn
   party: majority
   rank: 4
   bioguide: L000564
-  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 5
   bioguide: W000804
-  thomas: '01886'
 - name: Tom McClintock
   party: majority
   rank: 6
   bioguide: M001177
-  thomas: '01908'
 - name: Stevan Pearce
   party: majority
   rank: 7
   bioguide: P000588
-  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 8
   bioguide: T000467
-  thomas: '01952'
 - name: Paul A. Gosar
   party: majority
   rank: 9
   bioguide: G000565
-  thomas: '01992'
 - name: Raúl R. Labrador
   party: majority
   rank: 10
   bioguide: L000573
-  thomas: '02011'
 - name: Scott R. Tipton
   party: majority
   rank: 11
   bioguide: T000470
-  thomas: '01997'
 - name: Doug LaMalfa
   party: majority
   rank: 12
   bioguide: L000578
-  thomas: '02100'
 - name: Jeff Denham
   party: majority
   rank: 13
   bioguide: D000612
-  thomas: '01995'
 - name: Paul Cook
   party: majority
   rank: 14
   bioguide: C001094
-  thomas: '02103'
 - name: Bruce Westerman
   party: majority
   rank: 15
   bioguide: W000821
-  thomas: '02224'
 - name: Garret Graves
   party: majority
   rank: 16
   bioguide: G000577
-  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 17
   bioguide: H001071
-  thomas: '02237'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 18
   bioguide: R000600
-  thomas: '02222'
 - name: Darin LaHood
   party: majority
   rank: 19
   bioguide: L000585
-  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 20
   bioguide: W000806
-  thomas: '02002'
 - name: David Rouzer
   party: majority
   rank: 21
   bioguide: R000603
-  thomas: '02256'
 - name: Jack Bergman
   party: majority
   rank: 22
@@ -7729,62 +6411,50 @@ HSII:
   rank: 1
   title: Ranking Member
   bioguide: G000551
-  thomas: '01708'
 - name: Grace F. Napolitano
   party: minority
   rank: 2
   bioguide: N000179
-  thomas: '01602'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 3
   bioguide: B001245
-  thomas: '01723'
 - name: Jim Costa
   party: minority
   rank: 4
   bioguide: C001059
-  thomas: '01774'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 5
   bioguide: S001177
-  thomas: '01962'
 - name: Niki Tsongas
   party: minority
   rank: 6
   bioguide: T000465
-  thomas: '01884'
 - name: Jared Huffman
   party: minority
   rank: 7
   bioguide: H001068
-  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 8
   bioguide: L000579
-  thomas: '02111'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 9
   bioguide: B001292
-  thomas: '02272'
 - name: Norma J. Torres
   party: minority
   rank: 10
   bioguide: T000474
-  thomas: '02231'
 - name: Ruben Gallego
   party: minority
   rank: 11
   bioguide: G000574
-  thomas: '02226'
 - name: Colleen Hanabusa
   party: minority
   rank: 12
   bioguide: H001050
-  thomas: '02010'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 13
@@ -7809,69 +6479,56 @@ HSII:
   party: minority
   rank: 18
   bioguide: C001049
-  thomas: '01654'
 HSII06:
 - name: Paul A. Gosar
   party: majority
   rank: 1
   title: Chair
   bioguide: G000565
-  thomas: '01992'
 - name: Louie Gohmert
   party: majority
   rank: 2
   bioguide: G000552
-  thomas: '01801'
 - name: Doug Lamborn
   party: majority
   rank: 3
   bioguide: L000564
-  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 4
   bioguide: W000804
-  thomas: '01886'
 - name: Stevan Pearce
   party: majority
   rank: 5
   bioguide: P000588
-  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 6
   bioguide: T000467
-  thomas: '01952'
 - name: Scott R. Tipton
   party: majority
   rank: 7
   bioguide: T000470
-  thomas: '01997'
 - name: Paul Cook
   party: majority
   rank: 8
   bioguide: C001094
-  thomas: '02103'
 - name: Bruce Westerman
   party: majority
   rank: 9
   bioguide: W000821
-  thomas: '02224'
 - name: Garret Graves
   party: majority
   rank: 10
   bioguide: G000577
-  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 11
   bioguide: H001071
-  thomas: '02237'
 - name: Darin LaHood
   party: majority
   rank: 12
   bioguide: L000585
-  thomas: '02295'
 - name: Liz Cheney
   party: majority
   rank: 13
@@ -7880,14 +6537,12 @@ HSII06:
   party: majority
   rank: 14
   bioguide: B001250
-  thomas: '01753'
   title: Ex Officio
 - name: Alan S. Lowenthal
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000579
-  thomas: '02111'
 - name: Anthony G. Brown
   party: minority
   rank: 2
@@ -7896,22 +6551,18 @@ HSII06:
   party: minority
   rank: 3
   bioguide: C001059
-  thomas: '01774'
 - name: Niki Tsongas
   party: minority
   rank: 4
   bioguide: T000465
-  thomas: '01884'
 - name: Jared Huffman
   party: minority
   rank: 5
   bioguide: H001068
-  thomas: '02101'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
   bioguide: B001292
-  thomas: '02272'
 - name: Darren Soto
   party: minority
   rank: 7
@@ -7924,7 +6575,6 @@ HSII06:
   party: minority
   rank: 11
   bioguide: G000551
-  thomas: '01708'
   title: Ex Officio
 HSII10:
 - name: Tom McClintock
@@ -7932,52 +6582,42 @@ HSII10:
   rank: 1
   title: Chair
   bioguide: M001177
-  thomas: '01908'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
-  thomas: '01256'
 - name: Stevan Pearce
   party: majority
   rank: 3
   bioguide: P000588
-  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 4
   bioguide: T000467
-  thomas: '01952'
 - name: Raúl R. Labrador
   party: majority
   rank: 5
   bioguide: L000573
-  thomas: '02011'
 - name: Scott R. Tipton
   party: majority
   rank: 6
   bioguide: T000470
-  thomas: '01997'
 - name: Bruce Westerman
   party: majority
   rank: 7
   bioguide: W000821
-  thomas: '02224'
 - name: Darin LaHood
   party: majority
   rank: 8
   bioguide: L000585
-  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 9
   bioguide: W000806
-  thomas: '02002'
 - name: David Rouzer
   party: majority
   rank: 10
   bioguide: R000603
-  thomas: '02256'
 - name: Jack Bergman
   party: majority
   rank: 11
@@ -7990,34 +6630,28 @@ HSII10:
   party: majority
   rank: 13
   bioguide: B001250
-  thomas: '01753'
   title: Ex Officio
 - name: Colleen Hanabusa
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001050
-  thomas: '02010'
 - name: Niki Tsongas
   party: minority
   rank: 2
   bioguide: T000465
-  thomas: '01884'
 - name: Alan S. Lowenthal
   party: minority
   rank: 3
   bioguide: L000579
-  thomas: '02111'
 - name: Norma J. Torres
   party: minority
   rank: 4
   bioguide: T000474
-  thomas: '02231'
 - name: Ruben Gallego
   party: minority
   rank: 5
   bioguide: G000574
-  thomas: '02226'
 - name: Jimmy Panetta
   party: minority
   rank: 6
@@ -8034,7 +6668,6 @@ HSII10:
   party: minority
   rank: 10
   bioguide: G000551
-  thomas: '01708'
   title: Ex Officio
 HSII13:
 - name: Doug Lamborn
@@ -8042,52 +6675,42 @@ HSII13:
   rank: 1
   title: Chair
   bioguide: L000564
-  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 2
   bioguide: W000804
-  thomas: '01886'
 - name: Tom McClintock
   party: majority
   rank: 3
   bioguide: M001177
-  thomas: '01908'
 - name: Paul A. Gosar
   party: majority
   rank: 4
   bioguide: G000565
-  thomas: '01992'
 - name: Doug LaMalfa
   party: majority
   rank: 5
   bioguide: L000578
-  thomas: '02100'
 - name: Jeff Denham
   party: majority
   rank: 6
   bioguide: D000612
-  thomas: '01995'
 - name: Garret Graves
   party: majority
   rank: 7
   bioguide: G000577
-  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 8
   bioguide: H001071
-  thomas: '02237'
 - name: Daniel Webster
   party: majority
   rank: 9
   bioguide: W000806
-  thomas: '02002'
 - name: David Rouzer
   party: majority
   rank: 10
   bioguide: R000603
-  thomas: '02256'
 - name: Mike Johnson
   party: majority
   rank: 11
@@ -8096,29 +6719,24 @@ HSII13:
   party: majority
   rank: 12
   bioguide: B001250
-  thomas: '01753'
   title: Ex Officio
 - name: Jared Huffman
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001068
-  thomas: '02101'
 - name: Grace F. Napolitano
   party: minority
   rank: 2
   bioguide: N000179
-  thomas: '01602'
 - name: Jim Costa
   party: minority
   rank: 3
   bioguide: C001059
-  thomas: '01774'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 4
   bioguide: B001292
-  thomas: '02272'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 5
@@ -8131,17 +6749,14 @@ HSII13:
   party: minority
   rank: 7
   bioguide: B001245
-  thomas: '01723'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 8
   bioguide: S001177
-  thomas: '01962'
 - name: Raúl M. Grijalva
   party: minority
   rank: 9
   bioguide: G000551
-  thomas: '01708'
   title: Ex Officio
 HSII15:
 - name: Raúl R. Labrador
@@ -8149,17 +6764,14 @@ HSII15:
   rank: 1
   title: Chair
   bioguide: L000573
-  thomas: '02011'
 - name: Louie Gohmert
   party: majority
   rank: 2
   bioguide: G000552
-  thomas: '01801'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
   bioguide: R000600
-  thomas: '02222'
 - name: Jack Bergman
   party: majority
   rank: 4
@@ -8176,7 +6788,6 @@ HSII15:
   party: majority
   rank: 7
   bioguide: B001250
-  thomas: '01753'
   title: Ex Officio
 - name: A. Donald McEachin
   party: minority
@@ -8187,12 +6798,10 @@ HSII15:
   party: minority
   rank: 2
   bioguide: G000574
-  thomas: '02226'
 - name: Jared Huffman
   party: minority
   rank: 3
   bioguide: H001068
-  thomas: '02101'
 - name: Darren Soto
   party: minority
   rank: 4
@@ -8201,12 +6810,10 @@ HSII15:
   party: minority
   rank: 5
   bioguide: C001049
-  thomas: '01654'
 - name: Raúl M. Grijalva
   party: minority
   rank: 6
   bioguide: G000551
-  thomas: '01708'
   title: Ex Officio
 HSII24:
 - name: Doug LaMalfa
@@ -8214,32 +6821,26 @@ HSII24:
   rank: 1
   title: Chair
   bioguide: L000578
-  thomas: '02100'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
-  thomas: '01256'
 - name: Jeff Denham
   party: majority
   rank: 3
   bioguide: D000612
-  thomas: '01995'
 - name: Paul Cook
   party: majority
   rank: 4
   bioguide: C001094
-  thomas: '02103'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
   bioguide: R000600
-  thomas: '02222'
 - name: Darin LaHood
   party: majority
   rank: 6
   bioguide: L000585
-  thomas: '02295'
 - name: Jack Bergman
   party: majority
   rank: 7
@@ -8252,29 +6853,24 @@ HSII24:
   party: majority
   rank: 9
   bioguide: B001250
-  thomas: '01753'
   title: Ex Officio
 - name: Norma J. Torres
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: T000474
-  thomas: '02231'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 2
   bioguide: B001245
-  thomas: '01723'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 3
   bioguide: S001177
-  thomas: '01962'
 - name: Ruben Gallego
   party: minority
   rank: 4
   bioguide: G000574
-  thomas: '02226'
 - name: Darren Soto
   party: minority
   rank: 5
@@ -8283,12 +6879,10 @@ HSII24:
   party: minority
   rank: 6
   bioguide: H001050
-  thomas: '02010'
 - name: Raúl M. Grijalva
   party: minority
   rank: 7
   bioguide: G000551
-  thomas: '01708'
   title: Ex Officio
 HSJU:
 - name: Bob Goodlatte
@@ -8296,102 +6890,82 @@ HSJU:
   rank: 1
   title: Chair
   bioguide: G000289
-  thomas: '00446'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 2
   bioguide: S000244
-  thomas: '01041'
 - name: Lamar Smith
   party: majority
   rank: 3
   bioguide: S000583
-  thomas: '01075'
 - name: Steve Chabot
   party: majority
   rank: 4
   bioguide: C000266
-  thomas: '00186'
 - name: Darrell E. Issa
   party: majority
   rank: 5
   bioguide: I000056
-  thomas: '01640'
 - name: Steve King
   party: majority
   rank: 6
   bioguide: K000362
-  thomas: '01724'
 - name: Trent Franks
   party: majority
   rank: 7
   bioguide: F000448
-  thomas: '01707'
 - name: Louie Gohmert
   party: majority
   rank: 8
   bioguide: G000552
-  thomas: '01801'
 - name: Jim Jordan
   party: majority
   rank: 9
   bioguide: J000289
-  thomas: '01868'
 - name: Ted Poe
   party: majority
   rank: 10
   bioguide: P000592
-  thomas: '01802'
 - name: Jason Chaffetz
   party: majority
   rank: 11
   bioguide: C001076
-  thomas: '01956'
 - name: Tom Marino
   party: majority
   rank: 12
   bioguide: M001179
-  thomas: '02053'
 - name: Trey Gowdy
   party: majority
   rank: 13
   bioguide: G000566
-  thomas: '02058'
 - name: Raúl R. Labrador
   party: majority
   rank: 14
   bioguide: L000573
-  thomas: '02011'
 - name: Blake Farenthold
   party: majority
   rank: 15
   bioguide: F000460
-  thomas: '02067'
 - name: Doug Collins
   party: majority
   rank: 16
   bioguide: C001093
-  thomas: '02121'
 - name: Ron DeSantis
   party: majority
   rank: 17
   bioguide: D000621
-  thomas: '02116'
 - name: Ken Buck
   party: majority
   rank: 18
   bioguide: B001297
-  thomas: '02233'
 - name: John Ratcliffe
   party: majority
   rank: 19
   bioguide: R000601
-  thomas: '02268'
 - name: Martha Roby
   party: majority
   rank: 20
   bioguide: R000591
-  thomas: '01986'
 - name: Matt Gaetz
   party: majority
   rank: 21
@@ -8409,72 +6983,58 @@ HSJU:
   rank: 1
   title: Ranking Member
   bioguide: C000714
-  thomas: '00229'
 - name: Jerrold Nadler
   party: minority
   rank: 2
   bioguide: N000002
-  thomas: '00850'
 - name: Zoe Lofgren
   party: minority
   rank: 3
   bioguide: L000397
-  thomas: '00701'
 - name: Sheila Jackson Lee
   party: minority
   rank: 4
   bioguide: J000032
-  thomas: '00588'
 - name: Steve Cohen
   party: minority
   rank: 5
   bioguide: C001068
-  thomas: '01878'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 6
   bioguide: J000288
-  thomas: '01843'
 - name: Theodore E. Deutch
   party: minority
   rank: 7
   bioguide: D000610
-  thomas: '01976'
 - name: Luis V. Gutiérrez
   party: minority
   rank: 8
   bioguide: G000535
-  thomas: '00478'
 - name: Karen Bass
   party: minority
   rank: 9
   bioguide: B001270
-  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
   rank: 10
   bioguide: R000588
-  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 11
   bioguide: J000294
-  thomas: '02149'
 - name: David N. Cicilline
   party: minority
   rank: 12
   bioguide: C001084
-  thomas: '02055'
 - name: Eric Swalwell
   party: minority
   rank: 13
   bioguide: S001193
-  thomas: '02104'
 - name: Ted Lieu
   party: minority
   rank: 14
   bioguide: L000582
-  thomas: '02230'
 - name: Jamie Raskin
   party: minority
   rank: 15
@@ -8487,40 +7047,33 @@ HSJU:
   party: minority
   rank: 17
   bioguide: S001190
-  thomas: '02124'
 HSJU01:
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 1
   title: Chair
   bioguide: S000244
-  thomas: '01041'
 - name: Raúl R. Labrador
   party: majority
   rank: 2
   bioguide: L000573
-  thomas: '02011'
   title: Vice Chair
 - name: Lamar Smith
   party: majority
   rank: 3
   bioguide: S000583
-  thomas: '01075'
 - name: Steve King
   party: majority
   rank: 4
   bioguide: K000362
-  thomas: '01724'
 - name: Jim Jordan
   party: majority
   rank: 5
   bioguide: J000289
-  thomas: '01868'
 - name: Ken Buck
   party: majority
   rank: 6
   bioguide: B001297
-  thomas: '02233'
 - name: Mike Johnson
   party: majority
   rank: 7
@@ -8534,12 +7087,10 @@ HSJU01:
   rank: 1
   title: Ranking Member
   bioguide: L000397
-  thomas: '00701'
 - name: Luis V. Gutiérrez
   party: minority
   rank: 2
   bioguide: G000535
-  thomas: '00478'
 - name: Pramila Jayapal
   party: minority
   rank: 3
@@ -8548,70 +7099,57 @@ HSJU01:
   party: minority
   rank: 4
   bioguide: J000032
-  thomas: '00588'
 HSJU03:
 - name: Darrell E. Issa
   party: majority
   rank: 1
   title: Chair
   bioguide: I000056
-  thomas: '01640'
 - name: Doug Collins
   party: majority
   rank: 2
   bioguide: C001093
-  thomas: '02121'
   title: Vice Chair
 - name: Lamar Smith
   party: majority
   rank: 3
   bioguide: S000583
-  thomas: '01075'
 - name: Steve Chabot
   party: majority
   rank: 4
   bioguide: C000266
-  thomas: '00186'
 - name: Trent Franks
   party: majority
   rank: 5
   bioguide: F000448
-  thomas: '01707'
 - name: Jim Jordan
   party: majority
   rank: 6
   bioguide: J000289
-  thomas: '01868'
 - name: Ted Poe
   party: majority
   rank: 7
   bioguide: P000592
-  thomas: '01802'
 - name: Jason Chaffetz
   party: majority
   rank: 8
   bioguide: C001076
-  thomas: '01956'
 - name: Tom Marino
   party: majority
   rank: 9
   bioguide: M001179
-  thomas: '02053'
 - name: Raúl R. Labrador
   party: majority
   rank: 10
   bioguide: L000573
-  thomas: '02011'
 - name: Blake Farenthold
   party: majority
   rank: 11
   bioguide: F000460
-  thomas: '02067'
 - name: Ron DeSantis
   party: majority
   rank: 12
   bioguide: D000621
-  thomas: '02116'
 - name: Matt Gaetz
   party: majority
   rank: 13
@@ -8625,90 +7163,73 @@ HSJU03:
   rank: 1
   title: Ranking Member
   bioguide: N000002
-  thomas: '00850'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 2
   bioguide: J000288
-  thomas: '01843'
 - name: Theodore E. Deutch
   party: minority
   rank: 3
   bioguide: D000610
-  thomas: '01976'
 - name: Karen Bass
   party: minority
   rank: 4
   bioguide: B001270
-  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
   rank: 5
   bioguide: R000588
-  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 6
   bioguide: J000294
-  thomas: '02149'
 - name: Eric Swalwell
   party: minority
   rank: 7
   bioguide: S001193
-  thomas: '02104'
 - name: Ted Lieu
   party: minority
   rank: 8
   bioguide: L000582
-  thomas: '02230'
 - name: Zoe Lofgren
   party: minority
   rank: 9
   bioguide: L000397
-  thomas: '00701'
 - name: Steve Cohen
   party: minority
   rank: 10
   bioguide: C001068
-  thomas: '01878'
 - name: Luis V. Gutiérrez
   party: minority
   rank: 11
   bioguide: G000535
-  thomas: '00478'
 HSJU05:
 - name: Tom Marino
   party: majority
   rank: 1
   title: Chair
   bioguide: M001179
-  thomas: '02053'
 - name: Blake Farenthold
   party: majority
   rank: 2
   bioguide: F000460
-  thomas: '02067'
   title: Vice Chair
 - name: Darrell E. Issa
   party: majority
   rank: 3
   bioguide: I000056
-  thomas: '01640'
 - name: Doug Collins
   party: majority
   rank: 4
   bioguide: C001093
-  thomas: '02121'
 - name: Ken Buck
   party: majority
   rank: 5
   bioguide: B001297
-  thomas: '02233'
 - name: John Ratcliffe
   party: majority
   rank: 6
   bioguide: R000601
-  thomas: '02268'
 - name: Matt Gaetz
   party: majority
   rank: 7
@@ -8718,17 +7239,14 @@ HSJU05:
   rank: 1
   title: Ranking Member
   bioguide: C001084
-  thomas: '02055'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 2
   bioguide: J000288
-  thomas: '01843'
 - name: Eric Swalwell
   party: minority
   rank: 3
   bioguide: S001193
-  thomas: '02104'
 - name: Jamie Raskin
   party: minority
   rank: 4
@@ -8743,43 +7261,35 @@ HSJU08:
   rank: 1
   title: Chair
   bioguide: G000566
-  thomas: '02058'
 - name: Louie Gohmert
   party: majority
   rank: 2
   bioguide: G000552
-  thomas: '01801'
   title: Vice Chair
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 3
   bioguide: S000244
-  thomas: '01041'
 - name: Steve Chabot
   party: majority
   rank: 4
   bioguide: C000266
-  thomas: '00186'
 - name: Ted Poe
   party: majority
   rank: 5
   bioguide: P000592
-  thomas: '01802'
 - name: Jason Chaffetz
   party: majority
   rank: 6
   bioguide: C001076
-  thomas: '01956'
 - name: John Ratcliffe
   party: majority
   rank: 7
   bioguide: R000601
-  thomas: '02268'
 - name: Martha Roby
   party: majority
   rank: 8
   bioguide: R000591
-  thomas: '01986'
 - name: Mike Johnson
   party: majority
   rank: 9
@@ -8789,71 +7299,58 @@ HSJU08:
   rank: 1
   title: Ranking Member
   bioguide: J000032
-  thomas: '00588'
 - name: Theodore E. Deutch
   party: minority
   rank: 2
   bioguide: D000610
-  thomas: '01976'
 - name: Karen Bass
   party: minority
   rank: 3
   bioguide: B001270
-  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
   rank: 4
   bioguide: R000588
-  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
   bioguide: J000294
-  thomas: '02149'
 - name: David N. Cicilline
   party: minority
   rank: 6
   bioguide: C001084
-  thomas: '02055'
 - name: Ted Lieu
   party: minority
   rank: 7
   bioguide: L000582
-  thomas: '02230'
 HSJU10:
 - name: Steve King
   party: majority
   rank: 1
   title: Chair
   bioguide: K000362
-  thomas: '01724'
 - name: Ron DeSantis
   party: majority
   rank: 2
   bioguide: D000621
-  thomas: '02116'
   title: Vice Chair
 - name: Trent Franks
   party: majority
   rank: 3
   bioguide: F000448
-  thomas: '01707'
 - name: Louie Gohmert
   party: majority
   rank: 4
   bioguide: G000552
-  thomas: '01801'
 - name: Trey Gowdy
   party: majority
   rank: 5
   bioguide: G000566
-  thomas: '02058'
 - name: Steve Cohen
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001068
-  thomas: '01878'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -8862,150 +7359,121 @@ HSJU10:
   party: minority
   rank: 3
   bioguide: N000002
-  thomas: '00850'
 HSPW:
 - name: Bill Shuster
   party: majority
   rank: 1
   title: Chair
   bioguide: S001154
-  thomas: '01681'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
-  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
   bioguide: D000533
-  thomas: '00322'
   title: Vice Chair
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
   bioguide: L000554
-  thomas: '00699'
 - name: Sam Graves
   party: majority
   rank: 5
   bioguide: G000546
-  thomas: '01656'
 - name: Duncan Hunter
   party: majority
   rank: 6
   bioguide: H001048
-  thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 7
   bioguide: C001087
-  thomas: '01989'
 - name: Lou Barletta
   party: majority
   rank: 8
   bioguide: B001269
-  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 9
   bioguide: F000460
-  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 10
   bioguide: G000563
-  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 11
   bioguide: W000806
-  thomas: '02002'
 - name: Jeff Denham
   party: majority
   rank: 12
   bioguide: D000612
-  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 13
   bioguide: M001184
-  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 14
   bioguide: M001187
-  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 15
   bioguide: P000605
-  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 16
   bioguide: D000619
-  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 17
   bioguide: S000051
-  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 18
   bioguide: W000810
-  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 19
   bioguide: R000592
-  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 20
   bioguide: K000386
-  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 21
   bioguide: B001291
-  thomas: '02270'
 - name: Garret Graves
   party: majority
   rank: 22
   bioguide: G000577
-  thomas: '02245'
 - name: Barbara Comstock
   party: majority
   rank: 23
   bioguide: C001105
-  thomas: '02273'
 - name: David Rouzer
   party: majority
   rank: 24
   bioguide: R000603
-  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 25
   bioguide: B001295
-  thomas: '02243'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 26
   bioguide: W000814
-  thomas: '02161'
 - name: Doug LaMalfa
   party: majority
   rank: 27
   bioguide: L000578
-  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 28
   bioguide: W000821
-  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 29
@@ -9035,214 +7503,172 @@ HSPW:
   rank: 1
   title: Ranking Member
   bioguide: D000191
-  thomas: '00279'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 2
   bioguide: N000147
-  thomas: '00868'
 - name: Jerrold Nadler
   party: minority
   rank: 3
   bioguide: N000002
-  thomas: '00850'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 4
   bioguide: J000126
-  thomas: '00599'
 - name: Elijah E. Cummings
   party: minority
   rank: 5
   bioguide: C000984
-  thomas: '00256'
 - name: Rick Larsen
   party: minority
   rank: 6
   bioguide: L000560
-  thomas: '01675'
 - name: Michael E. Capuano
   party: minority
   rank: 7
   bioguide: C001037
-  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
   rank: 8
   bioguide: N000179
-  thomas: '01602'
 - name: Daniel Lipinski
   party: minority
   rank: 9
   bioguide: L000563
-  thomas: '01781'
 - name: Steve Cohen
   party: minority
   rank: 10
   bioguide: C001068
-  thomas: '01878'
 - name: Albio Sires
   party: minority
   rank: 11
   bioguide: S001165
-  thomas: '01818'
 - name: John Garamendi
   party: minority
   rank: 12
   bioguide: G000559
-  thomas: '01973'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 13
   bioguide: J000288
-  thomas: '01843'
 - name: André Carson
   party: minority
   rank: 14
   bioguide: C001072
-  thomas: '01889'
 - name: Richard M. Nolan
   party: minority
   rank: 15
   bioguide: N000127
-  thomas: '00867'
 - name: Dina Titus
   party: minority
   rank: 16
   bioguide: T000468
-  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 17
   bioguide: M001185
-  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
   rank: 18
   bioguide: E000293
-  thomas: '02114'
 - name: Lois Frankel
   party: minority
   rank: 19
   bioguide: F000462
-  thomas: '02119'
 - name: Cheri Bustos
   party: minority
   rank: 20
   bioguide: B001286
-  thomas: '02127'
 - name: Jared Huffman
   party: minority
   rank: 21
   bioguide: H001068
-  thomas: '02101'
 - name: Julia Brownley
   party: minority
   rank: 22
   bioguide: B001285
-  thomas: '02106'
 - name: Frederica S. Wilson
   party: minority
   rank: 23
   bioguide: W000808
-  thomas: '02004'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 24
   bioguide: P000604
-  thomas: '02097'
 - name: Alan S. Lowenthal
   party: minority
   rank: 25
   bioguide: L000579
-  thomas: '02111'
 - name: Brenda L. Lawrence
   party: minority
   rank: 26
   bioguide: L000581
-  thomas: '02252'
 - name: Mark DeSaulnier
   party: minority
   rank: 27
   bioguide: D000623
-  thomas: '02227'
 HSPW02:
 - name: Garret Graves
   party: majority
   rank: 1
   title: Chair
   bioguide: G000577
-  thomas: '02245'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
   bioguide: C001087
-  thomas: '01989'
 - name: Bob Gibbs
   party: majority
   rank: 3
   bioguide: G000563
-  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 4
   bioguide: W000806
-  thomas: '02002'
 - name: Thomas Massie
   party: majority
   rank: 5
   bioguide: M001184
-  thomas: '02094'
 - name: Rodney Davis
   party: majority
   rank: 6
   bioguide: D000619
-  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 7
   bioguide: S000051
-  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 8
   bioguide: W000810
-  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 9
   bioguide: R000592
-  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 10
   bioguide: K000386
-  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 11
   bioguide: B001291
-  thomas: '02270'
 - name: David Rouzer
   party: majority
   rank: 12
   bioguide: R000603
-  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 13
   bioguide: B001295
-  thomas: '02243'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 14
   bioguide: W000814
-  thomas: '02161'
 - name: Doug LaMalfa
   party: majority
   rank: 15
   bioguide: L000578
-  thomas: '02100'
 - name: A. Drew Ferguson IV
   party: majority
   rank: 16
@@ -9256,164 +7682,132 @@ HSPW02:
   rank: 1
   title: Ranking Member
   bioguide: N000179
-  thomas: '01602'
 - name: Lois Frankel
   party: minority
   rank: 2
   bioguide: F000462
-  thomas: '02119'
 - name: Frederica S. Wilson
   party: minority
   rank: 3
   bioguide: W000808
-  thomas: '02004'
 - name: Jared Huffman
   party: minority
   rank: 4
   bioguide: H001068
-  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
   bioguide: L000579
-  thomas: '02111'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
   bioguide: J000126
-  thomas: '00599'
 - name: John Garamendi
   party: minority
   rank: 7
   bioguide: G000559
-  thomas: '01973'
 - name: Dina Titus
   party: minority
   rank: 8
   bioguide: T000468
-  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 9
   bioguide: M001185
-  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
   rank: 10
   bioguide: E000293
-  thomas: '02114'
 - name: Cheri Bustos
   party: minority
   rank: 11
   bioguide: B001286
-  thomas: '02127'
 - name: Julia Brownley
   party: minority
   rank: 12
   bioguide: B001285
-  thomas: '02106'
 - name: Brenda L. Lawrence
   party: minority
   rank: 13
   bioguide: L000581
-  thomas: '02252'
 HSPW05:
 - name: Frank A. LoBiondo
   party: majority
   rank: 1
   title: Chair
   bioguide: L000554
-  thomas: '00699'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
-  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
   bioguide: D000533
-  thomas: '00322'
 - name: Sam Graves
   party: majority
   rank: 4
   bioguide: G000546
-  thomas: '01656'
 - name: Duncan Hunter
   party: majority
   rank: 5
   bioguide: H001048
-  thomas: '01909'
 - name: Blake Farenthold
   party: majority
   rank: 6
   bioguide: F000460
-  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 7
   bioguide: G000563
-  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 8
   bioguide: W000806
-  thomas: '02002'
 - name: Jeff Denham
   party: majority
   rank: 9
   bioguide: D000612
-  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 10
   bioguide: M001184
-  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 11
   bioguide: M001187
-  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 12
   bioguide: P000605
-  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 13
   bioguide: D000619
-  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 14
   bioguide: S000051
-  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 15
   bioguide: W000810
-  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 16
   bioguide: R000592
-  thomas: '02017'
 - name: Barbara Comstock
   party: majority
   rank: 17
   bioguide: C001105
-  thomas: '02273'
 - name: Doug LaMalfa
   party: majority
   rank: 18
   bioguide: L000578
-  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 19
   bioguide: W000821
-  thomas: '02224'
 - name: Paul Mitchell
   party: majority
   rank: 20
@@ -9427,114 +7821,92 @@ HSPW05:
   rank: 1
   title: Ranking Member
   bioguide: L000560
-  thomas: '01675'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 2
   bioguide: J000126
-  thomas: '00599'
 - name: Daniel Lipinski
   party: minority
   rank: 3
   bioguide: L000563
-  thomas: '01781'
 - name: André Carson
   party: minority
   rank: 4
   bioguide: C001072
-  thomas: '01889'
 - name: Cheri Bustos
   party: minority
   rank: 5
   bioguide: B001286
-  thomas: '02127'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 6
   bioguide: N000147
-  thomas: '00868'
 - name: Dina Titus
   party: minority
   rank: 7
   bioguide: T000468
-  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 8
   bioguide: M001185
-  thomas: '02150'
 - name: Julia Brownley
   party: minority
   rank: 9
   bioguide: B001285
-  thomas: '02106'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 10
   bioguide: P000604
-  thomas: '02097'
 - name: Brenda L. Lawrence
   party: minority
   rank: 11
   bioguide: L000581
-  thomas: '02252'
 - name: Michael E. Capuano
   party: minority
   rank: 12
   bioguide: C001037
-  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
   rank: 13
   bioguide: N000179
-  thomas: '01602'
 - name: Steve Cohen
   party: minority
   rank: 14
   bioguide: C001068
-  thomas: '01878'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 15
   bioguide: J000288
-  thomas: '01843'
 - name: Richard M. Nolan
   party: minority
   rank: 16
   bioguide: N000127
-  thomas: '00867'
 HSPW07:
 - name: Duncan Hunter
   party: majority
   rank: 1
   title: Chair
   bioguide: H001048
-  thomas: '01909'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
-  thomas: '01256'
 - name: Frank A. LoBiondo
   party: majority
   rank: 3
   bioguide: L000554
-  thomas: '00699'
 - name: Garret Graves
   party: majority
   rank: 4
   bioguide: G000577
-  thomas: '02245'
 - name: David Rouzer
   party: majority
   rank: 5
   bioguide: R000603
-  thomas: '02256'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 6
   bioguide: W000814
-  thomas: '02161'
 - name: Brian J. Mast
   party: majority
   rank: 7
@@ -9548,149 +7920,120 @@ HSPW07:
   rank: 1
   title: Ranking Member
   bioguide: G000559
-  thomas: '01973'
 - name: Elijah E. Cummings
   party: minority
   rank: 2
   bioguide: C000984
-  thomas: '00256'
 - name: Rick Larsen
   party: minority
   rank: 3
   bioguide: L000560
-  thomas: '01675'
 - name: Jared Huffman
   party: minority
   rank: 4
   bioguide: H001068
-  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
   bioguide: L000579
-  thomas: '02111'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 6
   bioguide: N000147
-  thomas: '00868'
 HSPW12:
 - name: Sam Graves
   party: majority
   rank: 1
   title: Chair
   bioguide: G000546
-  thomas: '01656'
 - name: Don Young
   party: majority
   rank: 2
   bioguide: Y000033
-  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
   bioguide: D000533
-  thomas: '00322'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
   bioguide: L000554
-  thomas: '00699'
 - name: Duncan Hunter
   party: majority
   rank: 5
   bioguide: H001048
-  thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 6
   bioguide: C001087
-  thomas: '01989'
 - name: Lou Barletta
   party: majority
   rank: 7
   bioguide: B001269
-  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 8
   bioguide: F000460
-  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 9
   bioguide: G000563
-  thomas: '02049'
 - name: Jeff Denham
   party: majority
   rank: 10
   bioguide: D000612
-  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 11
   bioguide: M001184
-  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 12
   bioguide: M001187
-  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 13
   bioguide: P000605
-  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 14
   bioguide: D000619
-  thomas: '02126'
 - name: Rob Woodall
   party: majority
   rank: 15
   bioguide: W000810
-  thomas: '02008'
 - name: John Katko
   party: majority
   rank: 16
   bioguide: K000386
-  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 17
   bioguide: B001291
-  thomas: '02270'
 - name: Garret Graves
   party: majority
   rank: 18
   bioguide: G000577
-  thomas: '02245'
 - name: Barbara Comstock
   party: majority
   rank: 19
   bioguide: C001105
-  thomas: '02273'
 - name: David Rouzer
   party: majority
   rank: 20
   bioguide: R000603
-  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 21
   bioguide: B001295
-  thomas: '02243'
 - name: Doug LaMalfa
   party: majority
   rank: 22
   bioguide: L000578
-  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 23
   bioguide: W000821
-  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 24
@@ -9712,129 +8055,104 @@ HSPW12:
   rank: 1
   title: Ranking Member
   bioguide: N000147
-  thomas: '00868'
 - name: Jerrold Nadler
   party: minority
   rank: 2
   bioguide: N000002
-  thomas: '00850'
 - name: Steve Cohen
   party: minority
   rank: 3
   bioguide: C001068
-  thomas: '01878'
 - name: Albio Sires
   party: minority
   rank: 4
   bioguide: S001165
-  thomas: '01818'
 - name: Richard M. Nolan
   party: minority
   rank: 5
   bioguide: N000127
-  thomas: '00867'
 - name: Dina Titus
   party: minority
   rank: 6
   bioguide: T000468
-  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 7
   bioguide: M001185
-  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
   rank: 8
   bioguide: E000293
-  thomas: '02114'
 - name: Jared Huffman
   party: minority
   rank: 9
   bioguide: H001068
-  thomas: '02101'
 - name: Julia Brownley
   party: minority
   rank: 10
   bioguide: B001285
-  thomas: '02106'
 - name: Alan S. Lowenthal
   party: minority
   rank: 11
   bioguide: L000579
-  thomas: '02111'
 - name: Brenda L. Lawrence
   party: minority
   rank: 12
   bioguide: L000581
-  thomas: '02252'
 - name: Mark DeSaulnier
   party: minority
   rank: 13
   bioguide: D000623
-  thomas: '02227'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 14
   bioguide: J000126
-  thomas: '00599'
 - name: Michael E. Capuano
   party: minority
   rank: 15
   bioguide: C001037
-  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
   rank: 16
   bioguide: N000179
-  thomas: '01602'
 - name: Daniel Lipinski
   party: minority
   rank: 17
   bioguide: L000563
-  thomas: '01781'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 18
   bioguide: J000288
-  thomas: '01843'
 - name: Lois Frankel
   party: minority
   rank: 19
   bioguide: F000462
-  thomas: '02119'
 - name: Cheri Bustos
   party: minority
   rank: 20
   bioguide: B001286
-  thomas: '02127'
 - name: Frederica S. Wilson
   party: minority
   rank: 21
   bioguide: W000808
-  thomas: '02004'
 HSPW13:
 - name: Lou Barletta
   party: majority
   rank: 1
   title: Chair
   bioguide: B001269
-  thomas: '02054'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
   bioguide: C001087
-  thomas: '01989'
 - name: Barbara Comstock
   party: majority
   rank: 3
   bioguide: C001105
-  thomas: '02273'
 - name: Mike Bost
   party: majority
   rank: 4
   bioguide: B001295
-  thomas: '02243'
 - name: Lloyd Smucker
   party: majority
   rank: 5
@@ -9856,99 +8174,80 @@ HSPW13:
   rank: 1
   title: Ranking Member
   bioguide: J000288
-  thomas: '01843'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 2
   bioguide: N000147
-  thomas: '00868'
 - name: Albio Sires
   party: minority
   rank: 3
   bioguide: S001165
-  thomas: '01818'
 - name: Grace F. Napolitano
   party: minority
   rank: 4
   bioguide: N000179
-  thomas: '01602'
 - name: Michael E. Capuano
   party: minority
   rank: 5
   bioguide: C001037
-  thomas: '01564'
 HSPW14:
 - name: Jeff Denham
   party: majority
   rank: 1
   title: Chair
   bioguide: D000612
-  thomas: '01995'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 2
   bioguide: D000533
-  thomas: '00322'
 - name: Sam Graves
   party: majority
   rank: 3
   bioguide: G000546
-  thomas: '01656'
 - name: Lou Barletta
   party: majority
   rank: 4
   bioguide: B001269
-  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 5
   bioguide: F000460
-  thomas: '02067'
 - name: Daniel Webster
   party: majority
   rank: 6
   bioguide: W000806
-  thomas: '02002'
 - name: Mark Meadows
   party: majority
   rank: 7
   bioguide: M001187
-  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 8
   bioguide: P000605
-  thomas: '02157'
 - name: Mark Sanford
   party: majority
   rank: 9
   bioguide: S000051
-  thomas: '01012'
 - name: Todd Rokita
   party: majority
   rank: 10
   bioguide: R000592
-  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 11
   bioguide: K000386
-  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 12
   bioguide: B001291
-  thomas: '02270'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 13
   bioguide: W000814
-  thomas: '02161'
 - name: Bruce Westerman
   party: majority
   rank: 14
   bioguide: W000821
-  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 15
@@ -9970,114 +8269,92 @@ HSPW14:
   rank: 1
   title: Ranking Member
   bioguide: C001037
-  thomas: '01564'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 2
   bioguide: P000604
-  thomas: '02097'
 - name: Jerrold Nadler
   party: minority
   rank: 3
   bioguide: N000002
-  thomas: '00850'
 - name: Elijah E. Cummings
   party: minority
   rank: 4
   bioguide: C000984
-  thomas: '00256'
 - name: Steve Cohen
   party: minority
   rank: 5
   bioguide: C001068
-  thomas: '01878'
 - name: Albio Sires
   party: minority
   rank: 6
   bioguide: S001165
-  thomas: '01818'
 - name: John Garamendi
   party: minority
   rank: 7
   bioguide: G000559
-  thomas: '01973'
 - name: André Carson
   party: minority
   rank: 8
   bioguide: C001072
-  thomas: '01889'
 - name: Richard M. Nolan
   party: minority
   rank: 9
   bioguide: N000127
-  thomas: '00867'
 - name: Elizabeth H. Esty
   party: minority
   rank: 10
   bioguide: E000293
-  thomas: '02114'
 - name: Cheri Bustos
   party: minority
   rank: 11
   bioguide: B001286
-  thomas: '02127'
 - name: Frederica S. Wilson
   party: minority
   rank: 12
   bioguide: W000808
-  thomas: '02004'
 - name: Mark DeSaulnier
   party: minority
   rank: 13
   bioguide: D000623
-  thomas: '02227'
 - name: Daniel Lipinski
   party: minority
   rank: 14
   bioguide: L000563
-  thomas: '01781'
 HSRU:
 - name: Pete Sessions
   party: majority
   rank: 1
   title: Chair
   bioguide: S000250
-  thomas: '01525'
 - name: Tom Cole
   party: majority
   rank: 2
   bioguide: C001053
-  thomas: '01742'
 - name: Rob Woodall
   party: majority
   rank: 3
   bioguide: W000810
-  thomas: '02008'
 - name: Michael C. Burgess
   party: majority
   rank: 4
   bioguide: B001248
-  thomas: '01751'
 - name: Doug Collins
   party: majority
   rank: 5
   bioguide: C001093
-  thomas: '02121'
 - name: Bradley Byrne
   party: majority
   rank: 6
   bioguide: B001289
-  thomas: '02197'
 - name: Dan Newhouse
   party: majority
   rank: 7
   bioguide: N000189
-  thomas: '02275'
 - name: Ken Buck
   party: majority
   rank: 8
   bioguide: B001297
-  thomas: '02233'
 - name: Liz Cheney
   party: majority
   rank: 9
@@ -10087,77 +8364,63 @@ HSRU:
   rank: 1
   title: Ranking Member
   bioguide: S000480
-  thomas: '01069'
 - name: James P. McGovern
   party: minority
   rank: 2
   bioguide: M000312
-  thomas: '01504'
 - name: Alcee L. Hastings
   party: minority
   rank: 3
   bioguide: H000324
-  thomas: '00511'
 - name: Jared Polis
   party: minority
   rank: 4
   bioguide: P000598
-  thomas: '01910'
 HSRU02:
 - name: Rob Woodall
   party: majority
   rank: 1
   title: Chair
   bioguide: W000810
-  thomas: '02008'
 - name: Michael C. Burgess
   party: majority
   rank: 2
   bioguide: B001248
-  thomas: '01751'
 - name: Bradley Byrne
   party: majority
   rank: 3
   bioguide: B001289
-  thomas: '02197'
 - name: Dan Newhouse
   party: majority
   rank: 4
   bioguide: N000189
-  thomas: '02275'
 - name: Ken Buck
   party: majority
   rank: 5
   bioguide: B001297
-  thomas: '02233'
 - name: Alcee L. Hastings
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H000324
-  thomas: '00511'
 - name: Jared Polis
   party: minority
   rank: 2
   bioguide: P000598
-  thomas: '01910'
 HSRU04:
 - name: Doug Collins
   party: majority
   rank: 1
   title: Chair
   bioguide: C001093
-  thomas: '02121'
 - name: Bradley Byrne
   party: majority
   rank: 2
   bioguide: B001289
-  thomas: '02197'
 - name: Dan Newhouse
   party: majority
   rank: 3
   bioguide: N000189
-  thomas: '02275'
 - name: Liz Cheney
   party: majority
   rank: 4
@@ -10166,60 +8429,49 @@ HSRU04:
   party: majority
   rank: 5
   bioguide: S000250
-  thomas: '01525'
 - name: Louise McIntosh Slaughter
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000480
-  thomas: '01069'
 - name: James P. McGovern
   party: minority
   rank: 2
   bioguide: M000312
-  thomas: '01504'
 HSSM:
 - name: Steve Chabot
   party: majority
   rank: 1
   title: Chair
   bioguide: C000266
-  thomas: '00186'
 - name: Steve King
   party: majority
   rank: 2
   bioguide: K000362
-  thomas: '01724'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
   bioguide: L000569
-  thomas: '01931'
 - name: Dave Brat
   party: majority
   rank: 4
   bioguide: B001290
-  thomas: '02203'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
   bioguide: R000600
-  thomas: '02222'
 - name: Stephen Knight
   party: majority
   rank: 6
   bioguide: K000387
-  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 7
   bioguide: K000388
-  thomas: '02294'
 - name: Rod Blum
   party: majority
   rank: 8
   bioguide: B001294
-  thomas: '02241'
 - name: James Comer
   party: majority
   rank: 9
@@ -10245,7 +8497,6 @@ HSSM:
   rank: 1
   title: Ranking Member
   bioguide: V000081
-  thomas: '01184'
 - name: Dwight Evans
   party: minority
   rank: 2
@@ -10262,17 +8513,14 @@ HSSM:
   party: minority
   rank: 5
   bioguide: C001067
-  thomas: '01864'
 - name: Judy Chu
   party: minority
   rank: 6
   bioguide: C001080
-  thomas: '01970'
 - name: Alma S. Adams
   party: minority
   rank: 7
   bioguide: A000370
-  thomas: '02201'
 - name: Adriano Espaillat
   party: minority
   rank: 8
@@ -10281,19 +8529,16 @@ HSSM:
   party: minority
   rank: 9
   bioguide: S001190
-  thomas: '02124'
 HSSM23:
 - name: Stephen Knight
   party: majority
   rank: 1
   title: Chair
   bioguide: K000387
-  thomas: '02228'
 - name: Steve King
   party: majority
   rank: 2
   bioguide: K000362
-  thomas: '01724'
 - name: James Comer
   party: majority
   rank: 3
@@ -10307,7 +8552,6 @@ HSSM23:
   party: minority
   rank: 2
   bioguide: C001067
-  thomas: '01864'
 - name: Dwight Evans
   party: minority
   rank: 3
@@ -10322,12 +8566,10 @@ HSSM24:
   rank: 1
   title: Chair
   bioguide: K000388
-  thomas: '02294'
 - name: Rod Blum
   party: majority
   rank: 2
   bioguide: B001294
-  thomas: '02241'
 - name: Don Bacon
   party: majority
   rank: 3
@@ -10341,29 +8583,24 @@ HSSM24:
   rank: 1
   title: Ranking Member
   bioguide: A000370
-  thomas: '02201'
 HSSM25:
 - name: Rod Blum
   party: majority
   rank: 1
   title: Chair
   bioguide: B001294
-  thomas: '02241'
 - name: Steve King
   party: majority
   rank: 2
   bioguide: K000362
-  thomas: '01724'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
   bioguide: L000569
-  thomas: '01931'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 4
   bioguide: R000600
-  thomas: '02222'
 - name: James Comer
   party: majority
   rank: 5
@@ -10377,7 +8614,6 @@ HSSM25:
   rank: 1
   title: Ranking Member
   bioguide: S001190
-  thomas: '02124'
 - name: Al Lawson, Jr.
   party: minority
   rank: 2
@@ -10388,17 +8624,14 @@ HSSM26:
   rank: 1
   title: Chair
   bioguide: R000600
-  thomas: '02222'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 2
   bioguide: L000569
-  thomas: '01931'
 - name: Dave Brat
   party: majority
   rank: 3
   bioguide: B001290
-  thomas: '02203'
 - name: Jenniffer González-Colón
   party: majority
   rank: 4
@@ -10426,17 +8659,14 @@ HSSM27:
   rank: 1
   title: Chair
   bioguide: B001290
-  thomas: '02203'
 - name: Stephen Knight
   party: majority
   rank: 2
   bioguide: K000387
-  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 3
   bioguide: K000388
-  thomas: '02294'
 - name: Jenniffer González-Colón
   party: majority
   rank: 4
@@ -10454,7 +8684,6 @@ HSSM27:
   party: minority
   rank: 2
   bioguide: C001080
-  thomas: '01970'
 - name: Stephanie N. Murphy
   party: minority
   rank: 3
@@ -10463,50 +8692,41 @@ HSSM27:
   party: minority
   rank: 4
   bioguide: C001067
-  thomas: '01864'
 HSSO:
 - name: Susan W. Brooks
   party: majority
   rank: 1
   title: Chair
   bioguide: B001284
-  thomas: '02129'
 - name: Patrick Meehan
   party: majority
   rank: 2
   bioguide: M001181
-  thomas: '02052'
 - name: Trey Gowdy
   party: majority
   rank: 3
   bioguide: G000566
-  thomas: '02058'
 - name: Kenny Marchant
   party: majority
   rank: 4
   bioguide: M001158
-  thomas: '01806'
 - name: Leonard Lance
   party: majority
   rank: 5
   bioguide: L000567
-  thomas: '01936'
 - name: Theodore E. Deutch
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000610
-  thomas: '01976'
 - name: Yvette D. Clarke
   party: minority
   rank: 2
   bioguide: C001067
-  thomas: '01864'
 - name: Jared Polis
   party: minority
   rank: 3
   bioguide: P000598
-  thomas: '01910'
 - name: Anthony G. Brown
   party: minority
   rank: 4
@@ -10515,94 +8735,76 @@ HSSO:
   party: minority
   rank: 5
   bioguide: C001068
-  thomas: '01878'
 HSSY:
 - name: Lamar Smith
   party: majority
   rank: 1
   title: Chair
   bioguide: S000583
-  thomas: '01075'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
   bioguide: R000409
-  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
   bioguide: L000491
-  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
   bioguide: B001274
-  thomas: '01987'
 - name: Randy Hultgren
   party: majority
   rank: 5
   bioguide: H001059
-  thomas: '02015'
 - name: Bill Posey
   party: majority
   rank: 6
   bioguide: P000599
-  thomas: '01915'
 - name: Thomas Massie
   party: majority
   rank: 7
   bioguide: M001184
-  thomas: '02094'
 - name: Jim Bridenstine
   party: majority
   rank: 8
   bioguide: B001283
-  thomas: '02155'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 9
   bioguide: W000814
-  thomas: '02161'
 - name: Stephen Knight
   party: majority
   rank: 10
   bioguide: K000387
-  thomas: '02228'
 - name: Brian Babin
   party: majority
   rank: 11
   bioguide: B001291
-  thomas: '02270'
 - name: Barbara Comstock
   party: majority
   rank: 12
   bioguide: C001105
-  thomas: '02273'
 - name: Gary J. Palmer
   party: majority
   rank: 13
   bioguide: P000609
-  thomas: '02221'
 - name: Barry Loudermilk
   party: majority
   rank: 14
   bioguide: L000583
-  thomas: '02238'
 - name: Ralph Lee Abraham
   party: majority
   rank: 15
   bioguide: A000374
-  thomas: '02244'
 - name: Darin LaHood
   party: majority
   rank: 16
   bioguide: L000585
-  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 17
   bioguide: W000806
-  thomas: '02002'
 - name: Jim Banks
   party: majority
   rank: 18
@@ -10628,42 +8830,34 @@ HSSY:
   rank: 1
   title: Ranking Member
   bioguide: J000126
-  thomas: '00599'
 - name: Zoe Lofgren
   party: minority
   rank: 2
   bioguide: L000397
-  thomas: '00701'
 - name: Daniel Lipinski
   party: minority
   rank: 3
   bioguide: L000563
-  thomas: '01781'
 - name: Suzanne Bonamici
   party: minority
   rank: 4
   bioguide: B001278
-  thomas: '02092'
 - name: Ami Bera
   party: minority
   rank: 5
   bioguide: B001287
-  thomas: '02102'
 - name: Elizabeth H. Esty
   party: minority
   rank: 6
   bioguide: E000293
-  thomas: '02114'
 - name: Marc A. Veasey
   party: minority
   rank: 7
   bioguide: V000131
-  thomas: '02166'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 8
   bioguide: B001292
-  thomas: '02272'
 - name: Jacky Rosen
   party: minority
   rank: 9
@@ -10672,32 +8866,26 @@ HSSY:
   party: minority
   rank: 10
   bioguide: M001166
-  thomas: '01832'
 - name: Ed Perlmutter
   party: minority
   rank: 11
   bioguide: P000593
-  thomas: '01835'
 - name: Paul Tonko
   party: minority
   rank: 12
   bioguide: T000469
-  thomas: '01942'
 - name: Bill Foster
   party: minority
   rank: 13
   bioguide: F000454
-  thomas: '01888'
 - name: Mark Takano
   party: minority
   rank: 14
   bioguide: T000472
-  thomas: '02110'
 - name: Colleen Hanabusa
   party: minority
   rank: 15
   bioguide: H001050
-  thomas: '02010'
 - name: Charlie Crist
   party: minority
   rank: 16
@@ -10708,38 +8896,31 @@ HSSY15:
   rank: 1
   title: Chair
   bioguide: C001105
-  thomas: '02273'
 - name: Frank D. Lucas
   party: majority
   rank: 2
   bioguide: L000491
-  thomas: '00711'
 - name: Randy Hultgren
   party: majority
   rank: 3
   bioguide: H001059
-  thomas: '02015'
 - name: Stephen Knight
   party: majority
   rank: 4
   bioguide: K000387
-  thomas: '02228'
 - name: Darin LaHood
   party: majority
   rank: 5
   bioguide: L000585
-  thomas: '02295'
 - name: Ralph Lee Abraham
   party: majority
   rank: 6
   bioguide: A000374
-  thomas: '02244'
   title: Vice Chair
 - name: Daniel Webster
   party: majority
   rank: 7
   bioguide: W000806
-  thomas: '02002'
 - name: Jim Banks
   party: majority
   rank: 8
@@ -10752,19 +8933,16 @@ HSSY15:
   party: majority
   rank: 10
   bioguide: S000583
-  thomas: '01075'
   title: Ex Officio
 - name: Daniel Lipinski
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000563
-  thomas: '01781'
 - name: Elizabeth H. Esty
   party: minority
   rank: 2
   bioguide: E000293
-  thomas: '02114'
 - name: Jacky Rosen
   party: minority
   rank: 3
@@ -10773,22 +8951,18 @@ HSSY15:
   party: minority
   rank: 4
   bioguide: B001278
-  thomas: '02092'
 - name: Ami Bera
   party: minority
   rank: 5
   bioguide: B001287
-  thomas: '02102'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
   bioguide: B001292
-  thomas: '02272'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 7
   bioguide: J000126
-  thomas: '00599'
   title: Ex Officio
 HSSY16:
 - name: Brian Babin
@@ -10796,53 +8970,43 @@ HSSY16:
   rank: 1
   title: Chair
   bioguide: B001291
-  thomas: '02270'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
   bioguide: R000409
-  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
   bioguide: L000491
-  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
   bioguide: B001274
-  thomas: '01987'
   title: Vice Chair
 - name: Bill Posey
   party: majority
   rank: 5
   bioguide: P000599
-  thomas: '01915'
 - name: Jim Bridenstine
   party: majority
   rank: 6
   bioguide: B001283
-  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 7
   bioguide: K000387
-  thomas: '02228'
 - name: Barbara Comstock
   party: majority
   rank: 8
   bioguide: C001105
-  thomas: '02273'
 - name: Ralph Lee Abraham
   party: majority
   rank: 9
   bioguide: A000374
-  thomas: '02244'
 - name: Daniel Webster
   party: majority
   rank: 10
   bioguide: W000806
-  thomas: '02002'
 - name: Jim Banks
   party: majority
   rank: 11
@@ -10863,39 +9027,32 @@ HSSY16:
   party: majority
   rank: 15
   bioguide: S000583
-  thomas: '01075'
   title: Ex Officio
 - name: Ami Bera
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001287
-  thomas: '02102'
 - name: Zoe Lofgren
   party: minority
   rank: 2
   bioguide: L000397
-  thomas: '00701'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 3
   bioguide: B001292
-  thomas: '02272'
 - name: Marc A. Veasey
   party: minority
   rank: 4
   bioguide: V000131
-  thomas: '02166'
 - name: Daniel Lipinski
   party: minority
   rank: 5
   bioguide: L000563
-  thomas: '01781'
 - name: Ed Perlmutter
   party: minority
   rank: 6
   bioguide: P000593
-  thomas: '01835'
 - name: Charlie Crist
   party: minority
   rank: 7
@@ -10904,12 +9061,10 @@ HSSY16:
   party: minority
   rank: 8
   bioguide: F000454
-  thomas: '01888'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 11
   bioguide: J000126
-  thomas: '00599'
   title: Ex Officio
 HSSY18:
 - name: Andy Biggs
@@ -10921,37 +9076,30 @@ HSSY18:
   party: majority
   rank: 2
   bioguide: R000409
-  thomas: '00979'
 - name: Bill Posey
   party: majority
   rank: 3
   bioguide: P000599
-  thomas: '01915'
 - name: Mo Brooks
   party: majority
   rank: 4
   bioguide: B001274
-  thomas: '01987'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 5
   bioguide: W000814
-  thomas: '02161'
 - name: Brian Babin
   party: majority
   rank: 6
   bioguide: B001291
-  thomas: '02270'
 - name: Gary J. Palmer
   party: majority
   rank: 7
   bioguide: P000609
-  thomas: '02221'
 - name: Barry Loudermilk
   party: majority
   rank: 8
   bioguide: L000583
-  thomas: '02238'
 - name: Jim Banks
   party: majority
   rank: 9
@@ -10965,19 +9113,16 @@ HSSY18:
   party: majority
   rank: 11
   bioguide: S000583
-  thomas: '01075'
   title: Ex Officio
 - name: Suzanne Bonamici
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001278
-  thomas: '02092'
 - name: Colleen Hanabusa
   party: minority
   rank: 2
   bioguide: H001050
-  thomas: '02010'
 - name: Charlie Crist
   party: minority
   rank: 3
@@ -10986,7 +9131,6 @@ HSSY18:
   party: minority
   rank: 8
   bioguide: J000126
-  thomas: '00599'
   title: Ex Officio
 HSSY20:
 - name: Randy K. Weber, Sr.
@@ -10994,53 +9138,43 @@ HSSY20:
   rank: 1
   title: Chair
   bioguide: W000814
-  thomas: '02161'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
   bioguide: R000409
-  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
   bioguide: L000491
-  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
   bioguide: B001274
-  thomas: '01987'
 - name: Randy Hultgren
   party: majority
   rank: 5
   bioguide: H001059
-  thomas: '02015'
 - name: Thomas Massie
   party: majority
   rank: 6
   bioguide: M001184
-  thomas: '02094'
 - name: Jim Bridenstine
   party: majority
   rank: 7
   bioguide: B001283
-  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 8
   bioguide: K000387
-  thomas: '02228'
   title: Vice Chair
 - name: Darin LaHood
   party: majority
   rank: 9
   bioguide: L000585
-  thomas: '02295'
 - name: Daniel Webster
   party: majority
   rank: 10
   bioguide: W000806
-  thomas: '02002'
 - name: Neal P. Dunn
   party: majority
   rank: 11
@@ -11049,24 +9183,20 @@ HSSY20:
   party: majority
   rank: 12
   bioguide: S000583
-  thomas: '01075'
   title: Ex Officio
 - name: Marc A. Veasey
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: V000131
-  thomas: '02166'
 - name: Zoe Lofgren
   party: minority
   rank: 2
   bioguide: L000397
-  thomas: '00701'
 - name: Daniel Lipinski
   party: minority
   rank: 3
   bioguide: L000563
-  thomas: '01781'
 - name: Jacky Rosen
   party: minority
   rank: 4
@@ -11075,27 +9205,22 @@ HSSY20:
   party: minority
   rank: 5
   bioguide: M001166
-  thomas: '01832'
 - name: Paul Tonko
   party: minority
   rank: 6
   bioguide: T000469
-  thomas: '01942'
 - name: Bill Foster
   party: minority
   rank: 7
   bioguide: F000454
-  thomas: '01888'
 - name: Mark Takano
   party: minority
   rank: 8
   bioguide: T000472
-  thomas: '02110'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 9
   bioguide: J000126
-  thomas: '00599'
   title: Ex Officio
 HSSY21:
 - name: Darin LaHood
@@ -11103,27 +9228,22 @@ HSSY21:
   rank: 1
   title: Chair
   bioguide: L000585
-  thomas: '02295'
 - name: Bill Posey
   party: majority
   rank: 2
   bioguide: P000599
-  thomas: '01915'
 - name: Thomas Massie
   party: majority
   rank: 3
   bioguide: M001184
-  thomas: '02094'
 - name: Gary J. Palmer
   party: majority
   rank: 4
   bioguide: P000609
-  thomas: '02221'
 - name: Barry Loudermilk
   party: majority
   rank: 5
   bioguide: L000583
-  thomas: '02238'
 - name: Roger W. Marshall
   party: majority
   rank: 6
@@ -11137,29 +9257,24 @@ HSSY21:
   party: majority
   rank: 8
   bioguide: S000583
-  thomas: '01075'
   title: Ex Officio
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001292
-  thomas: '02272'
 - name: Jerry McNerney
   party: minority
   rank: 2
   bioguide: M001166
-  thomas: '01832'
 - name: Ed Perlmutter
   party: minority
   rank: 3
   bioguide: P000593
-  thomas: '01835'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
   bioguide: J000126
-  thomas: '00599'
   title: Ex Officio
 HSVR:
 - name: David P. Roe
@@ -11167,37 +9282,30 @@ HSVR:
   rank: 1
   title: Chair
   bioguide: R000582
-  thomas: '01954'
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
   bioguide: B001257
-  thomas: '01838'
 - name: Mike Coffman
   party: majority
   rank: 3
   bioguide: C001077
-  thomas: '01912'
 - name: Brad R. Wenstrup
   party: majority
   rank: 4
   bioguide: W000815
-  thomas: '02152'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
   bioguide: R000600
-  thomas: '02222'
 - name: Mike Bost
   party: majority
   rank: 6
   bioguide: B001295
-  thomas: '02243'
 - name: Bruce Poliquin
   party: majority
   rank: 7
   bioguide: P000611
-  thomas: '02247'
 - name: Neal P. Dunn
   party: majority
   rank: 8
@@ -11231,32 +9339,26 @@ HSVR:
   rank: 1
   title: Ranking Member
   bioguide: W000799
-  thomas: '01856'
 - name: Mark Takano
   party: minority
   rank: 2
   bioguide: T000472
-  thomas: '02110'
 - name: Julia Brownley
   party: minority
   rank: 3
   bioguide: B001285
-  thomas: '02106'
 - name: Ann M. Kuster
   party: minority
   rank: 4
   bioguide: K000382
-  thomas: '02145'
 - name: Beto O'Rourke
   party: minority
   rank: 5
   bioguide: O000170
-  thomas: '02162'
 - name: Kathleen M. Rice
   party: minority
   rank: 6
   bioguide: R000602
-  thomas: '02262'
 - name: J. Luis Correa
   party: minority
   rank: 7
@@ -11265,34 +9367,28 @@ HSVR:
   party: minority
   rank: 8
   bioguide: S001177
-  thomas: '01962'
 - name: Elizabeth H. Esty
   party: minority
   rank: 9
   bioguide: E000293
-  thomas: '02114'
 - name: Scott H. Peters
   party: minority
   rank: 10
   bioguide: P000608
-  thomas: '02113'
 HSVR03:
 - name: Brad R. Wenstrup
   party: majority
   rank: 1
   title: Chair
   bioguide: W000815
-  thomas: '02152'
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
   bioguide: B001257
-  thomas: '01838'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
   bioguide: R000600
-  thomas: '02222'
 - name: Neal P. Dunn
   party: majority
   rank: 4
@@ -11314,22 +9410,18 @@ HSVR03:
   rank: 1
   title: Ranking Member
   bioguide: B001285
-  thomas: '02106'
 - name: Mark Takano
   party: minority
   rank: 2
   bioguide: T000472
-  thomas: '02110'
 - name: Ann M. Kuster
   party: minority
   rank: 3
   bioguide: K000382
-  thomas: '02145'
 - name: Beto O'Rourke
   party: minority
   rank: 4
   bioguide: O000170
-  thomas: '02162'
 - name: J. Luis Correa
   party: minority
   rank: 5
@@ -11344,12 +9436,10 @@ HSVR08:
   party: majority
   rank: 2
   bioguide: B001295
-  thomas: '02243'
 - name: Bruce Poliquin
   party: majority
   rank: 3
   bioguide: P000611
-  thomas: '02247'
 - name: Neal P. Dunn
   party: majority
   rank: 4
@@ -11367,39 +9457,32 @@ HSVR08:
   rank: 1
   title: Ranking Member
   bioguide: K000382
-  thomas: '02145'
 - name: Kathleen M. Rice
   party: minority
   rank: 2
   bioguide: R000602
-  thomas: '02262'
 - name: Scott H. Peters
   party: minority
   rank: 3
   bioguide: P000608
-  thomas: '02113'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 4
   bioguide: S001177
-  thomas: '01962'
 HSVR09:
 - name: Mike Bost
   party: majority
   rank: 1
   title: Chair
   bioguide: B001295
-  thomas: '02243'
 - name: Mike Coffman
   party: majority
   rank: 2
   bioguide: C001077
-  thomas: '01912'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
   bioguide: R000600
-  thomas: '02222'
 - name: Jack Bergman
   party: majority
   rank: 4
@@ -11413,17 +9496,14 @@ HSVR09:
   rank: 1
   title: Ranking Member
   bioguide: B001285
-  thomas: '02106'
 - name: Elizabeth H. Esty
   party: minority
   rank: 2
   bioguide: E000293
-  thomas: '02114'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 3
   bioguide: S001177
-  thomas: '01962'
 HSVR10:
 - name: Jodey C. Arrington
   party: majority
@@ -11434,12 +9514,10 @@ HSVR10:
   party: majority
   rank: 2
   bioguide: B001257
-  thomas: '01838'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
   bioguide: W000815
-  thomas: '02152'
 - name: John H. Rutherford
   party: majority
   rank: 4
@@ -11453,12 +9531,10 @@ HSVR10:
   rank: 1
   title: Ranking Member
   bioguide: O000170
-  thomas: '02162'
 - name: Mark Takano
   party: minority
   rank: 2
   bioguide: T000472
-  thomas: '02110'
 - name: J. Luis Correa
   party: minority
   rank: 3
@@ -11467,681 +9543,551 @@ HSVR10:
   party: minority
   rank: 4
   bioguide: R000602
-  thomas: '02262'
 HSWM:
 - name: Kevin Brady
   party: majority
   rank: 1
   title: Chair
   bioguide: B000755
-  thomas: '01468'
 - name: Sam Johnson
   party: majority
   rank: 2
   bioguide: J000174
-  thomas: '00603'
 - name: Devin Nunes
   party: majority
   rank: 3
   bioguide: N000181
-  thomas: '01710'
 - name: Patrick J. Tiberi
   party: majority
   rank: 4
   bioguide: T000462
-  thomas: '01664'
 - name: David G. Reichert
   party: majority
   rank: 5
   bioguide: R000578
-  thomas: '01810'
 - name: Peter J. Roskam
   party: majority
   rank: 6
   bioguide: R000580
-  thomas: '01848'
 - name: Vern Buchanan
   party: majority
   rank: 7
   bioguide: B001260
-  thomas: '01840'
 - name: Adrian Smith
   party: majority
   rank: 8
   bioguide: S001172
-  thomas: '01860'
 - name: Lynn Jenkins
   party: majority
   rank: 9
   bioguide: J000290
-  thomas: '01921'
 - name: Erik Paulsen
   party: majority
   rank: 10
   bioguide: P000594
-  thomas: '01930'
 - name: Kenny Marchant
   party: majority
   rank: 11
   bioguide: M001158
-  thomas: '01806'
 - name: Diane Black
   party: majority
   rank: 12
   bioguide: B001273
-  thomas: '02063'
 - name: Tom Reed
   party: majority
   rank: 13
   bioguide: R000585
-  thomas: '01982'
 - name: Mike Kelly
   party: majority
   rank: 14
   bioguide: K000376
-  thomas: '02051'
 - name: James B. Renacci
   party: majority
   rank: 15
   bioguide: R000586
-  thomas: '02048'
 - name: Patrick Meehan
   party: majority
   rank: 16
   bioguide: M001181
-  thomas: '02052'
 - name: Kristi L. Noem
   party: majority
   rank: 17
   bioguide: N000184
-  thomas: '02060'
 - name: George Holding
   party: majority
   rank: 18
   bioguide: H001065
-  thomas: '02143'
 - name: Jason Smith
   party: majority
   rank: 19
   bioguide: S001195
-  thomas: '02191'
 - name: Tom Rice
   party: majority
   rank: 20
   bioguide: R000597
-  thomas: '02160'
 - name: David Schweikert
   party: majority
   rank: 21
   bioguide: S001183
-  thomas: '01994'
 - name: Jackie Walorski
   party: majority
   rank: 22
   bioguide: W000813
-  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
   rank: 23
   bioguide: C001107
-  thomas: '02235'
 - name: Mike Bishop
   party: majority
   rank: 24
   bioguide: B001293
-  thomas: '02249'
 - name: Richard E. Neal
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: N000015
-  thomas: '00854'
 - name: Sander M. Levin
   party: minority
   rank: 2
   bioguide: L000263
-  thomas: '00683'
 - name: John Lewis
   party: minority
   rank: 3
   bioguide: L000287
-  thomas: '00688'
 - name: Lloyd Doggett
   party: minority
   rank: 4
   bioguide: D000399
-  thomas: '00303'
 - name: Mike Thompson
   party: minority
   rank: 5
   bioguide: T000460
-  thomas: '01593'
 - name: John B. Larson
   party: minority
   rank: 6
   bioguide: L000557
-  thomas: '01583'
 - name: Earl Blumenauer
   party: minority
   rank: 7
   bioguide: B000574
-  thomas: '00099'
 - name: Ron Kind
   party: minority
   rank: 8
   bioguide: K000188
-  thomas: '01498'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 9
   bioguide: P000096
-  thomas: '01510'
 - name: Joseph Crowley
   party: minority
   rank: 10
   bioguide: C001038
-  thomas: '01604'
 - name: Danny K. Davis
   party: minority
   rank: 11
   bioguide: D000096
-  thomas: '01477'
 - name: Linda T. Sánchez
   party: minority
   rank: 12
   bioguide: S001156
-  thomas: '01757'
 - name: Brian Higgins
   party: minority
   rank: 13
   bioguide: H001038
-  thomas: '01794'
 - name: Terri A. Sewell
   party: minority
   rank: 14
   bioguide: S001185
-  thomas: '01988'
 - name: Suzan K. DelBene
   party: minority
   rank: 15
   bioguide: D000617
-  thomas: '02096'
 - name: Judy Chu
   party: minority
   rank: 16
   bioguide: C001080
-  thomas: '01970'
 HSWM01:
 - name: Sam Johnson
   party: majority
   rank: 1
   title: Chair
   bioguide: J000174
-  thomas: '00603'
 - name: Tom Rice
   party: majority
   rank: 2
   bioguide: R000597
-  thomas: '02160'
 - name: David Schweikert
   party: majority
   rank: 3
   bioguide: S001183
-  thomas: '01994'
 - name: Vern Buchanan
   party: majority
   rank: 4
   bioguide: B001260
-  thomas: '01840'
 - name: Mike Kelly
   party: majority
   rank: 5
   bioguide: K000376
-  thomas: '02051'
 - name: James B. Renacci
   party: majority
   rank: 6
   bioguide: R000586
-  thomas: '02048'
 - name: Jason Smith
   party: majority
   rank: 7
   bioguide: S001195
-  thomas: '02191'
 - name: John B. Larson
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000557
-  thomas: '01583'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 2
   bioguide: P000096
-  thomas: '01510'
 - name: Joseph Crowley
   party: minority
   rank: 3
   bioguide: C001038
-  thomas: '01604'
 - name: Linda T. Sánchez
   party: minority
   rank: 4
   bioguide: S001156
-  thomas: '01757'
 HSWM02:
 - name: Patrick J. Tiberi
   party: majority
   rank: 1
   title: Chair
   bioguide: T000462
-  thomas: '01664'
 - name: Sam Johnson
   party: majority
   rank: 2
   bioguide: J000174
-  thomas: '00603'
 - name: Devin Nunes
   party: majority
   rank: 3
   bioguide: N000181
-  thomas: '01710'
 - name: Peter J. Roskam
   party: majority
   rank: 4
   bioguide: R000580
-  thomas: '01848'
 - name: Vern Buchanan
   party: majority
   rank: 5
   bioguide: B001260
-  thomas: '01840'
 - name: Adrian Smith
   party: majority
   rank: 6
   bioguide: S001172
-  thomas: '01860'
 - name: Lynn Jenkins
   party: majority
   rank: 7
   bioguide: J000290
-  thomas: '01921'
 - name: Kenny Marchant
   party: majority
   rank: 8
   bioguide: M001158
-  thomas: '01806'
 - name: Diane Black
   party: majority
   rank: 9
   bioguide: B001273
-  thomas: '02063'
 - name: Erik Paulsen
   party: majority
   rank: 10
   bioguide: P000594
-  thomas: '01930'
 - name: Tom Reed
   party: majority
   rank: 11
   bioguide: R000585
-  thomas: '01982'
 - name: Sander M. Levin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000263
-  thomas: '00683'
 - name: Mike Thompson
   party: minority
   rank: 2
   bioguide: T000460
-  thomas: '01593'
 - name: Ron Kind
   party: minority
   rank: 3
   bioguide: K000188
-  thomas: '01498'
 - name: Earl Blumenauer
   party: minority
   rank: 4
   bioguide: B000574
-  thomas: '00099'
 - name: Brian Higgins
   party: minority
   rank: 5
   bioguide: H001038
-  thomas: '01794'
 - name: Terri A. Sewell
   party: minority
   rank: 6
   bioguide: S001185
-  thomas: '01988'
 - name: Judy Chu
   party: minority
   rank: 7
   bioguide: C001080
-  thomas: '01970'
 HSWM03:
 - name: Adrian Smith
   party: majority
   rank: 1
   title: Chair
   bioguide: S001172
-  thomas: '01860'
 - name: Jason Smith
   party: majority
   rank: 2
   bioguide: S001195
-  thomas: '02191'
 - name: Jackie Walorski
   party: majority
   rank: 3
   bioguide: W000813
-  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
   rank: 4
   bioguide: C001107
-  thomas: '02235'
 - name: Mike Bishop
   party: majority
   rank: 5
   bioguide: B001293
-  thomas: '02249'
 - name: David G. Reichert
   party: majority
   rank: 6
   bioguide: R000578
-  thomas: '01810'
 - name: Tom Reed
   party: majority
   rank: 7
   bioguide: R000585
-  thomas: '01982'
 - name: Danny K. Davis
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000096
-  thomas: '01477'
 - name: Lloyd Doggett
   party: minority
   rank: 2
   bioguide: D000399
-  thomas: '00303'
 - name: Terri A. Sewell
   party: minority
   rank: 3
   bioguide: S001185
-  thomas: '01988'
 - name: Judy Chu
   party: minority
   rank: 4
   bioguide: C001080
-  thomas: '01970'
 HSWM04:
 - name: David G. Reichert
   party: majority
   rank: 1
   title: Chair
   bioguide: R000578
-  thomas: '01810'
 - name: Devin Nunes
   party: majority
   rank: 2
   bioguide: N000181
-  thomas: '01710'
 - name: Lynn Jenkins
   party: majority
   rank: 3
   bioguide: J000290
-  thomas: '01921'
 - name: Erik Paulsen
   party: majority
   rank: 4
   bioguide: P000594
-  thomas: '01930'
 - name: Mike Kelly
   party: majority
   rank: 5
   bioguide: K000376
-  thomas: '02051'
 - name: Patrick Meehan
   party: majority
   rank: 6
   bioguide: M001181
-  thomas: '02052'
 - name: Tom Reed
   party: majority
   rank: 7
   bioguide: R000585
-  thomas: '01982'
 - name: Kristi L. Noem
   party: majority
   rank: 8
   bioguide: N000184
-  thomas: '02060'
 - name: George Holding
   party: majority
   rank: 9
   bioguide: H001065
-  thomas: '02143'
 - name: Tom Rice
   party: majority
   rank: 10
   bioguide: R000597
-  thomas: '02160'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000096
-  thomas: '01510'
 - name: Ron Kind
   party: minority
   rank: 2
   bioguide: K000188
-  thomas: '01498'
 - name: Lloyd Doggett
   party: minority
   rank: 3
   bioguide: D000399
-  thomas: '00303'
 - name: Sander M. Levin
   party: minority
   rank: 4
   bioguide: L000263
-  thomas: '00683'
 - name: Danny K. Davis
   party: minority
   rank: 5
   bioguide: D000096
-  thomas: '01477'
 - name: Suzan K. DelBene
   party: minority
   rank: 6
   bioguide: D000617
-  thomas: '02096'
 HSWM05:
 - name: Peter J. Roskam
   party: majority
   rank: 1
   title: Chair
   bioguide: R000580
-  thomas: '01848'
 - name: David G. Reichert
   party: majority
   rank: 2
   bioguide: R000578
-  thomas: '01810'
 - name: Patrick J. Tiberi
   party: majority
   rank: 3
   bioguide: T000462
-  thomas: '01664'
 - name: Mike Kelly
   party: majority
   rank: 4
   bioguide: K000376
-  thomas: '02051'
 - name: James B. Renacci
   party: majority
   rank: 5
   bioguide: R000586
-  thomas: '02048'
 - name: Kristi L. Noem
   party: majority
   rank: 6
   bioguide: N000184
-  thomas: '02060'
 - name: George Holding
   party: majority
   rank: 7
   bioguide: H001065
-  thomas: '02143'
 - name: Kenny Marchant
   party: majority
   rank: 8
   bioguide: M001158
-  thomas: '01806'
 - name: Patrick Meehan
   party: majority
   rank: 9
   bioguide: M001181
-  thomas: '02052'
 - name: Lloyd Doggett
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000399
-  thomas: '00303'
 - name: John B. Larson
   party: minority
   rank: 2
   bioguide: L000557
-  thomas: '01583'
 - name: Linda T. Sánchez
   party: minority
   rank: 3
   bioguide: S001156
-  thomas: '01757'
 - name: Mike Thompson
   party: minority
   rank: 4
   bioguide: T000460
-  thomas: '01593'
 - name: Suzan K. DelBene
   party: minority
   rank: 5
   bioguide: D000617
-  thomas: '02096'
 - name: Earl Blumenauer
   party: minority
   rank: 6
   bioguide: B000574
-  thomas: '00099'
 HSWM06:
 - name: Vern Buchanan
   party: majority
   rank: 1
   title: Chair
   bioguide: B001260
-  thomas: '01840'
 - name: David Schweikert
   party: majority
   rank: 2
   bioguide: S001183
-  thomas: '01994'
 - name: Jackie Walorski
   party: majority
   rank: 3
   bioguide: W000813
-  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
   rank: 4
   bioguide: C001107
-  thomas: '02235'
 - name: Mike Bishop
   party: majority
   rank: 5
   bioguide: B001293
-  thomas: '02249'
 - name: Patrick Meehan
   party: majority
   rank: 6
   bioguide: M001181
-  thomas: '02052'
 - name: George Holding
   party: majority
   rank: 7
   bioguide: H001065
-  thomas: '02143'
 - name: John Lewis
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000287
-  thomas: '00688'
 - name: Joseph Crowley
   party: minority
   rank: 2
   bioguide: C001038
-  thomas: '01604'
 - name: Suzan K. DelBene
   party: minority
   rank: 3
   bioguide: D000617
-  thomas: '02096'
 - name: Earl Blumenauer
   party: minority
   rank: 4
   bioguide: B000574
-  thomas: '00099'
 JCSE:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Cochairman
   bioguide: W000437
-  thomas: '01226'
   chamber: senate
 - name: Richard Burr
   party: majority
   rank: 2
   bioguide: B001135
-  thomas: '00153'
   chamber: senate
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
-  thomas: '01687'
   chamber: senate
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
   bioguide: C000141
-  thomas: '00174'
   chamber: senate
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
   bioguide: W000802
-  thomas: '01823'
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 3
   bioguide: U000039
-  thomas: '01567'
   chamber: senate
 - name: Jeanne Shaheen
   party: minority
   rank: 4
   bioguide: S001181
-  thomas: '01901'
   chamber: senate
 - name: Christopher H. Smith
   party: majority
@@ -12186,55 +10132,46 @@ JSEC:
   rank: 1
   title: Vice Chairman
   bioguide: L000577
-  thomas: '02080'
   chamber: senate
 - name: Tom Cotton
   party: majority
   rank: 2
   bioguide: C001095
-  thomas: '02098'
   chamber: senate
 - name: Ben Sasse
   party: majority
   rank: 3
   bioguide: S001197
-  thomas: '02289'
   chamber: senate
 - name: Rob Portman
   party: majority
   rank: 4
   bioguide: P000449
-  thomas: '00924'
   chamber: senate
 - name: Ted Cruz
   party: majority
   rank: 5
   bioguide: C001098
-  thomas: '02175'
   chamber: senate
 - name: Bill Cassidy
   party: majority
   rank: 6
   bioguide: C001075
-  thomas: '01925'
   chamber: senate
 - name: Martin Heinrich
   party: minority
   rank: 1
   bioguide: H001046
-  thomas: '01937'
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 2
   bioguide: K000367
-  thomas: '01826'
   chamber: senate
 - name: Gary C. Peters
   party: minority
   rank: 3
   bioguide: P000595
-  thomas: '01929'
   chamber: senate
 - name: Margaret Wood Hassan
   party: minority
@@ -12290,31 +10227,26 @@ JSLC:
   rank: 1
   title: Chairman
   bioguide: B000575
-  thomas: '01464'
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
   bioguide: R000307
-  thomas: '00968'
   chamber: senate
 - name: Shelley Moore Capito
   party: majority
   rank: 3
   bioguide: C001047
-  thomas: '01676'
   chamber: senate
 - name: Charles E. Schumer
   party: minority
   rank: 1
   bioguide: S000148
-  thomas: '01036'
   chamber: senate
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -12347,31 +10279,26 @@ JSPR:
   rank: 1
   title: Vice Chairman
   bioguide: B000575
-  thomas: '01464'
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
   bioguide: R000307
-  thomas: '00968'
   chamber: senate
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
-  thomas: '01687'
   chamber: senate
 - name: Charles E. Schumer
   party: minority
   rank: 1
   bioguide: S000148
-  thomas: '01036'
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 2
   bioguide: U000039
-  thomas: '01567'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -12398,31 +10325,26 @@ JSTX:
   rank: 1
   title: Vice Chairman
   bioguide: H000338
-  thomas: '01351'
   chamber: senate
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
   chamber: senate
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-  thomas: '00250'
   chamber: senate
 - name: Ron Wyden
   party: minority
   rank: 1
   bioguide: W000779
-  thomas: '01247'
   chamber: senate
 - name: Debbie Stabenow
   party: minority
   rank: 2
   bioguide: S000770
-  thomas: '01531'
   chamber: senate
 - name: Paul Ryan
   party: majority
@@ -12455,138 +10377,112 @@ SCNC:
   rank: 1
   title: Chairman
   bioguide: G000386
-  thomas: '00457'
 - name: John Cornyn
   party: majority
   rank: 2
   bioguide: C001056
-  thomas: '01692'
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
-  thomas: '01896'
 - name: Dianne Feinstein
   party: minority
   rank: 1
   bioguide: F000062
-  thomas: '01332'
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
   bioguide: W000802
-  thomas: '01823'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
   bioguide: H001069
-  thomas: '02174'
 SLET:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000055
-  thomas: '01608'
 - name: Pat Roberts
   party: majority
   rank: 2
   bioguide: R000307
-  thomas: '00968'
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
-  thomas: '01896'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Vice Chairman
   bioguide: C001088
-  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 2
   bioguide: S001194
-  thomas: '02173'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
-  thomas: '01901'
 SLIA:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
   bioguide: H001061
-  thomas: '02079'
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
-  thomas: '01881'
 - name: John McCain
   party: majority
   rank: 3
   bioguide: M000303
-  thomas: '00754'
 - name: Lisa Murkowski
   party: majority
   rank: 4
   bioguide: M001153
-  thomas: '01694'
 - name: James Lankford
   party: majority
   rank: 5
   bioguide: L000575
-  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 6
   bioguide: D000618
-  thomas: '02138'
 - name: Mike Crapo
   party: majority
   rank: 7
   bioguide: C000880
-  thomas: '00250'
 - name: Jerry Moran
   party: majority
   rank: 8
   bioguide: M000934
-  thomas: '01507'
 - name: Tom Udall
   party: minority
   rank: 1
   title: Vice Chairman
   bioguide: U000039
-  thomas: '01567'
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
-  thomas: '00172'
 - name: Jon Tester
   party: minority
   rank: 3
   bioguide: T000464
-  thomas: '01829'
 - name: Al Franken
   party: minority
   rank: 4
   bioguide: F000457
-  thomas: '01969'
 - name: Brian Schatz
   party: minority
   rank: 5
   bioguide: S001194
-  thomas: '02173'
 - name: Heidi Heitkamp
   party: minority
   rank: 6
   bioguide: H001069
-  thomas: '02174'
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
@@ -12597,85 +10493,69 @@ SLIN:
   rank: 1
   title: Chairman
   bioguide: B001135
-  thomas: '00153'
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
-  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
   bioguide: R000595
-  thomas: '02084'
 - name: Susan M. Collins
   party: majority
   rank: 4
   bioguide: C001035
-  thomas: '01541'
 - name: Roy Blunt
   party: majority
   rank: 5
   bioguide: B000575
-  thomas: '01464'
 - name: James Lankford
   party: majority
   rank: 6
   bioguide: L000575
-  thomas: '02050'
 - name: Tom Cotton
   party: majority
   rank: 7
   bioguide: C001095
-  thomas: '02098'
 - name: John Cornyn
   party: majority
   rank: 8
   bioguide: C001056
-  thomas: '01692'
 - name: Mitch McConnell
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: M000355
-  thomas: '01395'
 - name: John McCain
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Vice Chairman
   bioguide: W000805
-  thomas: '01897'
 - name: Dianne Feinstein
   party: minority
   rank: 2
   bioguide: F000062
-  thomas: '01332'
 - name: Ron Wyden
   party: minority
   rank: 3
   bioguide: W000779
-  thomas: '01247'
 - name: Martin Heinrich
   party: minority
   rank: 4
   bioguide: H001046
-  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
   bioguide: K000383
-  thomas: '02185'
 - name: Joe Manchin, III
   party: minority
   rank: 6
   bioguide: M001183
-  thomas: '01983'
 - name: Kamala D. Harris
   party: minority
   rank: 7
@@ -12685,96 +10565,78 @@ SLIN:
   rank: 8
   title: Ex Officio
   bioguide: S000148
-  thomas: '01036'
 - name: Jack Reed
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SPAG:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001035
-  thomas: '01541'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
   bioguide: H000338
-  thomas: '01351'
 - name: Jeff Flake
   party: majority
   rank: 3
   bioguide: F000444
-  thomas: '01633'
 - name: Tim Scott
   party: majority
   rank: 4
   bioguide: S001184
-  thomas: '02056'
 - name: Thom Tillis
   party: majority
   rank: 5
   bioguide: T000476
-  thomas: '02291'
 - name: Bob Corker
   party: majority
   rank: 6
   bioguide: C001071
-  thomas: '01825'
 - name: Richard Burr
   party: majority
   rank: 7
   bioguide: B001135
-  thomas: '00153'
 - name: Marco Rubio
   party: majority
   rank: 8
   bioguide: R000595
-  thomas: '02084'
 - name: Deb Fischer
   party: majority
   rank: 9
   bioguide: F000463
-  thomas: '02179'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001070
-  thomas: '01828'
 - name: Bill Nelson
   party: minority
   rank: 2
   bioguide: N000032
-  thomas: '00859'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
   bioguide: W000802
-  thomas: '01823'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
   bioguide: G000555
-  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 5
   bioguide: B001277
-  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 6
   bioguide: D000607
-  thomas: '01850'
 - name: Elizabeth Warren
   party: minority
   rank: 7
   bioguide: W000817
-  thomas: '02182'
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
@@ -12785,52 +10647,42 @@ SSAF:
   rank: 1
   title: Chairman
   bioguide: R000307
-  thomas: '00968'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
   bioguide: M000355
-  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 4
   bioguide: B001236
-  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 5
   bioguide: H001061
-  thomas: '02079'
 - name: Joni Ernst
   party: majority
   rank: 6
   bioguide: E000295
-  thomas: '02283'
 - name: Chuck Grassley
   party: majority
   rank: 7
   bioguide: G000386
-  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 8
   bioguide: T000250
-  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 9
   bioguide: D000618
-  thomas: '02138'
 - name: David Perdue
   party: majority
   rank: 10
   bioguide: P000612
-  thomas: '02286'
 - name: Luther Strange
   party: majority
   rank: 11
@@ -12840,159 +10692,129 @@ SSAF:
   rank: 1
   title: Ranking Member
   bioguide: S000770
-  thomas: '01531'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Sherrod Brown
   party: minority
   rank: 3
   bioguide: B000944
-  thomas: '00136'
 - name: Amy Klobuchar
   party: minority
   rank: 4
   bioguide: K000367
-  thomas: '01826'
 - name: Michael F. Bennet
   party: minority
   rank: 5
   bioguide: B001267
-  thomas: '01965'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
   bioguide: G000555
-  thomas: '01866'
 - name: Joe Donnelly
   party: minority
   rank: 7
   bioguide: D000607
-  thomas: '01850'
 - name: Heidi Heitkamp
   party: minority
   rank: 8
   bioguide: H001069
-  thomas: '02174'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 9
   bioguide: C001070
-  thomas: '01828'
 - name: Chris Van Hollen
   party: minority
   rank: 10
   bioguide: V000128
-  thomas: '01729'
 SSAF13:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
   bioguide: B001236
-  thomas: '01687'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: John Hoeven
   party: majority
   rank: 3
   bioguide: H001061
-  thomas: '02079'
 - name: Chuck Grassley
   party: majority
   rank: 4
   bioguide: G000386
-  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 5
   bioguide: T000250
-  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
   bioguide: D000618
-  thomas: '02138'
 - name: David Perdue
   party: majority
   rank: 7
   bioguide: P000612
-  thomas: '02286'
 - name: Pat Roberts
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: R000307
-  thomas: '00968'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001069
-  thomas: '02174'
 - name: Sherrod Brown
   party: minority
   rank: 2
   bioguide: B000944
-  thomas: '00136'
 - name: Michael F. Bennet
   party: minority
   rank: 3
   bioguide: B001267
-  thomas: '01965'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
   bioguide: G000555
-  thomas: '01866'
 - name: Joe Donnelly
   party: minority
   rank: 5
   bioguide: D000607
-  thomas: '01850'
 - name: Chris Van Hollen
   party: minority
   rank: 6
   bioguide: V000128
-  thomas: '01729'
 - name: Debbie Stabenow
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: S000770
-  thomas: '01531'
 SSAF14:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
   bioguide: D000618
-  thomas: '02138'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
   bioguide: M000355
-  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 4
   bioguide: B001236
-  thomas: '01687'
 - name: Chuck Grassley
   party: majority
   rank: 5
   bioguide: G000386
-  thomas: '00457'
 - name: Luther Strange
   party: majority
   rank: 6
@@ -13002,71 +10824,58 @@ SSAF14:
   rank: 7
   title: Ex Officio
   bioguide: R000307
-  thomas: '00968'
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001267
-  thomas: '01965'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
-  thomas: '01826'
 - name: Joe Donnelly
   party: minority
   rank: 4
   bioguide: D000607
-  thomas: '01850'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
   bioguide: C001070
-  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
   bioguide: S000770
-  thomas: '01531'
 SSAF15:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
   bioguide: E000295
-  thomas: '02283'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
-  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 4
   bioguide: H001061
-  thomas: '02079'
 - name: John Thune
   party: majority
   rank: 5
   bioguide: T000250
-  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
   bioguide: D000618
-  thomas: '02138'
 - name: Luther Strange
   party: majority
   rank: 7
@@ -13076,44 +10885,36 @@ SSAF15:
   rank: 8
   title: Ex Officio
   bioguide: R000307
-  thomas: '00968'
 - name: Chris Van Hollen
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: V000128
-  thomas: '01729'
 - name: Sherrod Brown
   party: minority
   rank: 2
   bioguide: B000944
-  thomas: '00136'
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
-  thomas: '01826'
 - name: Michael F. Bennet
   party: minority
   rank: 4
   bioguide: B001267
-  thomas: '01965'
 - name: Joe Donnelly
   party: minority
   rank: 5
   bioguide: D000607
-  thomas: '01850'
 - name: Heidi Heitkamp
   party: minority
   rank: 6
   bioguide: H001069
-  thomas: '02174'
 - name: Debbie Stabenow
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: S000770
-  thomas: '01531'
 SSAF16:
 - name: Luther Strange
   party: majority
@@ -13124,207 +10925,168 @@ SSAF16:
   party: majority
   rank: 2
   bioguide: M000355
-  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
-  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 4
   bioguide: H001061
-  thomas: '02079'
 - name: Joni Ernst
   party: majority
   rank: 5
   bioguide: E000295
-  thomas: '02283'
 - name: David Perdue
   party: majority
   rank: 6
   bioguide: P000612
-  thomas: '02286'
 - name: Pat Roberts
   party: majority
   rank: 7
   title: Ex Officio
   bioguide: R000307
-  thomas: '00968'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001070
-  thomas: '01828'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Sherrod Brown
   party: minority
   rank: 3
   bioguide: B000944
-  thomas: '00136'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
   bioguide: G000555
-  thomas: '01866'
 - name: Chris Van Hollen
   party: minority
   rank: 5
   bioguide: V000128
-  thomas: '01729'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
   bioguide: S000770
-  thomas: '01531'
 SSAF17:
 - name: David Perdue
   party: majority
   rank: 1
   title: Chairman
   bioguide: P000612
-  thomas: '02286'
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
-  thomas: '01395'
 - name: Joni Ernst
   party: majority
   rank: 3
   bioguide: E000295
-  thomas: '02283'
 - name: Chuck Grassley
   party: majority
   rank: 4
   bioguide: G000386
-  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 5
   bioguide: T000250
-  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
   bioguide: D000618
-  thomas: '02138'
 - name: Pat Roberts
   party: majority
   rank: 7
   title: Ex Officio
   bioguide: R000307
-  thomas: '00968'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: G000555
-  thomas: '01866'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
-  thomas: '01826'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
   bioguide: H001069
-  thomas: '02174'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
   bioguide: C001070
-  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
   bioguide: S000770
-  thomas: '01531'
 SSAP:
 - name: Thad Cochran
   party: majority
   rank: 1
   title: Chairman
   bioguide: C000567
-  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
-  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 3
   bioguide: S000320
-  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
   bioguide: A000360
-  thomas: '01695'
 - name: Susan M. Collins
   party: majority
   rank: 5
   bioguide: C001035
-  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
   bioguide: M001153
-  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
   bioguide: G000359
-  thomas: '00452'
 - name: Roy Blunt
   party: majority
   rank: 8
   bioguide: B000575
-  thomas: '01464'
 - name: Jerry Moran
   party: majority
   rank: 9
   bioguide: M000934
-  thomas: '01507'
 - name: John Hoeven
   party: majority
   rank: 10
   bioguide: H001061
-  thomas: '02079'
 - name: John Boozman
   party: majority
   rank: 11
   bioguide: B001236
-  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 12
   bioguide: C001047
-  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 13
   bioguide: L000575
-  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 14
   bioguide: D000618
-  thomas: '02138'
 - name: John Kennedy
   party: majority
   rank: 15
@@ -13333,255 +11095,206 @@ SSAP:
   party: majority
   rank: 16
   bioguide: R000595
-  thomas: '02084'
 - name: Patrick J. Leahy
   party: minority
   rank: 1
   bioguide: L000174
-  thomas: '01383'
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
-  thomas: '01409'
 - name: Dianne Feinstein
   party: minority
   rank: 3
   bioguide: F000062
-  thomas: '01332'
 - name: Richard J. Durbin
   party: minority
   rank: 4
   bioguide: D000563
-  thomas: '00326'
 - name: Jack Reed
   party: minority
   rank: 5
   bioguide: R000122
-  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 6
   bioguide: T000464
-  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 7
   bioguide: U000039
-  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 8
   bioguide: S001181
-  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 9
   bioguide: M001176
-  thomas: '01900'
 - name: Christopher A. Coons
   party: minority
   rank: 10
   bioguide: C001088
-  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 11
   bioguide: S001194
-  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 12
   bioguide: B001230
-  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 13
   bioguide: M001169
-  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 14
   bioguide: M001183
-  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 15
   bioguide: V000128
-  thomas: '01729'
 SSAP01:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
   bioguide: H001061
-  thomas: '02079'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
   bioguide: M000355
-  thomas: '01395'
 - name: Susan M. Collins
   party: majority
   rank: 4
   bioguide: C001035
-  thomas: '01541'
 - name: Roy Blunt
   party: majority
   rank: 5
   bioguide: B000575
-  thomas: '01464'
 - name: Jerry Moran
   party: majority
   rank: 6
   bioguide: M000934
-  thomas: '01507'
 - name: Marco Rubio
   party: majority
   rank: 7
   bioguide: R000595
-  thomas: '02084'
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001176
-  thomas: '01900'
 - name: Dianne Feinstein
   party: minority
   rank: 2
   bioguide: F000062
-  thomas: '01332'
 - name: Jon Tester
   party: minority
   rank: 3
   bioguide: T000464
-  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 4
   bioguide: U000039
-  thomas: '01567'
 - name: Patrick J. Leahy
   party: minority
   rank: 5
   bioguide: L000174
-  thomas: '01383'
 - name: Tammy Baldwin
   party: minority
   rank: 6
   bioguide: B001230
-  thomas: '01558'
 SSAP02:
 - name: Thad Cochran
   party: majority
   rank: 1
   title: Chairman
   bioguide: C000567
-  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
-  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 3
   bioguide: S000320
-  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
   bioguide: A000360
-  thomas: '01695'
 - name: Susan M. Collins
   party: majority
   rank: 5
   bioguide: C001035
-  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
   bioguide: M001153
-  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
   bioguide: G000359
-  thomas: '00452'
 - name: Roy Blunt
   party: majority
   rank: 8
   bioguide: B000575
-  thomas: '01464'
 - name: Steve Daines
   party: majority
   rank: 9
   bioguide: D000618
-  thomas: '02138'
 - name: Jerry Moran
   party: majority
   rank: 10
   bioguide: M000934
-  thomas: '01507'
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000563
-  thomas: '00326'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Dianne Feinstein
   party: minority
   rank: 3
   bioguide: F000062
-  thomas: '01332'
 - name: Patty Murray
   party: minority
   rank: 4
   bioguide: M001111
-  thomas: '01409'
 - name: Jack Reed
   party: minority
   rank: 5
   bioguide: R000122
-  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 6
   bioguide: T000464
-  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 7
   bioguide: U000039
-  thomas: '01567'
 - name: Brian Schatz
   party: minority
   rank: 8
   bioguide: S001194
-  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 9
   bioguide: B001230
-  thomas: '01558'
 SSAP08:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
   bioguide: L000575
-  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 2
@@ -13590,62 +11303,51 @@ SSAP08:
   party: majority
   rank: 3
   bioguide: R000595
-  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 4
   title: Ex Officio
   bioguide: C000567
-  thomas: '00213'
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001169
-  thomas: '01837'
 - name: Chris Van Hollen
   party: minority
   rank: 2
   bioguide: V000128
-  thomas: '01729'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
   title: Ex Officio
   bioguide: L000174
-  thomas: '01383'
 SSAP14:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
   bioguide: B001236
-  thomas: '01687'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: Richard C. Shelby
   party: majority
   rank: 3
   bioguide: S000320
-  thomas: '01049'
 - name: Lisa Murkowski
   party: majority
   rank: 4
   bioguide: M001153
-  thomas: '01694'
 - name: John Hoeven
   party: majority
   rank: 5
   bioguide: H001061
-  thomas: '02079'
 - name: James Lankford
   party: majority
   rank: 6
   bioguide: L000575
-  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 7
@@ -13655,74 +11357,60 @@ SSAP14:
   rank: 1
   title: Ranking Member
   bioguide: T000464
-  thomas: '01829'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
   bioguide: S001181
-  thomas: '01901'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
   bioguide: L000174
-  thomas: '01383'
 - name: Patty Murray
   party: minority
   rank: 4
   bioguide: M001111
-  thomas: '01409'
 - name: Tammy Baldwin
   party: minority
   rank: 5
   bioguide: B001230
-  thomas: '01558'
 - name: Joe Manchin, III
   party: minority
   rank: 6
   bioguide: M001183
-  thomas: '01983'
 SSAP16:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
   bioguide: S000320
-  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 2
   bioguide: A000360
-  thomas: '01695'
 - name: Lisa Murkowski
   party: majority
   rank: 3
   bioguide: M001153
-  thomas: '01694'
 - name: Susan M. Collins
   party: majority
   rank: 4
   bioguide: C001035
-  thomas: '01541'
 - name: Lindsey Graham
   party: majority
   rank: 5
   bioguide: G000359
-  thomas: '00452'
 - name: John Boozman
   party: majority
   rank: 6
   bioguide: B001236
-  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
   bioguide: C001047
-  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 8
   bioguide: L000575
-  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -13732,168 +11420,136 @@ SSAP16:
   rank: 10
   title: Ex Officio
   bioguide: C000567
-  thomas: '00213'
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001181
-  thomas: '01901'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Dianne Feinstein
   party: minority
   rank: 3
   bioguide: F000062
-  thomas: '01332'
 - name: Jack Reed
   party: minority
   rank: 4
   bioguide: R000122
-  thomas: '00949'
 - name: Christopher A. Coons
   party: minority
   rank: 5
   bioguide: C001088
-  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 6
   bioguide: S001194
-  thomas: '02173'
 - name: Joe Manchin, III
   party: minority
   rank: 7
   bioguide: M001183
-  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 8
   bioguide: V000128
-  thomas: '01729'
 SSAP17:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
   bioguide: M001153
-  thomas: '01694'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: Lamar Alexander
   party: majority
   rank: 3
   bioguide: A000360
-  thomas: '01695'
 - name: Roy Blunt
   party: majority
   rank: 4
   bioguide: B000575
-  thomas: '01464'
 - name: John Hoeven
   party: majority
   rank: 5
   bioguide: H001061
-  thomas: '02079'
 - name: Mitch McConnell
   party: majority
   rank: 6
   bioguide: M000355
-  thomas: '01395'
 - name: Steve Daines
   party: majority
   rank: 7
   bioguide: D000618
-  thomas: '02138'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
   bioguide: C001047
-  thomas: '01676'
 - name: Tom Udall
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: U000039
-  thomas: '01567'
 - name: Dianne Feinstein
   party: minority
   rank: 2
   bioguide: F000062
-  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
   bioguide: L000174
-  thomas: '01383'
 - name: Jack Reed
   party: minority
   rank: 4
   bioguide: R000122
-  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 5
   bioguide: T000464
-  thomas: '01829'
 - name: Jeff Merkley
   party: minority
   rank: 6
   bioguide: M001176
-  thomas: '01900'
 - name: Chris Van Hollen
   party: minority
   rank: 7
   bioguide: V000128
-  thomas: '01729'
 SSAP18:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
   bioguide: B000575
-  thomas: '01464'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: Richard C. Shelby
   party: majority
   rank: 3
   bioguide: S000320
-  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
   bioguide: A000360
-  thomas: '01695'
 - name: Lindsey Graham
   party: majority
   rank: 5
   bioguide: G000359
-  thomas: '00452'
 - name: Jerry Moran
   party: majority
   rank: 6
   bioguide: M000934
-  thomas: '01507'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
   bioguide: C001047
-  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 8
   bioguide: L000575
-  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -13902,275 +11558,223 @@ SSAP18:
   party: majority
   rank: 10
   bioguide: R000595
-  thomas: '02084'
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001111
-  thomas: '01409'
 - name: Richard J. Durbin
   party: minority
   rank: 2
   bioguide: D000563
-  thomas: '00326'
 - name: Jack Reed
   party: minority
   rank: 3
   bioguide: R000122
-  thomas: '00949'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
   bioguide: S001181
-  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 5
   bioguide: M001176
-  thomas: '01900'
 - name: Brian Schatz
   party: minority
   rank: 6
   bioguide: S001194
-  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 7
   bioguide: B001230
-  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 8
   bioguide: M001169
-  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 9
   bioguide: M001183
-  thomas: '01983'
 - name: Patrick J. Leahy
   party: minority
   rank: 10
   title: Ex Officio
   bioguide: L000174
-  thomas: '01383'
 SSAP19:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
   bioguide: M000934
-  thomas: '01507'
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
-  thomas: '01395'
 - name: Lisa Murkowski
   party: majority
   rank: 3
   bioguide: M001153
-  thomas: '01694'
 - name: John Hoeven
   party: majority
   rank: 4
   bioguide: H001061
-  thomas: '02079'
 - name: Susan M. Collins
   party: majority
   rank: 5
   bioguide: C001035
-  thomas: '01541'
 - name: John Boozman
   party: majority
   rank: 6
   bioguide: B001236
-  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
   bioguide: C001047
-  thomas: '01676'
 - name: Marco Rubio
   party: majority
   rank: 8
   bioguide: R000595
-  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: C000567
-  thomas: '00213'
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001194
-  thomas: '02173'
 - name: Jon Tester
   party: minority
   rank: 2
   bioguide: T000464
-  thomas: '01829'
 - name: Patty Murray
   party: minority
   rank: 3
   bioguide: M001111
-  thomas: '01409'
 - name: Jack Reed
   party: minority
   rank: 4
   bioguide: R000122
-  thomas: '00949'
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
-  thomas: '01567'
 - name: Tammy Baldwin
   party: minority
   rank: 6
   bioguide: B001230
-  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 7
   bioguide: M001169
-  thomas: '01837'
 - name: Patrick J. Leahy
   party: minority
   rank: 8
   title: Ex Officio
   bioguide: L000174
-  thomas: '01383'
 SSAP20:
 - name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
   bioguide: G000359
-  thomas: '00452'
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
-  thomas: '01395'
 - name: Roy Blunt
   party: majority
   rank: 3
   bioguide: B000575
-  thomas: '01464'
 - name: John Boozman
   party: majority
   rank: 4
   bioguide: B001236
-  thomas: '01687'
 - name: Jerry Moran
   party: majority
   rank: 5
   bioguide: M000934
-  thomas: '01507'
 - name: James Lankford
   party: majority
   rank: 6
   bioguide: L000575
-  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 7
   bioguide: D000618
-  thomas: '02138'
 - name: Marco Rubio
   party: majority
   rank: 8
   bioguide: R000595
-  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: C000567
-  thomas: '00213'
 - name: Patrick J. Leahy
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000174
-  thomas: '01383'
 - name: Richard J. Durbin
   party: minority
   rank: 2
   bioguide: D000563
-  thomas: '00326'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
-  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 4
   bioguide: C001088
-  thomas: '01984'
 - name: Jeff Merkley
   party: minority
   rank: 5
   bioguide: M001176
-  thomas: '01900'
 - name: Christopher Murphy
   party: minority
   rank: 6
   bioguide: M001169
-  thomas: '01837'
 - name: Chris Van Hollen
   party: minority
   rank: 7
   bioguide: V000128
-  thomas: '01729'
 SSAP22:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
   bioguide: A000360
-  thomas: '01695'
 - name: Thad Cochran
   party: majority
   rank: 2
   bioguide: C000567
-  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
   bioguide: M000355
-  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 4
   bioguide: S000320
-  thomas: '01049'
 - name: Susan M. Collins
   party: majority
   rank: 5
   bioguide: C001035
-  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
   bioguide: M001153
-  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
   bioguide: G000359
-  thomas: '00452'
 - name: John Hoeven
   party: majority
   rank: 8
   bioguide: H001061
-  thomas: '02079'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -14180,275 +11784,223 @@ SSAP22:
   rank: 1
   title: Ranking Member
   bioguide: F000062
-  thomas: '01332'
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
-  thomas: '01409'
 - name: Jon Tester
   party: minority
   rank: 3
   bioguide: T000464
-  thomas: '01829'
 - name: Richard J. Durbin
   party: minority
   rank: 4
   bioguide: D000563
-  thomas: '00326'
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
-  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 6
   bioguide: S001181
-  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 7
   bioguide: M001176
-  thomas: '01900'
 - name: Christopher A. Coons
   party: minority
   rank: 8
   bioguide: C001088
-  thomas: '01984'
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: L000174
-  thomas: '01383'
 SSAP23:
 - name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001047
-  thomas: '01676'
 - name: Jerry Moran
   party: majority
   rank: 2
   bioguide: M000934
-  thomas: '01507'
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
-  thomas: '01687'
 - name: James Lankford
   party: majority
   rank: 4
   bioguide: L000575
-  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 5
   bioguide: D000618
-  thomas: '02138'
 - name: Thad Cochran
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C000567
-  thomas: '00213'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001088
-  thomas: '01984'
 - name: Richard J. Durbin
   party: minority
   rank: 2
   bioguide: D000563
-  thomas: '00326'
 - name: Joe Manchin, III
   party: minority
   rank: 3
   bioguide: M001183
-  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 4
   bioguide: V000128
-  thomas: '01729'
 - name: Patrick J. Leahy
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: L000174
-  thomas: '01383'
 SSAP24:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001035
-  thomas: '01541'
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
-  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 3
   bioguide: A000360
-  thomas: '01695'
 - name: Roy Blunt
   party: majority
   rank: 4
   bioguide: B000575
-  thomas: '01464'
 - name: John Boozman
   party: majority
   rank: 5
   bioguide: B001236
-  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 6
   bioguide: C001047
-  thomas: '01676'
 - name: Steve Daines
   party: majority
   rank: 7
   bioguide: D000618
-  thomas: '02138'
 - name: Lindsey Graham
   party: majority
   rank: 8
   bioguide: G000359
-  thomas: '00452'
 - name: John Hoeven
   party: majority
   rank: 9
   bioguide: H001061
-  thomas: '02079'
 - name: Thad Cochran
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: C000567
-  thomas: '00213'
 - name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: R000122
-  thomas: '00949'
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
-  thomas: '01409'
 - name: Richard J. Durbin
   party: minority
   rank: 3
   bioguide: D000563
-  thomas: '00326'
 - name: Dianne Feinstein
   party: minority
   rank: 4
   bioguide: F000062
-  thomas: '01332'
 - name: Christopher A. Coons
   party: minority
   rank: 5
   bioguide: C001088
-  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 6
   bioguide: S001194
-  thomas: '02173'
 - name: Christopher Murphy
   party: minority
   rank: 7
   bioguide: M001169
-  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 8
   bioguide: M001183
-  thomas: '01983'
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: L000174
-  thomas: '01383'
 SSAS:
 - name: John McCain
   party: majority
   rank: 1
   title: Chairman
   bioguide: M000303
-  thomas: '00754'
 - name: James M. Inhofe
   party: majority
   rank: 2
   bioguide: I000024
-  thomas: '00583'
 - name: Roger F. Wicker
   party: majority
   rank: 3
   bioguide: W000437
-  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 4
   bioguide: F000463
-  thomas: '02179'
 - name: Tom Cotton
   party: majority
   rank: 5
   bioguide: C001095
-  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 6
   bioguide: R000605
-  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 7
   bioguide: E000295
-  thomas: '02283'
 - name: Thom Tillis
   party: majority
   rank: 8
   bioguide: T000476
-  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 9
   bioguide: S001198
-  thomas: '02290'
 - name: David Perdue
   party: majority
   rank: 10
   bioguide: P000612
-  thomas: '02286'
 - name: Ted Cruz
   party: majority
   rank: 11
   bioguide: C001098
-  thomas: '02175'
 - name: Lindsey Graham
   party: majority
   rank: 12
   bioguide: G000359
-  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 13
   bioguide: S001197
-  thomas: '02289'
 - name: Luther Strange
   party: majority
   rank: 14
@@ -14458,94 +12010,76 @@ SSAS:
   rank: 1
   title: Ranking Member
   bioguide: R000122
-  thomas: '00949'
 - name: Bill Nelson
   party: minority
   rank: 2
   bioguide: N000032
-  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 3
   bioguide: M001170
-  thomas: '01820'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
   bioguide: S001181
-  thomas: '01901'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
   bioguide: G000555
-  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 6
   bioguide: B001277
-  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 7
   bioguide: D000607
-  thomas: '01850'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
   bioguide: H001042
-  thomas: '01844'
 - name: Tim Kaine
   party: minority
   rank: 9
   bioguide: K000384
-  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 10
   bioguide: K000383
-  thomas: '02185'
 - name: Martin Heinrich
   party: minority
   rank: 11
   bioguide: H001046
-  thomas: '01937'
 - name: Elizabeth Warren
   party: minority
   rank: 12
   bioguide: W000817
-  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 13
   bioguide: P000595
-  thomas: '01929'
 SSAS13:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
   bioguide: W000437
-  thomas: '01226'
 - name: Tom Cotton
   party: majority
   rank: 2
   bioguide: C001095
-  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 3
   bioguide: R000605
-  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 4
   bioguide: T000476
-  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 5
   bioguide: S001198
-  thomas: '02290'
 - name: Luther Strange
   party: majority
   rank: 6
@@ -14555,141 +12089,115 @@ SSAS13:
   rank: 7
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001042
-  thomas: '01844'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
   bioguide: S001181
-  thomas: '01901'
 - name: Richard Blumenthal
   party: minority
   rank: 3
   bioguide: B001277
-  thomas: '02076'
 - name: Tim Kaine
   party: minority
   rank: 4
   bioguide: K000384
-  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
   bioguide: K000383
-  thomas: '02185'
 - name: Jack Reed
   party: minority
   rank: 6
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SSAS14:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001095
-  thomas: '02098'
 - name: James M. Inhofe
   party: majority
   rank: 2
   bioguide: I000024
-  thomas: '00583'
 - name: Roger F. Wicker
   party: majority
   rank: 3
   bioguide: W000437
-  thomas: '01226'
 - name: Thom Tillis
   party: majority
   rank: 4
   bioguide: T000476
-  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 5
   bioguide: S001198
-  thomas: '02290'
 - name: Ted Cruz
   party: majority
   rank: 6
   bioguide: C001098
-  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 7
   bioguide: S001197
-  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000383
-  thomas: '02185'
 - name: Claire McCaskill
   party: minority
   rank: 2
   bioguide: M001170
-  thomas: '01820'
 - name: Richard Blumenthal
   party: minority
   rank: 3
   bioguide: B001277
-  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 4
   bioguide: D000607
-  thomas: '01850'
 - name: Elizabeth Warren
   party: minority
   rank: 5
   bioguide: W000817
-  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 6
   bioguide: P000595
-  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SSAS15:
 - name: James M. Inhofe
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000024
-  thomas: '00583'
 - name: Mike Rounds
   party: majority
   rank: 2
   bioguide: R000605
-  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 3
   bioguide: E000295
-  thomas: '02283'
 - name: David Perdue
   party: majority
   rank: 4
   bioguide: P000612
-  thomas: '02286'
 - name: Luther Strange
   party: majority
   rank: 5
@@ -14699,321 +12207,262 @@ SSAS15:
   rank: 6
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000384
-  thomas: '02176'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
   bioguide: S001181
-  thomas: '01901'
 - name: Mazie K. Hirono
   party: minority
   rank: 3
   bioguide: H001042
-  thomas: '01844'
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SSAS16:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
   bioguide: F000463
-  thomas: '02179'
 - name: James M. Inhofe
   party: majority
   rank: 2
   bioguide: I000024
-  thomas: '00583'
 - name: Tom Cotton
   party: majority
   rank: 3
   bioguide: C001095
-  thomas: '02098'
 - name: Dan Sullivan
   party: majority
   rank: 4
   bioguide: S001198
-  thomas: '02290'
 - name: Ted Cruz
   party: majority
   rank: 5
   bioguide: C001098
-  thomas: '02175'
 - name: Lindsey Graham
   party: majority
   rank: 6
   bioguide: G000359
-  thomas: '00452'
 - name: John McCain
   party: majority
   rank: 7
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Joe Donnelly
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000607
-  thomas: '01850'
 - name: Martin Heinrich
   party: minority
   rank: 2
   bioguide: H001046
-  thomas: '01937'
 - name: Elizabeth Warren
   party: minority
   rank: 3
   bioguide: W000817
-  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 4
   bioguide: P000595
-  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SSAS17:
 - name: Thom Tillis
   party: majority
   rank: 1
   title: Chairman
   bioguide: T000476
-  thomas: '02291'
 - name: Joni Ernst
   party: majority
   rank: 2
   bioguide: E000295
-  thomas: '02283'
 - name: Lindsey Graham
   party: majority
   rank: 3
   bioguide: G000359
-  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 4
   bioguide: S001197
-  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 5
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: G000555
-  thomas: '01866'
 - name: Claire McCaskill
   party: minority
   rank: 2
   bioguide: M001170
-  thomas: '01820'
 - name: Elizabeth Warren
   party: minority
   rank: 3
   bioguide: W000817
-  thomas: '02182'
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SSAS20:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
   bioguide: E000295
-  thomas: '02283'
 - name: Roger F. Wicker
   party: majority
   rank: 2
   bioguide: W000437
-  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 3
   bioguide: F000463
-  thomas: '02179'
 - name: David Perdue
   party: majority
   rank: 4
   bioguide: P000612
-  thomas: '02286'
 - name: Ted Cruz
   party: majority
   rank: 5
   bioguide: C001098
-  thomas: '02175'
 - name: John McCain
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Martin Heinrich
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001046
-  thomas: '01937'
 - name: Bill Nelson
   party: minority
   rank: 2
   bioguide: N000032
-  thomas: '00859'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
-  thomas: '01901'
 - name: Gary C. Peters
   party: minority
   rank: 4
   bioguide: P000595
-  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SSAS21:
 - name: Mike Rounds
   party: majority
   rank: 1
   title: Chairman
   bioguide: R000605
-  thomas: '02288'
 - name: Deb Fischer
   party: majority
   rank: 2
   bioguide: F000463
-  thomas: '02179'
 - name: David Perdue
   party: majority
   rank: 3
   bioguide: P000612
-  thomas: '02286'
 - name: Lindsey Graham
   party: majority
   rank: 4
   bioguide: G000359
-  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 5
   bioguide: S001197
-  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: M000303
-  thomas: '00754'
 - name: Bill Nelson
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: N000032
-  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 2
   bioguide: M001170
-  thomas: '01820'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 3
   bioguide: G000555
-  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 4
   bioguide: B001277
-  thomas: '02076'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: R000122
-  thomas: '00949'
 SSBK:
 - name: Mike Crapo
   party: majority
   rank: 1
   title: Chairman
   bioguide: C000880
-  thomas: '00250'
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
-  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
   bioguide: C001071
-  thomas: '01825'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
   bioguide: T000461
-  thomas: '02085'
 - name: Dean Heller
   party: majority
   rank: 5
   bioguide: H001041
-  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 6
   bioguide: S001184
-  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 7
   bioguide: S001197
-  thomas: '02289'
 - name: Tom Cotton
   party: majority
   rank: 8
   bioguide: C001095
-  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 9
   bioguide: R000605
-  thomas: '02288'
 - name: David Perdue
   party: majority
   rank: 10
   bioguide: P000612
-  thomas: '02286'
 - name: Thom Tillis
   party: majority
   rank: 11
   bioguide: T000476
-  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 12
@@ -15023,52 +12472,42 @@ SSBK:
   rank: 1
   title: Ranking Member
   bioguide: B000944
-  thomas: '00136'
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
-  thomas: '00949'
 - name: Robert Menendez
   party: minority
   rank: 3
   bioguide: M000639
-  thomas: '00791'
 - name: Jon Tester
   party: minority
   rank: 4
   bioguide: T000464
-  thomas: '01829'
 - name: Mark R. Warner
   party: minority
   rank: 5
   bioguide: W000805
-  thomas: '01897'
 - name: Elizabeth Warren
   party: minority
   rank: 6
   bioguide: W000817
-  thomas: '02182'
 - name: Heidi Heitkamp
   party: minority
   rank: 7
   bioguide: H001069
-  thomas: '02174'
 - name: Joe Donnelly
   party: minority
   rank: 8
   bioguide: D000607
-  thomas: '01850'
 - name: Brian Schatz
   party: minority
   rank: 9
   bioguide: S001194
-  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 10
   bioguide: V000128
-  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 11
@@ -15079,79 +12518,64 @@ SSBK04:
   rank: 1
   title: Chairman
   bioguide: H001041
-  thomas: '01863'
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
-  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
   bioguide: C001071
-  thomas: '01825'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
   bioguide: T000461
-  thomas: '02085'
 - name: Tim Scott
   party: majority
   rank: 5
   bioguide: S001184
-  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 6
   bioguide: S001197
-  thomas: '02289'
 - name: Mike Rounds
   party: majority
   rank: 7
   bioguide: R000605
-  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 8
   bioguide: T000476
-  thomas: '02291'
 - name: Mike Crapo
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: C000880
-  thomas: '00250'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000805
-  thomas: '01897'
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
-  thomas: '00949'
 - name: Robert Menendez
   party: minority
   rank: 3
   bioguide: M000639
-  thomas: '00791'
 - name: Jon Tester
   party: minority
   rank: 4
   bioguide: T000464
-  thomas: '01829'
 - name: Elizabeth Warren
   party: minority
   rank: 5
   bioguide: W000817
-  thomas: '02182'
 - name: Chris Van Hollen
   party: minority
   rank: 6
   bioguide: V000128
-  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
@@ -15161,109 +12585,89 @@ SSBK04:
   rank: 8
   title: Ex Officio
   bioguide: B000944
-  thomas: '00136'
 SSBK05:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
   bioguide: S001197
-  thomas: '02289'
 - name: Bob Corker
   party: majority
   rank: 2
   bioguide: C001071
-  thomas: '01825'
 - name: Tom Cotton
   party: majority
   rank: 3
   bioguide: C001095
-  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 4
   bioguide: R000605
-  thomas: '02288'
 - name: David Perdue
   party: majority
   rank: 5
   bioguide: P000612
-  thomas: '02286'
 - name: Mike Crapo
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C000880
-  thomas: '00250'
 - name: Joe Donnelly
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000607
-  thomas: '01850'
 - name: Mark R. Warner
   party: minority
   rank: 2
   bioguide: W000805
-  thomas: '01897'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
   bioguide: H001069
-  thomas: '02174'
 - name: Brian Schatz
   party: minority
   rank: 4
   bioguide: S001194
-  thomas: '02173'
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: B000944
-  thomas: '00136'
 SSBK08:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
   bioguide: T000461
-  thomas: '02085'
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
-  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
   bioguide: C001071
-  thomas: '01825'
 - name: Dean Heller
   party: majority
   rank: 4
   bioguide: H001041
-  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 5
   bioguide: S001184
-  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 6
   bioguide: S001197
-  thomas: '02289'
 - name: Tom Cotton
   party: majority
   rank: 7
   bioguide: C001095
-  thomas: '02098'
 - name: David Perdue
   party: majority
   rank: 8
   bioguide: P000612
-  thomas: '02286'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -15273,43 +12677,35 @@ SSBK08:
   rank: 10
   title: Ex Officio
   bioguide: C000880
-  thomas: '00250'
 - name: Elizabeth Warren
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000817
-  thomas: '02182'
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
-  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 3
   bioguide: T000464
-  thomas: '01829'
 - name: Mark R. Warner
   party: minority
   rank: 4
   bioguide: W000805
-  thomas: '01897'
 - name: Joe Donnelly
   party: minority
   rank: 5
   bioguide: D000607
-  thomas: '01850'
 - name: Brian Schatz
   party: minority
   rank: 6
   bioguide: S001194
-  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 7
   bioguide: V000128
-  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
@@ -15319,34 +12715,28 @@ SSBK08:
   rank: 9
   title: Ex Officio
   bioguide: B000944
-  thomas: '00136'
 SSBK09:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
   bioguide: S001184
-  thomas: '02056'
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
-  thomas: '01049'
 - name: Dean Heller
   party: majority
   rank: 3
   bioguide: H001041
-  thomas: '01863'
 - name: Mike Rounds
   party: majority
   rank: 4
   bioguide: R000605
-  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 5
   bioguide: T000476
-  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 6
@@ -15356,61 +12746,50 @@ SSBK09:
   rank: 7
   title: Ex Officio
   bioguide: C000880
-  thomas: '00250'
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M000639
-  thomas: '00791'
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
-  thomas: '00949'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
   bioguide: H001069
-  thomas: '02174'
 - name: Brian Schatz
   party: minority
   rank: 4
   bioguide: S001194
-  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 5
   bioguide: V000128
-  thomas: '01729'
 - name: Sherrod Brown
   party: minority
   rank: 6
   title: Ex Officio
   bioguide: B000944
-  thomas: '00136'
 SSBK12:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001095
-  thomas: '02098'
 - name: Patrick J. Toomey
   party: majority
   rank: 2
   bioguide: T000461
-  thomas: '02085'
 - name: David Perdue
   party: majority
   rank: 3
   bioguide: P000612
-  thomas: '02286'
 - name: Thom Tillis
   party: majority
   rank: 4
   bioguide: T000476
-  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 5
@@ -15420,81 +12799,66 @@ SSBK12:
   rank: 6
   title: Ex Officio
   bioguide: C000880
-  thomas: '00250'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001069
-  thomas: '02174'
 - name: Robert Menendez
   party: minority
   rank: 2
   bioguide: M000639
-  thomas: '00791'
 - name: Elizabeth Warren
   party: minority
   rank: 3
   bioguide: W000817
-  thomas: '02182'
 - name: Joe Donnelly
   party: minority
   rank: 4
   bioguide: D000607
-  thomas: '01850'
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: B000944
-  thomas: '00136'
 SSBU:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
   bioguide: E000285
-  thomas: '01542'
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-  thomas: '00250'
 - name: Lindsey Graham
   party: majority
   rank: 4
   bioguide: G000359
-  thomas: '00452'
 - name: Patrick J. Toomey
   party: majority
   rank: 5
   bioguide: T000461
-  thomas: '02085'
 - name: Ron Johnson
   party: majority
   rank: 6
   bioguide: J000293
-  thomas: '02086'
 - name: Bob Corker
   party: majority
   rank: 7
   bioguide: C001071
-  thomas: '01825'
 - name: David Perdue
   party: majority
   rank: 8
   bioguide: P000612
-  thomas: '02286'
 - name: Cory Gardner
   party: majority
   rank: 9
   bioguide: G000562
-  thomas: '01998'
 - name: John Kennedy
   party: majority
   rank: 10
@@ -15503,7 +12867,6 @@ SSBU:
   party: majority
   rank: 11
   bioguide: B001236
-  thomas: '01687'
 - name: Luther Strange
   party: majority
   rank: 12
@@ -15513,52 +12876,42 @@ SSBU:
   rank: 1
   title: Ranking Member
   bioguide: S000033
-  thomas: '01010'
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
-  thomas: '01409'
 - name: Ron Wyden
   party: minority
   rank: 3
   bioguide: W000779
-  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 4
   bioguide: S000770
-  thomas: '01531'
 - name: Sheldon Whitehouse
   party: minority
   rank: 5
   bioguide: W000802
-  thomas: '01823'
 - name: Mark R. Warner
   party: minority
   rank: 6
   bioguide: W000805
-  thomas: '01897'
 - name: Jeff Merkley
   party: minority
   rank: 7
   bioguide: M001176
-  thomas: '01900'
 - name: Tim Kaine
   party: minority
   rank: 8
   bioguide: K000384
-  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 9
   bioguide: K000383
-  thomas: '02185'
 - name: Chris Van Hollen
   party: minority
   rank: 10
   bioguide: V000128
-  thomas: '01729'
 - name: Kamala D. Harris
   party: minority
   rank: 11
@@ -15569,128 +12922,103 @@ SSCM:
   rank: 1
   title: Chairman
   bioguide: T000250
-  thomas: '01534'
 - name: Roger F. Wicker
   party: majority
   rank: 2
   bioguide: W000437
-  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 3
   bioguide: B000575
-  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 4
   bioguide: C001098
-  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 5
   bioguide: F000463
-  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 6
   bioguide: M000934
-  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 7
   bioguide: S001198
-  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 8
   bioguide: H001041
-  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 9
   bioguide: I000024
-  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 10
   bioguide: L000577
-  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 11
   bioguide: J000293
-  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 12
   bioguide: C001047
-  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 13
   bioguide: G000562
-  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 14
   bioguide: Y000064
-  thomas: '02019'
 - name: Bill Nelson
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: N000032
-  thomas: '00859'
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
-  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
-  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
   bioguide: B001277
-  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 5
   bioguide: S001194
-  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 6
   bioguide: M000133
-  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 7
   bioguide: B001288
-  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 8
   bioguide: U000039
-  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 9
   bioguide: P000595
-  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 10
   bioguide: B001230
-  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 11
   bioguide: D000622
-  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 12
@@ -15705,119 +13033,96 @@ SSCM01:
   rank: 1
   title: Chairman
   bioguide: B000575
-  thomas: '01464'
 - name: Roger F. Wicker
   party: majority
   rank: 2
   bioguide: W000437
-  thomas: '01226'
 - name: Ted Cruz
   party: majority
   rank: 3
   bioguide: C001098
-  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
   bioguide: F000463
-  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 5
   bioguide: M000934
-  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 6
   bioguide: S001198
-  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 7
   bioguide: H001041
-  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 8
   bioguide: I000024
-  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 9
   bioguide: L000577
-  thomas: '02080'
 - name: Shelley Moore Capito
   party: majority
   rank: 10
   bioguide: C001047
-  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 11
   bioguide: G000562
-  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 12
   bioguide: Y000064
-  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 13
   title: Ex Officio
   bioguide: T000250
-  thomas: '01534'
 - name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000127
-  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 2
   bioguide: K000367
-  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 3
   bioguide: B001277
-  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 4
   bioguide: S001194
-  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 5
   bioguide: M000133
-  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
   bioguide: B001288
-  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 7
   bioguide: U000039
-  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 8
   bioguide: P000595
-  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 9
   bioguide: B001230
-  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 10
   bioguide: D000622
-  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 11
@@ -15827,91 +13132,74 @@ SSCM01:
   rank: 12
   title: Ex Officio
   bioguide: N000032
-  thomas: '00859'
 SSCM20:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
   bioguide: M000934
-  thomas: '01507'
 - name: Roy Blunt
   party: majority
   rank: 2
   bioguide: B000575
-  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 3
   bioguide: C001098
-  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
   bioguide: F000463
-  thomas: '02179'
 - name: Dean Heller
   party: majority
   rank: 5
   bioguide: H001041
-  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 6
   bioguide: I000024
-  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 7
   bioguide: L000577
-  thomas: '02080'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
   bioguide: C001047
-  thomas: '01676'
 - name: Todd Young
   party: majority
   rank: 9
   bioguide: Y000064
-  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: T000250
-  thomas: '01534'
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001277
-  thomas: '02076'
 - name: Amy Klobuchar
   party: minority
   rank: 2
   bioguide: K000367
-  thomas: '01826'
 - name: Edward J. Markey
   party: minority
   rank: 3
   bioguide: M000133
-  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 4
   bioguide: B001288
-  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
-  thomas: '01567'
 - name: Tammy Duckworth
   party: minority
   rank: 6
   bioguide: D000622
-  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 7
@@ -15925,166 +13213,135 @@ SSCM20:
   rank: 9
   title: Ex Officio
   bioguide: N000032
-  thomas: '00859'
 SSCM22:
 - name: Dan Sullivan
   party: majority
   rank: 1
   title: Chairman
   bioguide: S001198
-  thomas: '02290'
 - name: Roger F. Wicker
   party: majority
   rank: 2
   bioguide: W000437
-  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 3
   bioguide: F000463
-  thomas: '02179'
 - name: James M. Inhofe
   party: majority
   rank: 4
   bioguide: I000024
-  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 5
   bioguide: L000577
-  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 6
   bioguide: J000293
-  thomas: '02086'
 - name: Cory Gardner
   party: majority
   rank: 7
   bioguide: G000562
-  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 8
   bioguide: Y000064
-  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: T000250
-  thomas: '01534'
 - name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000595
-  thomas: '01929'
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
-  thomas: '00172'
 - name: Richard Blumenthal
   party: minority
   rank: 3
   bioguide: B001277
-  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 4
   bioguide: S001194
-  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 5
   bioguide: M000133
-  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
   bioguide: B001288
-  thomas: '02194'
 - name: Tammy Baldwin
   party: minority
   rank: 7
   bioguide: B001230
-  thomas: '01558'
 - name: Bill Nelson
   party: minority
   rank: 8
   title: Ex Officio
   bioguide: N000032
-  thomas: '00859'
 SSCM24:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001098
-  thomas: '02175'
 - name: Jerry Moran
   party: majority
   rank: 2
   bioguide: M000934
-  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 3
   bioguide: S001198
-  thomas: '02290'
 - name: Mike Lee
   party: majority
   rank: 4
   bioguide: L000577
-  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 5
   bioguide: J000293
-  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 6
   bioguide: C001047
-  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 7
   bioguide: G000562
-  thomas: '01998'
 - name: John Thune
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: T000250
-  thomas: '01534'
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M000133
-  thomas: '00735'
 - name: Brian Schatz
   party: minority
   rank: 2
   bioguide: S001194
-  thomas: '02173'
 - name: Tom Udall
   party: minority
   rank: 3
   bioguide: U000039
-  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 4
   bioguide: P000595
-  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 5
   bioguide: B001230
-  thomas: '01558'
 - name: Margaret Wood Hassan
   party: minority
   rank: 6
@@ -16094,96 +13351,78 @@ SSCM24:
   rank: 7
   title: Ex Officio
   bioguide: N000032
-  thomas: '00859'
 SSCM25:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
   bioguide: F000463
-  thomas: '02179'
 - name: Roger F. Wicker
   party: majority
   rank: 2
   bioguide: W000437
-  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 3
   bioguide: B000575
-  thomas: '01464'
 - name: Dean Heller
   party: majority
   rank: 4
   bioguide: H001041
-  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 5
   bioguide: I000024
-  thomas: '00583'
 - name: Ron Johnson
   party: majority
   rank: 6
   bioguide: J000293
-  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
   bioguide: C001047
-  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 8
   bioguide: G000562
-  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 9
   bioguide: Y000064
-  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: T000250
-  thomas: '01534'
 - name: Cory A. Booker
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001288
-  thomas: '02194'
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
-  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
-  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
   bioguide: B001277
-  thomas: '02076'
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
-  thomas: '01567'
 - name: Tammy Baldwin
   party: minority
   rank: 6
   bioguide: B001230
-  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 7
   bioguide: D000622
-  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 8
@@ -16193,131 +13432,106 @@ SSCM25:
   rank: 9
   title: Ex Officio
   bioguide: N000032
-  thomas: '00859'
 SSCM26:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
   bioguide: W000437
-  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 2
   bioguide: B000575
-  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 3
   bioguide: C001098
-  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
   bioguide: F000463
-  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 5
   bioguide: M000934
-  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 6
   bioguide: S001198
-  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 7
   bioguide: H001041
-  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 8
   bioguide: I000024
-  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 9
   bioguide: L000577
-  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 10
   bioguide: J000293
-  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 11
   bioguide: C001047
-  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 12
   bioguide: G000562
-  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 13
   bioguide: Y000064
-  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 14
   title: Ex Officio
   bioguide: T000250
-  thomas: '01534'
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001194
-  thomas: '02173'
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
-  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
-  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
   bioguide: B001277
-  thomas: '02076'
 - name: Edward J. Markey
   party: minority
   rank: 5
   bioguide: M000133
-  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
   bioguide: B001288
-  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 7
   bioguide: U000039
-  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 8
   bioguide: P000595
-  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 9
   bioguide: B001230
-  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 10
   bioguide: D000622
-  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 11
@@ -16331,64 +13545,52 @@ SSCM26:
   rank: 13
   title: Ex Officio
   bioguide: N000032
-  thomas: '00859'
 SSEG:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
   bioguide: M001153
-  thomas: '01694'
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
-  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
-  thomas: '01896'
 - name: Mike Lee
   party: majority
   rank: 4
   bioguide: L000577
-  thomas: '02080'
 - name: Jeff Flake
   party: majority
   rank: 5
   bioguide: F000444
-  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 6
   bioguide: D000618
-  thomas: '02138'
 - name: Cory Gardner
   party: majority
   rank: 7
   bioguide: G000562
-  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 8
   bioguide: A000360
-  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 9
   bioguide: H001061
-  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 10
   bioguide: C001075
-  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 11
   bioguide: P000449
-  thomas: '00924'
 - name: Luther Strange
   party: majority
   rank: 12
@@ -16398,52 +13600,42 @@ SSEG:
   rank: 1
   title: Ranking Member
   bioguide: C000127
-  thomas: '00172'
 - name: Ron Wyden
   party: minority
   rank: 2
   bioguide: W000779
-  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
   bioguide: S000033
-  thomas: '01010'
 - name: Debbie Stabenow
   party: minority
   rank: 4
   bioguide: S000770
-  thomas: '01531'
 - name: Al Franken
   party: minority
   rank: 5
   bioguide: F000457
-  thomas: '01969'
 - name: Joe Manchin, III
   party: minority
   rank: 6
   bioguide: M001183
-  thomas: '01983'
 - name: Martin Heinrich
   party: minority
   rank: 7
   bioguide: H001046
-  thomas: '01937'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
   bioguide: H001042
-  thomas: '01844'
 - name: Angus S. King, Jr.
   party: minority
   rank: 9
   bioguide: K000383
-  thomas: '02185'
 - name: Tammy Duckworth
   party: minority
   rank: 10
   bioguide: D000622
-  thomas: '02123'
 - name: Catherine Cortez Masto
   party: minority
   rank: 11
@@ -16454,84 +13646,68 @@ SSEG01:
   rank: 1
   title: Chairman
   bioguide: G000562
-  thomas: '01998'
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
-  thomas: '01896'
 - name: Jeff Flake
   party: majority
   rank: 3
   bioguide: F000444
-  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 4
   bioguide: D000618
-  thomas: '02138'
 - name: Lamar Alexander
   party: majority
   rank: 5
   bioguide: A000360
-  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 6
   bioguide: H001061
-  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 7
   bioguide: C001075
-  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 8
   bioguide: P000449
-  thomas: '00924'
 - name: Lisa Murkowski
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: M001153
-  thomas: '01694'
 - name: Joe Manchin, III
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001183
-  thomas: '01983'
 - name: Ron Wyden
   party: minority
   rank: 2
   bioguide: W000779
-  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
   bioguide: S000033
-  thomas: '01010'
 - name: Al Franken
   party: minority
   rank: 4
   bioguide: F000457
-  thomas: '01969'
 - name: Martin Heinrich
   party: minority
   rank: 5
   bioguide: H001046
-  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
   rank: 6
   bioguide: K000383
-  thomas: '02185'
 - name: Tammy Duckworth
   party: minority
   rank: 7
   bioguide: D000622
-  thomas: '02123'
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
@@ -16541,91 +13717,74 @@ SSEG01:
   rank: 9
   title: Ex Officio
   bioguide: C000127
-  thomas: '00172'
 SSEG03:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
   bioguide: L000577
-  thomas: '02080'
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
-  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
-  thomas: '01896'
 - name: Jeff Flake
   party: majority
   rank: 4
   bioguide: F000444
-  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 5
   bioguide: D000618
-  thomas: '02138'
 - name: Cory Gardner
   party: majority
   rank: 6
   bioguide: G000562
-  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 7
   bioguide: A000360
-  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 8
   bioguide: H001061
-  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 9
   bioguide: C001075
-  thomas: '01925'
 - name: Lisa Murkowski
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: M001153
-  thomas: '01694'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000779
-  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 2
   bioguide: S000770
-  thomas: '01531'
 - name: Al Franken
   party: minority
   rank: 3
   bioguide: F000457
-  thomas: '01969'
 - name: Joe Manchin, III
   party: minority
   rank: 4
   bioguide: M001183
-  thomas: '01983'
 - name: Martin Heinrich
   party: minority
   rank: 5
   bioguide: H001046
-  thomas: '01937'
 - name: Mazie K. Hirono
   party: minority
   rank: 6
   bioguide: H001042
-  thomas: '01844'
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
@@ -16635,259 +13794,210 @@ SSEG03:
   rank: 8
   title: Ex Officio
   bioguide: C000127
-  thomas: '00172'
 SSEG04:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
   bioguide: D000618
-  thomas: '02138'
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
-  thomas: '01881'
 - name: Mike Lee
   party: majority
   rank: 3
   bioguide: L000577
-  thomas: '02080'
 - name: Cory Gardner
   party: majority
   rank: 4
   bioguide: G000562
-  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 5
   bioguide: A000360
-  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 6
   bioguide: H001061
-  thomas: '02079'
 - name: Rob Portman
   party: majority
   rank: 7
   bioguide: P000449
-  thomas: '00924'
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: M001153
-  thomas: '01694'
 - name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001042
-  thomas: '01844'
 - name: Bernard Sanders
   party: minority
   rank: 2
   bioguide: S000033
-  thomas: '01010'
 - name: Debbie Stabenow
   party: minority
   rank: 3
   bioguide: S000770
-  thomas: '01531'
 - name: Martin Heinrich
   party: minority
   rank: 4
   bioguide: H001046
-  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
   bioguide: K000383
-  thomas: '02185'
 - name: Maria Cantwell
   party: minority
   rank: 6
   title: Ex Officio
   bioguide: C000127
-  thomas: '00172'
 SSEG07:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
   bioguide: F000444
-  thomas: '01633'
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
-  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
-  thomas: '01896'
 - name: Mike Lee
   party: majority
   rank: 4
   bioguide: L000577
-  thomas: '02080'
 - name: Bill Cassidy
   party: majority
   rank: 5
   bioguide: C001075
-  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 6
   bioguide: P000449
-  thomas: '00924'
 - name: Lisa Murkowski
   party: majority
   rank: 7
   title: Ex Officio
   bioguide: M001153
-  thomas: '01694'
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000383
-  thomas: '02185'
 - name: Ron Wyden
   party: minority
   rank: 2
   bioguide: W000779
-  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
   bioguide: S000033
-  thomas: '01010'
 - name: Al Franken
   party: minority
   rank: 4
   bioguide: F000457
-  thomas: '01969'
 - name: Joe Manchin, III
   party: minority
   rank: 5
   bioguide: M001183
-  thomas: '01983'
 - name: Tammy Duckworth
   party: minority
   rank: 6
   bioguide: D000622
-  thomas: '02123'
 - name: Maria Cantwell
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: C000127
-  thomas: '00172'
 SSEV:
 - name: John Barrasso
   party: majority
   rank: 1
   title: Chairman
   bioguide: B001261
-  thomas: '01881'
 - name: James M. Inhofe
   party: majority
   rank: 2
   bioguide: I000024
-  thomas: '00583'
 - name: Shelley Moore Capito
   party: majority
   rank: 3
   bioguide: C001047
-  thomas: '01676'
 - name: John Boozman
   party: majority
   rank: 4
   bioguide: B001236
-  thomas: '01687'
 - name: Roger F. Wicker
   party: majority
   rank: 5
   bioguide: W000437
-  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 6
   bioguide: F000463
-  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 7
   bioguide: M000934
-  thomas: '01507'
 - name: Mike Rounds
   party: majority
   rank: 8
   bioguide: R000605
-  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 9
   bioguide: E000295
-  thomas: '02283'
 - name: Dan Sullivan
   party: majority
   rank: 10
   bioguide: S001198
-  thomas: '02290'
 - name: Richard C. Shelby
   party: majority
   rank: 11
   bioguide: S000320
-  thomas: '01049'
 - name: Thomas R. Carper
   party: minority
   rank: 1
   bioguide: C000174
-  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
   bioguide: C000141
-  thomas: '00174'
 - name: Bernard Sanders
   party: minority
   rank: 3
   bioguide: S000033
-  thomas: '01010'
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
   bioguide: W000802
-  thomas: '01823'
 - name: Jeff Merkley
   party: minority
   rank: 5
   bioguide: M001176
-  thomas: '01900'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
   bioguide: G000555
-  thomas: '01866'
 - name: Cory A. Booker
   party: minority
   rank: 7
   bioguide: B001288
-  thomas: '02194'
 - name: Edward J. Markey
   party: minority
   rank: 8
   bioguide: M000133
-  thomas: '00735'
 - name: Tammy Duckworth
   party: minority
   rank: 9
   bioguide: D000622
-  thomas: '02123'
 - name: Kamala D. Harris
   party: minority
   rank: 10
@@ -16902,1147 +14012,932 @@ SSFI:
   rank: 1
   title: Chairman
   bioguide: H000338
-  thomas: '01351'
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-  thomas: '00250'
 - name: Pat Roberts
   party: majority
   rank: 4
   bioguide: R000307
-  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 5
   bioguide: E000285
-  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 6
   bioguide: C001056
-  thomas: '01692'
 - name: John Thune
   party: majority
   rank: 7
   bioguide: T000250
-  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 8
   bioguide: B001135
-  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 9
   bioguide: I000055
-  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 10
   bioguide: P000449
-  thomas: '00924'
 - name: Patrick J. Toomey
   party: majority
   rank: 11
   bioguide: T000461
-  thomas: '02085'
 - name: Dean Heller
   party: majority
   rank: 12
   bioguide: H001041
-  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 13
   bioguide: S001184
-  thomas: '02056'
 - name: Bill Cassidy
   party: majority
   rank: 14
   bioguide: C001075
-  thomas: '01925'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000779
-  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 2
   bioguide: S000770
-  thomas: '01531'
 - name: Maria Cantwell
   party: minority
   rank: 3
   bioguide: C000127
-  thomas: '00172'
 - name: Bill Nelson
   party: minority
   rank: 4
   bioguide: N000032
-  thomas: '00859'
 - name: Robert Menendez
   party: minority
   rank: 5
   bioguide: M000639
-  thomas: '00791'
 - name: Thomas R. Carper
   party: minority
   rank: 6
   bioguide: C000174
-  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 7
   bioguide: C000141
-  thomas: '00174'
 - name: Sherrod Brown
   party: minority
   rank: 8
   bioguide: B000944
-  thomas: '00136'
 - name: Michael F. Bennet
   party: minority
   rank: 9
   bioguide: B001267
-  thomas: '01965'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 10
   bioguide: C001070
-  thomas: '01828'
 - name: Mark R. Warner
   party: minority
   rank: 11
   bioguide: W000805
-  thomas: '01897'
 - name: Claire McCaskill
   party: minority
   rank: 12
   bioguide: M001170
-  thomas: '01820'
 SSFI02:
 - name: Bill Cassidy
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001075
-  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 2
   bioguide: P000449
-  thomas: '00924'
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-  thomas: '00250'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
   bioguide: T000461
-  thomas: '02085'
 - name: Orrin G. Hatch
   party: majority
   rank: 5
   title: Ex Officio
   bioguide: H000338
-  thomas: '01351'
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B000944
-  thomas: '00136'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
   bioguide: C001070
-  thomas: '01828'
 - name: Ron Wyden
   party: minority
   rank: 3
   title: Ex Officio
   bioguide: W000779
-  thomas: '01247'
 SSFI10:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
   bioguide: T000461
-  thomas: '02085'
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
 - name: Pat Roberts
   party: majority
   rank: 3
   bioguide: R000307
-  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 4
   bioguide: E000285
-  thomas: '01542'
 - name: John Thune
   party: majority
   rank: 5
   bioguide: T000250
-  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 6
   bioguide: B001135
-  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 7
   bioguide: I000055
-  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 8
   bioguide: P000449
-  thomas: '00924'
 - name: Dean Heller
   party: majority
   rank: 9
   bioguide: H001041
-  thomas: '01863'
 - name: Bill Cassidy
   party: majority
   rank: 10
   bioguide: C001075
-  thomas: '01925'
 - name: Orrin G. Hatch
   party: majority
   rank: 11
   title: Ex Officio
   bioguide: H000338
-  thomas: '01351'
 - name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000770
-  thomas: '01531'
 - name: Robert Menendez
   party: minority
   rank: 2
   bioguide: M000639
-  thomas: '00791'
 - name: Maria Cantwell
   party: minority
   rank: 3
   bioguide: C000127
-  thomas: '00172'
 - name: Thomas R. Carper
   party: minority
   rank: 4
   bioguide: C000174
-  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   bioguide: C000141
-  thomas: '00174'
 - name: Sherrod Brown
   party: minority
   rank: 6
   bioguide: B000944
-  thomas: '00136'
 - name: Mark R. Warner
   party: minority
   rank: 7
   bioguide: W000805
-  thomas: '01897'
 - name: Ron Wyden
   party: minority
   rank: 8
   bioguide: W000779
-  thomas: '01247'
 SSFI11:
 - name: Rob Portman
   party: majority
   rank: 1
   title: Chairman
   bioguide: P000449
-  thomas: '00924'
 - name: Mike Crapo
   party: majority
   rank: 2
   bioguide: C000880
-  thomas: '00250'
 - name: Pat Roberts
   party: majority
   rank: 3
   bioguide: R000307
-  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 4
   bioguide: E000285
-  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 5
   bioguide: C001056
-  thomas: '01692'
 - name: John Thune
   party: majority
   rank: 6
   bioguide: T000250
-  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 7
   bioguide: B001135
-  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 8
   bioguide: I000055
-  thomas: '01608'
 - name: Patrick J. Toomey
   party: majority
   rank: 9
   bioguide: T000461
-  thomas: '02085'
 - name: Tim Scott
   party: majority
   rank: 10
   bioguide: S001184
-  thomas: '02056'
 - name: Orrin G. Hatch
   party: majority
   rank: 11
   title: Ex Officio
   bioguide: H000338
-  thomas: '01351'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000805
-  thomas: '01897'
 - name: Thomas R. Carper
   party: minority
   rank: 2
   bioguide: C000174
-  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 3
   bioguide: C000141
-  thomas: '00174'
 - name: Claire McCaskill
   party: minority
   rank: 4
   bioguide: M001170
-  thomas: '01820'
 - name: Robert Menendez
   party: minority
   rank: 5
   bioguide: M000639
-  thomas: '00791'
 - name: Michael F. Bennet
   party: minority
   rank: 6
   bioguide: B001267
-  thomas: '01965'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 7
   bioguide: C001070
-  thomas: '01828'
 - name: Maria Cantwell
   party: minority
   rank: 8
   bioguide: C000127
-  thomas: '00172'
 - name: Ron Wyden
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: W000779
-  thomas: '01247'
 SSFI12:
 - name: Dean Heller
   party: majority
   rank: 1
   title: Chairman
   bioguide: H001041
-  thomas: '01863'
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-  thomas: '00250'
 - name: Michael B. Enzi
   party: majority
   rank: 4
   bioguide: E000285
-  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 5
   bioguide: C001056
-  thomas: '01692'
 - name: Richard Burr
   party: majority
   rank: 6
   bioguide: B001135
-  thomas: '00153'
 - name: Tim Scott
   party: majority
   rank: 7
   bioguide: S001184
-  thomas: '02056'
 - name: Bill Cassidy
   party: majority
   rank: 8
   bioguide: C001075
-  thomas: '01925'
 - name: Orrin G. Hatch
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: H000338
-  thomas: '01351'
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001267
-  thomas: '01965'
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
-  thomas: '00172'
 - name: Bill Nelson
   party: minority
   rank: 3
   bioguide: N000032
-  thomas: '00859'
 - name: Robert Menendez
   party: minority
   rank: 4
   bioguide: M000639
-  thomas: '00791'
 - name: Thomas R. Carper
   party: minority
   rank: 5
   bioguide: C000174
-  thomas: '00179'
 - name: Mark R. Warner
   party: minority
   rank: 6
   bioguide: W000805
-  thomas: '01897'
 - name: Ron Wyden
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: W000779
-  thomas: '01247'
 SSFI13:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001056
-  thomas: '01692'
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
 - name: Pat Roberts
   party: majority
   rank: 3
   bioguide: R000307
-  thomas: '00968'
 - name: Johnny Isakson
   party: majority
   rank: 4
   bioguide: I000055
-  thomas: '01608'
 - name: John Thune
   party: majority
   rank: 5
   bioguide: T000250
-  thomas: '01534'
 - name: Dean Heller
   party: majority
   rank: 6
   bioguide: H001041
-  thomas: '01863'
 - name: Orrin G. Hatch
   party: majority
   rank: 7
   title: Ex Officio
   bioguide: H000338
-  thomas: '01351'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001070
-  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 2
   bioguide: S000770
-  thomas: '01531'
 - name: Bill Nelson
   party: minority
   rank: 3
   bioguide: N000032
-  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 4
   bioguide: M001170
-  thomas: '01820'
 - name: Ron Wyden
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: W000779
-  thomas: '01247'
 SSFI14:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
   bioguide: S001184
-  thomas: '02056'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
   bioguide: H000338
-  thomas: '01351'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000779
-  thomas: '01247'
 SSFR:
 - name: Bob Corker
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001071
-  thomas: '01825'
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
-  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
   bioguide: R000595
-  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 4
   bioguide: J000293
-  thomas: '02086'
 - name: Jeff Flake
   party: majority
   rank: 5
   bioguide: F000444
-  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 6
   bioguide: G000562
-  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 7
   bioguide: Y000064
-  thomas: '02019'
 - name: John Barrasso
   party: majority
   rank: 8
   bioguide: B001261
-  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 9
   bioguide: I000055
-  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 10
   bioguide: P000449
-  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 11
   bioguide: P000603
-  thomas: '02082'
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000141
-  thomas: '00174'
 - name: Robert Menendez
   party: minority
   rank: 2
   bioguide: M000639
-  thomas: '00791'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
-  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 4
   bioguide: C001088
-  thomas: '01984'
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
-  thomas: '01567'
 - name: Christopher Murphy
   party: minority
   rank: 6
   bioguide: M001169
-  thomas: '01837'
 - name: Tim Kaine
   party: minority
   rank: 7
   bioguide: K000384
-  thomas: '02176'
 - name: Edward J. Markey
   party: minority
   rank: 8
   bioguide: M000133
-  thomas: '00735'
 - name: Jeff Merkley
   party: minority
   rank: 9
   bioguide: M001176
-  thomas: '01900'
 - name: Cory A. Booker
   party: minority
   rank: 10
   bioguide: B001288
-  thomas: '02194'
 SSFR01:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
   bioguide: J000293
-  thomas: '02086'
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
-  thomas: '01896'
 - name: John Barrasso
   party: majority
   rank: 3
   bioguide: B001261
-  thomas: '01881'
 - name: Rob Portman
   party: majority
   rank: 4
   bioguide: P000449
-  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 5
   bioguide: P000603
-  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C001071
-  thomas: '01825'
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001169
-  thomas: '01837'
 - name: Edward J. Markey
   party: minority
   rank: 2
   bioguide: M000133
-  thomas: '00735'
 - name: Robert Menendez
   party: minority
   rank: 3
   bioguide: M000639
-  thomas: '00791'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
   bioguide: S001181
-  thomas: '01901'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: C000141
-  thomas: '00174'
 SSFR02:
 - name: Cory Gardner
   party: majority
   rank: 1
   title: Chairman
   bioguide: G000562
-  thomas: '01998'
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
-  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
   bioguide: R000595
-  thomas: '02084'
 - name: John Barrasso
   party: majority
   rank: 4
   bioguide: B001261
-  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 5
   bioguide: I000055
-  thomas: '01608'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C001071
-  thomas: '01825'
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M000133
-  thomas: '00735'
 - name: Jeff Merkley
   party: minority
   rank: 2
   bioguide: M001176
-  thomas: '01900'
 - name: Christopher Murphy
   party: minority
   rank: 3
   bioguide: M001169
-  thomas: '01837'
 - name: Tim Kaine
   party: minority
   rank: 4
   bioguide: K000384
-  thomas: '02176'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: C000141
-  thomas: '00174'
 SSFR06:
 - name: Marco Rubio
   party: majority
   rank: 1
   title: Chairman
   bioguide: R000595
-  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 2
   bioguide: J000293
-  thomas: '02086'
 - name: Jeff Flake
   party: majority
   rank: 3
   bioguide: F000444
-  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 4
   bioguide: G000562
-  thomas: '01998'
 - name: Johnny Isakson
   party: majority
   rank: 5
   bioguide: I000055
-  thomas: '01608'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C001071
-  thomas: '01825'
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M000639
-  thomas: '00791'
 - name: Tom Udall
   party: minority
   rank: 2
   bioguide: U000039
-  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
-  thomas: '01901'
 - name: Tim Kaine
   party: minority
   rank: 4
   bioguide: K000384
-  thomas: '02176'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: C000141
-  thomas: '00174'
 SSFR07:
 - name: James E. Risch
   party: majority
   rank: 1
   title: Chairman
   bioguide: R000584
-  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 2
   bioguide: R000595
-  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 3
   bioguide: J000293
-  thomas: '02086'
 - name: Todd Young
   party: majority
   rank: 4
   bioguide: Y000064
-  thomas: '02019'
 - name: Rob Portman
   party: majority
   rank: 5
   bioguide: P000449
-  thomas: '00924'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C001071
-  thomas: '01825'
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000384
-  thomas: '02176'
 - name: Robert Menendez
   party: minority
   rank: 2
   bioguide: M000639
-  thomas: '00791'
 - name: Christopher Murphy
   party: minority
   rank: 3
   title: Ranking Member
   bioguide: M001169
-  thomas: '01837'
 - name: Cory A. Booker
   party: minority
   rank: 4
   bioguide: B001288
-  thomas: '02194'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: C000141
-  thomas: '00174'
 SSFR09:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
   bioguide: F000444
-  thomas: '01633'
 - name: Todd Young
   party: majority
   rank: 2
   bioguide: Y000064
-  thomas: '02019'
 - name: John Barrasso
   party: majority
   rank: 3
   bioguide: B001261
-  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 4
   bioguide: I000055
-  thomas: '01608'
 - name: Rand Paul
   party: majority
   rank: 5
   bioguide: P000603
-  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C001071
-  thomas: '01825'
 - name: Cory A. Booker
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001288
-  thomas: '02194'
 - name: Christopher A. Coons
   party: minority
   rank: 2
   bioguide: C001088
-  thomas: '01984'
 - name: Tom Udall
   party: minority
   rank: 3
   bioguide: U000039
-  thomas: '01567'
 - name: Jeff Merkley
   party: minority
   rank: 4
   bioguide: M001176
-  thomas: '01900'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: C000141
-  thomas: '00174'
 SSFR14:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000055
-  thomas: '01608'
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
-  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
   bioguide: R000595
-  thomas: '02084'
 - name: Rob Portman
   party: majority
   rank: 4
   bioguide: P000449
-  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 5
   bioguide: P000603
-  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C001071
-  thomas: '01825'
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001181
-  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 2
   bioguide: C001088
-  thomas: '01984'
 - name: Cory A. Booker
   party: minority
   rank: 3
   bioguide: B001288
-  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 4
   bioguide: U000039
-  thomas: '01567'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: C000141
-  thomas: '00174'
 SSFR15:
 - name: Todd Young
   party: majority
   rank: 1
   title: Chairman
   bioguide: Y000064
-  thomas: '02019'
 - name: Jeff Flake
   party: majority
   rank: 2
   bioguide: F000444
-  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 3
   bioguide: G000562
-  thomas: '01998'
 - name: John Barrasso
   party: majority
   rank: 4
   bioguide: B001261
-  thomas: '01881'
 - name: Rob Portman
   party: majority
   rank: 5
   bioguide: P000449
-  thomas: '00924'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C001071
-  thomas: '01825'
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001176
-  thomas: '01900'
 - name: Tom Udall
   party: minority
   rank: 2
   bioguide: U000039
-  thomas: '01567'
 - name: Christopher A. Coons
   party: minority
   rank: 3
   bioguide: C001088
-  thomas: '01984'
 - name: Edward J. Markey
   party: minority
   rank: 4
   bioguide: M000133
-  thomas: '00735'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: C000141
-  thomas: '00174'
 SSGA:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
   bioguide: J000293
-  thomas: '02086'
 - name: John McCain
   party: majority
   rank: 2
   bioguide: M000303
-  thomas: '00754'
 - name: Rob Portman
   party: majority
   rank: 3
   bioguide: P000449
-  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 4
   bioguide: P000603
-  thomas: '02082'
 - name: James Lankford
   party: majority
   rank: 5
   bioguide: L000575
-  thomas: '02050'
 - name: Michael B. Enzi
   party: majority
   rank: 6
   bioguide: E000285
-  thomas: '01542'
 - name: John Hoeven
   party: majority
   rank: 7
   bioguide: H001061
-  thomas: '02079'
 - name: Steve Daines
   party: majority
   rank: 8
   bioguide: D000618
-  thomas: '02138'
 - name: Claire McCaskill
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001170
-  thomas: '01820'
 - name: Thomas R. Carper
   party: minority
   rank: 2
   bioguide: C000174
-  thomas: '00179'
 - name: Jon Tester
   party: minority
   rank: 3
   bioguide: T000464
-  thomas: '01829'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
   bioguide: H001069
-  thomas: '02174'
 - name: Gary C. Peters
   party: minority
   rank: 5
   bioguide: P000595
-  thomas: '01929'
 - name: Margaret Wood Hassan
   party: minority
   rank: 6
@@ -18057,94 +14952,77 @@ SSGA01:
   rank: 1
   title: Chairman
   bioguide: P000449
-  thomas: '00924'
 - name: James Lankford
   party: majority
   rank: 2
   bioguide: L000575
-  thomas: '02050'
 - name: John McCain
   party: majority
   rank: 3
   bioguide: M000303
-  thomas: '00754'
 - name: Rand Paul
   party: majority
   rank: 4
   bioguide: P000603
-  thomas: '02082'
 - name: Steve Daines
   party: majority
   rank: 5
   bioguide: D000618
-  thomas: '02138'
 - name: Ron Johnson
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: J000293
-  thomas: '02086'
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000174
-  thomas: '00179'
 - name: Jon Tester
   party: minority
   rank: 2
   bioguide: T000464
-  thomas: '01829'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
   bioguide: H001069
-  thomas: '02174'
 - name: Gary C. Peters
   party: minority
   rank: 4
   bioguide: P000595
-  thomas: '01929'
 - name: Claire McCaskill
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: M001170
-  thomas: '01820'
 SSGA18:
 - name: Rand Paul
   party: majority
   rank: 1
   title: Chairman
   bioguide: P000603
-  thomas: '02082'
 - name: James Lankford
   party: majority
   rank: 2
   bioguide: L000575
-  thomas: '02050'
 - name: Michael B. Enzi
   party: majority
   rank: 3
   bioguide: E000285
-  thomas: '01542'
 - name: John Hoeven
   party: majority
   rank: 4
   bioguide: H001061
-  thomas: '02079'
 - name: Ron Johnson
   party: majority
   rank: 5
   title: Ex Officio
   bioguide: J000293
-  thomas: '02086'
 - name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: P000595
-  thomas: '01929'
 - name: Margaret Wood Hassan
   party: minority
   rank: 2
@@ -18158,51 +15036,42 @@ SSGA18:
   rank: 4
   title: Ex Officio
   bioguide: M001170
-  thomas: '01820'
 SSGA19:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
   bioguide: L000575
-  thomas: '02050'
 - name: John McCain
   party: majority
   rank: 2
   bioguide: M000303
-  thomas: '00754'
 - name: Rob Portman
   party: majority
   rank: 3
   bioguide: P000449
-  thomas: '00924'
 - name: Michael B. Enzi
   party: majority
   rank: 4
   bioguide: E000285
-  thomas: '01542'
 - name: Steve Daines
   party: majority
   rank: 5
   bioguide: D000618
-  thomas: '02138'
 - name: Ron Johnson
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: J000293
-  thomas: '02086'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001069
-  thomas: '02174'
 - name: Thomas R. Carper
   party: minority
   rank: 2
   bioguide: C000174
-  thomas: '00179'
 - name: Margaret Wood Hassan
   party: minority
   rank: 3
@@ -18216,120 +15085,97 @@ SSGA19:
   rank: 5
   title: Ex Officio
   bioguide: M001170
-  thomas: '01820'
 SSHR:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
   bioguide: A000360
-  thomas: '01695'
 - name: Michael B. Enzi
   party: majority
   rank: 2
   bioguide: E000285
-  thomas: '01542'
 - name: Richard Burr
   party: majority
   rank: 3
   bioguide: B001135
-  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 4
   bioguide: I000055
-  thomas: '01608'
 - name: Rand Paul
   party: majority
   rank: 5
   bioguide: P000603
-  thomas: '02082'
 - name: Susan M. Collins
   party: majority
   rank: 6
   bioguide: C001035
-  thomas: '01541'
 - name: Bill Cassidy
   party: majority
   rank: 7
   bioguide: C001075
-  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 8
   bioguide: Y000064
-  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 9
   bioguide: H000338
-  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 10
   bioguide: R000307
-  thomas: '00968'
 - name: Lisa Murkowski
   party: majority
   rank: 11
   bioguide: M001153
-  thomas: '01694'
 - name: Tim Scott
   party: majority
   rank: 12
   bioguide: S001184
-  thomas: '02056'
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001111
-  thomas: '01409'
 - name: Bernard Sanders
   party: minority
   rank: 2
   bioguide: S000033
-  thomas: '01010'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 3
   bioguide: C001070
-  thomas: '01828'
 - name: Al Franken
   party: minority
   rank: 4
   bioguide: F000457
-  thomas: '01969'
 - name: Michael F. Bennet
   party: minority
   rank: 5
   bioguide: B001267
-  thomas: '01965'
 - name: Sheldon Whitehouse
   party: minority
   rank: 6
   bioguide: W000802
-  thomas: '01823'
 - name: Tammy Baldwin
   party: minority
   rank: 7
   bioguide: B001230
-  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 8
   bioguide: M001169
-  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
   rank: 9
   bioguide: W000817
-  thomas: '02182'
 - name: Tim Kaine
   party: minority
   rank: 10
   bioguide: K000384
-  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
   rank: 11
@@ -18340,69 +15186,56 @@ SSHR09:
   rank: 1
   title: Chairman
   bioguide: P000603
-  thomas: '02082'
 - name: Lisa Murkowski
   party: majority
   rank: 2
   bioguide: M001153
-  thomas: '01694'
 - name: Richard Burr
   party: majority
   rank: 3
   bioguide: B001135
-  thomas: '00153'
 - name: Bill Cassidy
   party: majority
   rank: 4
   bioguide: C001075
-  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 5
   bioguide: Y000064
-  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 6
   bioguide: H000338
-  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 7
   bioguide: R000307
-  thomas: '00968'
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: A000360
-  thomas: '01695'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001070
-  thomas: '01828'
 - name: Bernard Sanders
   party: minority
   rank: 2
   bioguide: S000033
-  thomas: '01010'
 - name: Al Franken
   party: minority
   rank: 3
   bioguide: F000457
-  thomas: '01969'
 - name: Michael F. Bennet
   party: minority
   rank: 4
   bioguide: B001267
-  thomas: '01965'
 - name: Tim Kaine
   party: minority
   rank: 5
   bioguide: K000384
-  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
   rank: 6
@@ -18412,176 +15245,143 @@ SSHR09:
   rank: 7
   title: Ex Officio
   bioguide: M001111
-  thomas: '01409'
 SSHR11:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000055
-  thomas: '01608'
 - name: Pat Roberts
   party: majority
   rank: 2
   bioguide: R000307
-  thomas: '00968'
 - name: Tim Scott
   party: majority
   rank: 3
   bioguide: S001184
-  thomas: '02056'
 - name: Richard Burr
   party: majority
   rank: 4
   bioguide: B001135
-  thomas: '00153'
 - name: Rand Paul
   party: majority
   rank: 5
   bioguide: P000603
-  thomas: '02082'
 - name: Bill Cassidy
   party: majority
   rank: 6
   bioguide: C001075
-  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 7
   bioguide: Y000064
-  thomas: '02019'
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: A000360
-  thomas: '01695'
 - name: Al Franken
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: F000457
-  thomas: '01969'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
   bioguide: C001070
-  thomas: '01828'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
   bioguide: W000802
-  thomas: '01823'
 - name: Tammy Baldwin
   party: minority
   rank: 4
   bioguide: B001230
-  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 5
   bioguide: M001169
-  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
   rank: 6
   bioguide: W000817
-  thomas: '02182'
 - name: Patty Murray
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: M001111
-  thomas: '01409'
 SSHR12:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
   bioguide: E000285
-  thomas: '01542'
 - name: Richard Burr
   party: majority
   rank: 2
   bioguide: B001135
-  thomas: '00153'
 - name: Susan M. Collins
   party: majority
   rank: 3
   bioguide: C001035
-  thomas: '01541'
 - name: Bill Cassidy
   party: majority
   rank: 4
   bioguide: C001075
-  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 5
   bioguide: Y000064
-  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 6
   bioguide: H000338
-  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 7
   bioguide: R000307
-  thomas: '00968'
 - name: Tim Scott
   party: majority
   rank: 8
   bioguide: S001184
-  thomas: '02056'
 - name: Lisa Murkowski
   party: majority
   rank: 9
   bioguide: M001153
-  thomas: '01694'
 - name: Lamar Alexander
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: A000360
-  thomas: '01695'
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000033
-  thomas: '01010'
 - name: Michael F. Bennet
   party: minority
   rank: 2
   bioguide: B001267
-  thomas: '01965'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
   bioguide: W000802
-  thomas: '01823'
 - name: Tammy Baldwin
   party: minority
   rank: 4
   bioguide: B001230
-  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 5
   bioguide: M001169
-  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
   rank: 6
   bioguide: W000817
-  thomas: '02182'
 - name: Tim Kaine
   party: minority
   rank: 7
   bioguide: K000384
-  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
   rank: 8
@@ -18591,59 +15391,48 @@ SSHR12:
   rank: 9
   title: Ex Officio
   bioguide: M001111
-  thomas: '01409'
 SSJU:
 - name: Chuck Grassley
   party: majority
   rank: 1
   title: Chairman
   bioguide: G000386
-  thomas: '00457'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
   bioguide: H000338
-  thomas: '01351'
 - name: Lindsey Graham
   party: majority
   rank: 3
   bioguide: G000359
-  thomas: '00452'
 - name: John Cornyn
   party: majority
   rank: 4
   bioguide: C001056
-  thomas: '01692'
 - name: Mike Lee
   party: majority
   rank: 5
   bioguide: L000577
-  thomas: '02080'
 - name: Ted Cruz
   party: majority
   rank: 6
   bioguide: C001098
-  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 7
   bioguide: S001197
-  thomas: '02289'
 - name: Jeff Flake
   party: majority
   rank: 8
   bioguide: F000444
-  thomas: '01633'
 - name: Mike Crapo
   party: majority
   rank: 9
   bioguide: C000880
-  thomas: '00250'
 - name: Thom Tillis
   party: majority
   rank: 10
   bioguide: T000476
-  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 11
@@ -18653,107 +15442,87 @@ SSJU:
   rank: 1
   title: Ranking Member
   bioguide: F000062
-  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Richard J. Durbin
   party: minority
   rank: 3
   bioguide: D000563
-  thomas: '00326'
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
   bioguide: W000802
-  thomas: '01823'
 - name: Amy Klobuchar
   party: minority
   rank: 5
   bioguide: K000367
-  thomas: '01826'
 - name: Al Franken
   party: minority
   rank: 6
   bioguide: F000457
-  thomas: '01969'
 - name: Christopher A. Coons
   party: minority
   rank: 7
   bioguide: C001088
-  thomas: '01984'
 - name: Richard Blumenthal
   party: minority
   rank: 8
   bioguide: B001277
-  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 9
   bioguide: H001042
-  thomas: '01844'
 SSJU01:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
   bioguide: L000577
-  thomas: '02080'
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
 - name: Orrin G. Hatch
   party: majority
   rank: 3
   bioguide: H000338
-  thomas: '01351'
 - name: Lindsey Graham
   party: majority
   rank: 4
   bioguide: G000359
-  thomas: '00452'
 - name: Thom Tillis
   party: majority
   rank: 5
   bioguide: T000476
-  thomas: '02291'
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000367
-  thomas: '01826'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Al Franken
   party: minority
   rank: 3
   bioguide: F000457
-  thomas: '01969'
 - name: Richard Blumenthal
   party: minority
   rank: 4
   bioguide: B001277
-  thomas: '02076'
 SSJU04:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001056
-  thomas: '01692'
 - name: Thom Tillis
   party: majority
   rank: 2
   bioguide: T000476
-  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 3
@@ -18762,133 +15531,108 @@ SSJU04:
   party: majority
   rank: 4
   bioguide: G000386
-  thomas: '00457'
 - name: Ted Cruz
   party: majority
   rank: 5
   bioguide: C001098
-  thomas: '02175'
 - name: Jeff Flake
   party: majority
   rank: 6
   bioguide: F000444
-  thomas: '01633'
 - name: Mike Crapo
   party: majority
   rank: 7
   bioguide: C000880
-  thomas: '00250'
 - name: Mike Lee
   party: majority
   rank: 8
   bioguide: L000577
-  thomas: '02080'
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000563
-  thomas: '00326'
 - name: Dianne Feinstein
   party: minority
   rank: 2
   bioguide: F000062
-  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
   bioguide: L000174
-  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 4
   bioguide: K000367
-  thomas: '01826'
 - name: Al Franken
   party: minority
   rank: 5
   bioguide: F000457
-  thomas: '01969'
 - name: Richard Blumenthal
   party: minority
   rank: 6
   bioguide: B001277
-  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 7
   bioguide: H001042
-  thomas: '01844'
 SSJU21:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001098
-  thomas: '02175'
 - name: John Cornyn
   party: majority
   rank: 2
   bioguide: C001056
-  thomas: '01692'
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-  thomas: '00250'
 - name: Ben Sasse
   party: majority
   rank: 4
   bioguide: S001197
-  thomas: '02289'
 - name: Lindsey Graham
   party: majority
   rank: 5
   bioguide: G000359
-  thomas: '00452'
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001277
-  thomas: '02076'
 - name: Richard J. Durbin
   party: minority
   rank: 2
   bioguide: D000563
-  thomas: '00326'
 - name: Al Franken
   party: minority
   rank: 3
   bioguide: F000457
-  thomas: '01969'
 - name: Christopher A. Coons
   party: minority
   rank: 4
   bioguide: C001088
-  thomas: '01984'
 SSJU22:
 - name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
   bioguide: G000359
-  thomas: '00452'
 - name: John Cornyn
   party: majority
   rank: 2
   bioguide: C001056
-  thomas: '01692'
 - name: Ted Cruz
   party: majority
   rank: 3
   bioguide: C001098
-  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 4
   bioguide: S001197
-  thomas: '02289'
 - name: John Kennedy
   party: majority
   rank: 5
@@ -18898,49 +15642,40 @@ SSJU22:
   rank: 1
   title: Ranking Member
   bioguide: W000802
-  thomas: '01823'
 - name: Richard J. Durbin
   party: minority
   rank: 2
   bioguide: D000563
-  thomas: '00326'
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
-  thomas: '01826'
 - name: Christopher A. Coons
   party: minority
   rank: 4
   bioguide: C001088
-  thomas: '01984'
 SSJU23:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
   bioguide: F000444
-  thomas: '01633'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
   bioguide: H000338
-  thomas: '01351'
 - name: Mike Lee
   party: majority
   rank: 3
   bioguide: L000577
-  thomas: '02080'
 - name: Thom Tillis
   party: majority
   rank: 4
   bioguide: T000476
-  thomas: '02291'
 - name: Mike Crapo
   party: majority
   rank: 5
   bioguide: C000880
-  thomas: '00250'
 - name: John Kennedy
   party: majority
   rank: 6
@@ -18950,44 +15685,36 @@ SSJU23:
   rank: 1
   title: Ranking Member
   bioguide: F000457
-  thomas: '01969'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
   bioguide: W000802
-  thomas: '01823'
 - name: Christopher A. Coons
   party: minority
   rank: 4
   bioguide: C001088
-  thomas: '01984'
 - name: Mazie K. Hirono
   party: minority
   rank: 5
   bioguide: H001042
-  thomas: '01844'
 SSJU25:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
   bioguide: S001197
-  thomas: '02289'
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
-  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-  thomas: '00250'
 - name: John Kennedy
   party: majority
   rank: 4
@@ -18996,152 +15723,123 @@ SSJU25:
   party: majority
   rank: 5
   bioguide: H000338
-  thomas: '01351'
 - name: Mike Lee
   party: majority
   rank: 6
   bioguide: L000577
-  thomas: '02080'
 - name: Jeff Flake
   party: majority
   rank: 7
   bioguide: F000444
-  thomas: '01633'
 - name: Thom Tillis
   party: majority
   rank: 8
   bioguide: T000476
-  thomas: '02291'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001088
-  thomas: '01984'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
-  thomas: '01383'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
   bioguide: W000802
-  thomas: '01823'
 - name: Amy Klobuchar
   party: minority
   rank: 4
   bioguide: K000367
-  thomas: '01826'
 - name: Al Franken
   party: minority
   rank: 5
   bioguide: F000457
-  thomas: '01969'
 - name: Richard Blumenthal
   party: minority
   rank: 6
   bioguide: B001277
-  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 7
   bioguide: H001042
-  thomas: '01844'
 SSRA:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
   bioguide: S000320
-  thomas: '01049'
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
-  thomas: '01395'
 - name: Thad Cochran
   party: majority
   rank: 3
   bioguide: C000567
-  thomas: '00213'
 - name: Lamar Alexander
   party: majority
   rank: 4
   bioguide: A000360
-  thomas: '01695'
 - name: Pat Roberts
   party: majority
   rank: 5
   bioguide: R000307
-  thomas: '00968'
 - name: Roy Blunt
   party: majority
   rank: 6
   title: Chairman
   bioguide: B000575
-  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 7
   bioguide: C001098
-  thomas: '02175'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
   bioguide: C001047
-  thomas: '01676'
 - name: Roger F. Wicker
   party: majority
   rank: 9
   bioguide: W000437
-  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 10
   bioguide: F000463
-  thomas: '02179'
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000367
-  thomas: '01826'
 - name: Dianne Feinstein
   party: minority
   rank: 2
   bioguide: F000062
-  thomas: '01332'
 - name: Charles E. Schumer
   party: minority
   rank: 3
   bioguide: S000148
-  thomas: '01036'
 - name: Richard J. Durbin
   party: minority
   rank: 4
   bioguide: D000563
-  thomas: '00326'
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
-  thomas: '01567'
 - name: Mark R. Warner
   party: minority
   rank: 6
   bioguide: W000805
-  thomas: '01897'
 - name: Patrick J. Leahy
   party: minority
   rank: 7
   bioguide: L000174
-  thomas: '01383'
 - name: Angus S. King, Jr.
   party: minority
   rank: 8
   bioguide: K000383
-  thomas: '02185'
 - name: Catherine Cortez Masto
   party: minority
   rank: 9
@@ -19152,47 +15850,38 @@ SSSB:
   rank: 1
   title: Chairman
   bioguide: R000584
-  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 2
   bioguide: R000595
-  thomas: '02084'
 - name: Rand Paul
   party: majority
   rank: 3
   bioguide: P000603
-  thomas: '02082'
 - name: Tim Scott
   party: majority
   rank: 4
   bioguide: S001184
-  thomas: '02056'
 - name: Joni Ernst
   party: majority
   rank: 5
   bioguide: E000295
-  thomas: '02283'
 - name: James M. Inhofe
   party: majority
   rank: 6
   bioguide: I000024
-  thomas: '00583'
 - name: Todd Young
   party: majority
   rank: 7
   bioguide: Y000064
-  thomas: '02019'
 - name: Michael B. Enzi
   party: majority
   rank: 8
   bioguide: E000285
-  thomas: '01542'
 - name: Mike Rounds
   party: majority
   rank: 9
   bioguide: R000605
-  thomas: '02288'
 - name: John Kennedy
   party: majority
   rank: 10
@@ -19202,122 +15891,98 @@ SSSB:
   rank: 1
   title: Ranking Member
   bioguide: S001181
-  thomas: '01901'
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
-  thomas: '00172'
 - name: Benjamin L. Cardin
   party: minority
   rank: 3
   bioguide: C000141
-  thomas: '00174'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
   bioguide: H001069
-  thomas: '02174'
 - name: Edward J. Markey
   party: minority
   rank: 5
   bioguide: M000133
-  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
   bioguide: B001288
-  thomas: '02194'
 - name: Christopher A. Coons
   party: minority
   rank: 7
   bioguide: C001088
-  thomas: '01984'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
   bioguide: H001042
-  thomas: '01844'
 - name: Tammy Duckworth
   party: minority
   rank: 9
   bioguide: D000622
-  thomas: '02123'
 SSVA:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000055
-  thomas: '01608'
 - name: Jerry Moran
   party: majority
   rank: 2
   bioguide: M000934
-  thomas: '01507'
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
-  thomas: '01687'
 - name: Dean Heller
   party: majority
   rank: 4
   bioguide: H001041
-  thomas: '01863'
 - name: Bill Cassidy
   party: majority
   rank: 5
   bioguide: C001075
-  thomas: '01925'
 - name: Mike Rounds
   party: majority
   rank: 6
   bioguide: R000605
-  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 7
   bioguide: T000476
-  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 8
   bioguide: S001198
-  thomas: '02290'
 - name: Jon Tester
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: T000464
-  thomas: '01829'
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
-  thomas: '01409'
 - name: Bernard Sanders
   party: minority
   rank: 3
   bioguide: S000033
-  thomas: '01010'
 - name: Sherrod Brown
   party: minority
   rank: 4
   bioguide: B000944
-  thomas: '00136'
 - name: Richard Blumenthal
   party: minority
   rank: 5
   bioguide: B001277
-  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 6
   bioguide: H001042
-  thomas: '01844'
 - name: Joe Manchin, III
   party: minority
   rank: 7
   bioguide: M001183
-  thomas: '01983'

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -82,7 +82,7 @@
     thomas_id: '24'
     address: HT2 CAPITOL; Washington, DC 20515
     phone: (202) 226-7252
-  - name: Military Construction, Veterans Affairs, and Related Agencies
+  - name: Military Construction, Veterans Affairs and Related Agencies
     thomas_id: '18'
     address: HVC227 CAPITOL; Washington, DC 20515
     phone: (202) 225-3047
@@ -90,7 +90,7 @@
     thomas_id: '04'
     address: HT2 CAPITOL; Washington, DC 20515
     phone: (202) 225-2041
-  - name: Transportation, and Housing and Urban Development, and Related Agencies
+  - name: Transportation, Housing and Urban Development, and Related Agencies
     thomas_id: '20'
     address: 2358A RHOB; Washington, DC 20515
     phone: (202) 225-2141

--- a/scripts/data/house_joint_committee_members.csv
+++ b/scripts/data/house_joint_committee_members.csv
@@ -1,0 +1,17 @@
+Committee,Bioguide,Name,Title
+JSEC,T000462,Pat Tiberi,Chairman
+JSEC,P000594,Erik Paulsen,
+JSEC,S001183,David Schweikert,
+JSEC,C001105,Barbara Comstock,
+JSEC,L000585,Darin LaHood,
+JSEC,R000607,Francis Rooney,
+JSEC,M000087,Carolyn Maloney,
+JSEC,D000620,John Delaney,
+JSEC,A000370,Alma Adams,
+JSEC,B001292,Don Beyer,
+JSTX,B000755,Kevin Brady,Vice Chairman
+JSTX,J000174,Sam Johnson,
+JSTX,N000181,Devin Nunes,
+JSTX,L000263,Sander Levin,
+JSLC,,,
+JSPR,,,


### PR DESCRIPTION
Hopefully this is acceptable...  House Joint committee memberships are loaded from the committee-memberships-current.yaml file.  This PR uses a CSV to load this data instead, which I thought made it easier to separate what entries are added manually versus imported from some other location.

This PR also includes removing the thomas id which was discussed in #436 

WIP because I did not add house members for JSLC or JSTX yet because the CHA pages on them still reference the 114th congress...  Not sure if these should just be brought forward or not.