### PR TITLE
SenKaineOffice (twitter) seems to have been deleted

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -4105,10 +4105,8 @@
     govtrack: 412582
   social:
     facebook: SenatorKaine
-    twitter: SenKaineOffice
     youtube: SenatorTimKaine
     youtube_id: UC27LgTZlUnBQoNEQFZdn9LA
-    twitter_id: 1267940407
 - id:
     bioguide: S001194
     thomas: '02173'


### PR DESCRIPTION
The account isn't linked from his homepage anymore and doesn't exist on twitter. I think the numeric ID is invalid now so that means the account was deleted/inactivated and not renamed.