### PR TITLE
Add social for N000190

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -5408,3 +5408,10 @@
     twitter: RepJimmyGomez
     twitter_id: 2371339658
     facebook: RepJimmyGomez
+- id:
+    bioguide: N000190 
+    govtrack: 412738
+  social:
+    facebook: RepRalphNorman
+    twitter: RepRalphNorman
+    twitter_id: '880480631108644864'


### PR DESCRIPTION
Adds social data for `N000190` in alignment with [official site](https://norman.house.gov/)