### PR TITLE
Sweep of House website updates, fixed scraper

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -3086,7 +3086,7 @@
     district: 3
     party: Republican
     phone: 202-225-3831
-    url: http://amash.house.gov
+    url: https://amash.house.gov
     rss_url: http://amash.house.gov/rss.xml
     address: 114 Cannon HOB; Washington DC 20515-2203
     office: 114 Cannon House Office Building
@@ -3251,7 +3251,7 @@
     district: 11
     party: Republican
     phone: 202-225-6511
-    url: http://barletta.house.gov
+    url: https://barletta.house.gov
     rss_url: http://barletta.house.gov/common/rss//index.cfm?rss=25
     address: 2049 Rayburn HOB; Washington DC 20515-3811
     office: 2049 Rayburn House Office Building
@@ -3736,7 +3736,7 @@
     district: 1
     party: Republican
     phone: 202-225-0453
-    url: http://robbishop.house.gov
+    url: https://robbishop.house.gov
     rss_url: http://robbishop.house.gov/news/rss.aspx
     address: 123 Cannon HOB; Washington DC 20515-4401
     office: 123 Cannon House Office Building
@@ -3870,7 +3870,7 @@
     district: 2
     party: Democrat
     phone: 202-225-3631
-    url: http://bishop.house.gov
+    url: https://bishop.house.gov
     rss_url: http://bishop.house.gov/rss.xml
     address: 2407 Rayburn HOB; Washington DC 20515-1002
     office: 2407 Rayburn House Office Building
@@ -3942,7 +3942,7 @@
     district: 6
     party: Republican
     phone: 202-225-4231
-    url: http://black.house.gov
+    url: https://black.house.gov
     rss_url: http://black.house.gov/rss.xml
     address: 1131 Longworth HOB; Washington DC 20515-4206
     office: 1131 Longworth House Office Building
@@ -4046,7 +4046,7 @@
     district: 7
     party: Republican
     phone: 202-225-2811
-    url: http://blackburn.house.gov
+    url: https://blackburn.house.gov
     rss_url: http://blackburn.house.gov/news/rss.aspx
     address: 2266 Rayburn HOB; Washington DC 20515-4207
     office: 2266 Rayburn House Office Building
@@ -4636,7 +4636,7 @@
     district: 8
     party: Republican
     phone: 202-225-4901
-    url: http://kevinbrady.house.gov
+    url: https://kevinbrady.house.gov
     rss_url: http://kevinbrady.house.gov/common/rss/index.cfm?rss=49
     address: 1011 Longworth HOB; Washington DC 20515-4308
     office: 1011 Longworth House Office Building
@@ -4757,7 +4757,7 @@
     district: 1
     party: Democrat
     phone: 202-225-4731
-    url: http://brady.house.gov
+    url: https://brady.house.gov
     rss_url: http://brady.house.gov/rss.xml
     address: 2004 Rayburn HOB; Washington DC 20515-3801
     office: 2004 Rayburn House Office Building
@@ -5094,7 +5094,7 @@
     district: 26
     party: Republican
     phone: 202-225-7772
-    url: http://burgess.house.gov
+    url: https://burgess.house.gov
     rss_url: http://burgess.house.gov/news/rss.aspx
     address: 2336 Rayburn HOB; Washington DC 20515-4326
     office: 2336 Rayburn House Office Building
@@ -5293,7 +5293,7 @@
     district: 1
     party: Democrat
     phone: 202-225-3101
-    url: http://butterfield.house.gov
+    url: https://butterfield.house.gov
     rss_url: http://butterfield.house.gov/rss/press-releases.xml/
     address: 2080 Rayburn HOB; Washington DC 20515-3301
     office: 2080 Rayburn House Office Building
@@ -5426,7 +5426,7 @@
     district: 42
     party: Republican
     phone: 202-225-1986
-    url: http://calvert.house.gov
+    url: https://calvert.house.gov
     rss_url: http://calvert.house.gov/news/rss.aspx
     address: 2205 Rayburn HOB; Washington DC 20515-0542
     office: 2205 Rayburn House Office Building
@@ -5731,7 +5731,7 @@
     district: 7
     party: Democrat
     phone: 202-225-4011
-    url: http://carson.house.gov
+    url: https://carson.house.gov
     rss_url: http://carson.house.gov/index.php?option=com_bca-rss-syndicator&amp;feed_id=1
     address: 2135 Rayburn HOB; Washington DC 20515-1407
     office: 2135 Rayburn House Office Building
@@ -5998,7 +5998,7 @@
     district: 14
     party: Democrat
     phone: 202-225-3376
-    url: http://castor.house.gov
+    url: https://castor.house.gov
     rss_url: http://castor.house.gov/news/rss.aspx
     address: 2052 Rayburn HOB; Washington DC 20515-0914
     office: 2052 Rayburn House Office Building
@@ -6118,7 +6118,7 @@
     district: 1
     party: Republican
     phone: 202-225-2216
-    url: http://chabot.house.gov
+    url: https://chabot.house.gov
     rss_url: http://chabot.house.gov/common/rss/index.cfm?rss=49
     address: 2371 Rayburn HOB; Washington DC 20515-3501
     office: 2371 Rayburn House Office Building
@@ -6274,7 +6274,7 @@
     district: 1
     party: Democrat
     phone: 202-225-4911
-    url: http://cicilline.house.gov
+    url: https://cicilline.house.gov
     rss_url: http://cicilline.house.gov/rss.xml
     address: 2244 Rayburn HOB; Washington DC 20515-3901
     office: 2244 Rayburn House Office Building
@@ -6567,7 +6567,7 @@
     district: 5
     party: Democrat
     phone: 202-225-4535
-    url: http://cleaver.house.gov
+    url: https://cleaver.house.gov
     rss_url: http://cleaver.house.gov/rss.xml
     address: 2335 Rayburn HOB; Washington DC 20515-2505
     office: 2335 Rayburn House Office Building
@@ -6702,7 +6702,7 @@
     district: 6
     party: Democrat
     phone: 202-225-3315
-    url: http://clyburn.house.gov
+    url: https://clyburn.house.gov
     rss_url: http://clyburn.house.gov/rss.xml
     address: 242 Cannon HOB; Washington DC 20515-4006
     office: 242 Cannon House Office Building
@@ -6787,7 +6787,7 @@
     district: 6
     party: Republican
     phone: 202-225-7882
-    url: http://coffman.house.gov
+    url: https://coffman.house.gov
     rss_url: http://coffman.house.gov/index.php?format=feed&amp;type=rss
     address: 2443 Rayburn HOB; Washington DC 20515-0606
     office: 2443 Rayburn House Office Building
@@ -7072,7 +7072,7 @@
     district: 11
     party: Republican
     phone: 202-225-3605
-    url: http://conaway.house.gov
+    url: https://conaway.house.gov
     address: 2430 Rayburn HOB; Washington DC 20515-4311
     office: 2430 Rayburn House Office Building
     fax: 202-225-1783
@@ -7511,7 +7511,7 @@
     district: 5
     party: Democrat
     phone: 202-225-4311
-    url: http://cooper.house.gov
+    url: https://cooper.house.gov
     rss_url: http://cooper.house.gov/index.php?format=feed&amp;type=rss
     address: 1536 Longworth HOB; Washington DC 20515-4205
     office: 1536 Longworth House Office Building
@@ -7853,7 +7853,7 @@
     district: 1
     party: Republican
     phone: 202-225-4076
-    url: http://crawford.house.gov
+    url: https://crawford.house.gov
     rss_url: http://crawford.house.gov/news/rss.aspx
     address: 2422 Rayburn HOB; Washington DC 20515-0401
     office: 2422 Rayburn House Office Building
@@ -7969,7 +7969,7 @@
     district: 14
     party: Democrat
     phone: 202-225-3965
-    url: http://crowley.house.gov
+    url: https://crowley.house.gov
     rss_url: http://crowley.house.gov/rss.xml
     address: 1035 Longworth HOB; Washington DC 20515-3214
     office: 1035 Longworth House Office Building
@@ -8063,7 +8063,7 @@
     district: 28
     party: Democrat
     phone: 202-225-1640
-    url: http://cuellar.house.gov
+    url: https://cuellar.house.gov
     rss_url: http://cuellar.house.gov/news/rss.aspx
     address: 2209 Rayburn HOB; Washington DC 20515-4328
     office: 2209 Rayburn House Office Building
@@ -8173,7 +8173,7 @@
     district: 7
     party: Republican
     phone: 202-225-2571
-    url: http://culberson.house.gov
+    url: https://culberson.house.gov
     rss_url: http://culberson.house.gov/rss/
     address: 2161 Rayburn HOB; Washington DC 20515-4307
     office: 2161 Rayburn House Office Building
@@ -8680,7 +8680,7 @@
     district: 4
     party: Democrat
     phone: 202-225-6416
-    url: http://defazio.house.gov
+    url: https://defazio.house.gov
     rss_url: http://www.defazio.house.gov/index.php?format=feed&amp;type=rss
     address: 2134 Rayburn HOB; Washington DC 20515-3704
     office: 2134 Rayburn House Office Building
@@ -8801,7 +8801,7 @@
     district: 1
     party: Democrat
     phone: 202-225-4431
-    url: http://degette.house.gov
+    url: https://degette.house.gov
     rss_url: http://degette.house.gov/index.php?option=com_ninjarsssyndicator&amp;feed_id=1&amp;format=raw
     address: 2111 Rayburn HOB; Washington DC 20515-0601
     office: 2111 Rayburn House Office Building
@@ -9013,7 +9013,7 @@
     district: 10
     party: Republican
     phone: 202-225-4540
-    url: http://denham.house.gov
+    url: https://denham.house.gov
     rss_url: http://denham.house.gov/rss.xml
     address: 1730 Longworth HOB; Washington DC 20515-0510
     office: 1730 Longworth House Office Building
@@ -9262,7 +9262,7 @@
     district: 22
     party: Democrat
     phone: 202-225-3001
-    url: http://teddeutch.house.gov
+    url: https://teddeutch.house.gov
     rss_url: http://teddeutch.house.gov/news/rss.aspx
     address: 2447 Rayburn HOB; Washington DC 20515-0922
     office: 2447 Rayburn House Office Building
@@ -9365,7 +9365,7 @@
     district: 25
     party: Republican
     phone: 202-225-4211
-    url: http://mariodiazbalart.house.gov
+    url: https://mariodiazbalart.house.gov
     rss_url: http://mariodiazbalart.house.gov/rss.xml
     address: 440 Cannon HOB; Washington DC 20515-0925
     office: 440 Cannon House Office Building
@@ -9691,7 +9691,7 @@
     district: 14
     party: Democrat
     phone: 202-225-2135
-    url: http://doyle.house.gov
+    url: https://doyle.house.gov
     rss_url: http://doyle.house.gov/rss.xml
     address: 239 Cannon HOB; Washington DC 20515-3814
     office: 239 Cannon House Office Building
@@ -9837,7 +9837,7 @@
     district: 3
     party: Republican
     phone: 202-225-5301
-    url: http://jeffduncan.house.gov
+    url: https://jeffduncan.house.gov
     rss_url: http://jeffduncan.house.gov/rss.xml
     address: 2229 Rayburn HOB; Washington DC 20515-4003
     office: 2229 Rayburn House Office Building
@@ -9990,7 +9990,7 @@
     district: 2
     party: Republican
     phone: 202-225-5435
-    url: http://duncan.house.gov
+    url: https://duncan.house.gov
     rss_url: http://duncan.house.gov/rss.xml
     address: 2207 Rayburn HOB; Washington DC 20515-4202
     office: 2207 Rayburn House Office Building
@@ -10430,7 +10430,7 @@
     district: 27
     party: Republican
     phone: 202-225-7742
-    url: http://farenthold.house.gov
+    url: https://farenthold.house.gov
     rss_url: http://farenthold.house.gov/index.php?format=feed&amp;type=rss
     address: 2331 Rayburn HOB; Washington DC 20515-4327
     office: 2331 Rayburn House Office Building
@@ -10591,7 +10591,7 @@
     district: 3
     party: Republican
     phone: 202-225-3271
-    url: http://fleischmann.house.gov
+    url: https://fleischmann.house.gov
     rss_url: http://fleischmann.house.gov/rss.xml
     address: 2410 Rayburn HOB; Washington DC 20515-4203
     office: 2410 Rayburn House Office Building
@@ -10663,7 +10663,7 @@
     district: 17
     party: Republican
     phone: 202-225-6105
-    url: http://flores.house.gov
+    url: https://flores.house.gov
     rss_url: http://flores.house.gov/common/rss//index.cfm?rss=25
     address: 2440 Rayburn HOB; Washington DC 20515-4317
     office: 2440 Rayburn House Office Building
@@ -10853,7 +10853,7 @@
     district: 5
     party: Republican
     phone: 202-225-2071
-    url: http://foxx.house.gov
+    url: https://foxx.house.gov
     rss_url: http://foxx.house.gov/common/rss/?rss=55
     address: 2262 Rayburn HOB; Washington DC 20515-3305
     office: 2262 Rayburn House Office Building
@@ -11259,7 +11259,7 @@
     district: 3
     party: Democrat
     phone: 202-225-1880
-    url: http://garamendi.house.gov
+    url: https://garamendi.house.gov
     rss_url: http://garamendi.house.gov/rss.xml
     address: 2438 Rayburn HOB; Washington DC 20515-0503
     office: 2438 Rayburn House Office Building
@@ -11699,7 +11699,7 @@
     district: 4
     party: Republican
     phone: 202-225-2315
-    url: http://gosar.house.gov
+    url: https://gosar.house.gov
     rss_url: http://gosar.house.gov/rss.xml
     address: 2057 Rayburn HOB; Washington DC 20515-0304
     office: 2057 Rayburn House Office Building
@@ -11892,7 +11892,7 @@
     district: 12
     party: Republican
     phone: 202-225-5071
-    url: http://kaygranger.house.gov
+    url: https://kaygranger.house.gov
     rss_url: http://kaygranger.house.gov/rss.xml
     address: 1026 Longworth HOB; Washington DC 20515-4312
     office: 1026 Longworth House Office Building
@@ -12188,7 +12188,7 @@
     district: 14
     party: Republican
     phone: 202-225-5211
-    url: http://tomgraves.house.gov
+    url: https://tomgraves.house.gov
     rss_url: http://tomgraves.house.gov/news/rss.aspx
     address: 2078 Rayburn HOB; Washington DC 20515-1014
     office: 2078 Rayburn House Office Building
@@ -12283,7 +12283,7 @@
     district: 9
     party: Democrat
     phone: 202-225-7508
-    url: http://algreen.house.gov
+    url: https://algreen.house.gov
     rss_url: http://algreen.house.gov/rss.xml
     address: 2347 Rayburn HOB; Washington DC 20515-4309
     office: 2347 Rayburn House Office Building
@@ -12490,7 +12490,7 @@
     district: 9
     party: Republican
     phone: 202-225-3861
-    url: http://morgangriffith.house.gov
+    url: https://morgangriffith.house.gov
     rss_url: http://morgangriffith.house.gov/news/rss.aspx
     address: 2202 Rayburn HOB; Washington DC 20515-4609
     office: 2202 Rayburn House Office Building
@@ -12889,7 +12889,7 @@
     district: 3
     party: Republican
     phone: 202-225-5031
-    url: http://harper.house.gov
+    url: https://harper.house.gov
     rss_url: http://harper.house.gov/rss.xml
     address: 2227 Rayburn HOB; Washington DC 20515-2403
     office: 2227 Rayburn House Office Building
@@ -12961,7 +12961,7 @@
     district: 1
     party: Republican
     phone: 202-225-5311
-    url: http://harris.house.gov
+    url: https://harris.house.gov
     rss_url: http://harris.house.gov/rss.xml
     address: 1533 Longworth HOB; Washington DC 20515-2001
     office: 1533 Longworth House Office Building
@@ -13168,7 +13168,7 @@
     district: 20
     party: Democrat
     phone: 202-225-1313
-    url: http://alceehastings.house.gov
+    url: https://alceehastings.house.gov
     rss_url: http://www.alceehastings.house.gov/news/rss.aspx
     address: 2353 Rayburn HOB; Washington DC 20515-0920
     office: 2353 Rayburn House Office Building
@@ -13329,7 +13329,7 @@
     district: 5
     party: Republican
     phone: 202-225-3484
-    url: http://hensarling.house.gov
+    url: https://hensarling.house.gov
     rss_url: http://hensarling.house.gov/atom.xml
     address: 2228 Rayburn HOB; Washington DC 20515-4305
     office: 2228 Rayburn House Office Building
@@ -13401,7 +13401,7 @@
     district: 3
     party: Republican
     phone: 202-225-3536
-    url: http://herrerabeutler.house.gov
+    url: https://herrerabeutler.house.gov
     rss_url: http://herrerabeutler.house.gov/news/rss.aspx
     address: 1107 Longworth HOB; Washington DC 20515-4703
     office: 1107 Longworth House Office Building
@@ -13496,7 +13496,7 @@
     district: 26
     party: Democrat
     phone: 202-225-3306
-    url: http://higgins.house.gov
+    url: https://higgins.house.gov
     rss_url: http://higgins.house.gov/rss.xml
     address: 2459 Rayburn HOB; Washington DC 20515-3226
     office: 2459 Rayburn House Office Building
@@ -13964,7 +13964,7 @@
     district: 2
     party: Republican
     phone: 202-225-4401
-    url: http://huizenga.house.gov
+    url: https://huizenga.house.gov
     rss_url: http://huizenga.house.gov/news/rss.aspx
     address: 2232 Rayburn HOB; Washington DC 20515-2202
     office: 2232 Rayburn House Office Building
@@ -14037,7 +14037,7 @@
     district: 14
     party: Republican
     phone: 202-225-2976
-    url: http://hultgren.house.gov
+    url: https://hultgren.house.gov
     rss_url: http://hultgren.house.gov/common/rss//index.cfm?rss=49
     address: 2455 Rayburn HOB; Washington DC 20515-1314
     office: 2455 Rayburn House Office Building
@@ -14440,7 +14440,7 @@
     district: 18
     party: Democrat
     phone: 202-225-3816
-    url: http://jacksonlee.house.gov
+    url: https://jacksonlee.house.gov
     rss_url: http://jacksonlee.house.gov/news/rss.aspx
     address: 2187 Rayburn HOB; Washington DC 20515-4318
     office: 2187 Rayburn House Office Building
@@ -14594,7 +14594,7 @@
     district: 6
     party: Republican
     phone: 202-225-5705
-    url: http://billjohnson.house.gov
+    url: https://billjohnson.house.gov
     rss_url: http://billjohnson.house.gov/constituentservices/opendoorsschedule.htm
     address: 1710 Longworth HOB; Washington DC 20515-3506
     office: 1710 Longworth House Office Building
@@ -14727,7 +14727,7 @@
     district: 30
     party: Democrat
     phone: 202-225-8885
-    url: http://ebjohnson.house.gov
+    url: https://ebjohnson.house.gov
     rss_url: http://ebjohnson.house.gov/common/rss//index.cfm?rss=21
     address: 2468 Rayburn HOB; Washington DC 20515-4330
     office: 2468 Rayburn House Office Building
@@ -15009,7 +15009,7 @@
     district: 3
     party: Republican
     phone: 202-225-4201
-    url: http://samjohnson.house.gov
+    url: https://samjohnson.house.gov
     rss_url: http://samjohnson.house.gov/news/rss.aspx
     address: 2304 Rayburn HOB; Washington DC 20515-4303
     office: 2304 Rayburn House Office Building
@@ -15138,7 +15138,7 @@
     district: 3
     party: Republican
     phone: 202-225-3415
-    url: http://jones.house.gov
+    url: https://jones.house.gov
     rss_url: http://jones.house.gov/rss.xml
     address: 2333 Rayburn HOB; Washington DC 20515-3303
     office: 2333 Rayburn House Office Building
@@ -15229,7 +15229,7 @@
     district: 4
     party: Republican
     phone: 202-225-2676
-    url: http://jordan.house.gov
+    url: https://jordan.house.gov
     rss_url: http://jordan.house.gov/news/rss.aspx
     address: 2056 Rayburn HOB; Washington DC 20515-3504
     office: 2056 Rayburn House Office Building
@@ -15537,7 +15537,7 @@
     district: 3
     party: Republican
     phone: 202-225-5406
-    url: http://kelly.house.gov
+    url: https://kelly.house.gov
     rss_url: http://kelly.house.gov/rss.xml
     address: 1707 Longworth HOB; Washington DC 20515-3803
     office: 1707 Longworth House Office Building
@@ -15794,7 +15794,7 @@
     district: 2
     party: Republican
     phone: 202-225-7896
-    url: http://peteking.house.gov
+    url: https://peteking.house.gov
     rss_url: http://peteking.house.gov/rss.xml
     address: 339 Cannon HOB; Washington DC 20515-3202
     office: 339 Cannon House Office Building
@@ -15971,7 +15971,7 @@
     district: 16
     party: Republican
     phone: 202-225-3635
-    url: http://kinzinger.house.gov
+    url: https://kinzinger.house.gov
     rss_url: http://kinzinger.house.gov/common/rss//index.cfm?rss=49
     address: 2245 Rayburn HOB; Washington DC 20515-1316
     office: 2245 Rayburn House Office Building
@@ -16133,7 +16133,7 @@
     district: 5
     party: Republican
     phone: 202-225-4422
-    url: http://lamborn.house.gov
+    url: https://lamborn.house.gov
     rss_url: http://lamborn.house.gov/news-rss-graphic/news-rss-graphic/
     address: 2402 Rayburn HOB; Washington DC 20515-0605
     office: 2402 Rayburn House Office Building
@@ -16214,7 +16214,7 @@
     district: 7
     party: Republican
     phone: 202-225-5361
-    url: http://lance.house.gov
+    url: https://lance.house.gov
     rss_url: http://lance.house.gov/rss-button/rss-button/
     address: 2352 Rayburn HOB; Washington DC 20515-3007
     office: 2352 Rayburn House Office Building
@@ -16324,7 +16324,7 @@
     district: 2
     party: Democrat
     phone: 202-225-2735
-    url: http://langevin.house.gov
+    url: https://langevin.house.gov
     rss_url: http://langevin.house.gov/rss.xml
     address: 2077 Rayburn HOB; Washington DC 20515-3902
     office: 2077 Rayburn House Office Building
@@ -16504,7 +16504,7 @@
     district: 2
     party: Democrat
     phone: 202-225-2605
-    url: http://larsen.house.gov
+    url: https://larsen.house.gov
     rss_url: http://larsen.house.gov/rss.xml
     address: 2113 Rayburn HOB; Washington DC 20515-4702
     office: 2113 Rayburn House Office Building
@@ -16708,7 +16708,7 @@
     district: 5
     party: Republican
     phone: 202-225-6405
-    url: http://latta.house.gov
+    url: https://latta.house.gov
     rss_url: http://latta.house.gov/news/rss.aspx
     address: 2448 Rayburn HOB; Washington DC 20515-3505
     office: 2448 Rayburn House Office Building
@@ -17137,7 +17137,7 @@
     district: 9
     party: Democrat
     phone: 202-225-4961
-    url: http://levin.house.gov
+    url: https://levin.house.gov
     rss_url: http://levin.house.gov/rss.xml
     address: 1236 Longworth HOB; Washington DC 20515-2209
     office: 1236 Longworth House Office Building
@@ -17518,7 +17518,7 @@
     district: 2
     party: Republican
     phone: 202-225-6572
-    url: http://lobiondo.house.gov
+    url: https://lobiondo.house.gov
     rss_url: http://lobiondo.house.gov/rss.xml
     address: 2427 Rayburn HOB; Washington DC 20515-3002
     office: 2427 Rayburn House Office Building
@@ -17606,7 +17606,7 @@
     district: 2
     party: Democrat
     phone: 202-225-6576
-    url: http://loebsack.house.gov
+    url: https://loebsack.house.gov
     rss_url: http://loebsack.house.gov/news/rss.aspx
     address: 1527 Longworth HOB; Washington DC 20515-1502
     office: 1527 Longworth House Office Building
@@ -18085,7 +18085,7 @@
     district: 3
     party: Republican
     phone: 202-225-5565
-    url: http://lucas.house.gov
+    url: https://lucas.house.gov
     rss_url: http://lucas.house.gov/rss.xml
     address: 2405 Rayburn HOB; Washington DC 20515-3603
     office: 2405 Rayburn House Office Building
@@ -18165,7 +18165,7 @@
     district: 3
     party: Republican
     phone: 202-225-2956
-    url: http://luetkemeyer.house.gov
+    url: https://luetkemeyer.house.gov
     rss_url: http://luetkemeyer.house.gov/news/rss.aspx
     address: 2230 Rayburn HOB; Washington DC 20515-2503
     office: 2230 Rayburn House Office Building
@@ -18356,7 +18356,7 @@
     district: 8
     party: Democrat
     phone: 202-225-8273
-    url: http://lynch.house.gov
+    url: https://lynch.house.gov
     rss_url: http://lynch.house.gov/rss.xml
     address: 2268 Rayburn HOB; Washington DC 20515-2108
     office: 2268 Rayburn House Office Building
@@ -18490,7 +18490,7 @@
     district: 12
     party: Democrat
     phone: 202-225-7944
-    url: http://maloney.house.gov
+    url: https://maloney.house.gov
     rss_url: http://maloney.house.gov/rss.xml
     address: 2308 Rayburn HOB; Washington DC 20515-3212
     office: 2308 Rayburn House Office Building
@@ -18942,7 +18942,7 @@
     district: 6
     party: Democrat
     phone: 202-225-7163
-    url: https://matsui.house.gov
+    url: http://matsui.house.gov
     rss_url: http://matsui.house.gov/index.php?format=feed&amp;type=rss
     address: 2311 Rayburn HOB; Washington DC 20515-0506
     office: 2311 Rayburn House Office Building
@@ -19146,7 +19146,7 @@
     district: 23
     party: Republican
     phone: 202-225-2915
-    url: http://kevinmccarthy.house.gov
+    url: https://kevinmccarthy.house.gov
     rss_url: http://kevinmccarthy.house.gov/index.php?format=feed&amp;type=rss
     address: 2421 Rayburn HOB; Washington DC 20515-0523
     office: 2421 Rayburn House Office Building
@@ -19240,7 +19240,7 @@
     district: 10
     party: Republican
     phone: 202-225-2401
-    url: http://mccaul.house.gov
+    url: https://mccaul.house.gov
     address: 2001 Rayburn HOB; Washington DC 20515-4310
     office: 2001 Rayburn House Office Building
     fax: 202-225-5955
@@ -19320,7 +19320,7 @@
     district: 4
     party: Republican
     phone: 202-225-2511
-    url: http://mcclintock.house.gov
+    url: https://mcclintock.house.gov
     rss_url: http://mcclintock.house.gov/atom.xml
     address: 2312 Rayburn HOB; Washington DC 20515-0504
     office: 2312 Rayburn House Office Building
@@ -19430,7 +19430,7 @@
     district: 4
     party: Democrat
     phone: 202-225-6631
-    url: http://mccollum.house.gov
+    url: https://mccollum.house.gov
     rss_url: http://mccollum.house.gov/rss.xml
     address: 2256 Rayburn HOB; Washington DC 20515-2304
     office: 2256 Rayburn House Office Building
@@ -19552,7 +19552,7 @@
     district: 2
     party: Democrat
     phone: 202-225-6101
-    url: http://mcgovern.house.gov
+    url: https://mcgovern.house.gov
     rss_url: http://mcgovern.house.gov/common/rss/?rss=15
     address: 438 Cannon HOB; Washington DC 20515-2102
     office: 438 Cannon House Office Building
@@ -19647,7 +19647,7 @@
     district: 10
     party: Republican
     phone: 202-225-2576
-    url: http://mchenry.house.gov
+    url: https://mchenry.house.gov
     rss_url: http://mchenry.house.gov/news/rss.aspx
     address: 2334 Rayburn HOB; Washington DC 20515-3310
     office: 2334 Rayburn House Office Building
@@ -19815,7 +19815,7 @@
     district: 5
     party: Republican
     phone: 202-225-2006
-    url: http://mcmorris.house.gov
+    url: https://mcmorris.house.gov
     rss_url: http://mcmorris.house.gov/common/rss/?rss=96
     address: 1314 Longworth HOB; Washington DC 20515-4705
     office: 1314 Longworth House Office Building
@@ -19902,7 +19902,7 @@
     district: 9
     party: Democrat
     phone: 202-225-1947
-    url: http://mcnerney.house.gov
+    url: https://mcnerney.house.gov
     rss_url: http://mcnerney.house.gov/rss.xml
     address: 2265 Rayburn HOB; Washington DC 20515-0509
     office: 2265 Rayburn House Office Building
@@ -20096,7 +20096,7 @@
     district: 5
     party: Democrat
     phone: 202-225-3461
-    url: http://meeks.house.gov
+    url: https://meeks.house.gov
     rss_url: http://meeks.house.gov/rss.xml
     address: 2234 Rayburn HOB; Washington DC 20515-3205
     office: 2234 Rayburn House Office Building
@@ -20746,7 +20746,7 @@
     district: 10
     party: Democrat
     phone: 202-225-5635
-    url: http://nadler.house.gov
+    url: https://nadler.house.gov
     rss_url: http://nadler.house.gov/rss.xml
     address: 2109 Rayburn HOB; Washington DC 20515-3210
     office: 2109 Rayburn House Office Building
@@ -20861,7 +20861,7 @@
     district: 32
     party: Democrat
     phone: 202-225-5256
-    url: http://napolitano.house.gov
+    url: https://napolitano.house.gov
     rss_url: http://napolitano.house.gov/rss.xml
     address: 1610 Longworth HOB; Washington DC 20515-0532
     office: 1610 Longworth House Office Building
@@ -21322,7 +21322,7 @@
     district: 22
     party: Republican
     phone: 202-225-2523
-    url: http://nunes.house.gov
+    url: https://nunes.house.gov
     rss_url: http://nunes.house.gov/news/rss.aspx
     address: 1013 Longworth HOB; Washington DC 20515-0522
     office: 1013 Longworth House Office Building
@@ -21475,7 +21475,7 @@
     district: 4
     party: Republican
     phone: 202-225-5772
-    url: http://palazzo.house.gov
+    url: https://palazzo.house.gov
     rss_url: http://palazzo.house.gov/rss.xml
     address: 2349 Rayburn HOB; Washington DC 20515-2404
     office: 2349 Rayburn House Office Building
@@ -21750,7 +21750,7 @@
     district: 9
     party: Democrat
     phone: 202-225-5751
-    url: http://pascrell.house.gov
+    url: https://pascrell.house.gov
     rss_url: http://www.house.gov/apps/list/press/nj08_pascrell/rss.xml
     address: 2370 Rayburn HOB; Washington DC 20515-3009
     office: 2370 Rayburn House Office Building
@@ -21980,7 +21980,7 @@
     district: 2
     party: Republican
     phone: 202-225-2365
-    url: http://pearce.house.gov
+    url: https://pearce.house.gov
     rss_url: http://pearce.house.gov/rss.xml
     address: 2432 Rayburn HOB; Washington DC 20515-3102
     office: 2432 Rayburn House Office Building
@@ -22146,7 +22146,7 @@
     district: 12
     party: Democrat
     phone: 202-225-4965
-    url: http://pelosi.house.gov
+    url: https://pelosi.house.gov
     rss_url: http://pelosi.house.gov/atom.xml
     address: 233 Cannon HOB; Washington DC 20515-0512
     office: 233 Cannon House Office Building
@@ -22449,7 +22449,7 @@
     district: 7
     party: Democrat
     phone: 202-225-2165
-    url: http://collinpeterson.house.gov
+    url: https://collinpeterson.house.gov
     rss_url: http://collinpeterson.house.gov/rss.xml
     address: 2204 Rayburn HOB; Washington DC 20515-2307
     office: 2204 Rayburn House Office Building
@@ -22707,7 +22707,7 @@
     district: 2
     party: Democrat
     phone: 202-225-2161
-    url: http://polis.house.gov
+    url: https://polis.house.gov
     rss_url: http://polis.house.gov/news/rss.aspx
     address: 1727 Longworth HOB; Washington DC 20515-0602
     office: 1727 Longworth House Office Building
@@ -22888,7 +22888,7 @@
     district: 8
     party: Republican
     phone: 202-225-3671
-    url: http://posey.house.gov
+    url: https://posey.house.gov
     rss_url: http://posey.house.gov/news/rss.aspx?documenttypeid=1487
     address: 2150 Rayburn HOB; Washington DC 20515-0908
     office: 2150 Rayburn House Office Building
@@ -23290,7 +23290,7 @@
     district: 8
     party: Republican
     phone: 202-225-7761
-    url: http://reichert.house.gov
+    url: https://reichert.house.gov
     rss_url: http://reichert.house.gov/rss.xml
     address: 1127 Longworth HOB; Washington DC 20515-4708
     office: 1127 Longworth House Office Building
@@ -23511,7 +23511,7 @@
     district: 2
     party: Republican
     phone: 202-225-2901
-    url: http://roby.house.gov
+    url: https://roby.house.gov
     rss_url: http://roby.house.gov/rss.xml
     address: 442 Cannon HOB; Washington DC 20515-0102
     office: 442 Cannon House Office Building
@@ -23591,7 +23591,7 @@
     district: 1
     party: Republican
     phone: 202-225-6356
-    url: http://roe.house.gov
+    url: https://roe.house.gov
     address: 336 Cannon HOB; Washington DC 20515-4201
     office: 336 Cannon House Office Building
     fax: 202-225-6356
@@ -23760,7 +23760,7 @@
     district: 5
     party: Republican
     phone: 202-225-4601
-    url: http://halrogers.house.gov
+    url: https://halrogers.house.gov
     rss_url: http://halrogers.house.gov/news/rss.aspx
     address: 2406 Rayburn HOB; Washington DC 20515-1705
     office: 2406 Rayburn House Office Building
@@ -24306,7 +24306,7 @@
     district: 27
     party: Republican
     phone: 202-225-3931
-    url: http://ros-lehtinen.house.gov
+    url: https://ros-lehtinen.house.gov
     rss_url: http://ros-lehtinen.house.gov/rss.xml
     address: 2206 Rayburn HOB; Washington DC 20515-0927
     office: 2206 Rayburn House Office Building
@@ -24470,7 +24470,7 @@
     district: 15
     party: Republican
     phone: 202-225-1252
-    url: http://dennisross.house.gov
+    url: https://dennisross.house.gov
     rss_url: http://dennisross.house.gov/news/rss.aspx
     address: 436 Cannon HOB; Washington DC 20515-0915
     office: 436 Cannon House Office Building
@@ -24602,7 +24602,7 @@
     district: 40
     party: Democrat
     phone: 202-225-1766
-    url: http://roybal-allard.house.gov
+    url: https://roybal-allard.house.gov
     rss_url: http://roybal-allard.house.gov/news/rss.aspx
     address: 2083 Rayburn HOB; Washington DC 20515-0540
     office: 2083 Rayburn House Office Building
@@ -24739,7 +24739,7 @@
     district: 39
     party: Republican
     phone: 202-225-4111
-    url: http://royce.house.gov
+    url: https://royce.house.gov
     rss_url: http://royce.house.gov/news/rss.aspx
     address: 2310 Rayburn HOB; Washington DC 20515-0539
     office: 2310 Rayburn House Office Building
@@ -24894,7 +24894,7 @@
     district: 2
     party: Democrat
     phone: 202-225-3061
-    url: http://ruppersberger.house.gov
+    url: https://ruppersberger.house.gov
     rss_url: http://dutch.house.gov/atom.xml
     address: 2416 Rayburn HOB; Washington DC 20515-2002
     office: 2416 Rayburn House Office Building
@@ -25028,7 +25028,7 @@
     district: 1
     party: Democrat
     phone: 202-225-4372
-    url: http://rush.house.gov
+    url: https://rush.house.gov
     rss_url: http://rush.house.gov/rss.xml
     address: 2188 Rayburn HOB; Washington DC 20515-1301
     office: 2188 Rayburn House Office Building
@@ -25152,7 +25152,7 @@
     district: 1
     party: Republican
     phone: 202-225-3031
-    url: http://paulryan.house.gov
+    url: https://paulryan.house.gov
     rss_url: http://paulryan.house.gov/news/rss.aspx
     address: 1233 Longworth HOB; Washington DC 20515-4901
     office: 1233 Longworth House Office Building
@@ -25256,7 +25256,7 @@
     district: 13
     party: Democrat
     phone: 202-225-5261
-    url: http://timryan.house.gov
+    url: https://timryan.house.gov
     rss_url: http://timryan.house.gov/rss.xml
     address: 1126 Longworth HOB; Washington DC 20515-3513
     office: 1126 Longworth House Office Building
@@ -25344,7 +25344,7 @@
     district: 0
     party: Democrat
     phone: 202-225-2646
-    url: http://sablan.house.gov
+    url: https://sablan.house.gov
     rss_url: http://sablan.house.gov/rss.xml
     address: 2411 Rayburn HOB; Washington DC 20515-5201
     office: 2411 Rayburn House Office Building
@@ -25536,7 +25536,7 @@
     district: 1
     party: Republican
     phone: 202-225-3015
-    url: http://scalise.house.gov
+    url: https://scalise.house.gov
     rss_url: http://scalise.house.gov/rss.xml
     address: 2338 Rayburn HOB; Washington DC 20515-1801
     office: 2338 Rayburn House Office Building
@@ -25762,7 +25762,7 @@
     district: 28
     party: Democrat
     phone: 202-225-4176
-    url: http://schiff.house.gov
+    url: https://schiff.house.gov
     rss_url: http://schiff.house.gov/common/rss/?rss=49
     address: 2372 Rayburn HOB; Washington DC 20515-0528
     office: 2372 Rayburn House Office Building
@@ -25843,7 +25843,7 @@
     district: 5
     party: Democrat
     phone: 202-225-5711
-    url: http://schrader.house.gov
+    url: https://schrader.house.gov
     rss_url: http://schrader.house.gov/news/rss.aspx
     address: 2431 Rayburn HOB; Washington DC 20515-3705
     office: 2431 Rayburn House Office Building
@@ -26219,7 +26219,7 @@
     district: 13
     party: Democrat
     phone: 202-225-2939
-    url: http://davidscott.house.gov
+    url: https://davidscott.house.gov
     rss_url: http://davidscott.house.gov/news/rss.aspx
     address: 225 Cannon HOB; Washington DC 20515-1013
     office: 225 Cannon House Office Building
@@ -26354,7 +26354,7 @@
     district: 3
     party: Democrat
     phone: 202-225-8351
-    url: http://bobbyscott.house.gov
+    url: https://bobbyscott.house.gov
     rss_url: http://www.house.gov/index.php?format=feed&amp;type=rss
     address: 1201 Longworth HOB; Washington DC 20515-4603
     office: 1201 Longworth House Office Building
@@ -26610,7 +26610,7 @@
     district: 5
     party: Republican
     phone: 202-225-5101
-    url: http://sensenbrenner.house.gov
+    url: https://sensenbrenner.house.gov
     rss_url: http://sensenbrenner.house.gov/news/rss.aspx
     address: 2449 Rayburn HOB; Washington DC 20515-4905
     office: 2449 Rayburn House Office Building
@@ -27184,7 +27184,7 @@
     district: 30
     party: Democrat
     phone: 202-225-5911
-    url: http://sherman.house.gov
+    url: https://sherman.house.gov
     rss_url: http://bradsherman.house.gov/press-releases-and-columns/rss.shtml
     address: 2181 Rayburn HOB; Washington DC 20515-0530
     office: 2181 Rayburn House Office Building
@@ -27533,7 +27533,7 @@
     district: 2
     party: Republican
     phone: 202-225-5531
-    url: http://simpson.house.gov
+    url: https://simpson.house.gov
     rss_url: http://simpson.house.gov/news/rss.aspx
     address: 2084 Rayburn HOB; Washington DC 20515-1202
     office: 2084 Rayburn House Office Building
@@ -27987,7 +27987,7 @@
     district: 3
     party: Republican
     phone: 202-225-6435
-    url: http://adriansmith.house.gov
+    url: https://adriansmith.house.gov
     rss_url: http://adriansmith.house.gov/rss.xml
     address: 320 Cannon HOB; Washington DC 20515-2703
     office: 320 Cannon House Office Building
@@ -28157,7 +28157,7 @@
     district: 4
     party: Republican
     phone: 202-225-3765
-    url: http://chrissmith.house.gov
+    url: https://chrissmith.house.gov
     rss_url: http://chrissmith.house.gov/news/rss.aspx
     address: 2373 Rayburn HOB; Washington DC 20515-3004
     office: 2373 Rayburn House Office Building
@@ -28309,7 +28309,7 @@
     district: 21
     party: Republican
     phone: 202-225-4236
-    url: http://lamarsmith.house.gov
+    url: https://lamarsmith.house.gov
     rss_url: http://lamarsmith.house.gov/news/rss.aspx
     address: 2409 Rayburn HOB; Washington DC 20515-4321
     office: 2409 Rayburn House Office Building
@@ -28469,7 +28469,7 @@
     district: 15
     party: Republican
     phone: 202-225-2015
-    url: http://stivers.house.gov
+    url: https://stivers.house.gov
     rss_url: http://stivers.house.gov/news/rss.aspx
     address: 1022 Longworth HOB; Washington DC 20515-3515
     office: 1022 Longworth House Office Building
@@ -28823,7 +28823,7 @@
     district: 5
     party: Democrat
     phone: 202-225-3311
-    url: http://mikethompson.house.gov
+    url: https://mikethompson.house.gov
     rss_url: http://mikethompson.house.gov/news/rss.aspx
     address: 231 Cannon HOB; Washington DC 20515-0505
     office: 231 Cannon House Office Building
@@ -28903,7 +28903,7 @@
     district: 5
     party: Republican
     phone: 202-225-5121
-    url: http://thompson.house.gov
+    url: https://thompson.house.gov
     rss_url: http://thompson.house.gov/rss.xml
     address: 124 Cannon HOB; Washington DC 20515-3805
     office: 124 Cannon House Office Building
@@ -29029,7 +29029,7 @@
     district: 13
     party: Republican
     phone: 202-225-3706
-    url: http://thornberry.house.gov
+    url: https://thornberry.house.gov
     address: 2208 Rayburn HOB; Washington DC 20515-4313
     office: 2208 Rayburn House Office Building
     fax: 202-225-3486
@@ -29218,7 +29218,7 @@
     district: 12
     party: Republican
     phone: 202-225-5355
-    url: http://tiberi.house.gov
+    url: https://tiberi.house.gov
     rss_url: http://tiberi.house.gov/news/rss.aspx
     address: 1203 Longworth HOB; Washington DC 20515-3512
     office: 1203 Longworth House Office Building
@@ -29292,7 +29292,7 @@
     district: 3
     party: Republican
     phone: 202-225-4761
-    url: http://tipton.house.gov
+    url: https://tipton.house.gov
     rss_url: http://tipton.house.gov/rss.xml
     address: 218 Cannon HOB; Washington DC 20515-0603
     office: 218 Cannon House Office Building
@@ -29795,7 +29795,7 @@
     district: 6
     party: Republican
     phone: 202-225-3761
-    url: http://upton.house.gov
+    url: https://upton.house.gov
     rss_url: http://www.house.gov/news/rss.aspx
     address: 2183 Rayburn HOB; Washington DC 20515-2206
     office: 2183 Rayburn House Office Building
@@ -30269,7 +30269,7 @@
     district: 7
     party: Republican
     phone: 202-225-6276
-    url: http://walberg.house.gov
+    url: https://walberg.house.gov
     rss_url: http://walberg.house.gov/news/rss.aspx
     address: 2436 Rayburn HOB; Washington DC 20515-2207
     office: 2436 Rayburn House Office Building
@@ -30782,7 +30782,7 @@
     district: 11
     party: Republican
     phone: 202-225-1002
-    url: http://webster.house.gov
+    url: https://webster.house.gov
     rss_url: http://webster.house.gov/news/rss.aspx
     address: 1210 Longworth HOB; Washington DC 20515-0911
     office: 1210 Longworth House Office Building
@@ -30981,7 +30981,7 @@
     district: 2
     party: Republican
     phone: 202-225-2452
-    url: http://joewilson.house.gov
+    url: https://joewilson.house.gov
     rss_url: http://joewilson.house.gov/news/rss.aspx
     address: 1436 Longworth HOB; Washington DC 20515-4002
     office: 1436 Longworth House Office Building
@@ -31145,7 +31145,7 @@
     district: 1
     party: Republican
     phone: 202-225-4261
-    url: http://wittman.house.gov
+    url: https://wittman.house.gov
     rss_url: http://www.wittman.house.gov/index.php?format=feed&amp;type=rss
     address: 2055 Rayburn HOB; Washington DC 20515-4601
     office: 2055 Rayburn House Office Building
@@ -31218,7 +31218,7 @@
     district: 3
     party: Republican
     phone: 202-225-4301
-    url: http://womack.house.gov
+    url: https://womack.house.gov
     rss_url: http://womack.house.gov/news/rss.aspx
     address: 2412 Rayburn HOB; Washington DC 20515-0403
     office: 2412 Rayburn House Office Building
@@ -31572,7 +31572,7 @@
     district: 3
     party: Republican
     phone: 202-225-2865
-    url: http://yoder.house.gov
+    url: https://yoder.house.gov
     rss_url: http://yoder.house.gov/common/rss/index.cfm?rss=49
     address: 2433 Rayburn HOB; Washington DC 20515-1603
     office: 2433 Rayburn House Office Building
@@ -31766,7 +31766,7 @@
     district: 0
     party: Republican
     phone: 202-225-5765
-    url: http://donyoung.house.gov
+    url: https://donyoung.house.gov
     rss_url: http://donyoung.house.gov/news/rss.aspx
     address: 2314 Rayburn HOB; Washington DC 20515-0200
     office: 2314 Rayburn House Office Building
@@ -32066,7 +32066,7 @@
     district: 1
     party: Democrat
     phone: 202-225-0855
-    url: http://bonamici.house.gov
+    url: https://bonamici.house.gov
     rss_url: http://bonamici.house.gov/rss.xml
     address: 439 Cannon HOB; Washington DC 20515-3701
     office: 439 Cannon House Office Building
@@ -32280,7 +32280,7 @@
     district: 10
     party: Democrat
     phone: 202-225-3436
-    url: http://payne.house.gov
+    url: https://payne.house.gov
     rss_url: http://payne.house.gov/rss.xml
     address: 132 Cannon HOB; Washington DC 20515-3010
     office: 132 Cannon House Office Building
@@ -32425,7 +32425,7 @@
     district: 11
     party: Democrat
     phone: 202-225-3515
-    url: http://foster.house.gov
+    url: https://foster.house.gov
     rss_url: http://foster.house.gov/rss.xml
     address: 1224 Longworth HOB; Washington DC 20515-1311
     office: 1224 Longworth House Office Building
@@ -32665,7 +32665,7 @@
     district: 1
     party: Republican
     phone: 202-225-3076
-    url: http://lamalfa.house.gov
+    url: https://lamalfa.house.gov
     rss_url: http://lamalfa.house.gov/rss.xml
     address: 322 Cannon HOB; Washington DC 20515-0501
     office: 322 Cannon House Office Building
@@ -32726,7 +32726,7 @@
     district: 2
     party: Democrat
     phone: 202-225-5161
-    url: http://huffman.house.gov
+    url: https://huffman.house.gov
     rss_url: http://huffman.house.gov/rss.xml
     address: 1406 Longworth HOB; Washington DC 20515-0502
     office: 1406 Longworth House Office Building
@@ -32787,7 +32787,7 @@
     district: 7
     party: Democrat
     phone: 202-225-5716
-    url: http://bera.house.gov
+    url: https://bera.house.gov
     rss_url: http://bera.house.gov/rss.xml
     address: 1431 Longworth HOB; Washington DC 20515-0507
     office: 1431 Longworth House Office Building
@@ -32847,7 +32847,7 @@
     party: Republican
     phone: 202-225-5861
     fax: 202-225-6498
-    url: http://cook.house.gov
+    url: https://cook.house.gov
     rss_url: http://cook.house.gov/rss.xml
     address: 1222 Longworth HOB; Washington DC 20515-0508
     office: 1222 Longworth House Office Building
@@ -32963,7 +32963,7 @@
     district: 21
     party: Republican
     phone: 202-225-4695
-    url: http://valadao.house.gov
+    url: https://valadao.house.gov
     rss_url: http://valadao.house.gov/rss.xml
     address: 1728 Longworth HOB; Washington DC 20515-0521
     office: 1728 Longworth House Office Building
@@ -33025,7 +33025,7 @@
     district: 26
     party: Democrat
     phone: 202-225-5811
-    url: http://juliabrownley.house.gov
+    url: https://juliabrownley.house.gov
     rss_url: http://juliabrownley.house.gov/rss.xml
     address: 1019 Longworth HOB; Washington DC 20515-0526
     office: 1019 Longworth House Office Building
@@ -33268,7 +33268,7 @@
     district: 47
     party: Democrat
     phone: 202-225-7924
-    url: http://lowenthal.house.gov
+    url: https://lowenthal.house.gov
     rss_url: http://lowenthal.house.gov/news/rss.aspx
     address: 125 Cannon HOB; Washington DC 20515-0547
     office: 125 Cannon House Office Building
@@ -33329,7 +33329,7 @@
     district: 51
     party: Democrat
     phone: 202-225-8045
-    url: http://vargas.house.gov
+    url: https://vargas.house.gov
     rss_url: http://vargas.house.gov/rss.xml
     address: 1605 Longworth HOB; Washington DC 20515-0551
     office: 1605 Longworth House Office Building
@@ -33391,7 +33391,7 @@
     district: 52
     party: Democrat
     phone: 202-225-0508
-    url: http://scottpeters.house.gov
+    url: https://scottpeters.house.gov
     rss_url: http://scottpeters.house.gov/rss.xml
     address: 1122 Longworth HOB; Washington DC 20515-0552
     office: 1122 Longworth House Office Building
@@ -33514,7 +33514,7 @@
     district: 3
     party: Republican
     phone: 202-225-5744
-    url: http://yoho.house.gov
+    url: https://yoho.house.gov
     rss_url: http://yoho.house.gov/rss.xml
     address: 511 Cannon HOB; Washington DC 20515-0903
     office: 511 Cannon House Office Building
@@ -33574,7 +33574,7 @@
     district: 6
     party: Republican
     phone: 202-225-2706
-    url: http://desantis.house.gov
+    url: https://desantis.house.gov
     rss_url: http://desantis.house.gov/rss.xml
     address: 1524 Longworth HOB; Washington DC 20515-0906
     office: 1524 Longworth House Office Building
@@ -33637,7 +33637,7 @@
     district: 21
     party: Democrat
     phone: 202-225-9890
-    url: http://frankel.house.gov
+    url: https://frankel.house.gov
     rss_url: http://frankel.house.gov/rss.xml
     address: 1037 Longworth HOB; Washington DC 20515-0921
     office: 1037 Longworth House Office Building
@@ -33882,7 +33882,7 @@
     district: 13
     party: Republican
     phone: 202-225-2371
-    url: http://rodneydavis.house.gov
+    url: https://rodneydavis.house.gov
     rss_url: http://rodneydavis.house.gov/rss.xml
     address: 1740 Longworth HOB; Washington DC 20515-1313
     office: 1740 Longworth House Office Building
@@ -34006,7 +34006,7 @@
     district: 2
     party: Republican
     phone: 202-225-3915
-    url: http://walorski.house.gov
+    url: https://walorski.house.gov
     rss_url: http://walorski.house.gov/rss.xml
     address: 419 Cannon HOB; Washington DC 20515-1402
     office: 419 Cannon House Office Building
@@ -34068,7 +34068,7 @@
     district: 5
     party: Republican
     phone: 202-225-2276
-    url: http://susanwbrooks.house.gov
+    url: https://susanwbrooks.house.gov
     rss_url: http://susanwbrooks.house.gov/rss.xml
     address: 1030 Longworth HOB; Washington DC 20515-1405
     office: 1030 Longworth House Office Building
@@ -34363,7 +34363,7 @@
     district: 6
     party: Democrat
     phone: 202-225-2721
-    url: http://delaney.house.gov
+    url: https://delaney.house.gov
     rss_url: http://delaney.house.gov/rss.xml
     address: 1632 Longworth HOB; Washington DC 20515-2006
     office: 1632 Longworth House Office Building
@@ -34463,7 +34463,7 @@
     district: 5
     party: Democrat
     phone: 202-225-3611
-    url: http://dankildee.house.gov
+    url: https://dankildee.house.gov
     rss_url: http://dankildee.house.gov/rss.xml
     address: 227 Cannon HOB; Washington DC 20515-2205
     office: 227 Cannon House Office Building
@@ -34546,7 +34546,7 @@
     district: 8
     party: Democrat
     phone: 202-225-6211
-    url: http://nolan.house.gov
+    url: https://nolan.house.gov
     rss_url: http://nolan.house.gov/rss.xml
     address: 2366 Rayburn HOB; Washington DC 20515-2308
     office: 2366 Rayburn House Office Building
@@ -34607,7 +34607,7 @@
     party: Republican
     phone: 202-225-1621
     fax: 202-225-2563
-    url: http://wagner.house.gov
+    url: https://wagner.house.gov
     rss_url: http://wagner.house.gov/rss.xml
     address: 435 Cannon HOB; Washington DC 20515-2502
     office: 435 Cannon House Office Building
@@ -34899,7 +34899,7 @@
     district: 2
     party: Republican
     phone: 202-225-3032
-    url: http://holding.house.gov
+    url: https://holding.house.gov
     rss_url: http://holding.house.gov/rss.xml
     address: 1110 Longworth HOB; Washington DC 20515-3302
     office: 1110 Longworth House Office Building
@@ -35000,7 +35000,7 @@
     district: 0
     party: Republican
     phone: 202-225-2611
-    url: http://cramer.house.gov
+    url: https://cramer.house.gov
     rss_url: http://cramer.house.gov/rss.xml
     address: 1717 Longworth HOB; Washington DC 20515-3400
     office: 1717 Longworth House Office Building
@@ -35102,7 +35102,7 @@
     district: 2
     party: Democrat
     phone: 202-225-5206
-    url: http://kuster.house.gov
+    url: https://kuster.house.gov
     rss_url: http://kuster.house.gov/rss.xml
     address: 137 Cannon HOB; Washington DC 20515-2902
     office: 137 Cannon House Office Building
@@ -35225,7 +35225,7 @@
     district: 6
     party: Democrat
     phone: 202-225-2601
-    url: http://meng.house.gov
+    url: https://meng.house.gov
     rss_url: http://meng.house.gov/rss.xml
     address: 1317 Longworth HOB; Washington DC 20515-3206
     office: 1317 Longworth House Office Building
@@ -35285,7 +35285,7 @@
     district: 8
     party: Democrat
     phone: 202-225-5936
-    url: http://jeffries.house.gov
+    url: https://jeffries.house.gov
     rss_url: http://jeffries.house.gov/rss.xml
     address: 1607 Longworth HOB; Washington DC 20515-3208
     office: 1607 Longworth House Office Building
@@ -35345,7 +35345,7 @@
     district: 18
     party: Democrat
     phone: 202-225-5441
-    url: http://seanmaloney.house.gov
+    url: https://seanmaloney.house.gov
     rss_url: http://seanmaloney.house.gov/rss.xml
     address: 1027 Longworth HOB; Washington DC 20515-3218
     office: 1027 Longworth House Office Building
@@ -35464,7 +35464,7 @@
     district: 2
     party: Republican
     phone: 202-225-3164
-    url: http://wenstrup.house.gov
+    url: https://wenstrup.house.gov
     address: 2419 Rayburn HOB; Washington DC 20515-3502
     office: 2419 Rayburn House Office Building
     fax: 202-225-1992
@@ -35524,7 +35524,7 @@
     district: 3
     party: Democrat
     phone: 202-225-4324
-    url: http://beatty.house.gov
+    url: https://beatty.house.gov
     rss_url: http://beatty.house.gov/rss.xml
     address: 133 Cannon HOB; Washington DC 20515-3503
     office: 133 Cannon House Office Building
@@ -35647,7 +35647,7 @@
     district: 1
     party: Republican
     phone: 202-225-2211
-    url: http://bridenstine.house.gov
+    url: https://bridenstine.house.gov
     rss_url: http://bridenstine.house.gov/rss.xml
     address: 216 Cannon HOB; Washington DC 20515-3601
     office: 216 Cannon House Office Building
@@ -35769,7 +35769,7 @@
     district: 4
     party: Republican
     phone: 202-225-5836
-    url: http://perry.house.gov
+    url: https://perry.house.gov
     rss_url: http://perry.house.gov/rss.xml
     address: 1207 Longworth HOB; Washington DC 20515-3804
     office: 1207 Longworth House Office Building
@@ -35892,7 +35892,7 @@
     district: 17
     party: Democrat
     phone: 202-225-5546
-    url: http://cartwright.house.gov
+    url: https://cartwright.house.gov
     rss_url: http://cartwright.house.gov/rss.xml
     address: 1034 Longworth HOB; Washington DC 20515-3817
     office: 1034 Longworth House Office Building
@@ -35952,7 +35952,7 @@
     district: 7
     party: Republican
     phone: 202-225-9895
-    url: http://rice.house.gov
+    url: https://rice.house.gov
     rss_url: http://rice.house.gov/rss.xml
     address: 223 Cannon HOB; Washington DC 20515-4007
     office: 223 Cannon House Office Building
@@ -36050,7 +36050,7 @@
     district: 14
     party: Republican
     phone: 202-225-2831
-    url: http://weber.house.gov
+    url: https://weber.house.gov
     rss_url: http://weber.house.gov/rss.xml
     address: 1708 Longworth HOB; Washington DC 20515-4314
     office: 1708 Longworth House Office Building
@@ -36109,7 +36109,7 @@
     district: 16
     party: Democrat
     phone: 202-225-4831
-    url: http://orourke.house.gov
+    url: https://orourke.house.gov
     rss_url: http://orourke.house.gov/rss.xml
     address: 1330 Longworth HOB; Washington DC 20515-4316
     office: 1330 Longworth House Office Building
@@ -36231,7 +36231,7 @@
     district: 25
     party: Republican
     phone: 202-225-9896
-    url: http://williams.house.gov
+    url: https://williams.house.gov
     rss_url: http://williams.house.gov/rss.xml
     address: 1323 Longworth HOB; Washington DC 20515-4325
     office: 1323 Longworth House Office Building
@@ -36292,7 +36292,7 @@
     district: 33
     party: Democrat
     phone: 202-225-9897
-    url: http://veasey.house.gov
+    url: https://veasey.house.gov
     rss_url: http://veasey.house.gov/rss.xml
     address: 1519 Longworth HOB; Washington DC 20515-4333
     office: 1519 Longworth House Office Building
@@ -36414,7 +36414,7 @@
     district: 2
     party: Republican
     phone: 202-225-9730
-    url: http://stewart.house.gov
+    url: https://stewart.house.gov
     rss_url: http://stewart.house.gov/rss.xml
     address: 323 Cannon HOB; Washington DC 20515-4402
     office: 323 Cannon House Office Building
@@ -36571,7 +36571,7 @@
     district: 10
     party: Democrat
     phone: 202-225-9740
-    url: http://dennyheck.house.gov
+    url: https://dennyheck.house.gov
     rss_url: http://dennyheck.house.gov/rss.xml
     address: 425 Cannon HOB; Washington DC 20515-4710
     office: 425 Cannon House Office Building
@@ -36632,7 +36632,7 @@
     district: 2
     party: Democrat
     phone: 202-225-2906
-    url: http://pocan.house.gov
+    url: https://pocan.house.gov
     rss_url: http://pocan.house.gov/rss.xml
     address: 1421 Longworth HOB; Washington DC 20515-4902
     office: 1421 Longworth House Office Building
@@ -37064,7 +37064,7 @@
     district: 7
     party: Republican
     phone: 202-225-2815
-    url: http://brat.house.gov
+    url: https://brat.house.gov
     address: 1628 Longworth HOB; Washington DC 20515-4607
     office: 1628 Longworth House Office Building
 - id:
@@ -37180,7 +37180,7 @@
     district: 12
     party: Democrat
     phone: 202-225-1510
-    url: http://adams.house.gov
+    url: https://adams.house.gov
     address: 222 Cannon HOB; Washington DC 20515-3312
     office: 222 Cannon House Office Building
     fax: 202-225-1512
@@ -37746,7 +37746,7 @@
     district: 26
     party: Republican
     phone: 202-225-2778
-    url: http://curbelo.house.gov
+    url: https://curbelo.house.gov
     address: 1404 Longworth HOB; Washington DC 20515-0926
     office: 1404 Longworth House Office Building
 - id:
@@ -37789,7 +37789,7 @@
     district: 1
     party: Republican
     phone: 202-225-5831
-    url: http://buddycarter.house.gov
+    url: https://buddycarter.house.gov
     address: 432 Cannon HOB; Washington DC 20515-1001
     office: 432 Cannon House Office Building
     fax: 202-226-2269
@@ -37877,7 +37877,7 @@
     district: 11
     party: Republican
     phone: 202-225-2931
-    url: http://loudermilk.house.gov
+    url: https://loudermilk.house.gov
     address: 329 Cannon HOB; Washington DC 20515-1011
     office: 329 Cannon House Office Building
     fax: 202-225-2944
@@ -37921,7 +37921,7 @@
     district: 12
     party: Republican
     phone: 202-225-2823
-    url: http://allen.house.gov
+    url: https://allen.house.gov
     address: 426 Cannon HOB; Washington DC 20515-1012
     office: 426 Cannon House Office Building
     fax: 202-225-3377
@@ -38183,7 +38183,7 @@
     district: 6
     party: Democrat
     phone: 202-225-8020
-    url: http://moulton.house.gov
+    url: https://moulton.house.gov
     address: 1408 Longworth HOB; Washington DC 20515-2106
     office: 1408 Longworth House Office Building
     fax: 202-225-5915
@@ -38712,7 +38712,7 @@
     district: 4
     party: Democrat
     phone: 202-225-5516
-    url: http://kathleenrice.house.gov
+    url: https://kathleenrice.house.gov
     address: 1508 Longworth HOB; Washington DC 20515-3204
     office: 1508 Longworth House Office Building
     fax: 202-225-5758
@@ -39062,7 +39062,7 @@
     district: 36
     party: Republican
     phone: 202-225-1555
-    url: http://babin.house.gov
+    url: https://babin.house.gov
     address: 316 Cannon HOB; Washington DC 20515-4336
     office: 316 Cannon House Office Building
     fax: 202-226-0396
@@ -39151,7 +39151,7 @@
     district: 8
     party: Democrat
     phone: 202-225-4376
-    url: http://beyer.house.gov
+    url: https://beyer.house.gov
     address: 1119 Longworth HOB; Washington DC 20515-4608
     office: 1119 Longworth House Office Building
     fax: 202-225-0017
@@ -39328,7 +39328,7 @@
     district: 6
     party: Republican
     phone: 202-225-2476
-    url: http://grothman.house.gov
+    url: https://grothman.house.gov
     address: 1217 Longworth HOB; Washington DC 20515-4906
     office: 1217 Longworth House Office Building
     fax: 202-225-2356
@@ -41563,7 +41563,7 @@
     phone: 202-225-4276
     address: 514 Cannon HOB; Washington DC 20515-3808
     office: 514 Cannon House Office Building
-    url: https://brianfitzpatrick.house.gov
+    url: https://fitzpatrick.house.gov
 - id:
     bioguide: S001199
     govtrack: 412722

--- a/scripts/house_websites.py
+++ b/scripts/house_websites.py
@@ -64,7 +64,11 @@ def run():
         continue
 
       district = str(cells[0].text_content())
-      if district == "At Large":
+      if (
+        (district == "At Large")
+        or (district == "Delegate")
+        or (district == "Resident Commissioner")
+      ):
         district = 0
 
       url = cells[1].cssselect("a")[0].get("href")


### PR DESCRIPTION
I did a sweep of House site URLs, and fixed the House website scraper to properly handle Delegates and Resident Commissioners. Mostly it's updating House URLs from http -> https, but there's at least one actual URL change in there.