### PR TITLE
Add NIMSP Entity IDs

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -643,6 +643,7 @@
     icpsr: 40700
     wikidata: Q22237
     google_entity_id: kg:/m/05fbpt
+    nimsp: '17659011'
   name:
     first: Amy
     middle: Jean
@@ -695,6 +696,7 @@
     icpsr: 40701
     wikidata: Q22260
     google_entity_id: kg:/m/040_w4
+    nimsp: '4742989'
   name:
     first: Claire
     last: McCaskill
@@ -853,6 +855,7 @@
     maplight: 598
     wikidata: Q358437
     google_entity_id: kg:/m/01_pb_
+    nimsp: '6416097'
   name:
     first: Bill
     last: Nelson
@@ -948,6 +951,7 @@
     house_history: 21173
     wikidata: Q359442
     google_entity_id: kg:/m/01_gbv
+    nimsp: '9960190'
   name:
     first: Bernard
     last: Sanders
@@ -1124,6 +1128,7 @@
     icpsr: 40702
     wikidata: Q529351
     google_entity_id: kg:/m/066cdp
+    nimsp: '13012599'
   name:
     first: Jon
     last: Tester
@@ -1174,6 +1179,7 @@
     icpsr: 40704
     wikidata: Q652066
     google_entity_id: kg:/m/07qw94
+    nimsp: '373538'
   name:
     first: Sheldon
     last: Whitehouse
@@ -1224,6 +1230,7 @@
     icpsr: 40707
     wikidata: Q720521
     google_entity_id: kg:/m/02rsm32
+    nimsp: '10154698'
   name:
     first: John
     middle: A.
@@ -1538,6 +1545,7 @@
     icpsr: 49703
     wikidata: Q22279
     google_entity_id: kg:/m/020y8m
+    nimsp: '10045641'
   name:
     first: Susan
     middle: M.
@@ -1605,6 +1613,7 @@
     icpsr: 40305
     wikidata: Q719568
     google_entity_id: kg:/m/01xcqs
+    nimsp: '6646197'
   name:
     first: John
     last: Cornyn
@@ -1891,6 +1900,7 @@
     icpsr: 29566
     wikidata: Q22212
     google_entity_id: kg:/m/01_pdg
+    nimsp: '8463292'
   name:
     first: Lindsey
     middle: O.
@@ -2178,6 +2188,7 @@
     icpsr: 40908
     wikidata: Q1368405
     google_entity_id: kg:/m/026k60f
+    nimsp: '13005237'
   name:
     first: Jeff
     last: Merkley
@@ -2485,6 +2496,7 @@
     house_history: 22618
     wikidata: Q270316
     google_entity_id: kg:/m/01rrm2
+    nimsp: '6434346'
   name:
     first: Jeanne
     last: Shaheen
@@ -2636,6 +2648,7 @@
     icpsr: 40909
     wikidata: Q453893
     google_entity_id: kg:/m/024mm1
+    nimsp: '12996544'
   name:
     first: Mark
     last: Warner
@@ -2690,6 +2703,7 @@
     icpsr: 20735
     wikidata: Q22222
     google_entity_id: kg:/m/0gnfc4
+    nimsp: '17658865'
   name:
     first: Kirsten
     middle: E.
@@ -3034,6 +3048,7 @@
     icpsr: 21143
     wikidata: Q1714165
     google_entity_id: kg:/m/0c00p_n
+    nimsp: '6676756'
   name:
     first: Justin
     last: Amash
@@ -3429,6 +3444,7 @@
     icpsr: 21110
     wikidata: Q461739
     google_entity_id: kg:/m/027g9m6
+    nimsp: '13008680'
   name:
     first: Karen
     last: Bass
@@ -3562,6 +3578,7 @@
     icpsr: 20758
     wikidata: Q1555314
     google_entity_id: kg:/m/0dy3z1
+    nimsp: '12998704'
   name:
     first: Gus
     last: Bilirakis
@@ -3654,6 +3671,7 @@
     icpsr: 20357
     wikidata: Q433857
     google_entity_id: kg:/m/02tn41
+    nimsp: '6646789'
   name:
     first: Rob
     last: Bishop
@@ -3963,6 +3981,7 @@
     icpsr: 20351
     wikidata: Q458971
     google_entity_id: kg:/m/01fnkt
+    nimsp: '6654369'
   name:
     first: Marsha
     middle: W.
@@ -4778,6 +4797,7 @@
     icpsr: 21193
     wikidata: Q1941306
     google_entity_id: kg:/m/0c3xdjf
+    nimsp: '6668470'
   name:
     first: Mo
     last: Brooks
@@ -5209,6 +5229,7 @@
     icpsr: 20340
     wikidata: Q983532
     google_entity_id: kg:/m/03g_pq
+    nimsp: '6135165'
   name:
     first: George
     middle: Kenneth
@@ -5449,6 +5470,7 @@
     lis: S372
     wikidata: Q459618
     google_entity_id: kg:/m/024pwq
+    nimsp: '6651319'
   name:
     first: Shelley
     middle: Moore
@@ -5931,6 +5953,7 @@
     icpsr: 20708
     wikidata: Q458492
     google_entity_id: kg:/m/0dq1v6
+    nimsp: '6416265'
   name:
     first: Kathy
     last: Castor
@@ -6302,6 +6325,7 @@
     icpsr: 21172
     wikidata: Q938498
     google_entity_id: kg:/m/04t97v
+    nimsp: '6441236'
   name:
     first: David
     last: Cicilline
@@ -6464,6 +6488,7 @@
     icpsr: 20147
     wikidata: Q959455
     google_entity_id: kg:/m/024vjr
+    nimsp: '13012488'
   name:
     first: Wm.
     middle: Lacy
@@ -7706,6 +7731,7 @@
     icpsr: 20706
     wikidata: Q434470
     google_entity_id: kg:/m/0700nd
+    nimsp: '6415093'
   name:
     first: Joe
     last: Courtney
@@ -7955,6 +7981,7 @@
     icpsr: 29925
     wikidata: Q971318
     google_entity_id: kg:/m/03v10s
+    nimsp: '4876353'
   name:
     first: Joseph
     last: Crowley
@@ -8070,6 +8097,7 @@
     icpsr: 20533
     wikidata: Q539562
     google_entity_id: kg:/m/04clj6
+    nimsp: '6443275'
   name:
     first: Henry
     last: Cuellar
@@ -8165,6 +8193,7 @@
     icpsr: 20139
     wikidata: Q671976
     google_entity_id: kg:/m/03sfhc
+    nimsp: '6646293'
   name:
     first: John
     middle: Abney
@@ -8524,6 +8553,7 @@
     icpsr: 20108
     wikidata: Q460675
     google_entity_id: kg:/m/024xs5
+    nimsp: '6451749'
   name:
     first: Susan
     middle: A.
@@ -9364,6 +9394,7 @@
     icpsr: 20316
     wikidata: Q767270
     google_entity_id: kg:/m/02536z
+    nimsp: '12999048'
   name:
     first: Mario
     last: Diaz-Balart
@@ -9866,6 +9897,7 @@
     icpsr: 21174
     wikidata: Q1027026
     google_entity_id: kg:/m/0ddgp1k
+    nimsp: '8045191'
   name:
     first: Jeff
     last: Duncan
@@ -10095,6 +10127,7 @@
     icpsr: 20727
     wikidata: Q40589
     google_entity_id: kg:/m/0dlwms
+    nimsp: '6515997'
   name:
     first: Keith
     middle: Maurice
@@ -10860,6 +10893,7 @@
     icpsr: 20521
     wikidata: Q458453
     google_entity_id: kg:/m/02b5dz
+    nimsp: '13012640'
   name:
     first: Virginia
     last: Foxx
@@ -11363,6 +11397,7 @@
     lis: S377
     wikidata: Q1135774
     google_entity_id: kg:/m/0czd33q
+    nimsp: '5988870'
   name:
     first: Cory
     last: Gardner
@@ -12099,6 +12134,7 @@
     icpsr: 20124
     wikidata: Q465638
     google_entity_id: kg:/m/03tnfy
+    nimsp: '3836803'
   name:
     first: Sam
     middle: B.
@@ -12209,6 +12245,7 @@
     icpsr: 20962
     wikidata: Q1647301
     google_entity_id: kg:/m/0c02hpl
+    nimsp: '6801736'
   name:
     first: Tom
     last: Graves
@@ -12518,6 +12555,7 @@
     icpsr: 21191
     wikidata: Q1684857
     google_entity_id: kg:/m/025vdrq
+    nimsp: '6276976'
   name:
     first: H.
     middle: Morgan
@@ -13063,6 +13101,7 @@
     icpsr: 21149
     wikidata: Q375389
     google_entity_id: kg:/m/09v2dv4
+    nimsp: '6632211'
   name:
     first: Vicky
     last: Hartzler
@@ -13430,6 +13469,7 @@
     icpsr: 21187
     wikidata: Q168592
     google_entity_id: kg:/m/0cz8yx2
+    nimsp: '2951218'
   name:
     first: Jaime
     last: Herrera Beutler
@@ -13503,6 +13543,7 @@
     icpsr: 20519
     wikidata: Q505581
     google_entity_id: kg:/m/04fc7g
+    nimsp: '6437224'
   name:
     first: Brian
     middle: M.
@@ -13682,6 +13723,7 @@
     icpsr: 20713
     wikidata: Q16476
     google_entity_id: kg:/m/0357cd
+    nimsp: '6401094'
   name:
     first: Mazie
     middle: K.
@@ -13993,6 +14035,7 @@
     icpsr: 21142
     wikidata: Q862199
     google_entity_id: kg:/m/05b0j1w
+    nimsp: '6574786'
   name:
     first: Bill
     last: Huizenga
@@ -14225,6 +14268,7 @@
     icpsr: 29909
     wikidata: Q130024
     google_entity_id: kg:/m/02556q
+    nimsp: '13011462'
   name:
     first: John
     middle: H.
@@ -16073,6 +16117,7 @@
     icpsr: 21125
     wikidata: Q555393
     google_entity_id: kg:/m/0c3zfwm
+    nimsp: '12999774'
   name:
     first: Raúl
     last: Labrador
@@ -16316,6 +16361,7 @@
     icpsr: 20136
     wikidata: Q1397290
     google_entity_id: kg:/m/02tvqy
+    nimsp: '13010828'
   name:
     first: James
     middle: R.
@@ -16721,6 +16767,7 @@
     icpsr: 20755
     wikidata: Q888061
     google_entity_id: kg:/m/02z6_j1
+    nimsp: '3428798'
   name:
     first: Robert
     middle: E.
@@ -17025,6 +17072,7 @@
     icpsr: 41110
     wikidata: Q627098
     google_entity_id: kg:/m/09v5q9x
+    nimsp: '6474397'
   name:
     first: Mike
     last: Lee
@@ -18186,6 +18234,7 @@
     icpsr: 20926
     wikidata: Q522181
     google_entity_id: kg:/m/04ycpq1
+    nimsp: '4243467'
   name:
     first: Blaine
     last: Luetkemeyer
@@ -18349,6 +18398,7 @@
     icpsr: 20119
     wikidata: Q2344921
     google_entity_id: kg:/m/028vsz
+    nimsp: '1819740'
   name:
     first: Stephen
     middle: F.
@@ -18591,6 +18641,7 @@
     icpsr: 20532
     wikidata: Q368184
     google_entity_id: kg:/m/04cvjb
+    nimsp: '13007002'
   name:
     first: Kenny
     middle: Ewell
@@ -19140,6 +19191,7 @@
     icpsr: 20703
     wikidata: Q766866
     google_entity_id: kg:/m/074qxm
+    nimsp: '6601044'
   name:
     first: Kevin
     last: McCarthy
@@ -19341,6 +19393,7 @@
     icpsr: 20903
     wikidata: Q535887
     google_entity_id: kg:/m/01r6jp
+    nimsp: '6612863'
   name:
     first: Tom
     last: McClintock
@@ -19422,6 +19475,7 @@
     icpsr: 20122
     wikidata: Q434893
     google_entity_id: kg:/m/0249hy
+    nimsp: '6428407'
   name:
     first: Betty
     middle: Louise
@@ -19654,6 +19708,7 @@
     icpsr: 20522
     wikidata: Q2057809
     google_entity_id: kg:/m/02b4rz
+    nimsp: '6009425'
   name:
     first: Patrick
     middle: T.
@@ -19823,6 +19878,7 @@
     icpsr: 20535
     wikidata: Q293343
     google_entity_id: kg:/m/03dlf3
+    nimsp: '6576950'
   name:
     first: Cathy
     last: McMorris Rodgers
@@ -20395,6 +20451,7 @@
     icpsr: 40300
     wikidata: Q22360
     google_entity_id: kg:/m/0202kt
+    nimsp: '6604204'
   name:
     first: Lisa
     middle: A.
@@ -20468,6 +20525,7 @@
     icpsr: 20707
     wikidata: Q1077594
     google_entity_id: kg:/m/0cy_dh
+    nimsp: '6384200'
   name:
     first: Christopher
     middle: S.
@@ -21108,6 +21166,7 @@
     icpsr: 21177
     wikidata: Q465749
     google_entity_id: kg:/m/0c3xgn9
+    nimsp: '6669590'
   name:
     first: Kristi
     last: Noem
@@ -21852,6 +21911,7 @@
     icpsr: 41104
     wikidata: Q463557
     google_entity_id: kg:/m/05pdb7q
+    nimsp: '19890282'
   name:
     first: Rand
     last: Paul
@@ -21907,6 +21967,7 @@
     icpsr: 20924
     wikidata: Q466085
     google_entity_id: kg:/m/0407tc8
+    nimsp: '17658795'
   name:
     first: Erik
     last: Paulsen
@@ -21989,6 +22050,7 @@
     icpsr: 20337
     wikidata: Q947168
     google_entity_id: kg:/m/033t2h
+    nimsp: '6638679'
   name:
     first: Stevan
     middle: E.
@@ -22341,6 +22403,7 @@
     lis: S380
     wikidata: Q1494930
     google_entity_id: kg:/m/02x0lnt
+    nimsp: '6427530'
   name:
     first: Gary
     middle: C.
@@ -22552,6 +22615,7 @@
     icpsr: 20920
     wikidata: Q457243
     google_entity_id: kg:/m/05gflq
+    nimsp: '1656640'
   name:
     first: Chellie
     last: Pingree
@@ -22909,6 +22973,7 @@
     icpsr: 20909
     wikidata: Q862373
     google_entity_id: kg:/m/0281vxy
+    nimsp: '12998616'
   name:
     first: Bill
     last: Posey
@@ -23862,6 +23927,7 @@
     icpsr: 20301
     wikidata: Q693238
     google_entity_id: kg:/m/024n_s
+    nimsp: '6571477'
   name:
     first: Mike
     last: Rogers
@@ -24109,6 +24175,7 @@
     icpsr: 21131
     wikidata: Q1521384
     google_entity_id: kg:/m/0bll9p
+    nimsp: '6592215'
   name:
     first: Todd
     last: Rokita
@@ -24498,6 +24565,7 @@
     icpsr: 21117
     wikidata: Q1188940
     google_entity_id: kg:/m/0bmd7xs
+    nimsp: '451808'
   name:
     first: Dennis
     last: Ross
@@ -24841,6 +24909,7 @@
     icpsr: 41102
     wikidata: Q324546
     google_entity_id: kg:/m/0dpr5f
+    nimsp: '12999040'
   name:
     first: Marco
     last: Rubio
@@ -25537,6 +25606,7 @@
     house_history: 22608
     wikidata: Q1857141
     google_entity_id: kg:/m/0br34c
+    nimsp: '6627583'
   name:
     first: Steve
     middle: Joseph
@@ -26145,6 +26215,7 @@
     house_history: 22631
     wikidata: Q781167
     google_entity_id: kg:/m/076zn3y
+    nimsp: '6805076'
   name:
     first: Austin
     last: Scott
@@ -26218,6 +26289,7 @@
     house_history: 22574
     wikidata: Q132071
     google_entity_id: kg:/m/0255r4
+    nimsp: '13011507'
   name:
     first: David
     last: Scott
@@ -26458,6 +26530,7 @@
     house_history: 22623
     wikidata: Q561315
     google_entity_id: kg:/m/0c407g6
+    nimsp: '6644860'
   name:
     first: Tim
     last: Scott
@@ -27518,6 +27591,7 @@
     house_history: 22556
     wikidata: Q549521
     google_entity_id: kg:/m/0255tn
+    nimsp: '6623202'
   name:
     first: Michael
     middle: K.
@@ -27635,6 +27709,7 @@
     house_history: 22587
     wikidata: Q527509
     google_entity_id: kg:/m/08bt8r
+    nimsp: '6389364'
   name:
     first: Albio
     last: Sires
@@ -27880,6 +27955,7 @@
     house_history: 21774
     wikidata: Q350916
     google_entity_id: kg:/m/024zj_
+    nimsp: '6445523'
   name:
     first: Adam
     last: Smith
@@ -28410,6 +28486,7 @@
     house_history: 22606
     wikidata: Q218544
     google_entity_id: kg:/m/06k27l
+    nimsp: '12997061'
   name:
     first: Jackie
     last: Speier
@@ -28924,6 +29001,7 @@
     house_history: 23213
     wikidata: Q1531120
     google_entity_id: kg:/m/0409b0_
+    nimsp: '13005755'
   name:
     first: Glenn
     last: Thompson
@@ -29209,6 +29287,7 @@
     house_history: 23204
     wikidata: Q603467
     google_entity_id: kg:/m/02zfh_
+    nimsp: '6641838'
   name:
     first: Patrick
     middle: J.
@@ -29320,6 +29399,7 @@
     house_history: 23219
     wikidata: Q782994
     google_entity_id: kg:/m/0bn82p
+    nimsp: '6677176'
   name:
     first: Scott
     last: Tipton
@@ -29393,6 +29473,7 @@
     house_history: 23217
     wikidata: Q1373548
     google_entity_id: kg:/m/0gzy4c
+    nimsp: '4469600'
   name:
     first: Paul
     last: Tonko
@@ -29898,6 +29979,7 @@
     wikidata: Q1077819
     google_entity_id: kg:/m/025kb5
     lis: S390
+    nimsp: '5764636'
   name:
     first: Chris
     last: Van Hollen
@@ -30291,6 +30373,7 @@
     house_history: 24179
     wikidata: Q978618
     google_entity_id: kg:/m/0d7n3m
+    nimsp: '200642'
   name:
     first: Tim
     last: Walberg
@@ -30371,6 +30454,7 @@
     house_history: 24165
     wikidata: Q1397359
     google_entity_id: kg:/m/033tx_
+    nimsp: '3106417'
   name:
     first: Greg
     middle: P.
@@ -30576,6 +30660,7 @@
     house_history: 24177
     wikidata: Q50104
     google_entity_id: kg:/m/04cmyw
+    nimsp: '704716'
   name:
     first: Debbie
     last: Wasserman Schultz
@@ -30885,6 +30970,7 @@
     house_history: 24183
     wikidata: Q1112656
     google_entity_id: kg:/m/0db4gl
+    nimsp: '13013766'
   name:
     first: Peter
     last: Welch
@@ -30973,6 +31059,7 @@
     house_history: 24173
     wikidata: Q928855
     google_entity_id: kg:/m/03tll0
+    nimsp: '6644962'
   name:
     first: Joe
     middle: G.
@@ -31157,6 +31244,7 @@
     house_history: 24189
     wikidata: Q541251
     google_entity_id: kg:/m/03cx7ld
+    nimsp: '6666723'
   name:
     first: Robert
     middle: J.
@@ -31601,6 +31689,7 @@
     icpsr: 21135
     wikidata: Q187037
     google_entity_id: kg:/m/06w90zv
+    nimsp: '6612812'
   name:
     first: Kevin
     last: Yoder
@@ -32095,6 +32184,7 @@
     icpsr: 21198
     wikidata: Q45946
     google_entity_id: kg:/m/02q453x
+    nimsp: '339835'
   name:
     first: Suzanne
     last: Bonamici
@@ -32527,6 +32617,7 @@
     house_history: 23215
     wikidata: Q524440
     google_entity_id: kg:/m/07hwl2
+    nimsp: '12996791'
   name:
     first: Dina
     last: Titus
@@ -32643,6 +32734,7 @@
     house_history: 15032387755
     wikidata: Q1556541
     google_entity_id: kg:/m/03qnndb
+    nimsp: '6459171'
   name:
     first: Kyrsten
     last: Sinema
@@ -32705,6 +32797,7 @@
     icpsr: 21302
     wikidata: Q1703840
     google_entity_id: kg:/m/0288tnx
+    nimsp: '6601183'
   name:
     first: Doug
     last: LaMalfa
@@ -32766,6 +32859,7 @@
     icpsr: 21303
     wikidata: Q3276717
     google_entity_id: kg:/m/0ksfyx
+    nimsp: '13008447'
   name:
     first: Jared
     last: Huffman
@@ -32888,6 +32982,7 @@
     icpsr: 21305
     wikidata: Q3408766
     google_entity_id: kg:/m/0288t_6
+    nimsp: '13008798'
   name:
     first: Paul
     last: Cook
@@ -33002,6 +33097,7 @@
     icpsr: 21307
     wikidata: Q3528567
     google_entity_id: kg:/m/0g55rlx
+    nimsp: '13008587'
   name:
     first: David
     last: Valadao
@@ -33065,6 +33161,7 @@
     house_history: 15032386871
     wikidata: Q3577073
     google_entity_id: kg:/m/027z42z
+    nimsp: '1256839'
   name:
     first: Julia
     last: Brownley
@@ -33126,6 +33223,7 @@
     icpsr: 21309
     wikidata: Q3620422
     google_entity_id: kg:/m/0cgzsw
+    nimsp: '6413490'
   name:
     first: Tony
     last: Cárdenas
@@ -33493,6 +33591,7 @@
     house_history: 15032387067
     wikidata: Q3090454
     google_entity_id: kg:/m/0l8ll7_
+    nimsp: '12998330'
   name:
     first: Elizabeth
     last: Esty
@@ -33677,6 +33776,7 @@
     house_history: 15032387115
     wikidata: Q3182451
     google_entity_id: kg:/m/0gjdw8_
+    nimsp: '12998905'
   name:
     first: Lois
     last: Frankel
@@ -33738,6 +33838,7 @@
     icpsr: 21323
     wikidata: Q3162841
     google_entity_id: kg:/m/0lq9rkz
+    nimsp: '6671754'
   name:
     first: Doug
     last: Collins
@@ -33923,6 +34024,7 @@
     icpsr: 21328
     wikidata: Q134035
     google_entity_id: kg:/m/0jwttjt
+    nimsp: '13000202'
   name:
     first: Rodney
     last: Davis
@@ -34046,6 +34148,7 @@
     house_history: 15032387909
     wikidata: Q3157413
     google_entity_id: kg:/m/0ksf92
+    nimsp: '6659187'
   name:
     first: Jackie
     last: Walorski
@@ -34170,6 +34273,7 @@
     icpsr: 21332
     wikidata: Q3225316
     google_entity_id: kg:/m/0n48dw8
+    nimsp: '6659146'
   name:
     first: Luke
     last: Messer
@@ -34465,6 +34569,7 @@
     icpsr: 41300
     wikidata: Q544464
     google_entity_id: kg:/m/02hfx0
+    nimsp: '1792907'
   name:
     first: Angus
     last: King
@@ -34818,6 +34923,7 @@
     icpsr: 21347
     wikidata: Q3956848
     google_entity_id: kg:/m/02b5bx
+    nimsp: '5956762'
   name:
     first: Robert
     last: Pittenger
@@ -35002,6 +35108,7 @@
     house_history: 15032390641
     wikidata: Q50597
     google_entity_id: kg:/m/02f501
+    nimsp: '6518686'
   name:
     first: Heidi
     last: Heitkamp
@@ -35266,6 +35373,7 @@
     house_history: 15032387500
     wikidata: Q5591303
     google_entity_id: kg:/m/04ld76x
+    nimsp: '6496578'
   name:
     first: Grace
     last: Meng
@@ -35326,6 +35434,7 @@
     icpsr: 21343
     wikidata: Q5640425
     google_entity_id: kg:/m/025_74m
+    nimsp: '13009236'
   name:
     first: Hakeem
     last: Jeffries
@@ -35565,6 +35674,7 @@
     house_history: 15032386867
     wikidata: Q976417
     google_entity_id: kg:/m/03lcwb
+    nimsp: '2954872'
   name:
     first: Joyce
     last: Beatty
@@ -35809,6 +35919,7 @@
     icpsr: 21356
     wikidata: Q7437040
     google_entity_id: kg:/m/04mwt6y
+    nimsp: '13005805'
   name:
     first: Scott
     last: Perry
@@ -36053,6 +36164,7 @@
     icpsr: 41304
     wikidata: Q2036942
     google_entity_id: kg:/m/07j6ty
+    nimsp: '210204'
   name:
     first: Ted
     last: Cruz
@@ -36089,6 +36201,7 @@
     icpsr: 21360
     wikidata: Q4014569
     google_entity_id: kg:/m/0km63t0
+    nimsp: '13006857'
   name:
     first: Randy
     last: Weber
@@ -36209,6 +36322,7 @@
     icpsr: 21362
     wikidata: Q1167934
     google_entity_id: kg:/m/0bmclg
+    nimsp: '6396620'
   name:
     first: Joaquin
     last: Castro
@@ -36332,6 +36446,7 @@
     icpsr: 21365
     wikidata: Q4068811
     google_entity_id: kg:/m/0kmnfw5
+    nimsp: '6453720'
   name:
     first: Marc
     last: Veasey
@@ -36516,6 +36631,7 @@
     icpsr: 41305
     wikidata: Q359888
     google_entity_id: kg:/m/053f8h
+    nimsp: '6209648'
   name:
     first: Timothy
     last: Kaine
@@ -36672,6 +36788,7 @@
     icpsr: 21370
     wikidata: Q1900355
     google_entity_id: kg:/m/0gyhpz
+    nimsp: '17658558'
   name:
     first: Mark
     last: Pocan
@@ -36734,6 +36851,7 @@
     maplight: 2045
     wikidata: Q3437091
     google_entity_id: kg:/m/0g8l32
+    nimsp: '2665398'
   name:
     first: Robin
     last: Kelly
@@ -36876,6 +36994,7 @@
     icpsr: 21373
     wikidata: Q6163589
     google_entity_id: kg:/m/0g9yj_2
+    nimsp: '6669122'
   name:
     first: Jason
     middle: T.
@@ -37047,6 +37166,7 @@
     maplight: 2054
     wikidata: Q4954892
     google_entity_id: kg:/m/09g6kty
+    nimsp: '6583839'
   name:
     first: Bradley
     last: Byrne
@@ -37164,6 +37284,7 @@
     google_entity_id: kg:/m/09g8b1_
     votesmart: 116277
     icpsr: 21536
+    nimsp: '6498707'
   name:
     first: Donald
     middle: W.
@@ -37223,6 +37344,7 @@
     google_entity_id: kg:/m/02b45d
     votesmart: 5935
     icpsr: 21545
+    nimsp: '5890773'
   name:
     first: Alma
     last: Adams
@@ -37367,6 +37489,7 @@
     votesmart: 119120
     cspan: 76097
     icpsr: 21563
+    nimsp: '6682617'
   name:
     first: Bruce
     last: Westerman
@@ -37844,6 +37967,7 @@
     votesmart: 32085
     cspan: 76158
     icpsr: 21513
+    nimsp: '12999360'
   name:
     first: Buddy
     last: Carter
@@ -37932,6 +38056,7 @@
     votesmart: 31618
     cspan: 76165
     icpsr: 21515
+    nimsp: '12999116'
   name:
     first: Barry
     last: Loudermilk
@@ -38370,6 +38495,7 @@
     votesmart: 20157
     cspan: 78290
     icpsr: 21527
+    nimsp: '13002323'
   name:
     first: Mike
     last: Bishop
@@ -38502,6 +38628,7 @@
     votesmart: 78851
     cspan: 79924
     icpsr: 21530
+    nimsp: '301691'
   name:
     first: Brenda
     last: Lawrence
@@ -38546,6 +38673,7 @@
     votesmart: 38894
     cspan: 75567
     icpsr: 21531
+    nimsp: '6666050'
   name:
     first: Tom
     last: Emmer
@@ -38590,6 +38718,7 @@
     votesmart: 102964
     cspan: 79710
     icpsr: 21544
+    nimsp: '5876933'
   name:
     first: David
     last: Rouzer
@@ -38679,6 +38808,7 @@
     votesmart: 24799
     cspan: 79091
     icpsr: 21538
+    nimsp: '6389632'
   name:
     first: Bonnie
     last: Watson Coleman
@@ -38767,6 +38897,7 @@
     votesmart: 127653
     cspan: 76332
     icpsr: 21540
+    nimsp: '6510977'
   name:
     first: Kathleen
     last: Rice
@@ -38987,6 +39118,7 @@
     votesmart: 47357
     cspan: 76428
     icpsr: 21548
+    nimsp: '13006066'
   name:
     first: Brendan
     last: Boyle
@@ -39252,6 +39384,7 @@
     ballotpedia: Barbara Comstock
     cspan: 57186
     icpsr: 21555
+    nimsp: '6680418'
   name:
     first: Barbara
     last: Comstock
@@ -39339,6 +39472,7 @@
     votesmart: 51522
     cspan: 78315
     icpsr: 21556
+    nimsp: '6600370'
   name:
     first: Dan
     last: Newhouse
@@ -39383,6 +39517,7 @@
     votesmart: 3493
     cspan: 77282
     icpsr: 21559
+    nimsp: '2927726'
   name:
     first: Glenn
     last: Grothman
@@ -39629,6 +39764,7 @@
     votesmart: 128583
     cspan: 75342
     icpsr: 41502
+    nimsp: '6151700'
   name:
     first: Joni
     last: Ernst
@@ -39664,6 +39800,7 @@
     votesmart: 57717
     cspan: 77055
     icpsr: 41504
+    nimsp: '5942566'
   name:
     first: Thom
     last: Tillis
@@ -39814,6 +39951,7 @@
     google_entity_id: kg:/m/0c036qd
     cspan: 74763
     icpsr: 21560
+    nimsp: '5036479'
   name:
     first: Daniel
     middle: M.
@@ -39904,6 +40042,7 @@
     google_entity_id: kg:/m/0gg7rcy
     cspan: 70020
     icpsr: 21562
+    nimsp: '2782492'
   name:
     first: Darin
     last: LaHood
@@ -40064,6 +40203,7 @@
     votesmart: 35169
     maplight: 2166
     icpsr: 21565
+    nimsp: '13000729'
   name:
     first: James
     last: Comer
@@ -40109,6 +40249,7 @@
     votesmart: 9128
     maplight: 2167
     icpsr: 21566
+    nimsp: '13006152'
   name:
     first: Dwight
     last: Evans
@@ -40190,6 +40331,7 @@
     google_entity_id: kg:/m/0fl2sv
     cspan: 1011723
     icpsr: 41703
+    nimsp: '13010864'
   name:
     first: John
     middle: Neely
@@ -40226,6 +40368,7 @@
     maplight: 2192
     cspan: 67481
     icpsr: 41702
+    nimsp: '9756790'
   name:
     first: Margaret
     middle: Wood
@@ -40407,6 +40550,7 @@
     google_entity_id: kg:/m/02z4x12
     cspan: 104523
     icpsr: 21739
+    nimsp: '12997748'
   name:
     first: Tom
     last: O’Halleran
@@ -40438,6 +40582,7 @@
     google_entity_id: kg:/m/0_1m23v
     cspan: 105145
     icpsr: 21705
+    nimsp: '6602301'
   name:
     first: Andy
     last: Biggs
@@ -40811,6 +40956,7 @@
     google_entity_id: kg:/m/05b_1xw
     cspan: 104534
     icpsr: 21746
+    nimsp: '198924'
   name:
     first: Darren
     last: Soto
@@ -41001,6 +41147,7 @@
     maplight: 2213
     cspan: 103408
     icpsr: 21730
+    nimsp: '6265333'
   name:
     first: Raja
     last: Krishnamoorthi
@@ -41158,6 +41305,7 @@
     google_entity_id: kg:/m/0131jn2m
     cspan: 106095
     icpsr: 21727
+    nimsp: '28215321'
   name:
     first: Mike
     last: Johnson
@@ -41469,6 +41617,7 @@
     maplight: 2228
     cspan: 79707
     icpsr: 21729
+    nimsp: '6476722'
   name:
     first: Ruben
     last: Kihuen
@@ -41500,6 +41649,7 @@
     google_entity_id: kg:/m/060n4d
     cspan: 104747
     icpsr: 21747
+    nimsp: '12996931'
   name:
     first: Thomas
     last: Suozzi
@@ -41532,6 +41682,7 @@
     maplight: 2230
     cspan: 68413
     icpsr: 21715
+    nimsp: '6512516'
   name:
     first: Adriano
     last: Espaillat
@@ -41564,6 +41715,7 @@
     maplight: 2231
     cspan: 1021406
     icpsr: 21716
+    nimsp: '12996930'
   name:
     first: John
     last: Faso
@@ -41596,6 +41748,7 @@
     maplight: 2232
     cspan: 103481
     icpsr: 21749
+    nimsp: '4681349'
   name:
     first: Claudia
     last: Tenney
@@ -41658,6 +41811,7 @@
     google_entity_id: kg:/m/05t08cn
     cspan: 103540
     icpsr: 21745
+    nimsp: '13013355'
   name:
     first: Lloyd
     last: Smucker
@@ -41780,6 +41934,7 @@
     google_entity_id: kg:/m/0g9_f_1
     cspan: 1016482
     icpsr: 21700
+    nimsp: '26357872'
   name:
     first: Jodey
     last: Arrington
@@ -41811,6 +41966,7 @@
     google_entity_id: kg:/m/011bsmj8
     cspan: 96047
     icpsr: 21748
+    nimsp: '16700084'
   name:
     first: Scott
     last: Taylor
@@ -41842,6 +41998,7 @@
     maplight: 2240
     cspan: 103621
     icpsr: 21736
+    nimsp: '6383551'
   name:
     first: A.
     middle: Donald
@@ -41874,6 +42031,7 @@
     maplight: 2241
     cspan: 103625
     icpsr: 21721
+    nimsp: '6698958'
   name:
     first: Thomas
     last: Garrett
@@ -42066,6 +42224,7 @@
     ballotpedia: Greg Gianforte
     google_entity_id: kg:/m/030pb5p
     house_history: 15032448990
+    nimsp: '39714710'
   name:
     first: Greg
     last: Gianforte
@@ -42098,6 +42257,7 @@
     ballotpedia: Ralph W. Norman
     google_entity_id: kg:/m/0f9kbx
     house_history: 15032448994
+    nimsp: '6126950'
   name:
     first: Ralph
     last: Norman
@@ -42131,6 +42291,7 @@
     ballotpedia: Karen Handel
     google_entity_id: kg:/m/0g838b
     house_history: 15032448993
+    nimsp: '6805507'
   name:
     first: Karen
     last: Handel

--- a/scripts/nimsp_ids.py
+++ b/scripts/nimsp_ids.py
@@ -1,0 +1,44 @@
+# gets nimsp IDs from votesmart manual data
+# https://github.com/votesmart/political-id-match/
+
+import utils
+from utils import load_data, save_data
+import csv
+
+
+# default to caching
+cache = utils.flags().get('cache', True)
+force = not cache
+
+historical = load_data("legislators-historical.yaml")
+current = load_data("legislators-current.yaml")
+
+vs_to_nimsp = {}
+
+destination = "matrix.csv"
+matrix_url = 'https://github.com/votesmart/political-id-match/raw/master/id_matrix.csv'
+matrix = utils.download(matrix_url, destination, force)
+
+for row in csv.DictReader(open('cache/matrix.csv'), delimiter=";"):
+    if row['votesmart_candidate_id'] and row['nimsp_entity_id']:
+        vs_to_nimsp[row['votesmart_candidate_id']] = row['nimsp_entity_id']
+
+for legislator in current:
+    if 'votesmart' in legislator['id']:
+        if str(legislator['id']['votesmart']) in vs_to_nimsp:
+            legislator['id']['nimsp'] = vs_to_nimsp[str(legislator['id']['votesmart'])]
+            print("Found {}, {} is {}".format(legislator['name']['last'],
+                                              legislator['id']['votesmart'],
+                                              legislator['id']['nimsp']))
+
+utils.save_data(current, "legislators-current.yaml")
+
+for legislator in historical:
+    if 'votesmart' in legislator['id']:
+        if str(legislator['id']['votesmart']) in vs_to_nimsp:
+            legislator['id']['nimsp'] = vs_to_nimsp[str(legislator['id']['votesmart'])]
+            print("Found {}, {} is {}".format(legislator['name']['last'],
+                                              legislator['id']['votesmart'],
+                                              legislator['id']['nimsp']))
+
+utils.save_data(historical, "legislators-historical.yaml")


### PR DESCRIPTION
Issue #372 

Someone at votesmart [published a CSV](https://github.com/votesmart/political-id-match/) with FollowTheMoney (NIMSP) Entity IDs for many legislators, that also has their votesmart IDs. Since congress-legislators has votesmart IDs, I wrote a script to cross-reference and add them.

Note that this isn't my data, but I spot checked a number of them and they look good.
