### PR TITLE
Combine the first and middle name fields when the first name is just an initial

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The following fields are available in `legislators-current.yaml` and `legislator
 	* bioguide_previous: When bioguide.congress.gov mistakenly listed a legislator under multiple IDs, this field is a *list* of alternative IDs. (This often ocurred for women who changed their name.) The IDs in this list probably were removed from bioguide.congress.gov but might still be in use in the wild.
 
 * name
-	* first: The legislator's first name. Sometimes a first initial and period (e.g. in W. Todd Akin), in which case it is suggested to not use the first name for display purposes.
-	* middle: The legislator's middle name or middle initial (with period).
+	* first: The legislator's given name. When a legislator uses a first initial and their middle name, this field combines both as a single string value with a space.
+	* middle: The legislator's middle name or middle initial (with period). The middle name is generally not used when displaying a legislators name. When it is, it is included in the `first` name field.
 	* last: The legislator's last name. Many last names include non-ASCII characters. When building search systems, it is advised to index both the raw value as well as a value with extended characters replaced with their ASCII equivalents (in Python that's: u"".join(c for c in unicodedata.normalize('NFKD', lastname) if not unicodedata.combining(c))).
 	* suffix: A suffix on the legislator's name, such as "Jr." or "III".
 	* nickname: The legislator's nick name when used as a common alternative to his first name.

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -6384,8 +6384,7 @@
     wikidata: Q959455
     google_entity_id: kg:/m/024vjr
   name:
-    first: Wm.
-    middle: Lacy
+    first: Wm. Lacy
     last: Clay
     suffix: Jr.
     official_full: Wm. Lacy Clay
@@ -7000,8 +6999,7 @@
     wikidata: Q538944
     google_entity_id: kg:/m/04cmt7
   name:
-    first: K.
-    middle: Michael
+    first: K. Michael
     last: Conaway
     official_full: K. Michael Conaway
   bio:
@@ -12438,8 +12436,7 @@
     wikidata: Q1684857
     google_entity_id: kg:/m/025vdrq
   name:
-    first: H.
-    middle: Morgan
+    first: H. Morgan
     last: Griffith
     official_full: H. Morgan Griffith
   bio:
@@ -24813,8 +24810,7 @@
     wikidata: Q981559
     google_entity_id: kg:/m/025k36
   name:
-    first: C.
-    middle: A. Dutch
+    first: C. A. Dutch
     last: Ruppersberger
     official_full: C. A. Dutch Ruppersberger
   bio:
@@ -26456,8 +26452,7 @@
     wikidata: Q952268
     google_entity_id: kg:/m/024tp2
   name:
-    first: F.
-    middle: James
+    first: F. James
     last: Sensenbrenner
     suffix: Jr.
     official_full: F. James Sensenbrenner, Jr.
@@ -40527,8 +40522,7 @@
     cspan: 46310
     icpsr: 21711
   name:
-    first: J.
-    middle: Luis
+    first: J. Luis
     last: Correa
     official_full: J. Luis Correa
   bio:
@@ -40902,8 +40896,7 @@
     cspan: 104731
     icpsr: 21717
   name:
-    first: A.
-    middle: Drew
+    first: A. Drew
     last: Ferguson
     suffix: IV
     official_full: A. Drew Ferguson IV
@@ -41776,8 +41769,7 @@
     cspan: 103621
     icpsr: 21736
   name:
-    first: A.
-    middle: Donald
+    first: A. Donald
     last: McEachin
     official_full: A. Donald McEachin
   bio:


### PR DESCRIPTION
On GovTrack, the logic for constructing legislator display names for FIRST LAST or LAST, FIRST format has always been:

1. take the first name

2. if the first name ends with a period (i.e. is an initial or in Wm. Lacy Clay's case, an abbreviation), forget the first name and use the middle name instead, and in other cases ignore the middle name

This logic has worked well and generally matches the display form that the legislator uses themselves. For instance, we have `first: F.` / ` middle: James` for Rep. Sensenbrenner, who generally goes not by `F. ` or `F. James` but by... `Jim`:

![image](https://user-images.githubusercontent.com/445875/31414553-7c4f1032-adec-11e7-9395-b3f0e879a289.png)

 except in some cases where the first initial is sometimes also used, like "F. James Sensenbrenner":

![image](https://user-images.githubusercontent.com/445875/31414340-757a9688-adeb-11e7-8b8d-65ebd200940d.png)

When the first name ends in a dot, the middle name seems to always be obligatorily a part of the proper way of displaying the name when showing a first name, either alone or with the first initial. In other cases, when the first name does not end in a dot, the middle name is generally _not_ used for display purposes at all.

This commit moves the middle name value to inside the first name field (with a preceding space) just when the first name ends in a dot, the purpose of which is to make it easier for users of this dataset to correctly construct display names for legislators. The new logic would be:

1. use the first name

2. WIN (i.e., don't ever use the middle name field)

This would differ from GovTrack's current logic by always including first initials instead of dropping them, which may not be better but is probably equally ok.

What do folks think?

Other alternatives to consider would be

* completely drop middle name values that are generally not included when displaying a legislator's name so that always including the middle name value would yield a more correct display string (than displaying all of the middle names we have now)

* move these middle names to the first name (i.e. `middle: Clay` => `first: Clay`) and move first initials to a new `first_initial` field (`first: Wm.` => `first_initial: Wm.`) so that data users would be more likely to correctly use the middle names in these cases and could choose whether or not to display the first initial

* add flags that indicate how to use the first/middle name fields in good display strings, i.e. `use_first: False` `use_middle: True` to suggest friendly name strings like "Lacy Clay" which is how the congressman is generally known