### PR TITLE
Update committee membership

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -3,428 +3,428 @@ HLIG:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01710'
   bioguide: N000181
+  thomas: '01710'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Thomas J. Rooney
   party: majority
   rank: 5
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 6
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Michael R. Turner
   party: majority
   rank: 7
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Brad R. Wenstrup
   party: majority
   rank: 8
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Chris Stewart
   party: majority
   rank: 9
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 10
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Trey Gowdy
   party: majority
   rank: 11
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Elise M. Stefanik
   party: majority
   rank: 12
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Will Hurd
   party: majority
   rank: 13
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Adam B. Schiff
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01635'
   bioguide: S001150
+  thomas: '01635'
 - name: James A. Himes
   party: minority
   rank: 2
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Terri A. Sewell
   party: minority
   rank: 3
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: André Carson
   party: minority
   rank: 4
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Jackie Speier
   party: minority
   rank: 5
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 6
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: Eric Swalwell
   party: minority
   rank: 7
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 - name: Joaquin Castro
   party: minority
   rank: 8
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 9
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 HLIG01:
 - name: Frank A. LoBiondo
   party: majority
   rank: 1
   title: Chair
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Thomas J. Rooney
   party: majority
   rank: 4
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 5
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Chris Stewart
   party: majority
   rank: 6
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: Eric Swalwell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 - name: James A. Himes
   party: minority
   rank: 2
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Joaquin Castro
   party: minority
   rank: 3
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 4
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 HLIG02:
 - name: Thomas J. Rooney
   party: majority
   rank: 1
   title: Chair
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Michael R. Turner
   party: majority
   rank: 4
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Trey Gowdy
   party: majority
   rank: 5
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Elise M. Stefanik
   party: majority
   rank: 6
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: James A. Himes
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Terri A. Sewell
   party: minority
   rank: 2
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: Jackie Speier
   party: minority
   rank: 3
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 4
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 HLIG03:
 - name: Peter T. King
   party: majority
   rank: 1
   title: Chair
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Frank A. LoBiondo
   party: majority
   rank: 2
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 4
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Trey Gowdy
   party: majority
   rank: 5
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: Will Hurd
   party: majority
   rank: 6
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: André Carson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Jackie Speier
   party: minority
   rank: 2
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Mike Quigley
   party: minority
   rank: 3
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: Eric Swalwell
   party: minority
   rank: 4
-  thomas: '02104'
   bioguide: S001193
+  thomas: '02104'
 HLIG04:
 - name: Chris Stewart
   party: majority
   rank: 1
   title: Chair
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: Michael R. Turner
   party: majority
   rank: 2
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 4
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Elise M. Stefanik
   party: majority
   rank: 5
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Will Hurd
   party: majority
   rank: 6
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Terri A. Sewell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: André Carson
   party: minority
   rank: 2
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Joaquin Castro
   party: minority
   rank: 3
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Denny Heck
   party: minority
   rank: 4
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 HSAG:
 - name: K. Michael Conaway
   party: majority
   rank: 1
   title: Chair
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Bob Goodlatte
   party: majority
   rank: 2
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Steve King
   party: majority
   rank: 4
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Mike Rogers
   party: majority
   rank: 5
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Glenn Thompson
   party: majority
   rank: 6
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Bob Gibbs
   party: majority
   rank: 7
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Austin Scott
   party: majority
   rank: 8
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 9
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Scott DesJarlais
   party: majority
   rank: 10
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 11
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Jeff Denham
   party: majority
   rank: 12
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Doug LaMalfa
   party: majority
   rank: 13
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Rodney Davis
   party: majority
   rank: 14
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Ted S. Yoho
   party: majority
   rank: 15
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Rick W. Allen
   party: majority
   rank: 16
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 17
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: David Rouzer
   party: majority
   rank: 18
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Ralph Lee Abraham
   party: majority
   rank: 19
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 20
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: James Comer
   party: majority
   rank: 21
@@ -453,73 +453,73 @@ HSAG:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00910'
   bioguide: P000258
+  thomas: '00910'
 - name: David Scott
   party: minority
   rank: 2
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Timothy J. Walz
   party: minority
   rank: 4
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Marcia L. Fudge
   party: minority
   rank: 5
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: James P. McGovern
   party: minority
   rank: 6
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Filemon Vela
   party: minority
   rank: 7
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 8
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Ann M. Kuster
   party: minority
   rank: 9
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Richard M. Nolan
   party: minority
   rank: 10
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Cheri Bustos
   party: minority
   rank: 11
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Sean Patrick Maloney
   party: minority
   rank: 12
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Stacey E. Plaskett
   party: minority
   rank: 13
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Alma S. Adams
   party: minority
   rank: 14
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Dwight Evans
   party: minority
   rank: 15
@@ -549,43 +549,43 @@ HSAG03:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 3
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Scott DesJarlais
   party: majority
   rank: 4
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 5
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Rodney Davis
   party: majority
   rank: 6
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Ted S. Yoho
   party: majority
   rank: 7
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: David Rouzer
   party: majority
   rank: 8
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: James Comer
   party: majority
   rank: 9
@@ -606,13 +606,13 @@ HSAG03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Alma S. Adams
   party: minority
   rank: 2
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Dwight Evans
   party: minority
   rank: 3
@@ -620,13 +620,13 @@ HSAG03:
 - name: Marcia L. Fudge
   party: minority
   rank: 4
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 5
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Al Lawson, Jr.
   party: minority
   rank: 6
@@ -642,35 +642,35 @@ HSAG03:
 - name: Sean Patrick Maloney
   party: minority
   rank: 9
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 HSAG14:
 - name: Rodney Davis
   party: majority
   rank: 1
   title: Chair
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Bob Gibbs
   party: majority
   rank: 2
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Jeff Denham
   party: majority
   rank: 3
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Ted S. Yoho
   party: majority
   rank: 4
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: David Rouzer
   party: majority
   rank: 5
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Don Bacon
   party: majority
   rank: 6
@@ -687,8 +687,8 @@ HSAG14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Al Lawson, Jr.
   party: minority
   rank: 2
@@ -700,13 +700,13 @@ HSAG14:
 - name: Jim Costa
   party: minority
   rank: 4
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: James P. McGovern
   party: minority
   rank: 5
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 6
@@ -716,64 +716,64 @@ HSAG15:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Glenn Thompson
   party: majority
   rank: 2
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Jeff Denham
   party: majority
   rank: 3
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Doug LaMalfa
   party: majority
   rank: 4
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Rick W. Allen
   party: majority
   rank: 5
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 6
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Ralph Lee Abraham
   party: majority
   rank: 7
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 8
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Marcia L. Fudge
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Timothy J. Walz
   party: minority
   rank: 2
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Ann M. Kuster
   party: minority
   rank: 3
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Richard M. Nolan
   party: minority
   rank: 4
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Tom O’Halleran
   party: minority
   rank: 5
@@ -781,55 +781,55 @@ HSAG15:
 - name: Filemon Vela
   party: minority
   rank: 6
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 HSAG16:
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 1
   title: Chair
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Frank D. Lucas
   party: majority
   rank: 2
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Mike Rogers
   party: majority
   rank: 3
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Bob Gibbs
   party: majority
   rank: 4
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Austin Scott
   party: majority
   rank: 5
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Scott DesJarlais
   party: majority
   rank: 6
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Rick W. Allen
   party: majority
   rank: 7
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Mike Bost
   party: majority
   rank: 8
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Ralph Lee Abraham
   party: majority
   rank: 9
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Don Bacon
   party: majority
   rank: 10
@@ -846,18 +846,18 @@ HSAG16:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 - name: Timothy J. Walz
   party: minority
   rank: 2
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Cheri Bustos
   party: minority
   rank: 3
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 4
@@ -865,18 +865,18 @@ HSAG16:
 - name: David Scott
   party: minority
   rank: 5
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Sean Patrick Maloney
   party: minority
   rank: 6
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Stacey E. Plaskett
   party: minority
   rank: 7
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Al Lawson, Jr.
   party: minority
   rank: 8
@@ -890,28 +890,28 @@ HSAG22:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Bob Goodlatte
   party: majority
   rank: 2
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: Mike Rogers
   party: majority
   rank: 3
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Doug LaMalfa
   party: majority
   rank: 4
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Rodney Davis
   party: majority
   rank: 5
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: James Comer
   party: majority
   rank: 6
@@ -928,23 +928,23 @@ HSAG22:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Sean Patrick Maloney
   party: minority
   rank: 2
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Ann M. Kuster
   party: minority
   rank: 3
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Stacey E. Plaskett
   party: minority
   rank: 4
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Tom O’Halleran
   party: minority
   rank: 5
@@ -958,38 +958,38 @@ HSAG29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Bob Goodlatte
   party: majority
   rank: 2
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: Steve King
   party: majority
   rank: 3
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Scott DesJarlais
   party: majority
   rank: 4
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Vicky Hartzler
   party: majority
   rank: 5
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Ted S. Yoho
   party: majority
   rank: 6
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Trent Kelly
   party: majority
   rank: 7
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Roger W. Marshall
   party: majority
   rank: 8
@@ -998,23 +998,23 @@ HSAG29:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Filemon Vela
   party: minority
   rank: 2
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Cheri Bustos
   party: minority
   rank: 3
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Stacey E. Plaskett
   party: minority
   rank: 4
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Dwight Evans
   party: minority
   rank: 5
@@ -1024,148 +1024,148 @@ HSAP:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00414'
   bioguide: F000372
+  thomas: '00414'
 - name: Harold Rogers
   party: majority
   rank: 2
-  thomas: '00977'
   bioguide: R000395
+  thomas: '00977'
 - name: Robert B. Aderholt
   party: majority
   rank: 3
-  thomas: '01460'
   bioguide: A000055
+  thomas: '01460'
 - name: Kay Granger
   party: majority
   rank: 4
-  thomas: '01487'
   bioguide: G000377
+  thomas: '01487'
 - name: Michael K. Simpson
   party: majority
   rank: 5
-  thomas: '01590'
   bioguide: S001148
+  thomas: '01590'
 - name: John Abney Culberson
   party: majority
   rank: 6
-  thomas: '01670'
   bioguide: C001048
+  thomas: '01670'
 - name: John R. Carter
   party: majority
   rank: 7
-  thomas: '01752'
   bioguide: C001051
+  thomas: '01752'
 - name: Ken Calvert
   party: majority
   rank: 8
-  thomas: '00165'
   bioguide: C000059
+  thomas: '00165'
 - name: Tom Cole
   party: majority
   rank: 9
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: Mario Diaz-Balart
   party: majority
   rank: 10
-  thomas: '01717'
   bioguide: D000600
+  thomas: '01717'
 - name: Charles W. Dent
   party: majority
   rank: 11
-  thomas: '01799'
   bioguide: D000604
+  thomas: '01799'
 - name: Tom Graves
   party: majority
   rank: 12
-  thomas: '01979'
   bioguide: G000560
+  thomas: '01979'
 - name: Kevin Yoder
   party: majority
   rank: 13
-  thomas: '02021'
   bioguide: Y000063
+  thomas: '02021'
 - name: Steve Womack
   party: majority
   rank: 14
-  thomas: '01991'
   bioguide: W000809
+  thomas: '01991'
 - name: Jeff Fortenberry
   party: majority
   rank: 15
-  thomas: '01793'
   bioguide: F000449
+  thomas: '01793'
 - name: Thomas J. Rooney
   party: majority
   rank: 16
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 17
-  thomas: '02061'
   bioguide: F000459
+  thomas: '02061'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 18
-  thomas: '02071'
   bioguide: H001056
+  thomas: '02071'
 - name: David P. Joyce
   party: majority
   rank: 19
-  thomas: '02154'
   bioguide: J000295
+  thomas: '02154'
 - name: David G. Valadao
   party: majority
   rank: 20
-  thomas: '02105'
   bioguide: V000129
+  thomas: '02105'
 - name: Andy Harris
   party: majority
   rank: 21
-  thomas: '02026'
   bioguide: H001052
+  thomas: '02026'
 - name: Martha Roby
   party: majority
   rank: 22
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Mark E. Amodei
   party: majority
   rank: 23
-  thomas: '02090'
   bioguide: A000369
+  thomas: '02090'
 - name: Chris Stewart
   party: majority
   rank: 24
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: David Young
   party: majority
   rank: 25
-  thomas: '02242'
   bioguide: Y000066
+  thomas: '02242'
 - name: Evan H. Jenkins
   party: majority
   rank: 26
-  thomas: '02278'
   bioguide: J000297
+  thomas: '02278'
 - name: Steven M. Palazzo
   party: majority
   rank: 27
-  thomas: '02035'
   bioguide: P000601
+  thomas: '02035'
 - name: Dan Newhouse
   party: majority
   rank: 28
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: John R. Moolenaar
   party: majority
   rank: 29
-  thomas: '02248'
   bioguide: M001194
+  thomas: '02248'
 - name: Scott Taylor
   party: majority
   rank: 30
@@ -1174,550 +1174,550 @@ HSAP:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00709'
   bioguide: L000480
+  thomas: '00709'
 - name: Marcy Kaptur
   party: minority
   rank: 2
-  thomas: '00616'
   bioguide: K000009
+  thomas: '00616'
 - name: Peter J. Visclosky
   party: minority
   rank: 3
-  thomas: '01188'
   bioguide: V000108
+  thomas: '01188'
 - name: José E. Serrano
   party: minority
   rank: 4
-  thomas: '01042'
   bioguide: S000248
+  thomas: '01042'
 - name: Rosa L. DeLauro
   party: minority
   rank: 5
-  thomas: '00281'
   bioguide: D000216
+  thomas: '00281'
 - name: David E. Price
   party: minority
   rank: 6
-  thomas: '00930'
   bioguide: P000523
+  thomas: '00930'
 - name: Lucille Roybal-Allard
   party: minority
   rank: 7
-  thomas: '00997'
   bioguide: R000486
+  thomas: '00997'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 8
-  thomas: '00091'
   bioguide: B000490
+  thomas: '00091'
 - name: Barbara Lee
   party: minority
   rank: 9
-  thomas: '01501'
   bioguide: L000551
+  thomas: '01501'
 - name: Betty McCollum
   party: minority
   rank: 10
-  thomas: '01653'
   bioguide: M001143
+  thomas: '01653'
 - name: Tim Ryan
   party: minority
   rank: 11
-  thomas: '01756'
   bioguide: R000577
+  thomas: '01756'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 12
-  thomas: '01728'
   bioguide: R000576
+  thomas: '01728'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 13
-  thomas: '01777'
   bioguide: W000797
+  thomas: '01777'
 - name: Henry Cuellar
   party: minority
   rank: 14
-  thomas: '01807'
   bioguide: C001063
+  thomas: '01807'
 - name: Chellie Pingree
   party: minority
   rank: 15
-  thomas: '01927'
   bioguide: P000597
+  thomas: '01927'
 - name: Mike Quigley
   party: minority
   rank: 16
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: Derek Kilmer
   party: minority
   rank: 17
-  thomas: '02169'
   bioguide: K000381
+  thomas: '02169'
 - name: Matt Cartwright
   party: minority
   rank: 18
-  thomas: '02159'
   bioguide: C001090
+  thomas: '02159'
 - name: Grace Meng
   party: minority
   rank: 19
-  thomas: '02148'
   bioguide: M001188
+  thomas: '02148'
 - name: Mark Pocan
   party: minority
   rank: 20
-  thomas: '02171'
   bioguide: P000607
+  thomas: '02171'
 - name: Katherine M. Clark
   party: minority
   rank: 21
-  thomas: '02196'
   bioguide: C001101
+  thomas: '02196'
 - name: Pete Aguilar
   party: minority
   rank: 22
-  thomas: '02229'
   bioguide: A000371
+  thomas: '02229'
 HSAP01:
 - name: Robert B. Aderholt
   party: majority
   rank: 1
   title: Chair
-  thomas: '01460'
   bioguide: A000055
+  thomas: '01460'
 - name: Kevin Yoder
   party: majority
   rank: 2
-  thomas: '02021'
   bioguide: Y000063
+  thomas: '02021'
 - name: Thomas J. Rooney
   party: majority
   rank: 3
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: David G. Valadao
   party: majority
   rank: 4
-  thomas: '02105'
   bioguide: V000129
+  thomas: '02105'
   title: Vice Chair
 - name: Andy Harris
   party: majority
   rank: 5
-  thomas: '02026'
   bioguide: H001052
+  thomas: '02026'
 - name: David Young
   party: majority
   rank: 6
-  thomas: '02242'
   bioguide: Y000066
+  thomas: '02242'
 - name: Steven M. Palazzo
   party: majority
   rank: 7
-  thomas: '02035'
   bioguide: P000601
+  thomas: '02035'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00091'
   bioguide: B000490
+  thomas: '00091'
 - name: Rosa L. DeLauro
   party: minority
   rank: 2
-  thomas: '00281'
   bioguide: D000216
+  thomas: '00281'
 - name: Chellie Pingree
   party: minority
   rank: 3
-  thomas: '01927'
   bioguide: P000597
+  thomas: '01927'
 - name: Mark Pocan
   party: minority
   rank: 4
-  thomas: '02171'
   bioguide: P000607
+  thomas: '02171'
 HSAP02:
 - name: Kay Granger
   party: majority
   rank: 1
   title: Chair
-  thomas: '01487'
   bioguide: G000377
+  thomas: '01487'
 - name: Harold Rogers
   party: majority
   rank: 2
-  thomas: '00977'
   bioguide: R000395
+  thomas: '00977'
 - name: Ken Calvert
   party: majority
   rank: 3
-  thomas: '00165'
   bioguide: C000059
+  thomas: '00165'
   title: Vice Chair
 - name: Tom Cole
   party: majority
   rank: 4
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: Steve Womack
   party: majority
   rank: 5
-  thomas: '01991'
   bioguide: W000809
+  thomas: '01991'
 - name: Robert B. Aderholt
   party: majority
   rank: 6
-  thomas: '01460'
   bioguide: A000055
+  thomas: '01460'
 - name: John R. Carter
   party: majority
   rank: 7
-  thomas: '01752'
   bioguide: C001051
+  thomas: '01752'
 - name: Mario Diaz-Balart
   party: majority
   rank: 8
-  thomas: '01717'
   bioguide: D000600
+  thomas: '01717'
 - name: Tom Graves
   party: majority
   rank: 9
-  thomas: '01979'
   bioguide: G000560
+  thomas: '01979'
 - name: Martha Roby
   party: majority
   rank: 10
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Peter J. Visclosky
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01188'
   bioguide: V000108
+  thomas: '01188'
 - name: Betty McCollum
   party: minority
   rank: 2
-  thomas: '01653'
   bioguide: M001143
+  thomas: '01653'
 - name: Tim Ryan
   party: minority
   rank: 3
-  thomas: '01756'
   bioguide: R000577
+  thomas: '01756'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 4
-  thomas: '01728'
   bioguide: R000576
+  thomas: '01728'
 - name: Marcy Kaptur
   party: minority
   rank: 5
-  thomas: '00616'
   bioguide: K000009
+  thomas: '00616'
 - name: Henry Cuellar
   party: minority
   rank: 6
-  thomas: '01807'
   bioguide: C001063
+  thomas: '01807'
 HSAP04:
 - name: Harold Rogers
   party: majority
   rank: 1
   title: Chair
-  thomas: '00977'
   bioguide: R000395
+  thomas: '00977'
 - name: Kay Granger
   party: majority
   rank: 2
-  thomas: '01487'
   bioguide: G000377
+  thomas: '01487'
 - name: Mario Diaz-Balart
   party: majority
   rank: 3
-  thomas: '01717'
   bioguide: D000600
+  thomas: '01717'
 - name: Charles W. Dent
   party: majority
   rank: 4
-  thomas: '01799'
   bioguide: D000604
+  thomas: '01799'
 - name: Thomas J. Rooney
   party: majority
   rank: 5
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
   title: Vice Chair
 - name: Jeff Fortenberry
   party: majority
   rank: 6
-  thomas: '01793'
   bioguide: F000449
+  thomas: '01793'
 - name: Chris Stewart
   party: majority
   rank: 7
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: Nita M. Lowey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00709'
   bioguide: L000480
+  thomas: '00709'
 - name: Barbara Lee
   party: minority
   rank: 2
-  thomas: '01501'
   bioguide: L000551
+  thomas: '01501'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 3
-  thomas: '01728'
   bioguide: R000576
+  thomas: '01728'
 - name: Grace Meng
   party: minority
   rank: 4
-  thomas: '02148'
   bioguide: M001188
+  thomas: '02148'
 - name: David E. Price
   party: minority
   rank: 5
-  thomas: '00930'
   bioguide: P000523
+  thomas: '00930'
 HSAP06:
 - name: Ken Calvert
   party: majority
   rank: 1
   title: Chair
-  thomas: '00165'
   bioguide: C000059
+  thomas: '00165'
 - name: Michael K. Simpson
   party: majority
   rank: 2
-  thomas: '01590'
   bioguide: S001148
+  thomas: '01590'
 - name: Tom Cole
   party: majority
   rank: 3
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: David P. Joyce
   party: majority
   rank: 4
-  thomas: '02154'
   bioguide: J000295
+  thomas: '02154'
 - name: Chris Stewart
   party: majority
   rank: 5
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
   title: Vice Chair
 - name: Mark E. Amodei
   party: majority
   rank: 6
-  thomas: '02090'
   bioguide: A000369
+  thomas: '02090'
 - name: Evan H. Jenkins
   party: majority
   rank: 7
-  thomas: '02278'
   bioguide: J000297
+  thomas: '02278'
 - name: Betty McCollum
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01653'
   bioguide: M001143
+  thomas: '01653'
 - name: Chellie Pingree
   party: minority
   rank: 2
-  thomas: '01927'
   bioguide: P000597
+  thomas: '01927'
 - name: Derek Kilmer
   party: minority
   rank: 3
-  thomas: '02169'
   bioguide: K000381
+  thomas: '02169'
 - name: Marcy Kaptur
   party: minority
   rank: 4
-  thomas: '00616'
   bioguide: K000009
+  thomas: '00616'
 HSAP07:
 - name: Tom Cole
   party: majority
   rank: 1
   title: Chair
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: Michael K. Simpson
   party: majority
   rank: 2
-  thomas: '01590'
   bioguide: S001148
+  thomas: '01590'
 - name: Steve Womack
   party: majority
   rank: 3
-  thomas: '01991'
   bioguide: W000809
+  thomas: '01991'
   title: Vice Chair
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 4
-  thomas: '02061'
   bioguide: F000459
+  thomas: '02061'
 - name: Andy Harris
   party: majority
   rank: 5
-  thomas: '02026'
   bioguide: H001052
+  thomas: '02026'
 - name: Martha Roby
   party: majority
   rank: 6
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 7
-  thomas: '02071'
   bioguide: H001056
+  thomas: '02071'
 - name: John R. Moolenaar
   party: majority
   rank: 8
-  thomas: '02248'
   bioguide: M001194
+  thomas: '02248'
 - name: Rosa L. DeLauro
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00281'
   bioguide: D000216
+  thomas: '00281'
 - name: Lucille Roybal-Allard
   party: minority
   rank: 2
-  thomas: '00997'
   bioguide: R000486
+  thomas: '00997'
 - name: Barbara Lee
   party: minority
   rank: 3
-  thomas: '01501'
   bioguide: L000551
+  thomas: '01501'
 - name: Mark Pocan
   party: minority
   rank: 4
-  thomas: '02171'
   bioguide: P000607
+  thomas: '02171'
 - name: Katherine M. Clark
   party: minority
   rank: 5
-  thomas: '02196'
   bioguide: C001101
+  thomas: '02196'
 HSAP10:
 - name: Michael K. Simpson
   party: majority
   rank: 1
   title: Chair
-  thomas: '01590'
   bioguide: S001148
+  thomas: '01590'
 - name: Ken Calvert
   party: majority
   rank: 2
-  thomas: '00165'
   bioguide: C000059
+  thomas: '00165'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 3
-  thomas: '02061'
   bioguide: F000459
+  thomas: '02061'
   title: Vice Chair
 - name: Jeff Fortenberry
   party: majority
   rank: 4
-  thomas: '01793'
   bioguide: F000449
+  thomas: '01793'
 - name: Kay Granger
   party: majority
   rank: 5
-  thomas: '01487'
   bioguide: G000377
+  thomas: '01487'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 6
-  thomas: '02071'
   bioguide: H001056
+  thomas: '02071'
 - name: David P. Joyce
   party: majority
   rank: 7
-  thomas: '02154'
   bioguide: J000295
+  thomas: '02154'
 - name: Dan Newhouse
   party: majority
   rank: 8
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: Marcy Kaptur
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00616'
   bioguide: K000009
+  thomas: '00616'
 - name: Peter J. Visclosky
   party: minority
   rank: 2
-  thomas: '01188'
   bioguide: V000108
+  thomas: '01188'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 3
-  thomas: '01777'
   bioguide: W000797
+  thomas: '01777'
 - name: Pete Aguilar
   party: minority
   rank: 4
-  thomas: '02229'
   bioguide: A000371
+  thomas: '02229'
 - name: José E. Serrano
   party: minority
   rank: 5
-  thomas: '01042'
   bioguide: S000248
+  thomas: '01042'
 HSAP15:
 - name: John R. Carter
   party: majority
   rank: 1
   title: Chair
-  thomas: '01752'
   bioguide: C001051
+  thomas: '01752'
 - name: John Abney Culberson
   party: majority
   rank: 2
-  thomas: '01670'
   bioguide: C001048
+  thomas: '01670'
 - name: Charles J. "Chuck" Fleischmann
   party: majority
   rank: 3
-  thomas: '02061'
   bioguide: F000459
+  thomas: '02061'
 - name: Andy Harris
   party: majority
   rank: 4
-  thomas: '02026'
   bioguide: H001052
+  thomas: '02026'
 - name: Steven M. Palazzo
   party: majority
   rank: 5
-  thomas: '02035'
   bioguide: P000601
+  thomas: '02035'
   title: Vice Chair
 - name: Dan Newhouse
   party: majority
   rank: 6
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: Scott Taylor
   party: majority
   rank: 7
@@ -1726,56 +1726,56 @@ HSAP15:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00997'
   bioguide: R000486
+  thomas: '00997'
 - name: Henry Cuellar
   party: minority
   rank: 2
-  thomas: '01807'
   bioguide: C001063
+  thomas: '01807'
 - name: David E. Price
   party: minority
   rank: 3
-  thomas: '00930'
   bioguide: P000523
+  thomas: '00930'
 - name: C. A. Dutch Ruppersberger
   party: minority
   rank: 4
-  thomas: '01728'
   bioguide: R000576
+  thomas: '01728'
 HSAP18:
 - name: Charles W. Dent
   party: majority
   rank: 1
   title: Chair
-  thomas: '01799'
   bioguide: D000604
+  thomas: '01799'
 - name: Jeff Fortenberry
   party: majority
   rank: 2
-  thomas: '01793'
   bioguide: F000449
+  thomas: '01793'
   title: Vice Chair
 - name: Thomas J. Rooney
   party: majority
   rank: 3
-  thomas: '01916'
   bioguide: R000583
+  thomas: '01916'
 - name: David G. Valadao
   party: majority
   rank: 4
-  thomas: '02105'
   bioguide: V000129
+  thomas: '02105'
 - name: Steve Womack
   party: majority
   rank: 5
-  thomas: '01991'
   bioguide: W000809
+  thomas: '01991'
 - name: Evan H. Jenkins
   party: majority
   rank: 6
-  thomas: '02278'
   bioguide: J000297
+  thomas: '02278'
 - name: Scott Taylor
   party: majority
   rank: 7
@@ -1784,223 +1784,223 @@ HSAP18:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01777'
   bioguide: W000797
+  thomas: '01777'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 2
-  thomas: '00091'
   bioguide: B000490
+  thomas: '00091'
 - name: Barbara Lee
   party: minority
   rank: 3
-  thomas: '01501'
   bioguide: L000551
+  thomas: '01501'
 - name: Tim Ryan
   party: minority
   rank: 4
-  thomas: '01756'
   bioguide: R000577
+  thomas: '01756'
 HSAP19:
 - name: John Abney Culberson
   party: majority
   rank: 1
   title: Chair
-  thomas: '01670'
   bioguide: C001048
+  thomas: '01670'
 - name: Harold Rogers
   party: majority
   rank: 2
-  thomas: '00977'
   bioguide: R000395
+  thomas: '00977'
 - name: Robert B. Aderholt
   party: majority
   rank: 3
-  thomas: '01460'
   bioguide: A000055
+  thomas: '01460'
 - name: John R. Carter
   party: majority
   rank: 4
-  thomas: '01752'
   bioguide: C001051
+  thomas: '01752'
 - name: Martha Roby
   party: majority
   rank: 5
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Steven M. Palazzo
   party: majority
   rank: 6
-  thomas: '02035'
   bioguide: P000601
+  thomas: '02035'
 - name: Evan H. Jenkins
   party: majority
   rank: 7
-  thomas: '02278'
   bioguide: J000297
+  thomas: '02278'
   title: Vice Chair
 - name: José E. Serrano
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01042'
   bioguide: S000248
+  thomas: '01042'
 - name: Derek Kilmer
   party: minority
   rank: 2
-  thomas: '02169'
   bioguide: K000381
+  thomas: '02169'
 - name: Matt Cartwright
   party: minority
   rank: 3
-  thomas: '02159'
   bioguide: C001090
+  thomas: '02159'
 - name: Grace Meng
   party: minority
   rank: 4
-  thomas: '02148'
   bioguide: M001188
+  thomas: '02148'
 HSAP20:
 - name: Mario Diaz-Balart
   party: majority
   rank: 1
   title: Chair
-  thomas: '01717'
   bioguide: D000600
+  thomas: '01717'
 - name: Charles W. Dent
   party: majority
   rank: 2
-  thomas: '01799'
   bioguide: D000604
+  thomas: '01799'
 - name: David P. Joyce
   party: majority
   rank: 3
-  thomas: '02154'
   bioguide: J000295
+  thomas: '02154'
   title: Vice Chair
 - name: John Abney Culberson
   party: majority
   rank: 4
-  thomas: '01670'
   bioguide: C001048
+  thomas: '01670'
 - name: David Young
   party: majority
   rank: 5
-  thomas: '02242'
   bioguide: Y000066
+  thomas: '02242'
 - name: David G. Valadao
   party: majority
   rank: 6
-  thomas: '02105'
   bioguide: V000129
+  thomas: '02105'
 - name: Tom Graves
   party: majority
   rank: 7
-  thomas: '01979'
   bioguide: G000560
+  thomas: '01979'
 - name: David E. Price
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00930'
   bioguide: P000523
+  thomas: '00930'
 - name: Mike Quigley
   party: minority
   rank: 2
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: Katherine M. Clark
   party: minority
   rank: 3
-  thomas: '02196'
   bioguide: C001101
+  thomas: '02196'
 - name: Pete Aguilar
   party: minority
   rank: 4
-  thomas: '02229'
   bioguide: A000371
+  thomas: '02229'
 HSAP23:
 - name: Tom Graves
   party: majority
   rank: 1
   title: Chair
-  thomas: '01979'
   bioguide: G000560
+  thomas: '01979'
 - name: Kevin Yoder
   party: majority
   rank: 2
-  thomas: '02021'
   bioguide: Y000063
+  thomas: '02021'
 - name: Jaime Herrera Beutler
   party: majority
   rank: 3
-  thomas: '02071'
   bioguide: H001056
+  thomas: '02071'
   title: Vice Chair
 - name: Mark E. Amodei
   party: majority
   rank: 4
-  thomas: '02090'
   bioguide: A000369
+  thomas: '02090'
 - name: Chris Stewart
   party: majority
   rank: 5
-  thomas: '02168'
   bioguide: S001192
+  thomas: '02168'
 - name: David Young
   party: majority
   rank: 6
-  thomas: '02242'
   bioguide: Y000066
+  thomas: '02242'
 - name: John R. Moolenaar
   party: majority
   rank: 7
-  thomas: '02248'
   bioguide: M001194
+  thomas: '02248'
 - name: Mike Quigley
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01967'
   bioguide: Q000023
+  thomas: '01967'
 - name: José E. Serrano
   party: minority
   rank: 2
-  thomas: '01042'
   bioguide: S000248
+  thomas: '01042'
 - name: Matt Cartwright
   party: minority
   rank: 3
-  thomas: '02159'
   bioguide: C001090
+  thomas: '02159'
 - name: Sanford D. Bishop, Jr.
   party: minority
   rank: 4
-  thomas: '00091'
   bioguide: B000490
+  thomas: '00091'
 HSAP24:
 - name: Kevin Yoder
   party: majority
   rank: 1
   title: Chair
-  thomas: '02021'
   bioguide: Y000063
+  thomas: '02021'
 - name: Mark E. Amodei
   party: majority
   rank: 2
-  thomas: '02090'
   bioguide: A000369
+  thomas: '02090'
   title: Vice Chair
 - name: Dan Newhouse
   party: majority
   rank: 3
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: John R. Moolenaar
   party: majority
   rank: 4
-  thomas: '02248'
   bioguide: M001194
+  thomas: '02248'
 - name: Scott Taylor
   party: majority
   rank: 5
@@ -2009,276 +2009,281 @@ HSAP24:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01756'
   bioguide: R000577
+  thomas: '01756'
 - name: Betty McCollum
   party: minority
   rank: 2
-  thomas: '01653'
   bioguide: M001143
+  thomas: '01653'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 3
-  thomas: '01777'
   bioguide: W000797
+  thomas: '01777'
 HSAS:
 - name: Mac Thornberry
   party: majority
   rank: 1
   title: Chair
-  thomas: '01155'
   bioguide: T000238
+  thomas: '01155'
 - name: Walter B. Jones
   party: majority
   rank: 2
-  thomas: '00612'
   bioguide: J000255
+  thomas: '00612'
 - name: Joe Wilson
   party: majority
   rank: 3
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Rob Bishop
   party: majority
   rank: 5
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Michael R. Turner
   party: majority
   rank: 6
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Mike Rogers
   party: majority
   rank: 7
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Bill Shuster
   party: majority
-  rank: 9
-  thomas: '01681'
+  rank: 8
   bioguide: S001154
+  thomas: '01681'
 - name: K. Michael Conaway
   party: majority
-  rank: 10
-  thomas: '01805'
+  rank: 9
   bioguide: C001062
+  thomas: '01805'
 - name: Doug Lamborn
   party: majority
-  rank: 11
-  thomas: '01834'
+  rank: 10
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
-  rank: 12
-  thomas: '01886'
+  rank: 11
   bioguide: W000804
+  thomas: '01886'
 - name: Duncan Hunter
   party: majority
-  rank: 13
-  thomas: '01909'
+  rank: 12
   bioguide: H001048
+  thomas: '01909'
 - name: Mike Coffman
   party: majority
-  rank: 14
-  thomas: '01912'
+  rank: 13
   bioguide: C001077
+  thomas: '01912'
 - name: Vicky Hartzler
   party: majority
-  rank: 15
-  thomas: '02032'
+  rank: 14
   bioguide: H001053
+  thomas: '02032'
 - name: Austin Scott
   party: majority
-  rank: 16
-  thomas: '02009'
+  rank: 15
   bioguide: S001189
+  thomas: '02009'
 - name: Mo Brooks
   party: majority
-  rank: 17
-  thomas: '01987'
+  rank: 16
   bioguide: B001274
+  thomas: '01987'
 - name: Paul Cook
   party: majority
-  rank: 18
-  thomas: '02103'
+  rank: 17
   bioguide: C001094
+  thomas: '02103'
 - name: Jim Bridenstine
   party: majority
-  rank: 19
-  thomas: '02155'
+  rank: 18
   bioguide: B001283
+  thomas: '02155'
 - name: Brad R. Wenstrup
   party: majority
-  rank: 20
-  thomas: '02152'
+  rank: 19
   bioguide: W000815
+  thomas: '02152'
 - name: Bradley Byrne
   party: majority
-  rank: 21
-  thomas: '02197'
+  rank: 20
   bioguide: B001289
+  thomas: '02197'
 - name: Sam Graves
   party: majority
-  rank: 22
-  thomas: '01656'
+  rank: 21
   bioguide: G000546
+  thomas: '01656'
 - name: Elise M. Stefanik
   party: majority
-  rank: 23
-  thomas: '02263'
+  rank: 22
   bioguide: S001196
+  thomas: '02263'
 - name: Martha McSally
   party: majority
-  rank: 24
-  thomas: '02225'
+  rank: 23
   bioguide: M001197
+  thomas: '02225'
 - name: Stephen Knight
   party: majority
-  rank: 25
-  thomas: '02228'
+  rank: 24
   bioguide: K000387
+  thomas: '02228'
 - name: Steve Russell
   party: majority
-  rank: 26
-  thomas: '02265'
+  rank: 25
   bioguide: R000604
+  thomas: '02265'
 - name: Scott DesJarlais
   party: majority
-  rank: 27
-  thomas: '02062'
+  rank: 26
   bioguide: D000616
+  thomas: '02062'
 - name: Ralph Lee Abraham
   party: majority
-  rank: 28
-  thomas: '02244'
+  rank: 27
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
-  rank: 29
-  thomas: '02294'
+  rank: 28
   bioguide: K000388
+  thomas: '02294'
 - name: Mike Gallagher
   party: majority
-  rank: 30
+  rank: 29
   bioguide: G000579
 - name: Matt Gaetz
   party: majority
-  rank: 31
+  rank: 30
   bioguide: G000578
 - name: Don Bacon
   party: majority
-  rank: 32
+  rank: 31
   bioguide: B001298
 - name: Jim Banks
   party: majority
-  rank: 33
+  rank: 32
   bioguide: B001299
 - name: Liz Cheney
   party: majority
-  rank: 34
+  rank: 33
   bioguide: C001109
+- name: Jody B. Hice
+  party: majority
+  rank: 34
+  bioguide: H001071
+  thomas: '02237'
 - name: Adam Smith
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01528'
   bioguide: S000510
+  thomas: '01528'
 - name: Robert A. Brady
   party: minority
   rank: 2
-  thomas: '01469'
   bioguide: B001227
+  thomas: '01469'
 - name: Susan A. Davis
   party: minority
   rank: 3
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: James R. Langevin
   party: minority
   rank: 4
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Rick Larsen
   party: minority
   rank: 5
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Jim Cooper
   party: minority
   rank: 6
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 7
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Joe Courtney
   party: minority
   rank: 8
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Niki Tsongas
   party: minority
   rank: 9
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: John Garamendi
   party: minority
   rank: 10
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Jackie Speier
   party: minority
   rank: 11
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Marc A. Veasey
   party: minority
   rank: 12
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Tulsi Gabbard
   party: minority
   rank: 13
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Beto O’Rourke
   party: minority
   rank: 14
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Donald Norcross
   party: minority
   rank: 15
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Ruben Gallego
   party: minority
   rank: 16
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Seth Moulton
   party: minority
   rank: 17
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Colleen Hanabusa
   party: minority
   rank: 18
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Carol Shea-Porter
   party: minority
   rank: 19
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Jacky Rosen
   party: minority
   rank: 20
@@ -2320,24 +2325,24 @@ HSAS02:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Walter B. Jones
   party: majority
   rank: 2
-  thomas: '00612'
   bioguide: J000255
+  thomas: '00612'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
   title: Vice Chair
 - name: Steve Russell
   party: majority
   rank: 4
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Don Bacon
   party: majority
   rank: 5
@@ -2345,44 +2350,44 @@ HSAS02:
 - name: Martha McSally
   party: majority
   rank: 6
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: Ralph Lee Abraham
   party: majority
   rank: 7
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Trent Kelly
   party: majority
   rank: 8
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Jackie Speier
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Robert A. Brady
   party: minority
   rank: 2
-  thomas: '01469'
   bioguide: B001227
+  thomas: '01469'
 - name: Niki Tsongas
   party: minority
   rank: 3
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Ruben Gallego
   party: minority
   rank: 4
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Carol Shea-Porter
   party: minority
   rank: 5
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Jacky Rosen
   party: minority
   rank: 6
@@ -2392,54 +2397,54 @@ HSAS03:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Rob Bishop
   party: majority
   rank: 2
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Austin Scott
   party: majority
   rank: 3
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Steve Russell
   party: majority
   rank: 4
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Mike Rogers
   party: majority
   rank: 5
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Vicky Hartzler
   party: majority
   rank: 6
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Elise M. Stefanik
   party: majority
   rank: 7
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Martha McSally
   party: majority
   rank: 8
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
   title: Vice Chair
 - name: Scott DesJarlais
   party: majority
   rank: 9
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Trent Kelly
   party: majority
   rank: 10
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Mike Gallagher
   party: majority
   rank: 11
@@ -2448,23 +2453,23 @@ HSAS03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Joe Courtney
   party: minority
   rank: 2
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Tulsi Gabbard
   party: minority
   rank: 3
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Carol Shea-Porter
   party: minority
   rank: 4
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: A. Donald McEachin
   party: minority
   rank: 5
@@ -2490,13 +2495,13 @@ HSAS06:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Matt Gaetz
   party: majority
   rank: 3
@@ -2512,14 +2517,14 @@ HSAS06:
 - name: Austin Scott
   party: majority
   rank: 6
-  thomas: '02009'
   bioguide: S001189
+  thomas: '02009'
 - name: Seth Moulton
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Tom O’Halleran
   party: minority
   rank: 2
@@ -2537,39 +2542,39 @@ HSAS25:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01741'
   bioguide: T000463
+  thomas: '01741'
 - name: Frank A. LoBiondo
   party: majority
   rank: 2
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Paul Cook
   party: majority
   rank: 3
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
   title: Vice Chair
 - name: Sam Graves
   party: majority
   rank: 4
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Martha McSally
   party: majority
   rank: 5
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: Stephen Knight
   party: majority
   rank: 6
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 7
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Matt Gaetz
   party: majority
   rank: 8
@@ -2585,49 +2590,49 @@ HSAS25:
 - name: Walter B. Jones
   party: majority
   rank: 11
-  thomas: '00612'
   bioguide: J000255
+  thomas: '00612'
 - name: Rob Bishop
   party: majority
   rank: 12
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Robert J. Wittman
   party: majority
   rank: 13
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Mo Brooks
   party: majority
   rank: 14
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Niki Tsongas
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: James R. Langevin
   party: minority
   rank: 2
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Jim Cooper
   party: minority
   rank: 3
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Marc A. Veasey
   party: minority
   rank: 4
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Ruben Gallego
   party: minority
   rank: 5
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Jacky Rosen
   party: minority
   rank: 6
@@ -2657,23 +2662,23 @@ HSAS26:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Bill Shuster
   party: majority
   rank: 2
-  thomas: '01681'
   bioguide: S001154
+  thomas: '01681'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Ralph Lee Abraham
   party: majority
   rank: 4
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Liz Cheney
   party: majority
   rank: 5
@@ -2682,59 +2687,64 @@ HSAS26:
 - name: Joe Wilson
   party: majority
   rank: 6
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Frank A. LoBiondo
   party: majority
   rank: 7
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Doug Lamborn
   party: majority
-  rank: 9
-  thomas: '01834'
+  rank: 8
   bioguide: L000564
+  thomas: '01834'
 - name: Austin Scott
   party: majority
-  rank: 10
-  thomas: '02009'
+  rank: 9
   bioguide: S001189
+  thomas: '02009'
+- name: Jody B. Hice
+  party: majority
+  rank: 10
+  bioguide: H001071
+  thomas: '02237'
 - name: James R. Langevin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Rick Larsen
   party: minority
   rank: 2
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Jim Cooper
   party: minority
   rank: 3
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Jackie Speier
   party: minority
   rank: 4
-  thomas: '01890'
   bioguide: S001175
+  thomas: '01890'
 - name: Marc A. Veasey
   party: minority
   rank: 5
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Beto O’Rourke
   party: minority
   rank: 7
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Stephanie N. Murphy
   party: minority
   rank: 8
@@ -2744,29 +2754,29 @@ HSAS28:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: K. Michael Conaway
   party: majority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
+  thomas: '01805'
 - name: Vicky Hartzler
   party: majority
   rank: 3
-  thomas: '02032'
   bioguide: H001053
+  thomas: '02032'
 - name: Bradley Byrne
   party: majority
   rank: 4
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
   title: Vice Chair
 - name: Scott DesJarlais
   party: majority
   rank: 5
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Mike Gallagher
   party: majority
   rank: 6
@@ -2774,69 +2784,69 @@ HSAS28:
 - name: Duncan Hunter
   party: majority
   rank: 7
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Paul Cook
   party: majority
   rank: 8
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Jim Bridenstine
   party: majority
   rank: 9
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 10
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Ralph Lee Abraham
   party: majority
   rank: 11
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Joe Courtney
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Susan A. Davis
   party: minority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: James R. Langevin
   party: minority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 4
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: John Garamendi
   party: minority
   rank: 5
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Donald Norcross
   party: minority
   rank: 6
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Seth Moulton
   party: minority
   rank: 7
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Colleen Hanabusa
   party: minority
   rank: 8
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: A. Donald McEachin
   party: minority
   rank: 9
@@ -2846,84 +2856,89 @@ HSAS29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Doug Lamborn
   party: majority
-  rank: 3
-  thomas: '01834'
+  rank: 2
   bioguide: L000564
+  thomas: '01834'
 - name: Duncan Hunter
   party: majority
-  rank: 4
-  thomas: '01909'
+  rank: 3
   bioguide: H001048
+  thomas: '01909'
 - name: Mo Brooks
   party: majority
-  rank: 5
-  thomas: '01987'
+  rank: 4
   bioguide: B001274
+  thomas: '01987'
 - name: Jim Bridenstine
   party: majority
-  rank: 6
-  thomas: '02155'
+  rank: 5
   bioguide: B001283
+  thomas: '02155'
 - name: Michael R. Turner
   party: majority
-  rank: 7
-  thomas: '01741'
+  rank: 6
   bioguide: T000463
+  thomas: '01741'
 - name: Mike Coffman
   party: majority
-  rank: 8
-  thomas: '01912'
+  rank: 7
   bioguide: C001077
+  thomas: '01912'
 - name: Bradley Byrne
   party: majority
-  rank: 9
-  thomas: '02197'
+  rank: 8
   bioguide: B001289
+  thomas: '02197'
 - name: Sam Graves
   party: majority
-  rank: 10
-  thomas: '01656'
+  rank: 9
   bioguide: G000546
+  thomas: '01656'
+- name: Jody B. Hice
+  party: majority
+  rank: 10
+  bioguide: H001071
+  thomas: '02237'
 - name: Jim Cooper
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Susan A. Davis
   party: minority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Rick Larsen
   party: minority
   rank: 3
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: John Garamendi
   party: minority
   rank: 4
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Beto O’Rourke
   party: minority
   rank: 5
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Donald Norcross
   party: minority
   rank: 6
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Colleen Hanabusa
   party: minority
   rank: 7
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Ro Khanna
   party: minority
   rank: 8
@@ -2933,153 +2948,153 @@ HSBA:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
 - name: Peter T. King
   party: majority
   rank: 2
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Edward R. Royce
   party: majority
   rank: 3
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Frank D. Lucas
   party: majority
   rank: 4
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Patrick T. McHenry
   party: majority
   rank: 5
-  thomas: '01792'
   bioguide: M001156
+  thomas: '01792'
 - name: Stevan Pearce
   party: majority
   rank: 6
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Bill Posey
   party: majority
   rank: 7
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 8
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Bill Huizenga
   party: majority
   rank: 9
-  thomas: '02028'
   bioguide: H001058
+  thomas: '02028'
 - name: Sean P. Duffy
   party: majority
   rank: 10
-  thomas: '02072'
   bioguide: D000614
+  thomas: '02072'
 - name: Steve Stivers
   party: majority
   rank: 11
-  thomas: '02047'
   bioguide: S001187
+  thomas: '02047'
 - name: Randy Hultgren
   party: majority
   rank: 12
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Dennis A. Ross
   party: majority
   rank: 13
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Robert Pittenger
   party: majority
   rank: 14
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
 - name: Ann Wagner
   party: majority
   rank: 15
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Andy Barr
   party: majority
   rank: 16
-  thomas: '02131'
   bioguide: B001282
+  thomas: '02131'
 - name: Keith J. Rothfus
   party: majority
   rank: 17
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
 - name: Luke Messer
   party: majority
   rank: 18
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Scott R. Tipton
   party: majority
   rank: 19
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 20
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
 - name: Bruce Poliquin
   party: majority
   rank: 21
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Mia B. Love
   party: majority
   rank: 22
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 23
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 24
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Lee M. Zeldin
   party: majority
   rank: 25
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 26
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 27
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Alexander X. Mooney
   party: majority
   rank: 28
-  thomas: '02277'
   bioguide: M001195
+  thomas: '02277'
 - name: Thomas MacArthur
   party: majority
   rank: 29
-  thomas: '02258'
   bioguide: M001193
+  thomas: '02258'
 - name: Warren Davidson
   party: majority
   rank: 30
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 31
@@ -3100,113 +3115,113 @@ HSBA:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Nydia M. Velázquez
   party: minority
   rank: 3
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Brad Sherman
   party: minority
   rank: 4
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Gregory W. Meeks
   party: minority
   rank: 5
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Michael E. Capuano
   party: minority
   rank: 6
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Wm. Lacy Clay
   party: minority
   rank: 7
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Stephen F. Lynch
   party: minority
   rank: 8
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: David Scott
   party: minority
   rank: 9
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Al Green
   party: minority
   rank: 10
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Emanuel Cleaver
   party: minority
   rank: 11
-  thomas: '01790'
   bioguide: C001061
+  thomas: '01790'
 - name: Gwen Moore
   party: minority
   rank: 12
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Keith Ellison
   party: minority
   rank: 13
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Ed Perlmutter
   party: minority
   rank: 14
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: James A. Himes
   party: minority
   rank: 15
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Bill Foster
   party: minority
   rank: 16
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Daniel T. Kildee
   party: minority
   rank: 17
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 18
-  thomas: '02133'
   bioguide: D000620
+  thomas: '02133'
 - name: Kyrsten Sinema
   party: minority
   rank: 19
-  thomas: '02099'
   bioguide: S001191
+  thomas: '02099'
 - name: Joyce Beatty
   party: minority
   rank: 20
-  thomas: '02153'
   bioguide: B001281
+  thomas: '02153'
 - name: Denny Heck
   party: minority
   rank: 21
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 - name: Juan Vargas
   party: minority
   rank: 22
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 23
@@ -3228,64 +3243,64 @@ HSBA01:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Robert Pittenger
   party: majority
   rank: 2
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
   title: Vice Chair
 - name: Keith J. Rothfus
   party: majority
   rank: 3
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
 - name: Luke Messer
   party: majority
   rank: 4
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Scott R. Tipton
   party: majority
   rank: 5
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 6
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
 - name: Bruce Poliquin
   party: majority
   rank: 7
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Mia B. Love
   party: majority
   rank: 8
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 9
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 10
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Lee M. Zeldin
   party: majority
   rank: 11
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: Warren Davidson
   party: majority
   rank: 12
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 13
@@ -3297,50 +3312,50 @@ HSBA01:
 - name: Jeb Hensarling
   party: majority
   rank: 15
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Ed Perlmutter
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: James A. Himes
   party: minority
   rank: 3
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Bill Foster
   party: minority
   rank: 4
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Daniel T. Kildee
   party: minority
   rank: 5
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 6
-  thomas: '02133'
   bioguide: D000620
+  thomas: '02133'
 - name: Kyrsten Sinema
   party: minority
   rank: 7
-  thomas: '02099'
   bioguide: S001191
+  thomas: '02099'
 - name: Juan Vargas
   party: minority
   rank: 8
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 9
@@ -3352,77 +3367,77 @@ HSBA01:
 - name: Stephen F. Lynch
   party: minority
   rank: 11
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Maxine Waters
   party: minority
   rank: 12
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA04:
 - name: Sean P. Duffy
   party: majority
   rank: 1
   title: Chair
-  thomas: '02072'
   bioguide: D000614
+  thomas: '02072'
 - name: Dennis A. Ross
   party: majority
   rank: 2
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
   title: Vice Chair
 - name: Edward R. Royce
   party: majority
   rank: 3
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Stevan Pearce
   party: majority
   rank: 4
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Bill Posey
   party: majority
   rank: 5
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 6
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Steve Stivers
   party: majority
   rank: 7
-  thomas: '02047'
   bioguide: S001187
+  thomas: '02047'
 - name: Randy Hultgren
   party: majority
   rank: 8
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Keith J. Rothfus
   party: majority
   rank: 9
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
 - name: Lee M. Zeldin
   party: majority
   rank: 10
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 11
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Thomas MacArthur
   party: majority
   rank: 12
-  thomas: '02258'
   bioguide: M001193
+  thomas: '02258'
 - name: Ted Budd
   party: majority
   rank: 13
@@ -3430,50 +3445,50 @@ HSBA04:
 - name: Jeb Hensarling
   party: majority
   rank: 14
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Emanuel Cleaver
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01790'
   bioguide: C001061
+  thomas: '01790'
 - name: Nydia M. Velázquez
   party: minority
   rank: 2
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Michael E. Capuano
   party: minority
   rank: 3
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Brad Sherman
   party: minority
   rank: 5
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Joyce Beatty
   party: minority
   rank: 6
-  thomas: '02153'
   bioguide: B001281
+  thomas: '02153'
 - name: Daniel T. Kildee
   party: minority
   rank: 7
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: John K. Delaney
   party: minority
   rank: 8
-  thomas: '02133'
   bioguide: D000620
+  thomas: '02133'
 - name: Ruben J. Kihuen
   party: minority
   rank: 9
@@ -3485,57 +3500,57 @@ HSBA04:
 - name: Maxine Waters
   party: minority
   rank: 11
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA09:
 - name: Ann Wagner
   party: majority
   rank: 1
   title: Chair
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Scott R. Tipton
   party: majority
   rank: 2
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
   title: Vice Chair
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Patrick T. McHenry
   party: majority
   rank: 4
-  thomas: '01792'
   bioguide: M001156
+  thomas: '01792'
 - name: Dennis A. Ross
   party: majority
   rank: 5
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Luke Messer
   party: majority
   rank: 6
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Lee M. Zeldin
   party: majority
   rank: 7
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: David A. Trott
   party: majority
   rank: 8
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 9
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: David Kustoff
   party: majority
   rank: 10
@@ -3551,40 +3566,40 @@ HSBA09:
 - name: Jeb Hensarling
   party: majority
   rank: 13
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Al Green
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Keith Ellison
   party: minority
   rank: 2
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Emanuel Cleaver
   party: minority
   rank: 3
-  thomas: '01790'
   bioguide: C001061
+  thomas: '01790'
 - name: Joyce Beatty
   party: minority
   rank: 4
-  thomas: '02153'
   bioguide: B001281
+  thomas: '02153'
 - name: Michael E. Capuano
   party: minority
   rank: 5
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Gwen Moore
   party: minority
   rank: 6
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Josh Gottheimer
   party: minority
   rank: 7
@@ -3600,77 +3615,77 @@ HSBA09:
 - name: Maxine Waters
   party: minority
   rank: 10
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA15:
 - name: Blaine Luetkemeyer
   party: majority
   rank: 1
   title: Chair
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Keith J. Rothfus
   party: majority
   rank: 2
-  thomas: '02158'
   bioguide: R000598
+  thomas: '02158'
   title: Vice Chair
 - name: Edward R. Royce
   party: majority
   rank: 3
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Frank D. Lucas
   party: majority
   rank: 4
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Bill Posey
   party: majority
   rank: 5
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Dennis A. Ross
   party: majority
   rank: 6
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Robert Pittenger
   party: majority
   rank: 7
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
 - name: Andy Barr
   party: majority
   rank: 8
-  thomas: '02131'
   bioguide: B001282
+  thomas: '02131'
 - name: Scott R. Tipton
   party: majority
   rank: 9
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Roger Williams
   party: majority
   rank: 10
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
 - name: Mia B. Love
   party: majority
   rank: 11
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: David A. Trott
   party: majority
   rank: 12
-  thomas: '02250'
   bioguide: T000475
+  thomas: '02250'
 - name: Barry Loudermilk
   party: majority
   rank: 13
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: David Kustoff
   party: majority
   rank: 14
@@ -3682,60 +3697,60 @@ HSBA15:
 - name: Jeb Hensarling
   party: majority
   rank: 16
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Wm. Lacy Clay
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Gregory W. Meeks
   party: minority
   rank: 3
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: David Scott
   party: minority
   rank: 4
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: Nydia M. Velázquez
   party: minority
   rank: 5
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Al Green
   party: minority
   rank: 6
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Keith Ellison
   party: minority
   rank: 7
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Michael E. Capuano
   party: minority
   rank: 8
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Denny Heck
   party: minority
   rank: 9
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 - name: Gwen Moore
   party: minority
   rank: 10
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Charlie Crist
   party: minority
   rank: 11
@@ -3743,82 +3758,82 @@ HSBA15:
 - name: Maxine Waters
   party: minority
   rank: 12
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA16:
 - name: Bill Huizenga
   party: majority
   rank: 1
   title: Chair
-  thomas: '02028'
   bioguide: H001058
+  thomas: '02028'
 - name: Randy Hultgren
   party: majority
   rank: 2
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
   title: Vice Chair
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Patrick T. McHenry
   party: majority
   rank: 4
-  thomas: '01792'
   bioguide: M001156
+  thomas: '01792'
 - name: Sean P. Duffy
   party: majority
   rank: 5
-  thomas: '02072'
   bioguide: D000614
+  thomas: '02072'
 - name: Steve Stivers
   party: majority
   rank: 6
-  thomas: '02047'
   bioguide: S001187
+  thomas: '02047'
 - name: Ann Wagner
   party: majority
   rank: 7
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Luke Messer
   party: majority
   rank: 8
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Bruce Poliquin
   party: majority
   rank: 9
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: J. French Hill
   party: majority
   rank: 10
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 11
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Alexander X. Mooney
   party: majority
   rank: 12
-  thomas: '02277'
   bioguide: M001195
+  thomas: '02277'
 - name: Thomas MacArthur
   party: majority
   rank: 13
-  thomas: '02258'
   bioguide: M001193
+  thomas: '02258'
 - name: Warren Davidson
   party: majority
   rank: 14
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Ted Budd
   party: majority
   rank: 15
@@ -3830,60 +3845,60 @@ HSBA16:
 - name: Jeb Hensarling
   party: majority
   rank: 17
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Carolyn B. Maloney
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Brad Sherman
   party: minority
   rank: 2
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Stephen F. Lynch
   party: minority
   rank: 3
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: David Scott
   party: minority
   rank: 4
-  thomas: '01722'
   bioguide: S001157
+  thomas: '01722'
 - name: James A. Himes
   party: minority
   rank: 5
-  thomas: '01913'
   bioguide: H001047
+  thomas: '01913'
 - name: Keith Ellison
   party: minority
   rank: 6
-  thomas: '01857'
   bioguide: E000288
+  thomas: '01857'
 - name: Bill Foster
   party: minority
   rank: 7
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Gregory W. Meeks
   party: minority
   rank: 8
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Kyrsten Sinema
   party: minority
   rank: 9
-  thomas: '02099'
   bioguide: S001191
+  thomas: '02099'
 - name: Juan Vargas
   party: minority
   rank: 10
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Josh Gottheimer
   party: minority
   rank: 11
@@ -3895,62 +3910,62 @@ HSBA16:
 - name: Maxine Waters
   party: minority
   rank: 13
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBA20:
 - name: Andy Barr
   party: majority
   rank: 1
   title: Chair
-  thomas: '02131'
   bioguide: B001282
+  thomas: '02131'
 - name: Roger Williams
   party: majority
   rank: 2
-  thomas: '02165'
   bioguide: W000816
+  thomas: '02165'
   title: Vice Chair
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Bill Huizenga
   party: majority
   rank: 4
-  thomas: '02028'
   bioguide: H001058
+  thomas: '02028'
 - name: Robert Pittenger
   party: majority
   rank: 5
-  thomas: '02141'
   bioguide: P000606
+  thomas: '02141'
 - name: Mia B. Love
   party: majority
   rank: 6
-  thomas: '02271'
   bioguide: L000584
+  thomas: '02271'
 - name: J. French Hill
   party: majority
   rank: 7
-  thomas: '02223'
   bioguide: H001072
+  thomas: '02223'
 - name: Tom Emmer
   party: majority
   rank: 8
-  thomas: '02253'
   bioguide: E000294
+  thomas: '02253'
 - name: Alexander X. Mooney
   party: majority
   rank: 9
-  thomas: '02277'
   bioguide: M001195
+  thomas: '02277'
 - name: Warren Davidson
   party: majority
   rank: 10
-  thomas: '02296'
   bioguide: D000626
+  thomas: '02296'
 - name: Claudia Tenney
   party: majority
   rank: 11
@@ -3962,50 +3977,50 @@ HSBA20:
 - name: Jeb Hensarling
   party: majority
   rank: 13
-  thomas: '01749'
   bioguide: H001036
+  thomas: '01749'
   title: Ex Officio
 - name: Gwen Moore
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01811'
   bioguide: M001160
+  thomas: '01811'
 - name: Gregory W. Meeks
   party: minority
   rank: 2
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Bill Foster
   party: minority
   rank: 3
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Brad Sherman
   party: minority
   rank: 4
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Al Green
   party: minority
   rank: 5
-  thomas: '01803'
   bioguide: G000553
+  thomas: '01803'
 - name: Denny Heck
   party: minority
   rank: 6
-  thomas: '02170'
   bioguide: H001064
+  thomas: '02170'
 - name: Daniel T. Kildee
   party: minority
   rank: 7
-  thomas: '02134'
   bioguide: K000380
+  thomas: '02134'
 - name: Juan Vargas
   party: minority
   rank: 8
-  thomas: '02112'
   bioguide: V000130
+  thomas: '02112'
 - name: Charlie Crist
   party: minority
   rank: 9
@@ -4013,86 +4028,86 @@ HSBA20:
 - name: Maxine Waters
   party: minority
   rank: 10
-  thomas: '01205'
   bioguide: W000187
+  thomas: '01205'
   title: Ex Officio
 HSBU:
-- name: Diane Black
+- name: Steve Womack
   party: majority
   rank: 1
   title: Chair
-  thomas: '02063'
-  bioguide: B001273
-- name: Mario Diaz-Balart
+  bioguide: W000809
+  thomas: '01991'
+- name: Diane Black
   party: majority
   rank: 2
-  thomas: '01717'
-  bioguide: D000600
-- name: Tom Cole
+  bioguide: B001273
+  thomas: '02063'
+- name: Mario Diaz-Balart
   party: majority
   rank: 3
-  thomas: '01742'
-  bioguide: C001053
-- name: Tom McClintock
+  bioguide: D000600
+  thomas: '01717'
+- name: Tom Cole
   party: majority
   rank: 4
-  thomas: '01908'
-  bioguide: M001177
-- name: Todd Rokita
+  bioguide: C001053
+  thomas: '01742'
+- name: Tom McClintock
   party: majority
   rank: 5
-  thomas: '02017'
-  bioguide: R000592
-- name: Rob Woodall
+  bioguide: M001177
+  thomas: '01908'
+- name: Todd Rokita
   party: majority
   rank: 6
-  thomas: '02008'
-  bioguide: W000810
-- name: Mark Sanford
+  bioguide: R000592
+  thomas: '02017'
+- name: Rob Woodall
   party: majority
   rank: 7
-  thomas: '01012'
-  bioguide: S000051
-- name: Steve Womack
+  bioguide: W000810
+  thomas: '02008'
+- name: Mark Sanford
   party: majority
   rank: 8
-  thomas: '01991'
-  bioguide: W000809
+  bioguide: S000051
+  thomas: '01012'
 - name: Dave Brat
   party: majority
   rank: 9
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 10
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Gary J. Palmer
   party: majority
   rank: 11
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: Bruce Westerman
   party: majority
   rank: 12
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: James B. Renacci
   party: majority
   rank: 13
-  thomas: '02048'
   bioguide: R000586
+  thomas: '02048'
 - name: Bill Johnson
   party: majority
   rank: 14
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Jason Smith
   party: majority
   rank: 15
-  thomas: '02191'
   bioguide: S001195
+  thomas: '02191'
 - name: Jason Lewis
   party: majority
   rank: 16
@@ -4125,48 +4140,48 @@ HSBU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01853'
   bioguide: Y000062
+  thomas: '01853'
 - name: Barbara Lee
   party: minority
   rank: 2
-  thomas: '01501'
   bioguide: L000551
+  thomas: '01501'
 - name: Michelle Lujan Grisham
   party: minority
   rank: 3
-  thomas: '02146'
   bioguide: L000580
+  thomas: '02146'
 - name: Seth Moulton
   party: minority
   rank: 4
-  thomas: '02246'
   bioguide: M001196
+  thomas: '02246'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
-  thomas: '02149'
   bioguide: J000294
+  thomas: '02149'
 - name: Brian Higgins
   party: minority
   rank: 6
-  thomas: '01794'
   bioguide: H001038
+  thomas: '01794'
 - name: Suzan K. DelBene
   party: minority
   rank: 7
-  thomas: '02096'
   bioguide: D000617
+  thomas: '02096'
 - name: Debbie Wasserman Schultz
   party: minority
   rank: 8
-  thomas: '01777'
   bioguide: W000797
+  thomas: '01777'
 - name: Brendan F. Boyle
   party: minority
   rank: 9
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Ro Khanna
   party: minority
   rank: 10
@@ -4182,91 +4197,91 @@ HSBU:
 - name: Sheila Jackson Lee
   party: minority
   rank: 13
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: Janice D. Schakowsky
   party: minority
   rank: 14
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 HSED:
 - name: Virginia Foxx
   party: majority
   rank: 1
   title: Chair
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
   title: Vice Chair
 - name: Duncan Hunter
   party: majority
   rank: 3
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: David P. Roe
   party: majority
   rank: 4
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Glenn Thompson
   party: majority
   rank: 5
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Tim Walberg
   party: majority
   rank: 6
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Brett Guthrie
   party: majority
   rank: 7
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Todd Rokita
   party: majority
   rank: 8
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Lou Barletta
   party: majority
   rank: 9
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Luke Messer
   party: majority
   rank: 10
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Bradley Byrne
   party: majority
   rank: 11
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Dave Brat
   party: majority
   rank: 12
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 13
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Elise M. Stefanik
   party: majority
   rank: 14
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Rick W. Allen
   party: majority
   rank: 15
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 16
@@ -4303,68 +4318,68 @@ HSED:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01037'
   bioguide: S000185
+  thomas: '01037'
 - name: Susan A. Davis
   party: minority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Raúl M. Grijalva
   party: minority
   rank: 3
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Joe Courtney
   party: minority
   rank: 4
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Marcia L. Fudge
   party: minority
   rank: 5
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Jared Polis
   party: minority
   rank: 6
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
   rank: 8
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Suzanne Bonamici
   party: minority
   rank: 9
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Mark Takano
   party: minority
   rank: 10
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Alma S. Adams
   party: minority
   rank: 11
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 12
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Donald Norcross
   party: minority
   rank: 13
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 14
@@ -4376,8 +4391,8 @@ HSED:
 - name: Carol Shea-Porter
   party: minority
   rank: 16
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Adriano Espaillat
   party: minority
   rank: 17
@@ -4387,33 +4402,33 @@ HSED02:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: David P. Roe
   party: majority
   rank: 3
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Todd Rokita
   party: majority
   rank: 4
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Lou Barletta
   party: majority
   rank: 5
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Rick W. Allen
   party: majority
   rank: 6
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 7
@@ -4442,18 +4457,18 @@ HSED02:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Frederica S. Wilson
   party: minority
   rank: 2
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Donald Norcross
   party: minority
   rank: 3
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 4
@@ -4461,8 +4476,8 @@ HSED02:
 - name: Carol Shea-Porter
   party: minority
   rank: 5
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 - name: Adriano Espaillat
   party: minority
   rank: 6
@@ -4470,50 +4485,50 @@ HSED02:
 - name: Joe Courtney
   party: minority
   rank: 7
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Marcia L. Fudge
   party: minority
   rank: 8
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Suzanne Bonamici
   party: minority
   rank: 9
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 HSED10:
 - name: Bradley Byrne
   party: majority
   rank: 1
   title: Chair
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Duncan Hunter
   party: majority
   rank: 3
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Dave Brat
   party: majority
   rank: 4
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Glenn Grothman
   party: majority
   rank: 5
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Elise M. Stefanik
   party: majority
   rank: 6
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Francis Rooney
   party: majority
   rank: 7
@@ -4530,28 +4545,28 @@ HSED10:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Raúl M. Grijalva
   party: minority
   rank: 2
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Alma S. Adams
   party: minority
   rank: 3
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 4
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Donald Norcross
   party: minority
   rank: 5
-  thomas: '02202'
   bioguide: N000188
+  thomas: '02202'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 6
@@ -4559,50 +4574,50 @@ HSED10:
 - name: Carol Shea-Porter
   party: minority
   rank: 7
-  thomas: '01861'
   bioguide: S001170
+  thomas: '01861'
 HSED13:
 - name: Brett Guthrie
   party: majority
   rank: 1
   title: Chair
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Glenn Thompson
   party: majority
   rank: 2
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Lou Barletta
   party: majority
   rank: 3
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Luke Messer
   party: majority
   rank: 4
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Bradley Byrne
   party: majority
   rank: 5
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Glenn Grothman
   party: majority
   rank: 6
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Elise M. Stefanik
   party: majority
   rank: 7
-  thomas: '02263'
   bioguide: S001196
+  thomas: '02263'
 - name: Rick W. Allen
   party: majority
   rank: 8
-  thomas: '02239'
   bioguide: A000372
+  thomas: '02239'
 - name: Jason Lewis
   party: majority
   rank: 9
@@ -4627,23 +4642,23 @@ HSED13:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Joe Courtney
   party: minority
   rank: 2
-  thomas: '01836'
   bioguide: C001069
+  thomas: '01836'
 - name: Alma S. Adams
   party: minority
   rank: 3
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Mark DeSaulnier
   party: minority
   rank: 4
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 5
@@ -4651,18 +4666,18 @@ HSED13:
 - name: Jared Polis
   party: minority
   rank: 6
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Mark Takano
   party: minority
   rank: 8
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Lisa Blunt Rochester
   party: minority
   rank: 9
@@ -4676,33 +4691,33 @@ HSED14:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Duncan Hunter
   party: majority
   rank: 2
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: David P. Roe
   party: majority
   rank: 3
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Glenn Thompson
   party: majority
   rank: 4
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Luke Messer
   party: majority
   rank: 5
-  thomas: '02130'
   bioguide: M001189
+  thomas: '02130'
 - name: Dave Brat
   party: majority
   rank: 6
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Thomas A. Garrett, Jr.
   party: majority
   rank: 7
@@ -4715,140 +4730,140 @@ HSED14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Raúl M. Grijalva
   party: minority
   rank: 2
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Marcia L. Fudge
   party: minority
   rank: 3
-  thomas: '01895'
   bioguide: F000455
+  thomas: '01895'
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Susan A. Davis
   party: minority
   rank: 5
-  thomas: '01641'
   bioguide: D000598
+  thomas: '01641'
 - name: Frederica S. Wilson
   party: minority
   rank: 6
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 HSFA:
 - name: Edward R. Royce
   party: majority
   rank: 1
   title: Chair
-  thomas: '00998'
   bioguide: R000487
+  thomas: '00998'
 - name: Christopher H. Smith
   party: majority
   rank: 2
-  thomas: '01071'
   bioguide: S000522
+  thomas: '01071'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Dana Rohrabacher
   party: majority
   rank: 4
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Steve Chabot
   party: majority
   rank: 5
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Joe Wilson
   party: majority
   rank: 6
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Michael T. McCaul
   party: majority
   rank: 7
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
 - name: Ted Poe
   party: majority
   rank: 8
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Darrell E. Issa
   party: majority
   rank: 9
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Tom Marino
   party: majority
   rank: 10
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Mo Brooks
   party: majority
   rank: 11
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Paul Cook
   party: majority
   rank: 12
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Scott Perry
   party: majority
   rank: 13
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Ron DeSantis
   party: majority
   rank: 14
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Mark Meadows
   party: majority
   rank: 15
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Ted S. Yoho
   party: majority
   rank: 16
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Adam Kinzinger
   party: majority
   rank: 17
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: Lee M. Zeldin
   party: majority
   rank: 18
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 19
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 20
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Ann Wagner
   party: majority
   rank: 21
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Brian J. Mast
   party: majority
   rank: 22
@@ -4865,97 +4880,101 @@ HSFA:
   party: majority
   rank: 25
   bioguide: G000580
+- name: John Curtis
+  party: majority
+  rank: 26
+  bioguide: C001114
 - name: Eliot L. Engel
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: Brad Sherman
   party: minority
   rank: 2
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Gregory W. Meeks
   party: minority
   rank: 3
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Albio Sires
   party: minority
   rank: 4
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: Gerald E. Connolly
   party: minority
   rank: 5
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Theodore E. Deutch
   party: minority
   rank: 6
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Karen Bass
   party: minority
   rank: 7
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: William R. Keating
   party: minority
   rank: 8
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: David N. Cicilline
   party: minority
   rank: 9
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Ami Bera
   party: minority
   rank: 10
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Lois Frankel
   party: minority
   rank: 11
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Tulsi Gabbard
   party: minority
   rank: 12
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Joaquin Castro
   party: minority
   rank: 13
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Robin L. Kelly
   party: minority
   rank: 14
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Brendan F. Boyle
   party: minority
   rank: 15
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Dina Titus
   party: minority
   rank: 16
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Norma J. Torres
   party: minority
   rank: 17
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Bradley Scott Schneider
   party: minority
   rank: 18
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 - name: Thomas R. Suozzi
   party: minority
   rank: 19
@@ -4967,112 +4986,118 @@ HSFA:
 - name: Ted Lieu
   party: minority
   rank: 21
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 HSFA05:
 - name: Ted S. Yoho
   party: majority
   rank: 1
   title: Chair
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Steve Chabot
   party: majority
   rank: 3
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Tom Marino
   party: majority
   rank: 4
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Mo Brooks
   party: majority
   rank: 5
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Scott Perry
   party: majority
   rank: 6
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Adam Kinzinger
   party: majority
   rank: 7
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: Ann Wagner
   party: majority
   rank: 8
-  thomas: '02137'
   bioguide: W000812
+  thomas: '02137'
 - name: Brad Sherman
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Ami Bera
   party: minority
   rank: 2
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Dina Titus
   party: minority
   rank: 3
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Gerald E. Connolly
   party: minority
   rank: 4
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Theodore E. Deutch
   party: minority
   rank: 5
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 HSFA07:
+- name: Paul Cook
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001094
+  thomas: '02103'
 - name: Christopher H. Smith
   party: majority
   rank: 2
-  thomas: '01071'
   bioguide: S000522
+  thomas: '01071'
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 3
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Michael T. McCaul
   party: majority
   rank: 4
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
 - name: Mo Brooks
   party: majority
   rank: 5
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Ron DeSantis
   party: majority
   rank: 6
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Ted S. Yoho
   party: majority
   rank: 7
-  thomas: '02115'
   bioguide: Y000065
+  thomas: '02115'
 - name: Francis Rooney
   party: majority
   rank: 8
@@ -5081,23 +5106,23 @@ HSFA07:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: Joaquin Castro
   party: minority
   rank: 2
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Robin L. Kelly
   party: minority
   rank: 3
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Norma J. Torres
   party: minority
   rank: 4
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Adriano Espaillat
   party: minority
   rank: 5
@@ -5105,104 +5130,103 @@ HSFA07:
 - name: Gregory W. Meeks
   party: minority
   rank: 6
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 HSFA13:
 - name: Ileana Ros-Lehtinen
   party: majority
   rank: 1
   title: Chair
-  thomas: '00985'
   bioguide: R000435
+  thomas: '00985'
 - name: Steve Chabot
   party: majority
   rank: 2
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Ron DeSantis
   party: majority
   rank: 4
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Mark Meadows
   party: majority
   rank: 5
-  thomas: '02142'
   bioguide: M001187
-- name: Paul Cook
-  party: majority
-  rank: 6
-  thomas: '02103'
-  bioguide: C001094
+  thomas: '02142'
 - name: Adam Kinzinger
   party: majority
-  rank: 7
-  thomas: '02014'
+  rank: 6
   bioguide: K000378
+  thomas: '02014'
 - name: Lee M. Zeldin
   party: majority
-  rank: 8
-  thomas: '02261'
+  rank: 7
   bioguide: Z000017
+  thomas: '02261'
 - name: Daniel M. Donovan, Jr.
   party: majority
-  rank: 9
-  thomas: '02293'
+  rank: 8
   bioguide: D000625
+  thomas: '02293'
 - name: Ann Wagner
   party: majority
-  rank: 10
-  thomas: '02137'
+  rank: 9
   bioguide: W000812
+  thomas: '02137'
 - name: Brian J. Mast
   party: majority
-  rank: 11
+  rank: 10
   bioguide: M001199
 - name: Brian K. Fitzpatrick
   party: majority
-  rank: 12
+  rank: 11
   bioguide: F000466
+- name: John Curtis
+  party: majority
+  rank: 12
+  bioguide: C001114
 - name: Theodore E. Deutch
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Gerald E. Connolly
   party: minority
   rank: 2
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: David N. Cicilline
   party: minority
   rank: 3
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Lois Frankel
   party: minority
   rank: 4
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Brendan F. Boyle
   party: minority
   rank: 5
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Tulsi Gabbard
   party: minority
   rank: 6
-  thomas: '02122'
   bioguide: G000571
+  thomas: '02122'
 - name: Bradley Scott Schneider
   party: minority
   rank: 7
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 - name: Thomas R. Suozzi
   party: minority
   rank: 8
@@ -5210,35 +5234,35 @@ HSFA13:
 - name: Ted Lieu
   party: minority
   rank: 9
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 HSFA14:
 - name: Dana Rohrabacher
   party: majority
   rank: 1
   title: Chair
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Ted Poe
   party: majority
   rank: 3
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Tom Marino
   party: majority
   rank: 4
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 5
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Francis Rooney
   party: majority
   rank: 6
@@ -5247,59 +5271,63 @@ HSFA14:
   party: majority
   rank: 7
   bioguide: F000466
+- name: John Curtis
+  party: majority
+  rank: 8
+  bioguide: C001114
 - name: Gregory W. Meeks
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01506'
   bioguide: M001137
+  thomas: '01506'
 - name: Brad Sherman
   party: minority
   rank: 2
-  thomas: '01526'
   bioguide: S000344
+  thomas: '01526'
 - name: Albio Sires
   party: minority
   rank: 3
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: William R. Keating
   party: minority
   rank: 4
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: David N. Cicilline
   party: minority
   rank: 5
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Robin L. Kelly
   party: minority
   rank: 6
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 HSFA16:
 - name: Christopher H. Smith
   party: majority
   rank: 1
   title: Chair
-  thomas: '01071'
   bioguide: S000522
+  thomas: '01071'
 - name: Mark Meadows
   party: majority
   rank: 2
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 3
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 4
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Thomas A. Garrett, Jr.
   party: majority
   rank: 5
@@ -5308,18 +5336,18 @@ HSFA16:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: Ami Bera
   party: minority
   rank: 2
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Joaquin Castro
   party: minority
   rank: 3
-  thomas: '02163'
   bioguide: C001091
+  thomas: '02163'
 - name: Thomas R. Suozzi
   party: minority
   rank: 4
@@ -5329,33 +5357,33 @@ HSFA18:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Joe Wilson
   party: majority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
+  thomas: '01688'
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Paul Cook
   party: majority
   rank: 4
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Scott Perry
   party: majority
   rank: 5
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Lee M. Zeldin
   party: majority
   rank: 6
-  thomas: '02261'
   bioguide: Z000017
+  thomas: '02261'
 - name: Brian J. Mast
   party: majority
   rank: 7
@@ -5368,140 +5396,140 @@ HSFA18:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Lois Frankel
   party: minority
   rank: 2
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Brendan F. Boyle
   party: minority
   rank: 3
-  thomas: '02267'
   bioguide: B001296
+  thomas: '02267'
 - name: Dina Titus
   party: minority
   rank: 4
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Norma J. Torres
   party: minority
   rank: 5
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Bradley Scott Schneider
   party: minority
   rank: 6
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 HSGO:
 - name: Trey Gowdy
   party: majority
   rank: 1
   title: Chair
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 2
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Jim Jordan
   party: majority
   rank: 4
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Mark Sanford
   party: majority
   rank: 5
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Justin Amash
   party: majority
   rank: 6
-  thomas: '02029'
   bioguide: A000367
+  thomas: '02029'
 - name: Paul A. Gosar
   party: majority
   rank: 7
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Scott DesJarlais
   party: majority
   rank: 8
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Blake Farenthold
   party: majority
   rank: 9
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Virginia Foxx
   party: majority
   rank: 10
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Thomas Massie
   party: majority
   rank: 11
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 12
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Ron DeSantis
   party: majority
   rank: 13
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Dennis A. Ross
   party: majority
   rank: 14
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Mark Walker
   party: majority
   rank: 15
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
 - name: Rod Blum
   party: majority
   rank: 16
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: Jody B. Hice
   party: majority
   rank: 17
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: Steve Russell
   party: majority
   rank: 18
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Glenn Grothman
   party: majority
   rank: 19
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Will Hurd
   party: majority
   rank: 20
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Gary J. Palmer
   party: majority
   rank: 21
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: James Comer
   party: majority
   rank: 22
@@ -5518,58 +5546,58 @@ HSGO:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00256'
   bioguide: C000984
+  thomas: '00256'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Stephen F. Lynch
   party: minority
   rank: 5
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Jim Cooper
   party: minority
   rank: 6
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Gerald E. Connolly
   party: minority
   rank: 7
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Robin L. Kelly
   party: minority
   rank: 8
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Brenda L. Lawrence
   party: minority
   rank: 9
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 10
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Stacey E. Plaskett
   party: minority
   rank: 11
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Val Butler Demings
   party: minority
   rank: 12
@@ -5585,18 +5613,18 @@ HSGO:
 - name: Peter Welch
   party: minority
   rank: 15
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Matt Cartwright
   party: minority
   rank: 16
-  thomas: '02159'
   bioguide: C001090
+  thomas: '02159'
 - name: Mark DeSaulnier
   party: minority
   rank: 17
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Jimmy Gomez
   party: minority
   rank: 18
@@ -5606,39 +5634,39 @@ HSGO06:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Steve Russell
   party: majority
   rank: 2
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
   title: Vice Chair
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Justin Amash
   party: majority
   rank: 4
-  thomas: '02029'
   bioguide: A000367
+  thomas: '02029'
 - name: Paul A. Gosar
   party: majority
   rank: 5
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Virginia Foxx
   party: majority
   rank: 6
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Jody B. Hice
   party: majority
   rank: 7
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: James Comer
   party: majority
   rank: 8
@@ -5647,8 +5675,8 @@ HSGO06:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Val Butler Demings
   party: minority
   rank: 2
@@ -5656,13 +5684,13 @@ HSGO06:
 - name: Peter Welch
   party: minority
   rank: 3
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Mark DeSaulnier
   party: minority
   rank: 4
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Jimmy Gomez
   party: minority
   rank: 5
@@ -5672,82 +5700,82 @@ HSGO24:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Jody B. Hice
   party: majority
   rank: 2
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
   title: Vice Chair
 - name: Jim Jordan
   party: majority
   rank: 3
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Mark Sanford
   party: majority
   rank: 4
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Thomas Massie
   party: majority
   rank: 5
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Ron DeSantis
   party: majority
   rank: 6
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Dennis A. Ross
   party: majority
   rank: 7
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Rod Blum
   party: majority
   rank: 8
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: Gerald E. Connolly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Carolyn B. Maloney
   party: minority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
+  thomas: '00729'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Brenda L. Lawrence
   party: minority
   rank: 5
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 6
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 HSGO25:
 - name: Will Hurd
   party: majority
   rank: 1
   title: Chair
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Paul Mitchell
   party: majority
   rank: 2
@@ -5756,23 +5784,23 @@ HSGO25:
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Justin Amash
   party: majority
   rank: 4
-  thomas: '02029'
   bioguide: A000367
+  thomas: '02029'
 - name: Blake Farenthold
   party: majority
   rank: 5
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Steve Russell
   party: majority
   rank: 6
-  thomas: '02265'
   bioguide: R000604
+  thomas: '02265'
 - name: Greg Gianforte
   party: majority
   rank: 7
@@ -5781,8 +5809,8 @@ HSGO25:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -5790,13 +5818,13 @@ HSGO25:
 - name: Stephen F. Lynch
   party: minority
   rank: 3
-  thomas: '01686'
   bioguide: L000562
+  thomas: '01686'
 - name: Gerald E. Connolly
   party: minority
   rank: 4
-  thomas: '01959'
   bioguide: C001078
+  thomas: '01959'
 - name: Raja Krishnamoorthi
   party: minority
   rank: 5
@@ -5806,39 +5834,39 @@ HSGO27:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Mark Walker
   party: majority
   rank: 2
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
   title: Vice Chair
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Mark Sanford
   party: majority
   rank: 4
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Scott DesJarlais
   party: majority
   rank: 5
-  thomas: '02062'
   bioguide: D000616
+  thomas: '02062'
 - name: Mark Meadows
   party: majority
   rank: 6
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Glenn Grothman
   party: majority
   rank: 7
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
 - name: Paul Mitchell
   party: majority
   rank: 8
@@ -5851,51 +5879,51 @@ HSGO27:
 - name: Jim Cooper
   party: minority
   rank: 2
-  thomas: '00231'
   bioguide: C000754
+  thomas: '00231'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Robin L. Kelly
   party: minority
   rank: 4
-  thomas: '02190'
   bioguide: K000385
+  thomas: '02190'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 5
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Stacey E. Plaskett
   party: minority
   rank: 6
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 HSGO28:
 - name: Blake Farenthold
   party: majority
   rank: 1
   title: Chair
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Paul A. Gosar
   party: majority
   rank: 2
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
   title: Vice Chair
 - name: Dennis A. Ross
   party: majority
   rank: 3
-  thomas: '02003'
   bioguide: R000593
+  thomas: '02003'
 - name: Gary J. Palmer
   party: majority
   rank: 4
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: James Comer
   party: majority
   rank: 5
@@ -5908,8 +5936,8 @@ HSGO28:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02274'
   bioguide: P000610
+  thomas: '02274'
 - name: Jamie Raskin
   party: minority
   rank: 2
@@ -5923,39 +5951,39 @@ HSGO29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02221'
   bioguide: P000609
+  thomas: '02221'
 - name: Glenn Grothman
   party: majority
   rank: 2
-  thomas: '02276'
   bioguide: G000576
+  thomas: '02276'
   title: Vice Chair
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Virginia Foxx
   party: majority
   rank: 4
-  thomas: '01791'
   bioguide: F000450
+  thomas: '01791'
 - name: Thomas Massie
   party: majority
   rank: 5
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Walker
   party: majority
   rank: 6
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
 - name: Mark Sanford
   party: majority
   rank: 7
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Val Butler Demings
   party: minority
   rank: 1
@@ -5964,61 +5992,61 @@ HSGO29:
 - name: Mark DeSaulnier
   party: minority
   rank: 2
-  thomas: '02227'
   bioguide: D000623
+  thomas: '02227'
 - name: Matt Cartwright
   party: minority
   rank: 3
-  thomas: '02159'
   bioguide: C001090
+  thomas: '02159'
 - name: Wm. Lacy Clay
   party: minority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 HSHA:
 - name: Gregg Harper
   party: majority
   rank: 1
   title: Chair
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: Rodney Davis
   party: majority
   rank: 2
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Barbara Comstock
   party: majority
   rank: 3
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Mark Walker
   party: majority
   rank: 4
-  thomas: '02255'
   bioguide: W000819
+  thomas: '02255'
 - name: Adrian Smith
   party: majority
   rank: 5
-  thomas: '01860'
   bioguide: S001172
+  thomas: '01860'
 - name: Barry Loudermilk
   party: majority
   rank: 6
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Robert A. Brady
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01469'
   bioguide: B001227
+  thomas: '01469'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Jamie Raskin
   party: minority
   rank: 3
@@ -6028,58 +6056,58 @@ HSHM:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
 - name: Lamar Smith
   party: majority
   rank: 2
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Peter T. King
   party: majority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Mike Rogers
   party: majority
   rank: 4
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Lou Barletta
   party: majority
   rank: 5
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Scott Perry
   party: majority
   rank: 6
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: John Katko
   party: majority
   rank: 7
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Will Hurd
   party: majority
   rank: 8
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Martha McSally
   party: majority
   rank: 9
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: John Ratcliffe
   party: majority
   rank: 10
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 11
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: Mike Gallagher
   party: majority
   rank: 12
@@ -6104,52 +6132,56 @@ HSHM:
   party: majority
   rank: 17
   bioguide: E000298
+- name: Don Bacon
+  party: majority
+  rank: 18
+  bioguide: B001298
 - name: Bennie G. Thompson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: James R. Langevin
   party: minority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Cedric L. Richmond
   party: minority
   rank: 4
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: William R. Keating
   party: minority
   rank: 5
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 6
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Filemon Vela
   party: minority
   rank: 7
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 8
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Kathleen M. Rice
   party: minority
   rank: 9
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: J. Luis Correa
   party: minority
   rank: 10
@@ -6167,23 +6199,23 @@ HSHM05:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Lou Barletta
   party: majority
   rank: 2
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Scott Perry
   party: majority
   rank: 3
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Will Hurd
   party: majority
   rank: 4
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: Mike Gallagher
   party: majority
   rank: 5
@@ -6191,43 +6223,43 @@ HSHM05:
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Kathleen M. Rice
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: William R. Keating
   party: minority
   rank: 3
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM07:
 - name: John Katko
   party: majority
   rank: 1
   title: Chair
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Mike Rogers
   party: majority
   rank: 2
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Clay Higgins
   party: majority
   rank: 3
@@ -6243,86 +6275,82 @@ HSHM07:
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Bonnie Watson Coleman
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: William R. Keating
   party: minority
   rank: 2
-  thomas: '02025'
   bioguide: K000375
+  thomas: '02025'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 3
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM08:
 - name: John Ratcliffe
   party: majority
   rank: 1
   title: Chair
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: John Katko
   party: majority
   rank: 2
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 3
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: Mike Gallagher
   party: majority
   rank: 4
   bioguide: G000579
-- name: Clay Higgins
-  party: majority
-  rank: 5
-  bioguide: H001077
-- name: Thomas A. Garrett, Jr.
-  party: majority
-  rank: 6
-  bioguide: G000580
 - name: Brian K. Fitzpatrick
   party: majority
-  rank: 7
+  rank: 5
   bioguide: F000466
+- name: Don Bacon
+  party: majority
+  rank: 6
+  bioguide: B001298
 - name: Michael T. McCaul
   party: majority
   rank: 8
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Cedric L. Richmond
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: Sheila Jackson Lee
   party: minority
   rank: 2
-  thomas: '00588'
   bioguide: J000032
+  thomas: '00588'
 - name: James R. Langevin
   party: minority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Val Butler Demings
   party: minority
   rank: 4
@@ -6330,34 +6358,38 @@ HSHM08:
 - name: Bennie G. Thompson
   party: minority
   rank: 5
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM09:
 - name: Scott Perry
   party: majority
   rank: 1
   title: Chair
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: John Ratcliffe
   party: majority
   rank: 2
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Clay Higgins
   party: majority
   rank: 3
   bioguide: H001077
-- name: Ron Estes
+- name: Thomas A. Garrett, Jr.
   party: majority
   rank: 4
+  bioguide: G000580
+- name: Ron Estes
+  party: majority
+  rank: 5
   bioguide: E000298
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: J. Luis Correa
   party: minority
@@ -6367,8 +6399,8 @@ HSHM09:
 - name: Kathleen M. Rice
   party: minority
   rank: 2
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 3
@@ -6376,57 +6408,61 @@ HSHM09:
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM11:
 - name: Martha McSally
   party: majority
   rank: 1
   title: Chair
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: Lamar Smith
   party: majority
   rank: 2
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Mike Rogers
   party: majority
   rank: 3
-  thomas: '01704'
   bioguide: R000575
+  thomas: '01704'
 - name: Lou Barletta
   party: majority
   rank: 4
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Will Hurd
   party: majority
   rank: 5
-  thomas: '02269'
   bioguide: H001073
+  thomas: '02269'
 - name: John H. Rutherford
   party: majority
   rank: 6
   bioguide: R000609
+- name: Don Bacon
+  party: majority
+  rank: 7
+  bioguide: B001298
 - name: Michael T. McCaul
   party: majority
   rank: 8
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Filemon Vela
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02167'
   bioguide: V000132
+  thomas: '02167'
 - name: Cedric L. Richmond
   party: minority
   rank: 2
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: J. Luis Correa
   party: minority
   rank: 3
@@ -6442,26 +6478,26 @@ HSHM11:
 - name: Bennie G. Thompson
   party: minority
   rank: 6
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSHM12:
 - name: Daniel M. Donovan, Jr.
   party: majority
   rank: 1
   title: Chair
-  thomas: '02293'
   bioguide: D000625
+  thomas: '02293'
 - name: Peter T. King
   party: majority
   rank: 2
-  thomas: '00635'
   bioguide: K000210
+  thomas: '00635'
 - name: Martha McSally
   party: majority
   rank: 3
-  thomas: '02225'
   bioguide: M001197
+  thomas: '02225'
 - name: John H. Rutherford
   party: majority
   rank: 4
@@ -6473,1327 +6509,1347 @@ HSHM12:
 - name: Michael T. McCaul
   party: majority
   rank: 6
-  thomas: '01804'
   bioguide: M001157
+  thomas: '01804'
   title: Ex Officio
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: James R. Langevin
   party: minority
   rank: 2
-  thomas: '01668'
   bioguide: L000559
+  thomas: '01668'
 - name: Bonnie Watson Coleman
   party: minority
   rank: 3
-  thomas: '02259'
   bioguide: W000822
+  thomas: '02259'
 - name: Bennie G. Thompson
   party: minority
   rank: 4
-  thomas: '01151'
   bioguide: T000193
+  thomas: '01151'
   title: Ex Officio
 HSIF:
 - name: Greg Walden
   party: majority
   rank: 1
   title: Chair
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
 - name: Joe Barton
   party: majority
   rank: 2
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Fred Upton
   party: majority
   rank: 3
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: John Shimkus
   party: majority
   rank: 4
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Michael C. Burgess
   party: majority
   rank: 5
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Marsha Blackburn
   party: majority
   rank: 6
-  thomas: '01748'
   bioguide: B001243
+  thomas: '01748'
 - name: Steve Scalise
   party: majority
   rank: 7
-  thomas: '01892'
   bioguide: S001176
+  thomas: '01892'
 - name: Robert E. Latta
   party: majority
   rank: 8
-  thomas: '01885'
   bioguide: L000566
+  thomas: '01885'
 - name: Cathy McMorris Rodgers
   party: majority
   rank: 9
-  thomas: '01809'
   bioguide: M001159
+  thomas: '01809'
 - name: Gregg Harper
   party: majority
   rank: 10
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: Leonard Lance
   party: majority
   rank: 11
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
 - name: Brett Guthrie
   party: majority
   rank: 12
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Pete Olson
   party: majority
   rank: 13
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
 - name: David B. McKinley
   party: majority
   rank: 14
-  thomas: '02074'
   bioguide: M001180
+  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 15
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
   rank: 16
-  thomas: '02070'
   bioguide: G000568
+  thomas: '02070'
 - name: Gus M. Bilirakis
   party: majority
   rank: 17
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Bill Johnson
   party: majority
   rank: 18
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 19
-  thomas: '02033'
   bioguide: L000576
+  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 20
-  thomas: '02018'
   bioguide: B001275
+  thomas: '02018'
 - name: Bill Flores
   party: majority
   rank: 21
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Susan W. Brooks
   party: majority
   rank: 22
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Markwayne Mullin
   party: majority
   rank: 23
-  thomas: '02156'
   bioguide: M001190
+  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 24
-  thomas: '02140'
   bioguide: H001067
+  thomas: '02140'
 - name: Chris Collins
   party: majority
   rank: 25
-  thomas: '02151'
   bioguide: C001092
+  thomas: '02151'
 - name: Kevin Cramer
   party: majority
   rank: 26
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 27
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Mimi Walters
   party: majority
   rank: 28
-  thomas: '02232'
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 29
-  thomas: '02266'
   bioguide: C001106
+  thomas: '02266'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 30
-  thomas: '02236'
   bioguide: C001103
+  thomas: '02236'
 - name: Jeff Duncan
   party: majority
   rank: 31
-  thomas: '02057'
   bioguide: D000615
+  thomas: '02057'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
 - name: Bobby L. Rush
   party: minority
   rank: 2
-  thomas: '01003'
   bioguide: R000515
+  thomas: '01003'
 - name: Anna G. Eshoo
   party: minority
   rank: 3
-  thomas: '00355'
   bioguide: E000215
+  thomas: '00355'
 - name: Eliot L. Engel
   party: minority
   rank: 4
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: Gene Green
   party: minority
   rank: 5
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Diana DeGette
   party: minority
   rank: 6
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Michael F. Doyle
   party: minority
   rank: 7
-  thomas: '00316'
   bioguide: D000482
+  thomas: '00316'
 - name: Janice D. Schakowsky
   party: minority
   rank: 8
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: G. K. Butterfield
   party: minority
   rank: 9
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 10
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Kathy Castor
   party: minority
   rank: 11
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 12
-  thomas: '01854'
   bioguide: S001168
+  thomas: '01854'
 - name: Jerry McNerney
   party: minority
   rank: 13
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Peter Welch
   party: minority
   rank: 14
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Ben Ray Luján
   party: minority
   rank: 15
-  thomas: '01939'
   bioguide: L000570
+  thomas: '01939'
 - name: Paul Tonko
   party: minority
   rank: 16
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Yvette D. Clarke
   party: minority
   rank: 17
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: David Loebsack
   party: minority
   rank: 18
-  thomas: '01846'
   bioguide: L000565
+  thomas: '01846'
 - name: Kurt Schrader
   party: minority
   rank: 19
-  thomas: '01950'
   bioguide: S001180
+  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 20
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: Tony Cárdenas
   party: minority
   rank: 21
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Raul Ruiz
   party: minority
   rank: 22
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 23
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Debbie Dingell
   party: minority
   rank: 24
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 HSIF02:
+- name: Gregg Harper
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: H001045
+  thomas: '01933'
 - name: H. Morgan Griffith
   party: majority
   rank: 2
-  thomas: '02070'
   bioguide: G000568
+  thomas: '02070'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Michael C. Burgess
   party: majority
   rank: 4
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Susan W. Brooks
   party: majority
   rank: 5
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Chris Collins
   party: majority
   rank: 6
-  thomas: '02151'
   bioguide: C001092
+  thomas: '02151'
 - name: Tim Walberg
   party: majority
   rank: 7
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Mimi Walters
   party: majority
   rank: 8
-  thomas: '02232'
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 9
-  thomas: '02266'
   bioguide: C001106
+  thomas: '02266'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 10
-  thomas: '02236'
   bioguide: C001103
+  thomas: '02236'
 - name: Greg Walden
   party: majority
   rank: 11
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Diana DeGette
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Janice D. Schakowsky
   party: minority
   rank: 2
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: Kathy Castor
   party: minority
   rank: 3
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: Paul Tonko
   party: minority
   rank: 4
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Yvette D. Clarke
   party: minority
   rank: 5
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Raul Ruiz
   party: minority
   rank: 6
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 7
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 8
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF03:
 - name: Fred Upton
   party: majority
   rank: 1
   title: Chair
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: Pete Olson
   party: majority
   rank: 2
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: John Shimkus
   party: majority
   rank: 4
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Robert E. Latta
   party: majority
   rank: 5
-  thomas: '01885'
   bioguide: L000566
+  thomas: '01885'
 - name: Gregg Harper
   party: majority
   rank: 6
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: David B. McKinley
   party: majority
   rank: 7
-  thomas: '02074'
   bioguide: M001180
+  thomas: '02074'
 - name: Adam Kinzinger
   party: majority
   rank: 8
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: H. Morgan Griffith
   party: majority
   rank: 9
-  thomas: '02070'
   bioguide: G000568
+  thomas: '02070'
 - name: Bill Johnson
   party: majority
   rank: 10
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 11
-  thomas: '02033'
   bioguide: L000576
+  thomas: '02033'
 - name: Larry Bucshon
   party: majority
   rank: 12
-  thomas: '02018'
   bioguide: B001275
+  thomas: '02018'
 - name: Bill Flores
   party: majority
   rank: 13
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Markwayne Mullin
   party: majority
   rank: 14
-  thomas: '02156'
   bioguide: M001190
+  thomas: '02156'
 - name: Richard Hudson
   party: majority
   rank: 15
-  thomas: '02140'
   bioguide: H001067
+  thomas: '02140'
 - name: Kevin Cramer
   party: majority
   rank: 16
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 17
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
+- name: Jeff Duncan
+  party: majority
+  rank: 18
+  bioguide: D000615
+  thomas: '02057'
 - name: Greg Walden
   party: majority
   rank: 19
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Bobby L. Rush
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01003'
   bioguide: R000515
+  thomas: '01003'
 - name: Jerry McNerney
   party: minority
   rank: 2
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Scott H. Peters
   party: minority
   rank: 3
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Gene Green
   party: minority
   rank: 4
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Michael F. Doyle
   party: minority
   rank: 5
-  thomas: '00316'
   bioguide: D000482
+  thomas: '00316'
 - name: Kathy Castor
   party: minority
   rank: 6
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 7
-  thomas: '01854'
   bioguide: S001168
+  thomas: '01854'
 - name: Peter Welch
   party: minority
   rank: 8
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Paul Tonko
   party: minority
   rank: 9
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: David Loebsack
   party: minority
   rank: 10
-  thomas: '01846'
   bioguide: L000565
+  thomas: '01846'
 - name: Kurt Schrader
   party: minority
   rank: 11
-  thomas: '01950'
   bioguide: S001180
+  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 12
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: G. K. Butterfield
   party: minority
   rank: 13
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 14
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF14:
 - name: Michael C. Burgess
   party: majority
   rank: 1
   title: Chair
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Brett Guthrie
   party: majority
   rank: 2
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Fred Upton
   party: majority
   rank: 4
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: John Shimkus
   party: majority
   rank: 5
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Marsha Blackburn
   party: majority
   rank: 6
-  thomas: '01748'
   bioguide: B001243
-- name: Cathy McMorris Rodgers
+  thomas: '01748'
+- name: Robert E. Latta
   party: majority
   rank: 7
-  thomas: '01809'
-  bioguide: M001159
-- name: Leonard Lance
+  bioguide: L000566
+  thomas: '01885'
+- name: Cathy McMorris Rodgers
   party: majority
   rank: 8
-  thomas: '01936'
-  bioguide: L000567
-- name: H. Morgan Griffith
+  bioguide: M001159
+  thomas: '01809'
+- name: Leonard Lance
   party: majority
   rank: 9
-  thomas: '02070'
-  bioguide: G000568
-- name: Gus M. Bilirakis
+  bioguide: L000567
+  thomas: '01936'
+- name: H. Morgan Griffith
   party: majority
   rank: 10
-  thomas: '01838'
-  bioguide: B001257
-- name: Billy Long
+  bioguide: G000568
+  thomas: '02070'
+- name: Gus M. Bilirakis
   party: majority
   rank: 11
-  thomas: '02033'
-  bioguide: L000576
-- name: Larry Bucshon
+  bioguide: B001257
+  thomas: '01838'
+- name: Billy Long
   party: majority
   rank: 12
-  thomas: '02018'
-  bioguide: B001275
-- name: Susan W. Brooks
+  bioguide: L000576
+  thomas: '02033'
+- name: Larry Bucshon
   party: majority
   rank: 13
-  thomas: '02129'
-  bioguide: B001284
-- name: Markwayne Mullin
+  bioguide: B001275
+  thomas: '02018'
+- name: Susan W. Brooks
   party: majority
   rank: 14
-  thomas: '02156'
-  bioguide: M001190
-- name: Richard Hudson
+  bioguide: B001284
+  thomas: '02129'
+- name: Markwayne Mullin
   party: majority
   rank: 15
-  thomas: '02140'
-  bioguide: H001067
-- name: Chris Collins
+  bioguide: M001190
+  thomas: '02156'
+- name: Richard Hudson
   party: majority
   rank: 16
-  thomas: '02151'
-  bioguide: C001092
-- name: Earl L. "Buddy" Carter
+  bioguide: H001067
+  thomas: '02140'
+- name: Chris Collins
   party: majority
   rank: 17
-  thomas: '02236'
+  bioguide: C001092
+  thomas: '02151'
+- name: Earl L. "Buddy" Carter
+  party: majority
+  rank: 18
   bioguide: C001103
+  thomas: '02236'
 - name: Greg Walden
   party: majority
   rank: 19
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Gene Green
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Eliot L. Engel
   party: minority
   rank: 2
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: Janice D. Schakowsky
   party: minority
   rank: 3
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: G. K. Butterfield
   party: minority
   rank: 4
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 5
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Kathy Castor
   party: minority
   rank: 6
-  thomas: '01839'
   bioguide: C001066
+  thomas: '01839'
 - name: John P. Sarbanes
   party: minority
   rank: 7
-  thomas: '01854'
   bioguide: S001168
+  thomas: '01854'
 - name: Ben Ray Luján
   party: minority
   rank: 8
-  thomas: '01939'
   bioguide: L000570
+  thomas: '01939'
 - name: Kurt Schrader
   party: minority
   rank: 9
-  thomas: '01950'
   bioguide: S001180
+  thomas: '01950'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 10
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: Tony Cárdenas
   party: minority
   rank: 11
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Anna G. Eshoo
   party: minority
   rank: 12
-  thomas: '00355'
   bioguide: E000215
+  thomas: '00355'
 - name: Diana DeGette
   party: minority
   rank: 13
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 14
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF16:
 - name: Marsha Blackburn
   party: majority
   rank: 1
   title: Chair
-  thomas: '01748'
   bioguide: B001243
+  thomas: '01748'
 - name: Leonard Lance
   party: majority
   rank: 2
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
   title: Vice Chair
 - name: John Shimkus
   party: majority
   rank: 3
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: Steve Scalise
   party: majority
   rank: 4
-  thomas: '01892'
   bioguide: S001176
+  thomas: '01892'
 - name: Robert E. Latta
   party: majority
   rank: 5
-  thomas: '01885'
   bioguide: L000566
+  thomas: '01885'
 - name: Brett Guthrie
   party: majority
   rank: 6
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: Pete Olson
   party: majority
   rank: 7
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
 - name: Adam Kinzinger
   party: majority
   rank: 8
-  thomas: '02014'
   bioguide: K000378
+  thomas: '02014'
 - name: Gus M. Bilirakis
   party: majority
   rank: 9
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Bill Johnson
   party: majority
   rank: 10
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Billy Long
   party: majority
   rank: 11
-  thomas: '02033'
   bioguide: L000576
+  thomas: '02033'
 - name: Bill Flores
   party: majority
   rank: 12
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Susan W. Brooks
   party: majority
   rank: 13
-  thomas: '02129'
   bioguide: B001284
+  thomas: '02129'
 - name: Chris Collins
   party: majority
   rank: 14
-  thomas: '02151'
   bioguide: C001092
+  thomas: '02151'
 - name: Kevin Cramer
   party: majority
   rank: 15
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Mimi Walters
   party: majority
   rank: 16
-  thomas: '02232'
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
   rank: 17
-  thomas: '02266'
   bioguide: C001106
+  thomas: '02266'
 - name: Greg Walden
   party: majority
   rank: 18
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Michael F. Doyle
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00316'
   bioguide: D000482
+  thomas: '00316'
 - name: Peter Welch
   party: minority
   rank: 2
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Yvette D. Clarke
   party: minority
   rank: 3
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: David Loebsack
   party: minority
   rank: 4
-  thomas: '01846'
   bioguide: L000565
+  thomas: '01846'
 - name: Raul Ruiz
   party: minority
   rank: 5
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Debbie Dingell
   party: minority
   rank: 6
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 - name: Bobby L. Rush
   party: minority
   rank: 7
-  thomas: '01003'
   bioguide: R000515
+  thomas: '01003'
 - name: Anna G. Eshoo
   party: minority
   rank: 8
-  thomas: '00355'
   bioguide: E000215
+  thomas: '00355'
 - name: Eliot L. Engel
   party: minority
   rank: 9
-  thomas: '00344'
   bioguide: E000179
+  thomas: '00344'
 - name: G. K. Butterfield
   party: minority
   rank: 10
-  thomas: '01761'
   bioguide: B001251
+  thomas: '01761'
 - name: Doris O. Matsui
   party: minority
   rank: 11
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Jerry McNerney
   party: minority
   rank: 12
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 13
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF17:
 - name: Robert E. Latta
   party: majority
   rank: 1
   title: Chair
-  thomas: '01885'
   bioguide: L000566
-- name: Gregg Harper
+  thomas: '01885'
+- name: Adam Kinzinger
   party: majority
   rank: 2
-  thomas: '01933'
-  bioguide: H001045
+  bioguide: K000378
+  thomas: '02014'
   title: Vice Chair
 - name: Fred Upton
   party: majority
   rank: 3
-  thomas: '01177'
   bioguide: U000031
+  thomas: '01177'
 - name: Michael C. Burgess
   party: majority
   rank: 4
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Leonard Lance
   party: majority
   rank: 5
-  thomas: '01936'
   bioguide: L000567
+  thomas: '01936'
 - name: Brett Guthrie
   party: majority
   rank: 6
-  thomas: '01922'
   bioguide: G000558
+  thomas: '01922'
 - name: David B. McKinley
   party: majority
   rank: 7
-  thomas: '02074'
   bioguide: M001180
-- name: Adam Kinzinger
-  party: majority
-  rank: 8
-  thomas: '02014'
-  bioguide: K000378
+  thomas: '02074'
 - name: Gus M. Bilirakis
   party: majority
-  rank: 9
-  thomas: '01838'
+  rank: 8
   bioguide: B001257
+  thomas: '01838'
 - name: Larry Bucshon
   party: majority
-  rank: 10
-  thomas: '02018'
+  rank: 9
   bioguide: B001275
+  thomas: '02018'
 - name: Markwayne Mullin
   party: majority
-  rank: 11
-  thomas: '02156'
+  rank: 10
   bioguide: M001190
+  thomas: '02156'
 - name: Mimi Walters
   party: majority
-  rank: 12
-  thomas: '02232'
+  rank: 11
   bioguide: W000820
+  thomas: '02232'
 - name: Ryan A. Costello
   party: majority
-  rank: 13
-  thomas: '02266'
+  rank: 12
   bioguide: C001106
+  thomas: '02266'
+- name: Jeff Duncan
+  party: majority
+  rank: 13
+  bioguide: D000615
+  thomas: '02057'
 - name: Greg Walden
   party: majority
   rank: 14
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Janice D. Schakowsky
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01588'
   bioguide: S001145
+  thomas: '01588'
 - name: Ben Ray Luján
   party: minority
   rank: 2
-  thomas: '01939'
   bioguide: L000570
+  thomas: '01939'
 - name: Yvette D. Clarke
   party: minority
   rank: 3
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Tony Cárdenas
   party: minority
   rank: 4
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Debbie Dingell
   party: minority
   rank: 5
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 - name: Doris O. Matsui
   party: minority
   rank: 6
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Peter Welch
   party: minority
   rank: 7
-  thomas: '01879'
   bioguide: W000800
+  thomas: '01879'
 - name: Joseph P. Kennedy III
   party: minority
   rank: 8
-  thomas: '02172'
   bioguide: K000379
+  thomas: '02172'
 - name: Gene Green
   party: minority
   rank: 9
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 10
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSIF18:
 - name: John Shimkus
   party: majority
   rank: 1
   title: Chair
-  thomas: '01527'
   bioguide: S000364
+  thomas: '01527'
 - name: David B. McKinley
   party: majority
   rank: 2
-  thomas: '02074'
   bioguide: M001180
+  thomas: '02074'
   title: Vice Chair
 - name: Joe Barton
   party: majority
   rank: 3
-  thomas: '00062'
   bioguide: B000213
+  thomas: '00062'
 - name: Marsha Blackburn
   party: majority
   rank: 4
-  thomas: '01748'
   bioguide: B001243
+  thomas: '01748'
 - name: Gregg Harper
   party: majority
   rank: 5
-  thomas: '01933'
   bioguide: H001045
+  thomas: '01933'
 - name: Pete Olson
   party: majority
   rank: 6
-  thomas: '01955'
   bioguide: O000168
+  thomas: '01955'
 - name: Bill Johnson
   party: majority
   rank: 7
-  thomas: '02046'
   bioguide: J000292
+  thomas: '02046'
 - name: Bill Flores
   party: majority
   rank: 8
-  thomas: '02065'
   bioguide: F000461
+  thomas: '02065'
 - name: Richard Hudson
   party: majority
   rank: 9
-  thomas: '02140'
   bioguide: H001067
+  thomas: '02140'
 - name: Kevin Cramer
   party: majority
   rank: 10
-  thomas: '02144'
   bioguide: C001096
+  thomas: '02144'
 - name: Tim Walberg
   party: majority
   rank: 11
-  thomas: '01855'
   bioguide: W000798
+  thomas: '01855'
 - name: Earl L. "Buddy" Carter
   party: majority
   rank: 12
-  thomas: '02236'
   bioguide: C001103
+  thomas: '02236'
+- name: Jeff Duncan
+  party: majority
+  rank: 13
+  bioguide: D000615
+  thomas: '02057'
 - name: Greg Walden
   party: majority
   rank: 14
-  thomas: '01596'
   bioguide: W000791
+  thomas: '01596'
   title: Ex Officio
 - name: Paul Tonko
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Raul Ruiz
   party: minority
   rank: 2
-  thomas: '02109'
   bioguide: R000599
+  thomas: '02109'
 - name: Scott H. Peters
   party: minority
   rank: 3
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Gene Green
   party: minority
   rank: 4
-  thomas: '00462'
   bioguide: G000410
+  thomas: '00462'
 - name: Diana DeGette
   party: minority
   rank: 5
-  thomas: '01479'
   bioguide: D000197
+  thomas: '01479'
 - name: Jerry McNerney
   party: minority
   rank: 6
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Tony Cárdenas
   party: minority
   rank: 7
-  thomas: '02107'
   bioguide: C001097
+  thomas: '02107'
 - name: Debbie Dingell
   party: minority
   rank: 8
-  thomas: '02251'
   bioguide: D000624
+  thomas: '02251'
 - name: Doris O. Matsui
   party: minority
   rank: 9
-  thomas: '01814'
   bioguide: M001163
+  thomas: '01814'
 - name: Frank Pallone, Jr.
   party: minority
   rank: 10
-  thomas: '00887'
   bioguide: P000034
+  thomas: '00887'
   title: Ex Officio
 HSII:
 - name: Rob Bishop
   party: majority
   rank: 1
   title: Chair
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Louie Gohmert
   party: majority
   rank: 3
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Doug Lamborn
   party: majority
   rank: 4
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 5
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Tom McClintock
   party: majority
   rank: 6
-  thomas: '01908'
   bioguide: M001177
+  thomas: '01908'
 - name: Stevan Pearce
   party: majority
   rank: 7
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 8
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Paul A. Gosar
   party: majority
   rank: 9
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Raúl R. Labrador
   party: majority
   rank: 10
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Scott R. Tipton
   party: majority
   rank: 11
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Doug LaMalfa
   party: majority
   rank: 12
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Jeff Denham
   party: majority
   rank: 13
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Paul Cook
   party: majority
   rank: 14
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Bruce Westerman
   party: majority
   rank: 15
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Garret Graves
   party: majority
   rank: 16
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 17
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 18
-  thomas: '02222'
   bioguide: R000600
-- name: Darin LaHood
-  party: majority
-  rank: 19
-  thomas: '02295'
-  bioguide: L000585
+  thomas: '02222'
 - name: Daniel Webster
   party: majority
-  rank: 20
-  thomas: '02002'
+  rank: 19
   bioguide: W000806
+  thomas: '02002'
 - name: Jack Bergman
   party: majority
-  rank: 21
+  rank: 20
   bioguide: B001301
 - name: Liz Cheney
   party: majority
-  rank: 22
+  rank: 21
   bioguide: C001109
 - name: Mike Johnson
   party: majority
-  rank: 23
+  rank: 22
   bioguide: J000299
 - name: Jenniffer González-Colón
   party: majority
-  rank: 24
+  rank: 23
   bioguide: G000582
 - name: Greg Gianforte
   party: majority
-  rank: 25
+  rank: 24
   bioguide: G000584
+- name: John Curtis
+  party: majority
+  rank: 25
+  bioguide: C001114
 - name: Raúl M. Grijalva
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
 - name: Grace F. Napolitano
   party: minority
   rank: 2
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 3
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Jim Costa
   party: minority
   rank: 4
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 5
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Niki Tsongas
   party: minority
   rank: 6
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Jared Huffman
   party: minority
   rank: 7
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 8
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 9
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Norma J. Torres
   party: minority
   rank: 10
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Ruben Gallego
   party: minority
   rank: 11
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Colleen Hanabusa
   party: minority
   rank: 12
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 13
@@ -7813,8 +7869,8 @@ HSII:
 - name: Wm. Lacy Clay
   party: minority
   rank: 17
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Jimmy Gomez
   party: minority
   rank: 18
@@ -7824,78 +7880,73 @@ HSII06:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Doug Lamborn
   party: majority
   rank: 3
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 4
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Stevan Pearce
   party: majority
   rank: 5
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 6
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Scott R. Tipton
   party: majority
   rank: 7
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Paul Cook
   party: majority
   rank: 8
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Garret Graves
   party: majority
   rank: 9
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 10
-  thomas: '02237'
   bioguide: H001071
-- name: Darin LaHood
-  party: majority
-  rank: 11
-  thomas: '02295'
-  bioguide: L000585
+  thomas: '02237'
 - name: Jack Bergman
   party: majority
-  rank: 12
+  rank: 11
   bioguide: B001301
 - name: Liz Cheney
   party: majority
-  rank: 13
+  rank: 12
   bioguide: C001109
 - name: Rob Bishop
   party: majority
   rank: 14
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Alan S. Lowenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Anthony G. Brown
   party: minority
   rank: 2
@@ -7903,23 +7954,23 @@ HSII06:
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Niki Tsongas
   party: minority
   rank: 4
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Jared Huffman
   party: minority
   rank: 5
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Darren Soto
   party: minority
   rank: 7
@@ -7931,100 +7982,95 @@ HSII06:
 - name: Raúl M. Grijalva
   party: minority
   rank: 11
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII10:
 - name: Tom McClintock
   party: majority
   rank: 1
   title: Chair
-  thomas: '01908'
   bioguide: M001177
+  thomas: '01908'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Stevan Pearce
   party: majority
   rank: 3
-  thomas: '01738'
   bioguide: P000588
+  thomas: '01738'
 - name: Glenn Thompson
   party: majority
   rank: 4
-  thomas: '01952'
   bioguide: T000467
+  thomas: '01952'
 - name: Raúl R. Labrador
   party: majority
   rank: 5
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Scott R. Tipton
   party: majority
   rank: 6
-  thomas: '01997'
   bioguide: T000470
+  thomas: '01997'
 - name: Bruce Westerman
   party: majority
   rank: 7
-  thomas: '02224'
   bioguide: W000821
-- name: Darin LaHood
-  party: majority
-  rank: 8
-  thomas: '02295'
-  bioguide: L000585
+  thomas: '02224'
 - name: Daniel Webster
   party: majority
-  rank: 9
-  thomas: '02002'
+  rank: 8
   bioguide: W000806
+  thomas: '02002'
 - name: Jack Bergman
   party: majority
-  rank: 10
+  rank: 9
   bioguide: B001301
 - name: Liz Cheney
   party: majority
-  rank: 11
+  rank: 10
   bioguide: C001109
 - name: Greg Gianforte
   party: majority
-  rank: 12
+  rank: 11
   bioguide: G000584
 - name: Rob Bishop
   party: majority
   rank: 13
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Colleen Hanabusa
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Niki Tsongas
   party: minority
   rank: 2
-  thomas: '01884'
   bioguide: T000465
+  thomas: '01884'
 - name: Alan S. Lowenthal
   party: minority
   rank: 3
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Norma J. Torres
   party: minority
   rank: 4
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Ruben Gallego
   party: minority
   rank: 5
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: A. Donald McEachin
   party: minority
   rank: 6
@@ -8040,56 +8086,56 @@ HSII10:
 - name: Raúl M. Grijalva
   party: minority
   rank: 10
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII13:
 - name: Doug Lamborn
   party: majority
   rank: 1
   title: Chair
-  thomas: '01834'
   bioguide: L000564
+  thomas: '01834'
 - name: Robert J. Wittman
   party: majority
   rank: 2
-  thomas: '01886'
   bioguide: W000804
+  thomas: '01886'
 - name: Tom McClintock
   party: majority
   rank: 3
-  thomas: '01908'
   bioguide: M001177
+  thomas: '01908'
 - name: Paul A. Gosar
   party: majority
   rank: 4
-  thomas: '01992'
   bioguide: G000565
+  thomas: '01992'
 - name: Doug LaMalfa
   party: majority
   rank: 5
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Jeff Denham
   party: majority
   rank: 6
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Garret Graves
   party: majority
   rank: 7
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Jody B. Hice
   party: majority
   rank: 8
-  thomas: '02237'
   bioguide: H001071
+  thomas: '02237'
 - name: Daniel Webster
   party: majority
   rank: 9
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Mike Johnson
   party: majority
   rank: 10
@@ -8101,30 +8147,30 @@ HSII13:
 - name: Rob Bishop
   party: majority
   rank: 12
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Jared Huffman
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Grace F. Napolitano
   party: minority
   rank: 2
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
+  thomas: '01774'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 4
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Nanette Diaz Barragán
   party: minority
   rank: 5
@@ -8132,13 +8178,13 @@ HSII13:
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 6
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Jimmy Gomez
   party: minority
   rank: 8
@@ -8146,31 +8192,31 @@ HSII13:
 - name: Raúl M. Grijalva
   party: minority
   rank: 9
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII15:
 - name: Bruce Westerman
   party: majority
   rank: 1
   title: Chair
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
 - name: Raúl R. Labrador
   party: majority
   rank: 3
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 4
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Mike Johnson
   party: majority
   rank: 5
@@ -8182,8 +8228,8 @@ HSII15:
 - name: Rob Bishop
   party: majority
   rank: 7
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: A. Donald McEachin
   party: minority
@@ -8193,13 +8239,13 @@ HSII15:
 - name: Ruben Gallego
   party: minority
   rank: 2
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Jared Huffman
   party: minority
   rank: 3
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Darren Soto
   party: minority
   rank: 4
@@ -8207,81 +8253,76 @@ HSII15:
 - name: Wm. Lacy Clay
   party: minority
   rank: 5
-  thomas: '01654'
   bioguide: C001049
+  thomas: '01654'
 - name: Raúl M. Grijalva
   party: minority
   rank: 6
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSII24:
 - name: Doug LaMalfa
   party: majority
   rank: 1
   title: Chair
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Jeff Denham
   party: majority
   rank: 3
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Paul Cook
   party: majority
   rank: 4
-  thomas: '02103'
   bioguide: C001094
+  thomas: '02103'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
-- name: Darin LaHood
-  party: majority
-  rank: 6
-  thomas: '02295'
-  bioguide: L000585
+  thomas: '02222'
 - name: Jack Bergman
   party: majority
-  rank: 7
+  rank: 6
   bioguide: B001301
 - name: Jenniffer González-Colón
   party: majority
-  rank: 8
+  rank: 7
   bioguide: G000582
 - name: Rob Bishop
   party: majority
   rank: 9
-  thomas: '01753'
   bioguide: B001250
+  thomas: '01753'
   title: Ex Officio
 - name: Norma J. Torres
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02231'
   bioguide: T000474
+  thomas: '02231'
 - name: Madeleine Z. Bordallo
   party: minority
   rank: 2
-  thomas: '01723'
   bioguide: B001245
+  thomas: '01723'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 3
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Ruben Gallego
   party: minority
   rank: 4
-  thomas: '02226'
   bioguide: G000574
+  thomas: '02226'
 - name: Darren Soto
   party: minority
   rank: 5
@@ -8289,236 +8330,241 @@ HSII24:
 - name: Colleen Hanabusa
   party: minority
   rank: 6
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Raúl M. Grijalva
   party: minority
   rank: 7
-  thomas: '01708'
   bioguide: G000551
+  thomas: '01708'
   title: Ex Officio
 HSJU:
 - name: Bob Goodlatte
   party: majority
   rank: 1
   title: Chair
-  thomas: '00446'
   bioguide: G000289
+  thomas: '00446'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 2
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Lamar Smith
   party: majority
   rank: 3
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Steve Chabot
   party: majority
   rank: 4
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Darrell E. Issa
   party: majority
   rank: 5
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Steve King
   party: majority
   rank: 6
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Louie Gohmert
   party: majority
-  rank: 8
-  thomas: '01801'
+  rank: 7
   bioguide: G000552
+  thomas: '01801'
 - name: Jim Jordan
   party: majority
-  rank: 9
-  thomas: '01868'
+  rank: 8
   bioguide: J000289
+  thomas: '01868'
 - name: Ted Poe
   party: majority
-  rank: 10
-  thomas: '01802'
+  rank: 9
   bioguide: P000592
+  thomas: '01802'
 - name: Tom Marino
   party: majority
-  rank: 11
-  thomas: '02053'
+  rank: 10
   bioguide: M001179
+  thomas: '02053'
 - name: Trey Gowdy
   party: majority
-  rank: 12
-  thomas: '02058'
+  rank: 11
   bioguide: G000566
+  thomas: '02058'
 - name: Raúl R. Labrador
   party: majority
-  rank: 13
-  thomas: '02011'
+  rank: 12
   bioguide: L000573
+  thomas: '02011'
 - name: Blake Farenthold
   party: majority
-  rank: 14
-  thomas: '02067'
+  rank: 13
   bioguide: F000460
+  thomas: '02067'
 - name: Doug Collins
   party: majority
-  rank: 15
-  thomas: '02121'
+  rank: 14
   bioguide: C001093
+  thomas: '02121'
 - name: Ron DeSantis
   party: majority
-  rank: 16
-  thomas: '02116'
+  rank: 15
   bioguide: D000621
+  thomas: '02116'
 - name: Ken Buck
   party: majority
-  rank: 17
-  thomas: '02233'
+  rank: 16
   bioguide: B001297
+  thomas: '02233'
 - name: John Ratcliffe
   party: majority
-  rank: 18
-  thomas: '02268'
+  rank: 17
   bioguide: R000601
+  thomas: '02268'
 - name: Martha Roby
   party: majority
-  rank: 19
-  thomas: '01986'
+  rank: 18
   bioguide: R000591
+  thomas: '01986'
 - name: Matt Gaetz
   party: majority
-  rank: 20
+  rank: 19
   bioguide: G000578
 - name: Mike Johnson
   party: majority
-  rank: 21
+  rank: 20
   bioguide: J000299
 - name: Andy Biggs
   party: majority
-  rank: 22
+  rank: 21
   bioguide: B001302
 - name: John H. Rutherford
   party: majority
-  rank: 23
+  rank: 22
   bioguide: R000609
 - name: Karen C. Handel
   party: majority
-  rank: 24
+  rank: 23
   bioguide: H001078
 - name: Jerrold Nadler
   party: minority
-  rank: 2
-  thomas: '00850'
+  rank: 1
+  title: Ranking Member
   bioguide: N000002
+  thomas: '00850'
 - name: Zoe Lofgren
   party: minority
-  rank: 3
-  thomas: '00701'
+  rank: 2
   bioguide: L000397
+  thomas: '00701'
 - name: Sheila Jackson Lee
   party: minority
-  rank: 4
-  thomas: '00588'
+  rank: 3
   bioguide: J000032
+  thomas: '00588'
 - name: Steve Cohen
   party: minority
-  rank: 5
-  thomas: '01878'
+  rank: 4
   bioguide: C001068
+  thomas: '01878'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
-  rank: 6
-  thomas: '01843'
+  rank: 5
   bioguide: J000288
+  thomas: '01843'
 - name: Theodore E. Deutch
   party: minority
-  rank: 7
-  thomas: '01976'
+  rank: 6
   bioguide: D000610
+  thomas: '01976'
 - name: Luis V. Gutiérrez
   party: minority
-  rank: 8
-  thomas: '00478'
+  rank: 7
   bioguide: G000535
+  thomas: '00478'
 - name: Karen Bass
   party: minority
-  rank: 9
-  thomas: '01996'
+  rank: 8
   bioguide: B001270
+  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
-  rank: 10
-  thomas: '02023'
+  rank: 9
   bioguide: R000588
+  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
-  rank: 11
-  thomas: '02149'
+  rank: 10
   bioguide: J000294
+  thomas: '02149'
 - name: David N. Cicilline
   party: minority
-  rank: 12
-  thomas: '02055'
+  rank: 11
   bioguide: C001084
+  thomas: '02055'
 - name: Eric Swalwell
   party: minority
-  rank: 13
-  thomas: '02104'
+  rank: 12
   bioguide: S001193
+  thomas: '02104'
 - name: Ted Lieu
   party: minority
-  rank: 14
-  thomas: '02230'
+  rank: 13
   bioguide: L000582
+  thomas: '02230'
 - name: Jamie Raskin
   party: minority
-  rank: 15
+  rank: 14
   bioguide: R000606
 - name: Pramila Jayapal
   party: minority
-  rank: 16
+  rank: 15
   bioguide: J000298
 - name: Bradley Scott Schneider
   party: minority
-  rank: 17
-  thomas: '02124'
+  rank: 16
   bioguide: S001190
+  thomas: '02124'
+- name: Val Butler Demings
+  party: minority
+  rank: 17
+  bioguide: D000627
 HSJU01:
 - name: Raúl R. Labrador
   party: majority
   rank: 1
   title: Chair
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 2
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Lamar Smith
   party: majority
   rank: 3
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Steve King
   party: majority
   rank: 4
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Jim Jordan
   party: majority
   rank: 5
-  thomas: '01868'
   bioguide: J000289
+  thomas: '01868'
 - name: Ken Buck
   party: majority
   rank: 6
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: Mike Johnson
   party: majority
   rank: 7
@@ -8531,13 +8577,13 @@ HSJU01:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Luis V. Gutiérrez
   party: minority
   rank: 2
-  thomas: '00478'
   bioguide: G000535
+  thomas: '00478'
 - name: Pramila Jayapal
   party: minority
   rank: 3
@@ -8545,66 +8591,70 @@ HSJU01:
 - name: Sheila Jackson Lee
   party: minority
   rank: 4
-  thomas: '00588'
   bioguide: J000032
-- name: David N. Cicilline
+  thomas: '00588'
+- name: Jamie Raskin
   party: minority
   rank: 5
-  thomas: '02055'
-  bioguide: C001084
+  bioguide: R000606
 HSJU03:
 - name: Darrell E. Issa
   party: majority
   rank: 1
   title: Chair
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Doug Collins
   party: majority
   rank: 2
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
   title: Vice Chair
 - name: Lamar Smith
   party: majority
   rank: 3
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Steve Chabot
   party: majority
   rank: 4
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Jim Jordan
   party: majority
-  rank: 6
-  thomas: '01868'
+  rank: 5
   bioguide: J000289
+  thomas: '01868'
 - name: Ted Poe
   party: majority
-  rank: 7
-  thomas: '01802'
+  rank: 6
   bioguide: P000592
+  thomas: '01802'
 - name: Tom Marino
   party: majority
-  rank: 8
-  thomas: '02053'
+  rank: 7
   bioguide: M001179
+  thomas: '02053'
+- name: Trey Gowdy
+  party: majority
+  rank: 8
+  bioguide: G000566
+  thomas: '02058'
 - name: Raúl R. Labrador
   party: majority
   rank: 9
-  thomas: '02011'
   bioguide: L000573
+  thomas: '02011'
 - name: Blake Farenthold
   party: majority
   rank: 10
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Ron DeSantis
   party: majority
   rank: 11
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
 - name: Matt Gaetz
   party: majority
   rank: 12
@@ -8613,105 +8663,99 @@ HSJU03:
   party: majority
   rank: 13
   bioguide: B001302
-- name: Trey Gowdy
-  party: majority
-  rank: 14
-  thomas: '02058'
-  bioguide: G000566
-- name: Jerrold Nadler
+- name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00850'
-  bioguide: N000002
-- name: Henry C. "Hank" Johnson, Jr.
-  party: minority
-  rank: 2
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Theodore E. Deutch
   party: minority
-  rank: 3
-  thomas: '01976'
+  rank: 2
   bioguide: D000610
+  thomas: '01976'
 - name: Karen Bass
   party: minority
-  rank: 4
-  thomas: '01996'
+  rank: 3
   bioguide: B001270
+  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
-  rank: 5
-  thomas: '02023'
+  rank: 4
   bioguide: R000588
+  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
-  rank: 6
-  thomas: '02149'
+  rank: 5
   bioguide: J000294
+  thomas: '02149'
 - name: Eric Swalwell
   party: minority
-  rank: 7
-  thomas: '02104'
+  rank: 6
   bioguide: S001193
+  thomas: '02104'
 - name: Ted Lieu
   party: minority
-  rank: 8
-  thomas: '02230'
+  rank: 7
   bioguide: L000582
+  thomas: '02230'
 - name: Bradley Scott Schneider
   party: minority
-  rank: 9
-  thomas: '02124'
+  rank: 8
   bioguide: S001190
+  thomas: '02124'
 - name: Zoe Lofgren
   party: minority
-  rank: 10
-  thomas: '00701'
+  rank: 9
   bioguide: L000397
+  thomas: '00701'
 - name: Steve Cohen
   party: minority
-  rank: 11
-  thomas: '01878'
+  rank: 10
   bioguide: C001068
-- name: Luis V. Gutiérrez
+  thomas: '01878'
+- name: David N. Cicilline
+  party: minority
+  rank: 11
+  bioguide: C001084
+  thomas: '02055'
+- name: Pramila Jayapal
   party: minority
   rank: 12
-  thomas: '00478'
-  bioguide: G000535
+  bioguide: J000298
 HSJU05:
 - name: Tom Marino
   party: majority
   rank: 1
   title: Chair
-  thomas: '02053'
   bioguide: M001179
+  thomas: '02053'
 - name: Blake Farenthold
   party: majority
   rank: 2
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
   title: Vice Chair
 - name: Darrell E. Issa
   party: majority
   rank: 3
-  thomas: '01640'
   bioguide: I000056
+  thomas: '01640'
 - name: Doug Collins
   party: majority
   rank: 4
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
 - name: Ken Buck
   party: majority
   rank: 5
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: John Ratcliffe
   party: majority
   rank: 6
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Matt Gaetz
   party: majority
   rank: 7
@@ -8724,65 +8768,65 @@ HSJU05:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02055'
   bioguide: C001084
+  thomas: '02055'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 2
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Eric Swalwell
   party: minority
   rank: 3
-  thomas: '02104'
   bioguide: S001193
-- name: Pramila Jayapal
-  party: minority
-  rank: 4
-  bioguide: J000298
+  thomas: '02104'
 - name: Bradley Scott Schneider
   party: minority
-  rank: 5
-  thomas: '02124'
+  rank: 4
   bioguide: S001190
+  thomas: '02124'
+- name: Val Butler Demings
+  party: minority
+  rank: 5
+  bioguide: D000627
 HSJU08:
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 1
   title: Chair
-  thomas: '01041'
   bioguide: S000244
+  thomas: '01041'
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
+  thomas: '01801'
   title: Vice Chair
 - name: Steve Chabot
   party: majority
   rank: 3
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Ted Poe
   party: majority
   rank: 4
-  thomas: '01802'
   bioguide: P000592
+  thomas: '01802'
 - name: Trey Gowdy
   party: majority
   rank: 5
-  thomas: '02058'
   bioguide: G000566
+  thomas: '02058'
 - name: John Ratcliffe
   party: majority
   rank: 6
-  thomas: '02268'
   bioguide: R000601
+  thomas: '02268'
 - name: Martha Roby
   party: majority
   rank: 7
-  thomas: '01986'
   bioguide: R000591
+  thomas: '01986'
 - name: Mike Johnson
   party: majority
   rank: 8
@@ -8795,33 +8839,32 @@ HSJU08:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00588'
   bioguide: J000032
-- name: Theodore E. Deutch
+  thomas: '00588'
+- name: Val Butler Demings
   party: minority
   rank: 2
-  thomas: '01976'
-  bioguide: D000610
+  bioguide: D000627
 - name: Karen Bass
   party: minority
   rank: 3
-  thomas: '01996'
   bioguide: B001270
+  thomas: '01996'
 - name: Cedric L. Richmond
   party: minority
   rank: 4
-  thomas: '02023'
   bioguide: R000588
+  thomas: '02023'
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
-  thomas: '02149'
   bioguide: J000294
+  thomas: '02149'
 - name: Ted Lieu
   party: minority
   rank: 6
-  thomas: '02230'
   bioguide: L000582
+  thomas: '02230'
 - name: Jamie Raskin
   party: minority
   rank: 7
@@ -8831,181 +8874,181 @@ HSJU10:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Ron DeSantis
   party: majority
   rank: 2
-  thomas: '02116'
   bioguide: D000621
+  thomas: '02116'
   title: Vice Chair
 - name: Louie Gohmert
   party: majority
-  rank: 4
-  thomas: '01801'
+  rank: 3
   bioguide: G000552
+  thomas: '01801'
 - name: Karen C. Handel
   party: majority
-  rank: 5
+  rank: 4
   bioguide: H001078
 - name: Steve Cohen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Jamie Raskin
   party: minority
   rank: 2
   bioguide: R000606
-- name: Jerrold Nadler
+- name: Theodore E. Deutch
   party: minority
   rank: 3
-  thomas: '00850'
-  bioguide: N000002
+  bioguide: D000610
+  thomas: '01976'
 HSPW:
 - name: Bill Shuster
   party: majority
   rank: 1
   title: Chair
-  thomas: '01681'
   bioguide: S001154
+  thomas: '01681'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
   title: Vice Chair
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Sam Graves
   party: majority
   rank: 5
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Duncan Hunter
   party: majority
   rank: 6
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 7
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Lou Barletta
   party: majority
   rank: 8
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 9
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 10
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 11
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jeff Denham
   party: majority
   rank: 12
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 13
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 14
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 15
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 16
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 17
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 18
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 19
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 20
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 21
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Garret Graves
   party: majority
   rank: 22
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Barbara Comstock
   party: majority
   rank: 23
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: David Rouzer
   party: majority
   rank: 24
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 25
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 26
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Doug LaMalfa
   party: majority
   rank: 27
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 28
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 29
@@ -9034,215 +9077,215 @@ HSPW:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00279'
   bioguide: D000191
+  thomas: '00279'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 2
-  thomas: '00868'
   bioguide: N000147
-- name: Jerrold Nadler
-  party: minority
-  rank: 3
-  thomas: '00850'
-  bioguide: N000002
+  thomas: '00868'
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 4
-  thomas: '00599'
+  rank: 3
   bioguide: J000126
+  thomas: '00599'
 - name: Elijah E. Cummings
   party: minority
-  rank: 5
-  thomas: '00256'
+  rank: 4
   bioguide: C000984
+  thomas: '00256'
 - name: Rick Larsen
   party: minority
-  rank: 6
-  thomas: '01675'
+  rank: 5
   bioguide: L000560
+  thomas: '01675'
 - name: Michael E. Capuano
   party: minority
-  rank: 7
-  thomas: '01564'
+  rank: 6
   bioguide: C001037
+  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
-  rank: 8
-  thomas: '01602'
+  rank: 7
   bioguide: N000179
+  thomas: '01602'
 - name: Daniel Lipinski
   party: minority
-  rank: 9
-  thomas: '01781'
+  rank: 8
   bioguide: L000563
+  thomas: '01781'
 - name: Steve Cohen
   party: minority
-  rank: 10
-  thomas: '01878'
+  rank: 9
   bioguide: C001068
+  thomas: '01878'
 - name: Albio Sires
   party: minority
-  rank: 11
-  thomas: '01818'
+  rank: 10
   bioguide: S001165
+  thomas: '01818'
 - name: John Garamendi
   party: minority
-  rank: 12
-  thomas: '01973'
+  rank: 11
   bioguide: G000559
+  thomas: '01973'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
-  rank: 13
-  thomas: '01843'
+  rank: 12
   bioguide: J000288
+  thomas: '01843'
 - name: André Carson
   party: minority
-  rank: 14
-  thomas: '01889'
+  rank: 13
   bioguide: C001072
+  thomas: '01889'
 - name: Richard M. Nolan
   party: minority
-  rank: 15
-  thomas: '00867'
+  rank: 14
   bioguide: N000127
+  thomas: '00867'
 - name: Dina Titus
   party: minority
-  rank: 16
-  thomas: '01940'
+  rank: 15
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
-  rank: 17
-  thomas: '02150'
+  rank: 16
   bioguide: M001185
+  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
-  rank: 18
-  thomas: '02114'
+  rank: 17
   bioguide: E000293
+  thomas: '02114'
 - name: Lois Frankel
   party: minority
-  rank: 19
-  thomas: '02119'
+  rank: 18
   bioguide: F000462
+  thomas: '02119'
 - name: Cheri Bustos
   party: minority
-  rank: 20
-  thomas: '02127'
+  rank: 19
   bioguide: B001286
+  thomas: '02127'
 - name: Jared Huffman
   party: minority
-  rank: 21
-  thomas: '02101'
+  rank: 20
   bioguide: H001068
+  thomas: '02101'
 - name: Julia Brownley
   party: minority
-  rank: 22
-  thomas: '02106'
+  rank: 21
   bioguide: B001285
+  thomas: '02106'
 - name: Frederica S. Wilson
   party: minority
-  rank: 23
-  thomas: '02004'
+  rank: 22
   bioguide: W000808
+  thomas: '02004'
 - name: Donald M. Payne, Jr.
   party: minority
-  rank: 24
-  thomas: '02097'
+  rank: 23
   bioguide: P000604
+  thomas: '02097'
 - name: Alan S. Lowenthal
   party: minority
-  rank: 25
-  thomas: '02111'
+  rank: 24
   bioguide: L000579
+  thomas: '02111'
 - name: Brenda L. Lawrence
   party: minority
-  rank: 26
-  thomas: '02252'
+  rank: 25
   bioguide: L000581
+  thomas: '02252'
 - name: Mark DeSaulnier
   party: minority
-  rank: 27
-  thomas: '02227'
+  rank: 26
   bioguide: D000623
+  thomas: '02227'
+- name: Stacey E. Plaskett
+  party: minority
+  rank: 27
+  bioguide: P000610
+  thomas: '02274'
 HSPW02:
 - name: Garret Graves
   party: majority
   rank: 1
   title: Chair
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Bob Gibbs
   party: majority
   rank: 3
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 4
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Thomas Massie
   party: majority
   rank: 5
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Rodney Davis
   party: majority
   rank: 6
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 7
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 8
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 9
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 10
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 11
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: David Rouzer
   party: majority
   rank: 12
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 13
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 14
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Doug LaMalfa
   party: majority
   rank: 15
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: A. Drew Ferguson IV
   party: majority
   rank: 16
@@ -9255,165 +9298,165 @@ HSPW02:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Lois Frankel
   party: minority
   rank: 2
-  thomas: '02119'
   bioguide: F000462
+  thomas: '02119'
 - name: Frederica S. Wilson
   party: minority
   rank: 3
-  thomas: '02004'
   bioguide: W000808
+  thomas: '02004'
 - name: Jared Huffman
   party: minority
   rank: 4
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: John Garamendi
   party: minority
   rank: 7
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Dina Titus
   party: minority
   rank: 8
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 9
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
   rank: 10
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Cheri Bustos
   party: minority
   rank: 11
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Julia Brownley
   party: minority
   rank: 12
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Brenda L. Lawrence
   party: minority
   rank: 13
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 HSPW05:
 - name: Frank A. LoBiondo
   party: majority
   rank: 1
   title: Chair
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Sam Graves
   party: majority
   rank: 4
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Duncan Hunter
   party: majority
   rank: 5
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Blake Farenthold
   party: majority
   rank: 6
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 7
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Daniel Webster
   party: majority
   rank: 8
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jeff Denham
   party: majority
   rank: 9
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 10
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 11
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 12
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 13
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Mark Sanford
   party: majority
   rank: 14
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Rob Woodall
   party: majority
   rank: 15
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Todd Rokita
   party: majority
   rank: 16
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: Barbara Comstock
   party: majority
   rank: 17
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Doug LaMalfa
   party: majority
   rank: 18
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 19
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Paul Mitchell
   party: majority
   rank: 20
@@ -9426,115 +9469,115 @@ HSPW05:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 2
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: André Carson
   party: minority
   rank: 4
-  thomas: '01889'
   bioguide: C001072
+  thomas: '01889'
 - name: Cheri Bustos
   party: minority
   rank: 5
-  thomas: '02127'
   bioguide: B001286
+  thomas: '02127'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 6
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Dina Titus
   party: minority
   rank: 7
-  thomas: '01940'
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
   rank: 8
-  thomas: '02150'
   bioguide: M001185
+  thomas: '02150'
 - name: Julia Brownley
   party: minority
   rank: 9
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 10
-  thomas: '02097'
   bioguide: P000604
+  thomas: '02097'
 - name: Brenda L. Lawrence
   party: minority
   rank: 11
-  thomas: '02252'
   bioguide: L000581
+  thomas: '02252'
 - name: Michael E. Capuano
   party: minority
   rank: 12
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
   rank: 13
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Steve Cohen
   party: minority
   rank: 14
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 15
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Richard M. Nolan
   party: minority
   rank: 16
-  thomas: '00867'
   bioguide: N000127
+  thomas: '00867'
 HSPW07:
 - name: Duncan Hunter
   party: majority
   rank: 1
   title: Chair
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: Frank A. LoBiondo
   party: majority
   rank: 3
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Garret Graves
   party: majority
   rank: 4
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: David Rouzer
   party: majority
   rank: 5
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 6
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Brian J. Mast
   party: majority
   rank: 7
@@ -9547,150 +9590,150 @@ HSPW07:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01973'
   bioguide: G000559
+  thomas: '01973'
 - name: Elijah E. Cummings
   party: minority
   rank: 2
-  thomas: '00256'
   bioguide: C000984
+  thomas: '00256'
 - name: Rick Larsen
   party: minority
   rank: 3
-  thomas: '01675'
   bioguide: L000560
+  thomas: '01675'
 - name: Jared Huffman
   party: minority
   rank: 4
-  thomas: '02101'
   bioguide: H001068
+  thomas: '02101'
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
-  thomas: '02111'
   bioguide: L000579
+  thomas: '02111'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 6
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 HSPW12:
 - name: Sam Graves
   party: majority
   rank: 1
   title: Chair
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
+  thomas: '01256'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 3
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Frank A. LoBiondo
   party: majority
   rank: 4
-  thomas: '00699'
   bioguide: L000554
+  thomas: '00699'
 - name: Duncan Hunter
   party: majority
   rank: 5
-  thomas: '01909'
   bioguide: H001048
+  thomas: '01909'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 6
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Lou Barletta
   party: majority
   rank: 7
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 8
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Bob Gibbs
   party: majority
   rank: 9
-  thomas: '02049'
   bioguide: G000563
+  thomas: '02049'
 - name: Jeff Denham
   party: majority
   rank: 10
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: Thomas Massie
   party: majority
   rank: 11
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Mark Meadows
   party: majority
   rank: 12
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 13
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Rodney Davis
   party: majority
   rank: 14
-  thomas: '02126'
   bioguide: D000619
+  thomas: '02126'
 - name: Rob Woodall
   party: majority
   rank: 15
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: John Katko
   party: majority
   rank: 16
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 17
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Garret Graves
   party: majority
   rank: 18
-  thomas: '02245'
   bioguide: G000577
+  thomas: '02245'
 - name: Barbara Comstock
   party: majority
   rank: 19
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: David Rouzer
   party: majority
   rank: 20
-  thomas: '02256'
   bioguide: R000603
+  thomas: '02256'
 - name: Mike Bost
   party: majority
   rank: 21
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Doug LaMalfa
   party: majority
   rank: 22
-  thomas: '02100'
   bioguide: L000578
+  thomas: '02100'
 - name: Bruce Westerman
   party: majority
   rank: 23
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 24
@@ -9711,130 +9754,125 @@ HSPW12:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00868'
   bioguide: N000147
-- name: Jerrold Nadler
-  party: minority
-  rank: 2
-  thomas: '00850'
-  bioguide: N000002
+  thomas: '00868'
 - name: Steve Cohen
   party: minority
-  rank: 3
-  thomas: '01878'
+  rank: 2
   bioguide: C001068
+  thomas: '01878'
 - name: Albio Sires
   party: minority
-  rank: 4
-  thomas: '01818'
+  rank: 3
   bioguide: S001165
+  thomas: '01818'
 - name: Richard M. Nolan
   party: minority
-  rank: 5
-  thomas: '00867'
+  rank: 4
   bioguide: N000127
+  thomas: '00867'
 - name: Dina Titus
   party: minority
-  rank: 6
-  thomas: '01940'
+  rank: 5
   bioguide: T000468
+  thomas: '01940'
 - name: Sean Patrick Maloney
   party: minority
-  rank: 7
-  thomas: '02150'
+  rank: 6
   bioguide: M001185
+  thomas: '02150'
 - name: Elizabeth H. Esty
   party: minority
-  rank: 8
-  thomas: '02114'
+  rank: 7
   bioguide: E000293
+  thomas: '02114'
 - name: Jared Huffman
   party: minority
-  rank: 9
-  thomas: '02101'
+  rank: 8
   bioguide: H001068
+  thomas: '02101'
 - name: Julia Brownley
   party: minority
-  rank: 10
-  thomas: '02106'
+  rank: 9
   bioguide: B001285
+  thomas: '02106'
 - name: Alan S. Lowenthal
   party: minority
-  rank: 11
-  thomas: '02111'
+  rank: 10
   bioguide: L000579
+  thomas: '02111'
 - name: Brenda L. Lawrence
   party: minority
-  rank: 12
-  thomas: '02252'
+  rank: 11
   bioguide: L000581
+  thomas: '02252'
 - name: Mark DeSaulnier
   party: minority
-  rank: 13
-  thomas: '02227'
+  rank: 12
   bioguide: D000623
+  thomas: '02227'
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 14
-  thomas: '00599'
+  rank: 13
   bioguide: J000126
+  thomas: '00599'
 - name: Michael E. Capuano
   party: minority
-  rank: 15
-  thomas: '01564'
+  rank: 14
   bioguide: C001037
+  thomas: '01564'
 - name: Grace F. Napolitano
   party: minority
-  rank: 16
-  thomas: '01602'
+  rank: 15
   bioguide: N000179
+  thomas: '01602'
 - name: Daniel Lipinski
   party: minority
-  rank: 17
-  thomas: '01781'
+  rank: 16
   bioguide: L000563
+  thomas: '01781'
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
-  rank: 18
-  thomas: '01843'
+  rank: 17
   bioguide: J000288
+  thomas: '01843'
 - name: Lois Frankel
   party: minority
-  rank: 19
-  thomas: '02119'
+  rank: 18
   bioguide: F000462
+  thomas: '02119'
 - name: Cheri Bustos
   party: minority
-  rank: 20
-  thomas: '02127'
+  rank: 19
   bioguide: B001286
+  thomas: '02127'
 - name: Frederica S. Wilson
   party: minority
-  rank: 21
-  thomas: '02004'
+  rank: 20
   bioguide: W000808
+  thomas: '02004'
 HSPW13:
 - name: Lou Barletta
   party: majority
   rank: 1
   title: Chair
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
-  thomas: '01989'
   bioguide: C001087
+  thomas: '01989'
 - name: Barbara Comstock
   party: majority
   rank: 3
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Mike Bost
   party: majority
   rank: 4
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Lloyd Smucker
   party: majority
   rank: 5
@@ -9855,100 +9893,100 @@ HSPW13:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01843'
   bioguide: J000288
+  thomas: '01843'
 - name: Eleanor Holmes Norton
   party: minority
   rank: 2
-  thomas: '00868'
   bioguide: N000147
+  thomas: '00868'
 - name: Albio Sires
   party: minority
   rank: 3
-  thomas: '01818'
   bioguide: S001165
+  thomas: '01818'
 - name: Grace F. Napolitano
   party: minority
   rank: 4
-  thomas: '01602'
   bioguide: N000179
+  thomas: '01602'
 - name: Michael E. Capuano
   party: minority
   rank: 5
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 HSPW14:
 - name: Jeff Denham
   party: majority
   rank: 1
   title: Chair
-  thomas: '01995'
   bioguide: D000612
+  thomas: '01995'
 - name: John J. Duncan, Jr.
   party: majority
   rank: 2
-  thomas: '00322'
   bioguide: D000533
+  thomas: '00322'
 - name: Sam Graves
   party: majority
   rank: 3
-  thomas: '01656'
   bioguide: G000546
+  thomas: '01656'
 - name: Lou Barletta
   party: majority
   rank: 4
-  thomas: '02054'
   bioguide: B001269
+  thomas: '02054'
 - name: Blake Farenthold
   party: majority
   rank: 5
-  thomas: '02067'
   bioguide: F000460
+  thomas: '02067'
 - name: Daniel Webster
   party: majority
   rank: 6
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Mark Meadows
   party: majority
   rank: 7
-  thomas: '02142'
   bioguide: M001187
+  thomas: '02142'
 - name: Scott Perry
   party: majority
   rank: 8
-  thomas: '02157'
   bioguide: P000605
+  thomas: '02157'
 - name: Mark Sanford
   party: majority
   rank: 9
-  thomas: '01012'
   bioguide: S000051
+  thomas: '01012'
 - name: Todd Rokita
   party: majority
   rank: 10
-  thomas: '02017'
   bioguide: R000592
+  thomas: '02017'
 - name: John Katko
   party: majority
   rank: 11
-  thomas: '02264'
   bioguide: K000386
+  thomas: '02264'
 - name: Brian Babin
   party: majority
   rank: 12
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 13
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Bruce Westerman
   party: majority
   rank: 14
-  thomas: '02224'
   bioguide: W000821
+  thomas: '02224'
 - name: Lloyd Smucker
   party: majority
   rank: 15
@@ -9969,115 +10007,110 @@ HSPW14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01564'
   bioguide: C001037
+  thomas: '01564'
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 2
-  thomas: '02097'
   bioguide: P000604
-- name: Jerrold Nadler
-  party: minority
-  rank: 3
-  thomas: '00850'
-  bioguide: N000002
+  thomas: '02097'
 - name: Elijah E. Cummings
   party: minority
-  rank: 4
-  thomas: '00256'
+  rank: 3
   bioguide: C000984
+  thomas: '00256'
 - name: Steve Cohen
   party: minority
-  rank: 5
-  thomas: '01878'
+  rank: 4
   bioguide: C001068
+  thomas: '01878'
 - name: Albio Sires
   party: minority
-  rank: 6
-  thomas: '01818'
+  rank: 5
   bioguide: S001165
+  thomas: '01818'
 - name: John Garamendi
   party: minority
-  rank: 7
-  thomas: '01973'
+  rank: 6
   bioguide: G000559
+  thomas: '01973'
 - name: André Carson
   party: minority
-  rank: 8
-  thomas: '01889'
+  rank: 7
   bioguide: C001072
+  thomas: '01889'
 - name: Richard M. Nolan
   party: minority
-  rank: 9
-  thomas: '00867'
+  rank: 8
   bioguide: N000127
+  thomas: '00867'
 - name: Elizabeth H. Esty
   party: minority
-  rank: 10
-  thomas: '02114'
+  rank: 9
   bioguide: E000293
+  thomas: '02114'
 - name: Cheri Bustos
   party: minority
-  rank: 11
-  thomas: '02127'
+  rank: 10
   bioguide: B001286
+  thomas: '02127'
 - name: Frederica S. Wilson
   party: minority
-  rank: 12
-  thomas: '02004'
+  rank: 11
   bioguide: W000808
+  thomas: '02004'
 - name: Mark DeSaulnier
   party: minority
-  rank: 13
-  thomas: '02227'
+  rank: 12
   bioguide: D000623
+  thomas: '02227'
 - name: Daniel Lipinski
   party: minority
-  rank: 14
-  thomas: '01781'
+  rank: 13
   bioguide: L000563
+  thomas: '01781'
 HSRU:
 - name: Pete Sessions
   party: majority
   rank: 1
   title: Chair
-  thomas: '01525'
   bioguide: S000250
+  thomas: '01525'
 - name: Tom Cole
   party: majority
   rank: 2
-  thomas: '01742'
   bioguide: C001053
+  thomas: '01742'
 - name: Rob Woodall
   party: majority
   rank: 3
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Michael C. Burgess
   party: majority
   rank: 4
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Doug Collins
   party: majority
   rank: 5
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
 - name: Bradley Byrne
   party: majority
   rank: 6
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Dan Newhouse
   party: majority
   rank: 7
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: Ken Buck
   party: majority
   rank: 8
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: Liz Cheney
   party: majority
   rank: 9
@@ -10086,78 +10119,78 @@ HSRU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01069'
   bioguide: S000480
+  thomas: '01069'
 - name: James P. McGovern
   party: minority
   rank: 2
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 - name: Alcee L. Hastings
   party: minority
   rank: 3
-  thomas: '00511'
   bioguide: H000324
+  thomas: '00511'
 - name: Jared Polis
   party: minority
   rank: 4
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 HSRU02:
 - name: Rob Woodall
   party: majority
   rank: 1
   title: Chair
-  thomas: '02008'
   bioguide: W000810
+  thomas: '02008'
 - name: Michael C. Burgess
   party: majority
   rank: 2
-  thomas: '01751'
   bioguide: B001248
+  thomas: '01751'
 - name: Bradley Byrne
   party: majority
   rank: 3
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Dan Newhouse
   party: majority
   rank: 4
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: Ken Buck
   party: majority
   rank: 5
-  thomas: '02233'
   bioguide: B001297
+  thomas: '02233'
 - name: Alcee L. Hastings
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00511'
   bioguide: H000324
+  thomas: '00511'
 - name: Jared Polis
   party: minority
   rank: 2
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 HSRU04:
 - name: Doug Collins
   party: majority
   rank: 1
   title: Chair
-  thomas: '02121'
   bioguide: C001093
+  thomas: '02121'
 - name: Bradley Byrne
   party: majority
   rank: 2
-  thomas: '02197'
   bioguide: B001289
+  thomas: '02197'
 - name: Dan Newhouse
   party: majority
   rank: 3
-  thomas: '02275'
   bioguide: N000189
+  thomas: '02275'
 - name: Liz Cheney
   party: majority
   rank: 4
@@ -10165,61 +10198,61 @@ HSRU04:
 - name: Pete Sessions
   party: majority
   rank: 5
-  thomas: '01525'
   bioguide: S000250
+  thomas: '01525'
 - name: Louise McIntosh Slaughter
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01069'
   bioguide: S000480
+  thomas: '01069'
 - name: James P. McGovern
   party: minority
   rank: 2
-  thomas: '01504'
   bioguide: M000312
+  thomas: '01504'
 HSSM:
 - name: Steve Chabot
   party: majority
   rank: 1
   title: Chair
-  thomas: '00186'
   bioguide: C000266
+  thomas: '00186'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Dave Brat
   party: majority
   rank: 4
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Stephen Knight
   party: majority
   rank: 6
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 7
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Rod Blum
   party: majority
   rank: 8
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: James Comer
   party: majority
   rank: 9
@@ -10228,28 +10261,28 @@ HSSM:
   party: majority
   rank: 10
   bioguide: G000582
-- name: Don Bacon
-  party: majority
-  rank: 11
-  bioguide: B001298
 - name: Brian K. Fitzpatrick
   party: majority
-  rank: 12
+  rank: 11
   bioguide: F000466
 - name: Roger W. Marshall
   party: majority
-  rank: 13
+  rank: 12
   bioguide: M001198
 - name: Ralph Norman
   party: majority
-  rank: 14
+  rank: 13
   bioguide: N000190
+- name: John Curtis
+  party: majority
+  rank: 14
+  bioguide: C001114
 - name: Nydia M. Velázquez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01184'
   bioguide: V000081
+  thomas: '01184'
 - name: Dwight Evans
   party: minority
   rank: 2
@@ -10265,18 +10298,18 @@ HSSM:
 - name: Yvette D. Clarke
   party: minority
   rank: 5
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Judy Chu
   party: minority
   rank: 6
-  thomas: '01970'
   bioguide: C001080
+  thomas: '01970'
 - name: Alma S. Adams
   party: minority
   rank: 7
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 - name: Adriano Espaillat
   party: minority
   rank: 8
@@ -10284,20 +10317,20 @@ HSSM:
 - name: Bradley Scott Schneider
   party: minority
   rank: 9
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 HSSM23:
 - name: Stephen Knight
   party: majority
   rank: 1
   title: Chair
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: James Comer
   party: majority
   rank: 3
@@ -10314,8 +10347,8 @@ HSSM23:
 - name: Yvette D. Clarke
   party: minority
   rank: 2
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Dwight Evans
   party: minority
   rank: 3
@@ -10329,67 +10362,67 @@ HSSM24:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Rod Blum
   party: majority
   rank: 2
-  thomas: '02241'
   bioguide: B001294
-- name: Don Bacon
-  party: majority
-  rank: 3
-  bioguide: B001298
+  thomas: '02241'
 - name: Roger W. Marshall
   party: majority
-  rank: 4
+  rank: 3
   bioguide: M001198
 - name: Ralph Norman
   party: majority
-  rank: 5
+  rank: 4
   bioguide: N000190
+- name: John Curtis
+  party: majority
+  rank: 5
+  bioguide: C001114
 - name: Alma S. Adams
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02201'
   bioguide: A000370
+  thomas: '02201'
 HSSM25:
 - name: Rod Blum
   party: majority
   rank: 1
   title: Chair
-  thomas: '02241'
   bioguide: B001294
+  thomas: '02241'
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
+  thomas: '01724'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 4
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: James Comer
   party: majority
   rank: 5
   bioguide: C001108
-- name: Don Bacon
+- name: John Curtis
   party: majority
   rank: 6
-  bioguide: B001298
+  bioguide: C001114
 - name: Bradley Scott Schneider
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02124'
   bioguide: S001190
+  thomas: '02124'
 - name: Al Lawson, Jr.
   party: minority
   rank: 2
@@ -10399,18 +10432,18 @@ HSSM26:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Blaine Luetkemeyer
   party: majority
   rank: 2
-  thomas: '01931'
   bioguide: L000569
+  thomas: '01931'
 - name: Dave Brat
   party: majority
   rank: 3
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Jenniffer González-Colón
   party: majority
   rank: 4
@@ -10437,18 +10470,18 @@ HSSM27:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02203'
   bioguide: B001290
+  thomas: '02203'
 - name: Stephen Knight
   party: majority
   rank: 2
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Trent Kelly
   party: majority
   rank: 3
-  thomas: '02294'
   bioguide: K000388
+  thomas: '02294'
 - name: Jenniffer González-Colón
   party: majority
   rank: 4
@@ -10465,8 +10498,8 @@ HSSM27:
 - name: Judy Chu
   party: minority
   rank: 2
-  thomas: '01970'
   bioguide: C001080
+  thomas: '01970'
 - name: Stephanie N. Murphy
   party: minority
   rank: 3
@@ -10474,51 +10507,51 @@ HSSM27:
 - name: Yvette D. Clarke
   party: minority
   rank: 4
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 HSSO:
 - name: Susan W. Brooks
   party: majority
   rank: 1
   title: Chair
-  thomas: '02129'
   bioguide: B001284
-- name: Patrick Meehan
-  party: majority
-  rank: 2
-  thomas: '02052'
-  bioguide: M001181
-- name: Trey Gowdy
-  party: majority
-  rank: 3
-  thomas: '02058'
-  bioguide: G000566
+  thomas: '02129'
 - name: Kenny Marchant
   party: majority
-  rank: 4
-  thomas: '01806'
+  rank: 2
   bioguide: M001158
+  thomas: '01806'
 - name: Leonard Lance
   party: majority
-  rank: 5
-  thomas: '01936'
+  rank: 3
   bioguide: L000567
+  thomas: '01936'
+- name: Mimi Walters
+  party: majority
+  rank: 4
+  bioguide: W000820
+  thomas: '02232'
+- name: John Ratcliffe
+  party: majority
+  rank: 5
+  bioguide: R000601
+  thomas: '02268'
 - name: Theodore E. Deutch
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01976'
   bioguide: D000610
+  thomas: '01976'
 - name: Yvette D. Clarke
   party: minority
   rank: 2
-  thomas: '01864'
   bioguide: C001067
+  thomas: '01864'
 - name: Jared Polis
   party: minority
   rank: 3
-  thomas: '01910'
   bioguide: P000598
+  thomas: '01910'
 - name: Anthony G. Brown
   party: minority
   rank: 4
@@ -10526,155 +10559,151 @@ HSSO:
 - name: Steve Cohen
   party: minority
   rank: 5
-  thomas: '01878'
   bioguide: C001068
+  thomas: '01878'
 HSSY:
 - name: Lamar Smith
   party: majority
   rank: 1
   title: Chair
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
+  title: Vice Chair
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Randy Hultgren
   party: majority
   rank: 5
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Bill Posey
   party: majority
   rank: 6
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Thomas Massie
   party: majority
   rank: 7
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Jim Bridenstine
   party: majority
   rank: 8
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 9
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Stephen Knight
   party: majority
   rank: 10
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Brian Babin
   party: majority
   rank: 11
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Barbara Comstock
   party: majority
   rank: 12
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Barry Loudermilk
   party: majority
   rank: 13
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Ralph Lee Abraham
   party: majority
   rank: 14
-  thomas: '02244'
   bioguide: A000374
-- name: Darin LaHood
-  party: majority
-  rank: 15
-  thomas: '02295'
-  bioguide: L000585
+  thomas: '02244'
 - name: Daniel Webster
   party: majority
-  rank: 16
-  thomas: '02002'
+  rank: 15
   bioguide: W000806
+  thomas: '02002'
 - name: Jim Banks
   party: majority
-  rank: 17
+  rank: 16
   bioguide: B001299
 - name: Andy Biggs
   party: majority
-  rank: 18
+  rank: 17
   bioguide: B001302
 - name: Roger W. Marshall
   party: majority
-  rank: 19
+  rank: 18
   bioguide: M001198
 - name: Neal P. Dunn
   party: majority
-  rank: 20
+  rank: 19
   bioguide: D000628
 - name: Clay Higgins
   party: majority
-  rank: 21
+  rank: 20
   bioguide: H001077
 - name: Ralph Norman
   party: majority
-  rank: 22
+  rank: 21
   bioguide: N000190
 - name: Eddie Bernice Johnson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Ami Bera
   party: minority
   rank: 5
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Elizabeth H. Esty
   party: minority
   rank: 6
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Marc A. Veasey
   party: minority
   rank: 7
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 8
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Jacky Rosen
   party: minority
   rank: 9
@@ -10682,33 +10711,33 @@ HSSY:
 - name: Jerry McNerney
   party: minority
   rank: 10
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Ed Perlmutter
   party: minority
   rank: 11
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Paul Tonko
   party: minority
   rank: 12
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Bill Foster
   party: minority
   rank: 13
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Mark Takano
   party: minority
   rank: 14
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Colleen Hanabusa
   party: minority
   rank: 15
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Charlie Crist
   party: minority
   rank: 16
@@ -10718,64 +10747,59 @@ HSSY15:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Frank D. Lucas
   party: majority
   rank: 2
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Randy Hultgren
   party: majority
   rank: 3
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Stephen Knight
   party: majority
   rank: 4
-  thomas: '02228'
   bioguide: K000387
-- name: Darin LaHood
-  party: majority
-  rank: 5
-  thomas: '02295'
-  bioguide: L000585
+  thomas: '02228'
 - name: Ralph Lee Abraham
   party: majority
-  rank: 6
-  thomas: '02244'
+  rank: 5
   bioguide: A000374
-  title: Vice Chair
+  thomas: '02244'
 - name: Daniel Webster
   party: majority
-  rank: 7
-  thomas: '02002'
+  rank: 6
   bioguide: W000806
+  thomas: '02002'
 - name: Jim Banks
   party: majority
-  rank: 8
+  rank: 7
   bioguide: B001299
 - name: Roger W. Marshall
   party: majority
-  rank: 9
+  rank: 8
   bioguide: M001198
+  title: Vice Chair
 - name: Lamar Smith
   party: majority
   rank: 10
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Daniel Lipinski
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Elizabeth H. Esty
   party: minority
   rank: 2
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Jacky Rosen
   party: minority
   rank: 3
@@ -10783,77 +10807,77 @@ HSSY15:
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Ami Bera
   party: minority
   rank: 5
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 7
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY16:
 - name: Brian Babin
   party: majority
   rank: 1
   title: Chair
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
   title: Vice Chair
 - name: Bill Posey
   party: majority
   rank: 5
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Jim Bridenstine
   party: majority
   rank: 6
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 7
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
 - name: Barbara Comstock
   party: majority
   rank: 8
-  thomas: '02273'
   bioguide: C001105
+  thomas: '02273'
 - name: Ralph Lee Abraham
   party: majority
   rank: 9
-  thomas: '02244'
   bioguide: A000374
+  thomas: '02244'
 - name: Daniel Webster
   party: majority
   rank: 10
-  thomas: '02002'
   bioguide: W000806
+  thomas: '02002'
 - name: Jim Banks
   party: majority
   rank: 11
@@ -10873,40 +10897,40 @@ HSSY16:
 - name: Lamar Smith
   party: majority
   rank: 15
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Ami Bera
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02102'
   bioguide: B001287
+  thomas: '02102'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 3
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Marc A. Veasey
   party: minority
   rank: 4
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Daniel Lipinski
   party: minority
   rank: 5
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Ed Perlmutter
   party: minority
   rank: 6
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Charlie Crist
   party: minority
   rank: 7
@@ -10914,13 +10938,13 @@ HSSY16:
 - name: Bill Foster
   party: minority
   rank: 8
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 11
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY18:
 - name: Andy Biggs
@@ -10931,33 +10955,33 @@ HSSY18:
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Bill Posey
   party: majority
   rank: 3
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 5
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Brian Babin
   party: majority
   rank: 6
-  thomas: '02270'
   bioguide: B001291
+  thomas: '02270'
 - name: Barry Loudermilk
   party: majority
   rank: 7
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Jim Banks
   party: majority
   rank: 8
@@ -10974,20 +10998,20 @@ HSSY18:
 - name: Lamar Smith
   party: majority
   rank: 11
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Suzanne Bonamici
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02092'
   bioguide: B001278
+  thomas: '02092'
 - name: Colleen Hanabusa
   party: minority
   rank: 2
-  thomas: '02010'
   bioguide: H001050
+  thomas: '02010'
 - name: Charlie Crist
   party: minority
   rank: 3
@@ -10995,88 +11019,83 @@ HSSY18:
 - name: Eddie Bernice Johnson
   party: minority
   rank: 8
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY20:
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 1
   title: Chair
-  thomas: '02161'
   bioguide: W000814
+  thomas: '02161'
 - name: Dana Rohrabacher
   party: majority
   rank: 2
-  thomas: '00979'
   bioguide: R000409
+  thomas: '00979'
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
+  thomas: '00711'
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
+  thomas: '01987'
 - name: Randy Hultgren
   party: majority
   rank: 5
-  thomas: '02015'
   bioguide: H001059
+  thomas: '02015'
 - name: Thomas Massie
   party: majority
   rank: 6
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Jim Bridenstine
   party: majority
   rank: 7
-  thomas: '02155'
   bioguide: B001283
+  thomas: '02155'
 - name: Stephen Knight
   party: majority
   rank: 8
-  thomas: '02228'
   bioguide: K000387
+  thomas: '02228'
   title: Vice Chair
-- name: Darin LaHood
-  party: majority
-  rank: 9
-  thomas: '02295'
-  bioguide: L000585
 - name: Daniel Webster
   party: majority
-  rank: 10
-  thomas: '02002'
+  rank: 9
   bioguide: W000806
+  thomas: '02002'
 - name: Neal P. Dunn
   party: majority
-  rank: 11
+  rank: 10
   bioguide: D000628
 - name: Lamar Smith
   party: majority
   rank: 12
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Marc A. Veasey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02166'
   bioguide: V000131
+  thomas: '02166'
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
+  thomas: '00701'
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
+  thomas: '01781'
 - name: Jacky Rosen
   party: minority
   rank: 4
@@ -11084,60 +11103,60 @@ HSSY20:
 - name: Jerry McNerney
   party: minority
   rank: 5
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Paul Tonko
   party: minority
   rank: 6
-  thomas: '01942'
   bioguide: T000469
+  thomas: '01942'
 - name: Bill Foster
   party: minority
   rank: 7
-  thomas: '01888'
   bioguide: F000454
+  thomas: '01888'
 - name: Mark Takano
   party: minority
   rank: 8
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 9
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSSY21:
-- name: Darin LaHood
+- name: Ralph Lee Abraham
   party: majority
   rank: 1
   title: Chair
-  thomas: '02295'
-  bioguide: L000585
+  bioguide: A000374
+  thomas: '02244'
 - name: Bill Posey
   party: majority
   rank: 2
-  thomas: '01915'
   bioguide: P000599
+  thomas: '01915'
 - name: Thomas Massie
   party: majority
   rank: 3
-  thomas: '02094'
   bioguide: M001184
+  thomas: '02094'
 - name: Barry Loudermilk
   party: majority
   rank: 4
-  thomas: '02238'
   bioguide: L000583
+  thomas: '02238'
 - name: Roger W. Marshall
   party: majority
   rank: 5
   bioguide: M001198
-  title: Vice Chair
 - name: Clay Higgins
   party: majority
   rank: 6
   bioguide: H001077
+  title: Vice Chair
 - name: Ralph Norman
   party: majority
   rank: 7
@@ -11145,68 +11164,68 @@ HSSY21:
 - name: Lamar Smith
   party: majority
   rank: 8
-  thomas: '01075'
   bioguide: S000583
+  thomas: '01075'
   title: Ex Officio
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02272'
   bioguide: B001292
+  thomas: '02272'
 - name: Jerry McNerney
   party: minority
   rank: 2
-  thomas: '01832'
   bioguide: M001166
+  thomas: '01832'
 - name: Ed Perlmutter
   party: minority
   rank: 3
-  thomas: '01835'
   bioguide: P000593
+  thomas: '01835'
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
-  thomas: '00599'
   bioguide: J000126
+  thomas: '00599'
   title: Ex Officio
 HSVR:
 - name: David P. Roe
   party: majority
   rank: 1
   title: Chair
-  thomas: '01954'
   bioguide: R000582
+  thomas: '01954'
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Mike Coffman
   party: majority
   rank: 3
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Brad R. Wenstrup
   party: majority
   rank: 4
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Mike Bost
   party: majority
   rank: 6
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Bruce Poliquin
   party: majority
   rank: 7
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Neal P. Dunn
   party: majority
   rank: 8
@@ -11239,33 +11258,33 @@ HSVR:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01856'
   bioguide: W000799
+  thomas: '01856'
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Julia Brownley
   party: minority
   rank: 3
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Ann M. Kuster
   party: minority
   rank: 4
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Beto O’Rourke
   party: minority
   rank: 5
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Kathleen M. Rice
   party: minority
   rank: 6
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: J. Luis Correa
   party: minority
   rank: 7
@@ -11273,35 +11292,35 @@ HSVR:
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 8
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 - name: Elizabeth H. Esty
   party: minority
   rank: 9
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Scott H. Peters
   party: minority
   rank: 10
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 HSVR03:
 - name: Brad R. Wenstrup
   party: majority
   rank: 1
   title: Chair
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Neal P. Dunn
   party: majority
   rank: 4
@@ -11322,23 +11341,23 @@ HSVR03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: Ann M. Kuster
   party: minority
   rank: 3
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Beto O’Rourke
   party: minority
   rank: 4
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: J. Luis Correa
   party: minority
   rank: 5
@@ -11352,13 +11371,13 @@ HSVR08:
 - name: Mike Bost
   party: majority
   rank: 2
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Bruce Poliquin
   party: majority
   rank: 3
-  thomas: '02247'
   bioguide: P000611
+  thomas: '02247'
 - name: Neal P. Dunn
   party: majority
   rank: 4
@@ -11375,40 +11394,40 @@ HSVR08:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02145'
   bioguide: K000382
+  thomas: '02145'
 - name: Kathleen M. Rice
   party: minority
   rank: 2
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 - name: Scott H. Peters
   party: minority
   rank: 3
-  thomas: '02113'
   bioguide: P000608
+  thomas: '02113'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 4
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 HSVR09:
 - name: Mike Bost
   party: majority
   rank: 1
   title: Chair
-  thomas: '02243'
   bioguide: B001295
+  thomas: '02243'
 - name: Mike Coffman
   party: majority
   rank: 2
-  thomas: '01912'
   bioguide: C001077
+  thomas: '01912'
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
-  thomas: '02222'
   bioguide: R000600
+  thomas: '02222'
 - name: Jack Bergman
   party: majority
   rank: 4
@@ -11421,18 +11440,18 @@ HSVR09:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02114'
   bioguide: E000293
+  thomas: '02114'
 - name: Julia Brownley
   party: minority
   rank: 2
-  thomas: '02106'
   bioguide: B001285
+  thomas: '02106'
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 3
-  thomas: '01962'
   bioguide: S001177
+  thomas: '01962'
 HSVR10:
 - name: Jodey C. Arrington
   party: majority
@@ -11442,13 +11461,13 @@ HSVR10:
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
+  thomas: '01838'
 - name: Brad R. Wenstrup
   party: majority
   rank: 3
-  thomas: '02152'
   bioguide: W000815
+  thomas: '02152'
 - name: John H. Rutherford
   party: majority
   rank: 4
@@ -11461,13 +11480,13 @@ HSVR10:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02162'
   bioguide: O000170
+  thomas: '02162'
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
+  thomas: '02110'
 - name: J. Luis Correa
   party: minority
   rank: 3
@@ -11475,678 +11494,699 @@ HSVR10:
 - name: Kathleen M. Rice
   party: minority
   rank: 4
-  thomas: '02262'
   bioguide: R000602
+  thomas: '02262'
 HSWM:
 - name: Kevin Brady
   party: majority
   rank: 1
   title: Chair
-  thomas: '01468'
   bioguide: B000755
+  thomas: '01468'
 - name: Sam Johnson
   party: majority
   rank: 2
-  thomas: '00603'
   bioguide: J000174
+  thomas: '00603'
 - name: Devin Nunes
   party: majority
   rank: 3
-  thomas: '01710'
   bioguide: N000181
+  thomas: '01710'
 - name: David G. Reichert
   party: majority
-  rank: 5
-  thomas: '01810'
+  rank: 4
   bioguide: R000578
+  thomas: '01810'
 - name: Peter J. Roskam
   party: majority
-  rank: 6
-  thomas: '01848'
+  rank: 5
   bioguide: R000580
+  thomas: '01848'
 - name: Vern Buchanan
   party: majority
-  rank: 7
-  thomas: '01840'
+  rank: 6
   bioguide: B001260
+  thomas: '01840'
 - name: Adrian Smith
   party: majority
-  rank: 8
-  thomas: '01860'
+  rank: 7
   bioguide: S001172
+  thomas: '01860'
 - name: Lynn Jenkins
   party: majority
-  rank: 9
-  thomas: '01921'
+  rank: 8
   bioguide: J000290
+  thomas: '01921'
 - name: Erik Paulsen
   party: majority
-  rank: 10
-  thomas: '01930'
+  rank: 9
   bioguide: P000594
+  thomas: '01930'
 - name: Kenny Marchant
   party: majority
-  rank: 11
-  thomas: '01806'
+  rank: 10
   bioguide: M001158
+  thomas: '01806'
 - name: Diane Black
   party: majority
-  rank: 12
-  thomas: '02063'
+  rank: 11
   bioguide: B001273
+  thomas: '02063'
 - name: Tom Reed
   party: majority
-  rank: 13
-  thomas: '01982'
+  rank: 12
   bioguide: R000585
+  thomas: '01982'
 - name: Mike Kelly
   party: majority
-  rank: 14
-  thomas: '02051'
+  rank: 13
   bioguide: K000376
+  thomas: '02051'
 - name: James B. Renacci
   party: majority
-  rank: 15
-  thomas: '02048'
+  rank: 14
   bioguide: R000586
+  thomas: '02048'
 - name: Patrick Meehan
   party: majority
-  rank: 16
-  thomas: '02052'
+  rank: 15
   bioguide: M001181
+  thomas: '02052'
 - name: Kristi L. Noem
   party: majority
-  rank: 17
-  thomas: '02060'
+  rank: 16
   bioguide: N000184
+  thomas: '02060'
 - name: George Holding
   party: majority
-  rank: 18
-  thomas: '02143'
+  rank: 17
   bioguide: H001065
+  thomas: '02143'
 - name: Jason Smith
   party: majority
-  rank: 19
-  thomas: '02191'
+  rank: 18
   bioguide: S001195
+  thomas: '02191'
 - name: Tom Rice
   party: majority
-  rank: 20
-  thomas: '02160'
+  rank: 19
   bioguide: R000597
+  thomas: '02160'
 - name: David Schweikert
   party: majority
-  rank: 21
-  thomas: '01994'
+  rank: 20
   bioguide: S001183
+  thomas: '01994'
 - name: Jackie Walorski
   party: majority
-  rank: 22
-  thomas: '02128'
+  rank: 21
   bioguide: W000813
+  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
-  rank: 23
-  thomas: '02235'
+  rank: 22
   bioguide: C001107
+  thomas: '02235'
 - name: Mike Bishop
   party: majority
-  rank: 24
-  thomas: '02249'
+  rank: 23
   bioguide: B001293
+  thomas: '02249'
+- name: Darin LaHood
+  party: majority
+  rank: 24
+  bioguide: L000585
+  thomas: '02295'
 - name: Richard E. Neal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00854'
   bioguide: N000015
+  thomas: '00854'
 - name: Sander M. Levin
   party: minority
   rank: 2
-  thomas: '00683'
   bioguide: L000263
+  thomas: '00683'
 - name: John Lewis
   party: minority
   rank: 3
-  thomas: '00688'
   bioguide: L000287
+  thomas: '00688'
 - name: Lloyd Doggett
   party: minority
   rank: 4
-  thomas: '00303'
   bioguide: D000399
+  thomas: '00303'
 - name: Mike Thompson
   party: minority
   rank: 5
-  thomas: '01593'
   bioguide: T000460
+  thomas: '01593'
 - name: John B. Larson
   party: minority
   rank: 6
-  thomas: '01583'
   bioguide: L000557
+  thomas: '01583'
 - name: Earl Blumenauer
   party: minority
   rank: 7
-  thomas: '00099'
   bioguide: B000574
+  thomas: '00099'
 - name: Ron Kind
   party: minority
   rank: 8
-  thomas: '01498'
   bioguide: K000188
+  thomas: '01498'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 9
-  thomas: '01510'
   bioguide: P000096
+  thomas: '01510'
 - name: Joseph Crowley
   party: minority
   rank: 10
-  thomas: '01604'
   bioguide: C001038
+  thomas: '01604'
 - name: Danny K. Davis
   party: minority
   rank: 11
-  thomas: '01477'
   bioguide: D000096
+  thomas: '01477'
 - name: Linda T. Sánchez
   party: minority
   rank: 12
-  thomas: '01757'
   bioguide: S001156
+  thomas: '01757'
 - name: Brian Higgins
   party: minority
   rank: 13
-  thomas: '01794'
   bioguide: H001038
+  thomas: '01794'
 - name: Terri A. Sewell
   party: minority
   rank: 14
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: Suzan K. DelBene
   party: minority
   rank: 15
-  thomas: '02096'
   bioguide: D000617
+  thomas: '02096'
 - name: Judy Chu
   party: minority
   rank: 16
-  thomas: '01970'
   bioguide: C001080
+  thomas: '01970'
 HSWM01:
 - name: Sam Johnson
   party: majority
   rank: 1
   title: Chair
-  thomas: '00603'
   bioguide: J000174
-- name: Tom Rice
-  party: majority
-  rank: 2
-  thomas: '02160'
-  bioguide: R000597
-- name: David Schweikert
-  party: majority
-  rank: 3
-  thomas: '01994'
-  bioguide: S001183
+  thomas: '00603'
 - name: Vern Buchanan
   party: majority
-  rank: 4
-  thomas: '01840'
+  rank: 2
   bioguide: B001260
+  thomas: '01840'
 - name: Mike Kelly
   party: majority
-  rank: 5
-  thomas: '02051'
+  rank: 3
   bioguide: K000376
-- name: James B. Renacci
+  thomas: '02051'
+- name: George Holding
   party: majority
-  rank: 6
-  thomas: '02048'
-  bioguide: R000586
+  rank: 4
+  bioguide: H001065
+  thomas: '02143'
 - name: Jason Smith
   party: majority
-  rank: 7
-  thomas: '02191'
+  rank: 5
   bioguide: S001195
+  thomas: '02191'
+- name: Tom Rice
+  party: majority
+  rank: 6
+  bioguide: R000597
+  thomas: '02160'
+- name: David Schweikert
+  party: majority
+  rank: 7
+  bioguide: S001183
+  thomas: '01994'
 - name: John B. Larson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01583'
   bioguide: L000557
+  thomas: '01583'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 2
-  thomas: '01510'
   bioguide: P000096
+  thomas: '01510'
 - name: Joseph Crowley
   party: minority
   rank: 3
-  thomas: '01604'
   bioguide: C001038
+  thomas: '01604'
 - name: Linda T. Sánchez
   party: minority
   rank: 4
-  thomas: '01757'
   bioguide: S001156
+  thomas: '01757'
 HSWM02:
+- name: Peter J. Roskam
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000580
+  thomas: '01848'
 - name: Sam Johnson
   party: majority
   rank: 2
-  thomas: '00603'
   bioguide: J000174
+  thomas: '00603'
 - name: Devin Nunes
   party: majority
   rank: 3
-  thomas: '01710'
   bioguide: N000181
-- name: Peter J. Roskam
-  party: majority
-  rank: 4
-  thomas: '01848'
-  bioguide: R000580
+  thomas: '01710'
 - name: Vern Buchanan
   party: majority
-  rank: 5
-  thomas: '01840'
+  rank: 4
   bioguide: B001260
+  thomas: '01840'
 - name: Adrian Smith
   party: majority
-  rank: 6
-  thomas: '01860'
+  rank: 5
   bioguide: S001172
+  thomas: '01860'
 - name: Lynn Jenkins
   party: majority
-  rank: 7
-  thomas: '01921'
+  rank: 6
   bioguide: J000290
+  thomas: '01921'
 - name: Kenny Marchant
   party: majority
-  rank: 8
-  thomas: '01806'
+  rank: 7
   bioguide: M001158
+  thomas: '01806'
 - name: Diane Black
   party: majority
-  rank: 9
-  thomas: '02063'
+  rank: 8
   bioguide: B001273
+  thomas: '02063'
 - name: Erik Paulsen
   party: majority
-  rank: 10
-  thomas: '01930'
+  rank: 9
   bioguide: P000594
+  thomas: '01930'
 - name: Tom Reed
   party: majority
-  rank: 11
-  thomas: '01982'
+  rank: 10
   bioguide: R000585
+  thomas: '01982'
+- name: Mike Kelly
+  party: majority
+  rank: 11
+  bioguide: K000376
+  thomas: '02051'
 - name: Sander M. Levin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00683'
   bioguide: L000263
+  thomas: '00683'
 - name: Mike Thompson
   party: minority
   rank: 2
-  thomas: '01593'
   bioguide: T000460
+  thomas: '01593'
 - name: Ron Kind
   party: minority
   rank: 3
-  thomas: '01498'
   bioguide: K000188
+  thomas: '01498'
 - name: Earl Blumenauer
   party: minority
   rank: 4
-  thomas: '00099'
   bioguide: B000574
+  thomas: '00099'
 - name: Brian Higgins
   party: minority
   rank: 5
-  thomas: '01794'
   bioguide: H001038
+  thomas: '01794'
 - name: Terri A. Sewell
   party: minority
   rank: 6
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: Judy Chu
   party: minority
   rank: 7
-  thomas: '01970'
   bioguide: C001080
+  thomas: '01970'
 HSWM03:
 - name: Adrian Smith
   party: majority
   rank: 1
   title: Chair
-  thomas: '01860'
   bioguide: S001172
-- name: Jason Smith
-  party: majority
-  rank: 2
-  thomas: '02191'
-  bioguide: S001195
+  thomas: '01860'
 - name: Jackie Walorski
   party: majority
-  rank: 3
-  thomas: '02128'
+  rank: 2
   bioguide: W000813
+  thomas: '02128'
 - name: Carlos Curbelo
   party: majority
-  rank: 4
-  thomas: '02235'
+  rank: 3
   bioguide: C001107
+  thomas: '02235'
 - name: Mike Bishop
   party: majority
-  rank: 5
-  thomas: '02249'
+  rank: 4
   bioguide: B001293
-- name: David G. Reichert
+  thomas: '02249'
+- name: David Schweikert
+  party: majority
+  rank: 5
+  bioguide: S001183
+  thomas: '01994'
+- name: Darin LaHood
   party: majority
   rank: 6
-  thomas: '01810'
-  bioguide: R000578
-- name: Tom Reed
+  bioguide: L000585
+  thomas: '02295'
+- name: David G. Reichert
   party: majority
   rank: 7
-  thomas: '01982'
-  bioguide: R000585
+  bioguide: R000578
+  thomas: '01810'
 - name: Danny K. Davis
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01477'
   bioguide: D000096
+  thomas: '01477'
 - name: Lloyd Doggett
   party: minority
   rank: 2
-  thomas: '00303'
   bioguide: D000399
+  thomas: '00303'
 - name: Terri A. Sewell
   party: minority
   rank: 3
-  thomas: '01988'
   bioguide: S001185
+  thomas: '01988'
 - name: Judy Chu
   party: minority
   rank: 4
-  thomas: '01970'
   bioguide: C001080
+  thomas: '01970'
 HSWM04:
 - name: David G. Reichert
   party: majority
   rank: 1
   title: Chair
-  thomas: '01810'
   bioguide: R000578
+  thomas: '01810'
 - name: Devin Nunes
   party: majority
   rank: 2
-  thomas: '01710'
   bioguide: N000181
-- name: Lynn Jenkins
-  party: majority
-  rank: 3
-  thomas: '01921'
-  bioguide: J000290
+  thomas: '01710'
 - name: Erik Paulsen
   party: majority
-  rank: 4
-  thomas: '01930'
+  rank: 3
   bioguide: P000594
+  thomas: '01930'
 - name: Mike Kelly
   party: majority
-  rank: 5
-  thomas: '02051'
+  rank: 4
   bioguide: K000376
+  thomas: '02051'
 - name: Patrick Meehan
   party: majority
-  rank: 6
-  thomas: '02052'
+  rank: 5
   bioguide: M001181
+  thomas: '02052'
 - name: Tom Reed
   party: majority
-  rank: 7
-  thomas: '01982'
+  rank: 6
   bioguide: R000585
+  thomas: '01982'
 - name: Kristi L. Noem
   party: majority
-  rank: 8
-  thomas: '02060'
+  rank: 7
   bioguide: N000184
+  thomas: '02060'
 - name: George Holding
   party: majority
-  rank: 9
-  thomas: '02143'
+  rank: 8
   bioguide: H001065
+  thomas: '02143'
 - name: Tom Rice
   party: majority
-  rank: 10
-  thomas: '02160'
+  rank: 9
   bioguide: R000597
+  thomas: '02160'
+- name: Kenny Marchant
+  party: majority
+  rank: 10
+  bioguide: M001158
+  thomas: '01806'
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01510'
   bioguide: P000096
+  thomas: '01510'
 - name: Ron Kind
   party: minority
   rank: 2
-  thomas: '01498'
   bioguide: K000188
+  thomas: '01498'
 - name: Lloyd Doggett
   party: minority
   rank: 3
-  thomas: '00303'
   bioguide: D000399
+  thomas: '00303'
 - name: Sander M. Levin
   party: minority
   rank: 4
-  thomas: '00683'
   bioguide: L000263
+  thomas: '00683'
 - name: Danny K. Davis
   party: minority
   rank: 5
-  thomas: '01477'
   bioguide: D000096
+  thomas: '01477'
 - name: Brian Higgins
   party: minority
   rank: 6
-  thomas: '01794'
   bioguide: H001038
+  thomas: '01794'
 HSWM05:
-- name: Peter J. Roskam
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01848'
-  bioguide: R000580
-- name: David G. Reichert
-  party: majority
-  rank: 2
-  thomas: '01810'
-  bioguide: R000578
-- name: Mike Kelly
-  party: majority
-  rank: 4
-  thomas: '02051'
-  bioguide: K000376
-- name: James B. Renacci
-  party: majority
-  rank: 5
-  thomas: '02048'
-  bioguide: R000586
-- name: Kristi L. Noem
-  party: majority
-  rank: 6
-  thomas: '02060'
-  bioguide: N000184
-- name: George Holding
-  party: majority
-  rank: 7
-  thomas: '02143'
-  bioguide: H001065
-- name: Kenny Marchant
-  party: majority
-  rank: 8
-  thomas: '01806'
-  bioguide: M001158
-- name: Patrick Meehan
-  party: majority
-  rank: 9
-  thomas: '02052'
-  bioguide: M001181
-- name: Lloyd Doggett
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '00303'
-  bioguide: D000399
-- name: John B. Larson
-  party: minority
-  rank: 2
-  thomas: '01583'
-  bioguide: L000557
-- name: Linda T. Sánchez
-  party: minority
-  rank: 3
-  thomas: '01757'
-  bioguide: S001156
-- name: Mike Thompson
-  party: minority
-  rank: 4
-  thomas: '01593'
-  bioguide: T000460
-- name: Suzan K. DelBene
-  party: minority
-  rank: 5
-  thomas: '02096'
-  bioguide: D000617
-- name: Earl Blumenauer
-  party: minority
-  rank: 6
-  thomas: '00099'
-  bioguide: B000574
-HSWM06:
 - name: Vern Buchanan
   party: majority
   rank: 1
   title: Chair
-  thomas: '01840'
   bioguide: B001260
-- name: David Schweikert
+  thomas: '01840'
+- name: Peter J. Roskam
   party: majority
   rank: 2
-  thomas: '01994'
-  bioguide: S001183
-- name: Jackie Walorski
+  bioguide: R000580
+  thomas: '01848'
+- name: David G. Reichert
   party: majority
   rank: 3
-  thomas: '02128'
-  bioguide: W000813
-- name: Carlos Curbelo
+  bioguide: R000578
+  thomas: '01810'
+- name: James B. Renacci
   party: majority
   rank: 4
-  thomas: '02235'
-  bioguide: C001107
-- name: Mike Bishop
+  bioguide: R000586
+  thomas: '02048'
+- name: Kristi L. Noem
   party: majority
   rank: 5
-  thomas: '02249'
-  bioguide: B001293
-- name: Patrick Meehan
+  bioguide: N000184
+  thomas: '02060'
+- name: Mike Kelly
   party: majority
   rank: 6
-  thomas: '02052'
-  bioguide: M001181
+  bioguide: K000376
+  thomas: '02051'
 - name: George Holding
   party: majority
   rank: 7
-  thomas: '02143'
   bioguide: H001065
+  thomas: '02143'
+- name: Patrick Meehan
+  party: majority
+  rank: 8
+  bioguide: M001181
+  thomas: '02052'
+- name: Jason Smith
+  party: majority
+  rank: 9
+  bioguide: S001195
+  thomas: '02191'
+- name: Tom Rice
+  party: majority
+  rank: 10
+  bioguide: R000597
+  thomas: '02160'
+- name: Lloyd Doggett
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000399
+  thomas: '00303'
+- name: John B. Larson
+  party: minority
+  rank: 2
+  bioguide: L000557
+  thomas: '01583'
+- name: Linda T. Sánchez
+  party: minority
+  rank: 3
+  bioguide: S001156
+  thomas: '01757'
+- name: Mike Thompson
+  party: minority
+  rank: 4
+  bioguide: T000460
+  thomas: '01593'
+- name: Suzan K. DelBene
+  party: minority
+  rank: 5
+  bioguide: D000617
+  thomas: '02096'
+- name: Earl Blumenauer
+  party: minority
+  rank: 6
+  bioguide: B000574
+  thomas: '00099'
+HSWM06:
+- name: Lynn Jenkins
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: J000290
+  thomas: '01921'
+- name: David Schweikert
+  party: majority
+  rank: 2
+  bioguide: S001183
+  thomas: '01994'
+- name: Jackie Walorski
+  party: majority
+  rank: 3
+  bioguide: W000813
+  thomas: '02128'
+- name: Carlos Curbelo
+  party: majority
+  rank: 4
+  bioguide: C001107
+  thomas: '02235'
+- name: Mike Bishop
+  party: majority
+  rank: 5
+  bioguide: B001293
+  thomas: '02249'
+- name: Darin LaHood
+  party: majority
+  rank: 6
+  bioguide: L000585
+  thomas: '02295'
+- name: Tom Reed
+  party: majority
+  rank: 7
+  bioguide: R000585
+  thomas: '01982'
 - name: John Lewis
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00688'
   bioguide: L000287
+  thomas: '00688'
 - name: Joseph Crowley
   party: minority
   rank: 2
-  thomas: '01604'
   bioguide: C001038
+  thomas: '01604'
 - name: Suzan K. DelBene
   party: minority
   rank: 3
-  thomas: '02096'
   bioguide: D000617
+  thomas: '02096'
 - name: Earl Blumenauer
   party: minority
   rank: 4
-  thomas: '00099'
   bioguide: B000574
+  thomas: '00099'
 JCSE:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Cochairman
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
   chamber: senate
 - name: John Boozman
   party: majority
   rank: 2
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
   chamber: senate
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
   chamber: senate
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
   chamber: senate
 - name: Cory Gardner
   party: majority
   rank: 5
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
   chamber: senate
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
   chamber: senate
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
   chamber: senate
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
   chamber: senate
 - name: Christopher H. Smith
   party: majority
@@ -12190,56 +12230,56 @@ JSEC:
   party: majority
   rank: 1
   title: Vice Chairman
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
   chamber: senate
 - name: Tom Cotton
   party: majority
   rank: 2
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
   chamber: senate
 - name: Ben Sasse
   party: majority
   rank: 3
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
   chamber: senate
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
   chamber: senate
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
   chamber: senate
 - name: Bill Cassidy
   party: majority
   rank: 6
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
   chamber: senate
 - name: Martin Heinrich
   party: minority
   rank: 1
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
   chamber: senate
 - name: Gary C. Peters
   party: minority
   rank: 3
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
   chamber: senate
 - name: Margaret Wood Hassan
   party: minority
@@ -12294,32 +12334,32 @@ JSLC:
   party: majority
   rank: 1
   title: Vice Chairman
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
   chamber: senate
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 1
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
   chamber: senate
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -12351,32 +12391,32 @@ JSPR:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
   chamber: senate
 - name: Roger F. Wicker
   party: majority
   rank: 3
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 1
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
   chamber: senate
 - name: Gregg Harper
   party: majority
@@ -12401,33 +12441,33 @@ JSTX:
 - name: Orrin G. Hatch
   party: majority
   rank: 1
-  title: Vice Chairman
-  thomas: '01351'
+  title: Chairman
   bioguide: H000338
+  thomas: '01351'
   chamber: senate
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
   chamber: senate
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
   chamber: senate
 - name: Ron Wyden
   party: minority
   rank: 1
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
   chamber: senate
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
   chamber: senate
 - name: Paul Ryan
   party: majority
@@ -12459,223 +12499,227 @@ SCNC:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Cornyn
   party: majority
   rank: 2
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Dianne Feinstein
   party: minority
   rank: 1
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 SLET:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 2
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 SLIA:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: John McCain
   party: majority
   rank: 3
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Lisa Murkowski
   party: majority
   rank: 4
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: James Lankford
   party: majority
   rank: 5
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Mike Crapo
   party: majority
   rank: 7
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Jerry Moran
   party: majority
   rank: 8
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Tom Udall
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Brian Schatz
   party: minority
-  rank: 5
-  thomas: '02173'
+  rank: 4
   bioguide: S001194
+  thomas: '02173'
 - name: Heidi Heitkamp
   party: minority
-  rank: 6
-  thomas: '02174'
+  rank: 5
   bioguide: H001069
+  thomas: '02174'
 - name: Catherine Cortez Masto
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C001113
+- name: Tina Smith
+  party: minority
+  rank: 7
+  bioguide: S001203
 SLIN:
 - name: Richard Burr
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Roy Blunt
   party: majority
   rank: 5
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Tom Cotton
   party: majority
   rank: 7
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: John Cornyn
   party: majority
   rank: 8
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Mitch McConnell
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: John McCain
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Ron Wyden
   party: minority
   rank: 3
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Joe Manchin, III
   party: minority
   rank: 6
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Kamala D. Harris
   party: minority
   rank: 7
@@ -12684,630 +12728,617 @@ SLIN:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '01036'
   bioguide: S000148
+  thomas: '01036'
 - name: Jack Reed
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SPAG:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Jeff Flake
   party: majority
   rank: 3
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Tim Scott
   party: majority
   rank: 4
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Bob Corker
   party: majority
   rank: 6
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Richard Burr
   party: majority
   rank: 7
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Deb Fischer
   party: majority
   rank: 9
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Bill Nelson
   party: minority
   rank: 2
-  thomas: '00859'
   bioguide: N000032
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  thomas: '01823'
-  bioguide: W000802
+  thomas: '00859'
 - name: Kirsten E. Gillibrand
   party: minority
-  rank: 4
-  thomas: '01866'
+  rank: 3
   bioguide: G000555
+  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
-  rank: 5
-  thomas: '02076'
+  rank: 4
   bioguide: B001277
+  thomas: '02076'
 - name: Joe Donnelly
   party: minority
-  rank: 6
-  thomas: '01850'
+  rank: 5
   bioguide: D000607
+  thomas: '01850'
 - name: Elizabeth Warren
   party: minority
-  rank: 7
-  thomas: '02182'
+  rank: 6
   bioguide: W000817
+  thomas: '02182'
 - name: Catherine Cortez Masto
   party: minority
-  rank: 8
+  rank: 7
   bioguide: C001113
+- name: Doug Jones
+  party: minority
+  rank: 8
+  bioguide: J000300
 SSAF:
 - name: Pat Roberts
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 5
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Joni Ernst
   party: majority
   rank: 6
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Chuck Grassley
   party: majority
   rank: 7
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 8
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 9
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: David Perdue
   party: majority
   rank: 10
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
+- name: Deb Fischer
+  party: majority
+  rank: 11
+  bioguide: F000463
+  thomas: '02179'
 - name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sherrod Brown
   party: minority
   rank: 3
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Michael F. Bennet
   party: minority
   rank: 5
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Joe Donnelly
   party: minority
   rank: 7
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Heidi Heitkamp
   party: minority
   rank: 8
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 9
-  thomas: '01828'
   bioguide: C001070
-- name: Chris Van Hollen
+  thomas: '01828'
+- name: Tina Smith
   party: minority
   rank: 10
-  thomas: '01729'
-  bioguide: V000128
+  bioguide: S001203
 SSAF13:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: John Hoeven
   party: majority
   rank: 3
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: David Perdue
   party: majority
   rank: 7
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Pat Roberts
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Sherrod Brown
   party: minority
   rank: 2
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Michael F. Bennet
   party: minority
   rank: 3
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Joe Donnelly
   party: minority
   rank: 5
-  thomas: '01850'
   bioguide: D000607
-- name: Chris Van Hollen
-  party: minority
-  rank: 6
-  thomas: '01729'
-  bioguide: V000128
+  thomas: '01850'
 - name: Debbie Stabenow
   party: minority
-  rank: 7
+  rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAF14:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Chuck Grassley
   party: majority
   rank: 5
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 6
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Joe Donnelly
   party: minority
   rank: 4
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAF15:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Pat Roberts
   party: majority
-  rank: 8
-  title: Ex Officio
-  thomas: '00968'
-  bioguide: R000307
-- name: Chris Van Hollen
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01729'
-  bioguide: V000128
-- name: Sherrod Brown
-  party: minority
-  rank: 2
-  thomas: '00136'
-  bioguide: B000944
-- name: Amy Klobuchar
-  party: minority
-  rank: 3
-  thomas: '01826'
-  bioguide: K000367
-- name: Michael F. Bennet
-  party: minority
-  rank: 4
-  thomas: '01965'
-  bioguide: B001267
-- name: Joe Donnelly
-  party: minority
-  rank: 5
-  thomas: '01850'
-  bioguide: D000607
-- name: Heidi Heitkamp
-  party: minority
-  rank: 6
-  thomas: '02174'
-  bioguide: H001069
-- name: Debbie Stabenow
-  party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01531'
+  bioguide: R000307
+  thomas: '00968'
+- name: Sherrod Brown
+  party: minority
+  rank: 1
+  bioguide: B000944
+  thomas: '00136'
+- name: Amy Klobuchar
+  party: minority
+  rank: 2
+  bioguide: K000367
+  thomas: '01826'
+- name: Michael F. Bennet
+  party: minority
+  rank: 3
+  bioguide: B001267
+  thomas: '01965'
+- name: Joe Donnelly
+  party: minority
+  rank: 4
+  bioguide: D000607
+  thomas: '01850'
+- name: Heidi Heitkamp
+  party: minority
+  rank: 5
+  bioguide: H001069
+  thomas: '02174'
+- name: Debbie Stabenow
+  party: minority
+  rank: 6
+  title: Ex Officio
   bioguide: S000770
+  thomas: '01531'
 SSAF16:
 - name: Mitch McConnell
   party: majority
-  rank: 2
-  thomas: '01395'
+  rank: 1
   bioguide: M000355
+  thomas: '01395'
 - name: John Boozman
   party: majority
-  rank: 3
-  thomas: '01687'
+  rank: 2
   bioguide: B001236
+  thomas: '01687'
 - name: John Hoeven
   party: majority
-  rank: 4
-  thomas: '02079'
+  rank: 3
   bioguide: H001061
+  thomas: '02079'
 - name: Joni Ernst
   party: majority
-  rank: 5
-  thomas: '02283'
+  rank: 4
   bioguide: E000295
+  thomas: '02283'
 - name: David Perdue
   party: majority
-  rank: 6
-  thomas: '02286'
+  rank: 5
   bioguide: P000612
+  thomas: '02286'
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 6
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sherrod Brown
   party: minority
   rank: 3
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  thomas: '01866'
   bioguide: G000555
-- name: Chris Van Hollen
-  party: minority
-  rank: 5
-  thomas: '01729'
-  bioguide: V000128
+  thomas: '01866'
 - name: Debbie Stabenow
   party: minority
-  rank: 6
+  rank: 5
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAF17:
 - name: David Perdue
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Pat Roberts
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 SSAP:
 - name: Thad Cochran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Roy Blunt
   party: majority
   rank: 8
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Jerry Moran
   party: majority
   rank: 9
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: John Hoeven
   party: majority
   rank: 10
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Boozman
   party: majority
   rank: 11
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 12
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 13
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 14
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: John Kennedy
   party: majority
   rank: 15
@@ -13315,257 +13346,257 @@ SSAP:
 - name: Marco Rubio
   party: majority
   rank: 16
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Patrick J. Leahy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Jack Reed
   party: minority
   rank: 5
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 6
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 8
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 9
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher A. Coons
   party: minority
   rank: 10
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 11
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 12
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 13
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 14
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 15
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP01:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Roy Blunt
   party: majority
   rank: 5
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Marco Rubio
   party: majority
   rank: 7
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 4
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Patrick J. Leahy
   party: minority
   rank: 5
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 SSAP02:
 - name: Thad Cochran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Roy Blunt
   party: majority
   rank: 8
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Steve Daines
   party: majority
   rank: 9
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Jerry Moran
   party: majority
   rank: 10
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patty Murray
   party: minority
   rank: 4
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Jack Reed
   party: minority
   rank: 5
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 6
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Brian Schatz
   party: minority
   rank: 8
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 9
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 SSAP08:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 2
@@ -13573,63 +13604,63 @@ SSAP08:
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 4
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Chris Van Hollen
   party: minority
   rank: 2
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP14:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lisa Murkowski
   party: majority
   rank: 4
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: John Hoeven
   party: majority
   rank: 5
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 7
@@ -13638,75 +13669,75 @@ SSAP14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Patty Murray
   party: minority
   rank: 4
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Tammy Baldwin
   party: minority
   rank: 5
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Joe Manchin, III
   party: minority
   rank: 6
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 SSAP16:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 2
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Boozman
   party: majority
   rank: 6
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 8
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -13715,169 +13746,169 @@ SSAP16:
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Joe Manchin, III
   party: minority
   rank: 7
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 8
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP17:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Roy Blunt
   party: majority
   rank: 4
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: John Hoeven
   party: majority
   rank: 5
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Mitch McConnell
   party: majority
   rank: 6
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Tom Udall
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 5
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Jeff Merkley
   party: minority
   rank: 6
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP18:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: James Lankford
   party: majority
   rank: 8
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -13885,276 +13916,276 @@ SSAP18:
 - name: Marco Rubio
   party: majority
   rank: 10
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Jack Reed
   party: minority
   rank: 3
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tammy Baldwin
   party: minority
   rank: 7
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 8
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 9
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Patrick J. Leahy
   party: minority
   rank: 10
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP19:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: John Boozman
   party: majority
   rank: 6
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Jon Tester
   party: minority
   rank: 2
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Patty Murray
   party: minority
   rank: 3
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
   rank: 7
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Patrick J. Leahy
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP20:
 - name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Thad Cochran
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Patrick J. Leahy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher Murphy
   party: minority
   rank: 6
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 SSAP22:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Thad Cochran
   party: majority
   rank: 2
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Mitch McConnell
   party: majority
   rank: 3
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Richard C. Shelby
   party: majority
   rank: 4
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Lisa Murkowski
   party: majority
   rank: 6
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lindsey Graham
   party: majority
   rank: 7
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Hoeven
   party: majority
   rank: 8
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -14163,967 +14194,991 @@ SSAP22:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 6
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Jeff Merkley
   party: minority
   rank: 7
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher A. Coons
   party: minority
   rank: 8
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP23:
 - name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: James Lankford
   party: majority
   rank: 4
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Thad Cochran
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Joe Manchin, III
   party: minority
   rank: 3
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Chris Van Hollen
   party: minority
   rank: 4
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Patrick J. Leahy
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAP24:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Roy Blunt
   party: majority
   rank: 4
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: John Boozman
   party: majority
   rank: 5
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Lindsey Graham
   party: majority
   rank: 8
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Hoeven
   party: majority
   rank: 9
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Thad Cochran
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Dianne Feinstein
   party: minority
   rank: 4
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Christopher Murphy
   party: minority
   rank: 7
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Joe Manchin, III
   party: minority
   rank: 8
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 SSAS:
 - name: John McCain
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Roger F. Wicker
   party: majority
   rank: 3
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Tom Cotton
   party: majority
   rank: 5
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 6
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 7
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 9
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: David Perdue
   party: majority
   rank: 10
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Ted Cruz
   party: majority
   rank: 11
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Lindsey Graham
   party: majority
   rank: 12
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 13
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
+- name: Tim Scott
+  party: majority
+  rank: 14
+  bioguide: S001184
+  thomas: '02056'
 - name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Bill Nelson
   party: minority
   rank: 2
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 3
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 6
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 7
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Tim Kaine
   party: minority
   rank: 9
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 10
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Martin Heinrich
   party: minority
   rank: 11
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Elizabeth Warren
   party: minority
   rank: 12
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 13
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 SSAS13:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Tom Cotton
   party: majority
   rank: 2
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 3
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 5
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
+- name: Tim Scott
+  party: majority
+  rank: 6
+  bioguide: S001184
+  thomas: '02056'
 - name: John McCain
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Jack Reed
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS14:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Roger F. Wicker
   party: majority
   rank: 3
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 5
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Ted Cruz
   party: majority
   rank: 6
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Claire McCaskill
   party: minority
   rank: 2
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Joe Donnelly
   party: minority
   rank: 4
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Elizabeth Warren
   party: minority
   rank: 5
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 6
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS15:
 - name: James M. Inhofe
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Rounds
   party: majority
   rank: 2
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: David Perdue
   party: majority
   rank: 4
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: John McCain
   party: majority
-  rank: 6
+  rank: 5
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Mazie K. Hirono
   party: minority
   rank: 3
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS16:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Tom Cotton
   party: majority
   rank: 3
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Dan Sullivan
   party: majority
   rank: 4
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Lindsey Graham
   party: majority
   rank: 6
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John McCain
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Joe Donnelly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Martin Heinrich
   party: minority
   rank: 2
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS17:
 - name: Thom Tillis
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Joni Ernst
   party: majority
   rank: 2
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Lindsey Graham
   party: majority
   rank: 3
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 4
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Claire McCaskill
   party: minority
   rank: 2
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS20:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 3
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: David Perdue
   party: majority
   rank: 4
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
-- name: John McCain
+  thomas: '02175'
+- name: Tim Scott
   party: majority
   rank: 6
+  bioguide: S001184
+  thomas: '02056'
+- name: John McCain
+  party: majority
+  rank: 7
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Martin Heinrich
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01937'
   bioguide: H001046
+  thomas: '01937'
 - name: Bill Nelson
   party: minority
   rank: 2
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSAS21:
 - name: Mike Rounds
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Deb Fischer
   party: majority
   rank: 2
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: David Perdue
   party: majority
   rank: 3
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Ben Sasse
   party: majority
   rank: 5
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: John McCain
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Bill Nelson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 2
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 3
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 SSBK:
 - name: Mike Crapo
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Dean Heller
   party: majority
   rank: 5
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 6
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Tom Cotton
   party: majority
   rank: 8
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 9
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: David Perdue
   party: majority
   rank: 10
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Thom Tillis
   party: majority
   rank: 11
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 12
   bioguide: K000393
+- name: Jerry Moran
+  party: majority
+  rank: 13
+  bioguide: M000934
+  thomas: '01507'
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Robert Menendez
   party: minority
   rank: 3
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jon Tester
   party: minority
   rank: 4
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Mark R. Warner
   party: minority
   rank: 5
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Elizabeth Warren
   party: minority
   rank: 6
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Heidi Heitkamp
   party: minority
   rank: 7
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Joe Donnelly
   party: minority
   rank: 8
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Brian Schatz
   party: minority
   rank: 9
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 11
   bioguide: C001113
+- name: Doug Jones
+  party: minority
+  rank: 12
+  bioguide: J000300
 SSBK04:
 - name: Dean Heller
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Tim Scott
   party: majority
   rank: 5
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Mike Rounds
   party: majority
   rank: 7
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Mike Crapo
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Robert Menendez
   party: minority
   rank: 3
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jon Tester
   party: minority
   rank: 4
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Elizabeth Warren
   party: minority
   rank: 5
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Chris Van Hollen
   party: minority
   rank: 6
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
@@ -15132,110 +15187,110 @@ SSBK04:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK05:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Bob Corker
   party: majority
   rank: 2
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Tom Cotton
   party: majority
   rank: 3
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Mike Rounds
   party: majority
   rank: 4
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: David Perdue
   party: majority
   rank: 5
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Mike Crapo
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Joe Donnelly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Mark R. Warner
   party: minority
   rank: 2
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK08:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Bob Corker
   party: majority
   rank: 3
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Dean Heller
   party: majority
   rank: 4
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 5
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Tom Cotton
   party: majority
   rank: 7
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: David Perdue
   party: majority
   rank: 8
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: John Kennedy
   party: majority
   rank: 9
@@ -15244,44 +15299,44 @@ SSBK08:
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Elizabeth Warren
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Mark R. Warner
   party: minority
   rank: 4
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Joe Donnelly
   party: minority
   rank: 5
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
@@ -15290,35 +15345,35 @@ SSBK08:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK09:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Dean Heller
   party: majority
   rank: 3
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Mike Rounds
   party: majority
   rank: 4
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 6
@@ -15327,62 +15382,62 @@ SSBK09:
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
+  thomas: '00949'
 - name: Heidi Heitkamp
   party: minority
   rank: 3
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Chris Van Hollen
   party: minority
   rank: 5
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Sherrod Brown
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBK12:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02098'
   bioguide: C001095
+  thomas: '02098'
 - name: Patrick J. Toomey
   party: majority
   rank: 2
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: David Perdue
   party: majority
   rank: 3
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 5
@@ -15391,82 +15446,82 @@ SSBK12:
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
+  thomas: '02182'
 - name: Joe Donnelly
   party: minority
   rank: 4
-  thomas: '01850'
   bioguide: D000607
+  thomas: '01850'
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 SSBU:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Patrick J. Toomey
   party: majority
   rank: 5
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Bob Corker
   party: majority
   rank: 7
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: David Perdue
   party: majority
   rank: 8
-  thomas: '02286'
   bioguide: P000612
+  thomas: '02286'
 - name: Cory Gardner
   party: majority
   rank: 9
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: John Kennedy
   party: majority
   rank: 10
@@ -15474,59 +15529,64 @@ SSBU:
 - name: John Boozman
   party: majority
   rank: 11
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
+- name: Tom Cotton
+  party: majority
+  rank: 12
+  bioguide: C001095
+  thomas: '02098'
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Ron Wyden
   party: minority
   rank: 3
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 4
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Sheldon Whitehouse
   party: minority
   rank: 5
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Jeff Merkley
   party: minority
   rank: 7
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Tim Kaine
   party: minority
   rank: 8
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Angus S. King, Jr.
   party: minority
   rank: 9
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
+  thomas: '01729'
 - name: Kamala D. Harris
   party: minority
   rank: 11
@@ -15536,523 +15596,513 @@ SSCM:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 4
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 7
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 8
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 9
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 10
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 11
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 12
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 13
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 14
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Bill Nelson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 5
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 7
-  thomas: '02194'
-  bioguide: B001288
+  thomas: '00735'
 - name: Tom Udall
   party: minority
-  rank: 8
-  thomas: '01567'
+  rank: 7
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
-  rank: 9
-  thomas: '01929'
+  rank: 8
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
-  rank: 10
-  thomas: '01558'
+  rank: 9
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
-  rank: 11
-  thomas: '02123'
+  rank: 10
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 12
+  rank: 11
   bioguide: H001076
 - name: Catherine Cortez Masto
   party: minority
-  rank: 13
+  rank: 12
   bioguide: C001113
+- name: Jon Tester
+  party: minority
+  rank: 13
+  bioguide: T000464
+  thomas: '01829'
 SSCM01:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 6
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 7
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 8
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 9
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Shelley Moore Capito
   party: majority
   rank: 10
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 11
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 12
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 13
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 6
-  thomas: '02194'
-  bioguide: B001288
+  thomas: '00735'
 - name: Tom Udall
   party: minority
-  rank: 7
-  thomas: '01567'
+  rank: 6
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
-  rank: 8
-  thomas: '01929'
+  rank: 7
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
-  rank: 9
-  thomas: '01558'
+  rank: 8
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
-  rank: 10
-  thomas: '02123'
+  rank: 9
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 11
+  rank: 10
   bioguide: H001076
+- name: Jon Tester
+  party: minority
+  rank: 11
+  bioguide: T000464
+  thomas: '01829'
 - name: Bill Nelson
   party: minority
   rank: 12
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM20:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Roy Blunt
   party: majority
   rank: 2
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Dean Heller
   party: majority
   rank: 5
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 6
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 7
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Todd Young
   party: majority
   rank: 9
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Edward J. Markey
   party: minority
   rank: 3
-  thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 4
-  thomas: '02194'
-  bioguide: B001288
+  thomas: '00735'
 - name: Tom Udall
   party: minority
-  rank: 5
-  thomas: '01567'
+  rank: 4
   bioguide: U000039
+  thomas: '01567'
 - name: Tammy Duckworth
   party: minority
-  rank: 6
-  thomas: '02123'
+  rank: 5
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 7
+  rank: 6
   bioguide: H001076
 - name: Catherine Cortez Masto
   party: minority
-  rank: 8
+  rank: 7
   bioguide: C001113
 - name: Bill Nelson
   party: minority
-  rank: 9
+  rank: 8
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM22:
 - name: Dan Sullivan
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 3
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: James M. Inhofe
   party: majority
   rank: 4
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 5
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 8
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
-- name: Gary C. Peters
+  thomas: '01534'
+- name: Tammy Baldwin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01929'
-  bioguide: P000595
+  bioguide: B001230
+  thomas: '01558'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
+  thomas: '00735'
+- name: Gary C. Peters
   party: minority
   rank: 6
-  thomas: '02194'
-  bioguide: B001288
-- name: Tammy Baldwin
-  party: minority
-  rank: 7
-  thomas: '01558'
-  bioguide: B001230
+  bioguide: P000595
+  thomas: '01929'
 - name: Bill Nelson
   party: minority
-  rank: 8
+  rank: 7
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM24:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 3
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 5
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: John Thune
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Brian Schatz
   party: minority
   rank: 2
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
   rank: 5
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Margaret Wood Hassan
   party: minority
   rank: 6
@@ -16061,97 +16111,97 @@ SSCM24:
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM25:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Dean Heller
   party: majority
   rank: 4
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 5
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 8
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 9
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
-- name: Cory A. Booker
+  thomas: '01534'
+- name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02194'
-  bioguide: B001288
+  bioguide: P000595
+  thomas: '01929'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
   rank: 8
@@ -16160,2324 +16210,2365 @@ SSCM25:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSCM26:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Roy Blunt
   party: majority
   rank: 2
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Dan Sullivan
   party: majority
   rank: 6
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Dean Heller
   party: majority
   rank: 7
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: James M. Inhofe
   party: majority
   rank: 8
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Mike Lee
   party: majority
   rank: 9
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ron Johnson
   party: majority
   rank: 10
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Shelley Moore Capito
   party: majority
   rank: 11
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Cory Gardner
   party: majority
   rank: 12
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 13
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Thune
   party: majority
   rank: 14
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02173'
   bioguide: S001194
+  thomas: '02173'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 6
-  thomas: '02194'
-  bioguide: B001288
+  thomas: '00735'
 - name: Tom Udall
   party: minority
-  rank: 7
-  thomas: '01567'
+  rank: 6
   bioguide: U000039
+  thomas: '01567'
 - name: Gary C. Peters
   party: minority
-  rank: 8
-  thomas: '01929'
+  rank: 7
   bioguide: P000595
+  thomas: '01929'
 - name: Tammy Baldwin
   party: minority
-  rank: 9
-  thomas: '01558'
+  rank: 8
   bioguide: B001230
+  thomas: '01558'
 - name: Tammy Duckworth
   party: minority
-  rank: 10
-  thomas: '02123'
+  rank: 9
   bioguide: D000622
+  thomas: '02123'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 11
+  rank: 10
   bioguide: H001076
 - name: Catherine Cortez Masto
   party: minority
-  rank: 12
+  rank: 11
   bioguide: C001113
+- name: Jon Tester
+  party: minority
+  rank: 12
+  bioguide: T000464
+  thomas: '01829'
 - name: Bill Nelson
   party: minority
   rank: 13
   title: Ex Officio
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 SSEG:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Jeff Flake
   party: majority
   rank: 5
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 8
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 9
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 10
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 11
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 12
+  bioguide: C001047
+  thomas: '01676'
 - name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Debbie Stabenow
   party: minority
   rank: 4
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Joe Manchin, III
   party: minority
-  rank: 6
-  thomas: '01983'
+  rank: 5
   bioguide: M001183
+  thomas: '01983'
 - name: Martin Heinrich
   party: minority
-  rank: 7
-  thomas: '01937'
+  rank: 6
   bioguide: H001046
+  thomas: '01937'
 - name: Mazie K. Hirono
   party: minority
-  rank: 8
-  thomas: '01844'
+  rank: 7
   bioguide: H001042
+  thomas: '01844'
 - name: Angus S. King, Jr.
   party: minority
-  rank: 9
-  thomas: '02185'
+  rank: 8
   bioguide: K000383
+  thomas: '02185'
 - name: Tammy Duckworth
   party: minority
-  rank: 10
-  thomas: '02123'
+  rank: 9
   bioguide: D000622
+  thomas: '02123'
 - name: Catherine Cortez Masto
   party: minority
-  rank: 11
+  rank: 10
   bioguide: C001113
+- name: Tina Smith
+  party: minority
+  rank: 11
+  bioguide: S001203
 SSEG01:
 - name: Cory Gardner
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Jeff Flake
   party: majority
   rank: 3
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 4
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Lamar Alexander
   party: majority
   rank: 5
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 6
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 7
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 8
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 9
+  bioguide: C001047
+  thomas: '01676'
 - name: Lisa Murkowski
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Joe Manchin, III
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Martin Heinrich
   party: minority
-  rank: 5
-  thomas: '01937'
+  rank: 4
   bioguide: H001046
+  thomas: '01937'
 - name: Angus S. King, Jr.
   party: minority
-  rank: 6
-  thomas: '02185'
+  rank: 5
   bioguide: K000383
+  thomas: '02185'
 - name: Tammy Duckworth
   party: minority
-  rank: 7
-  thomas: '02123'
+  rank: 6
   bioguide: D000622
-- name: Catherine Cortez Masto
+  thomas: '02123'
+- name: Tina Smith
   party: minority
-  rank: 8
-  bioguide: C001113
+  rank: 7
+  bioguide: S001203
 - name: Maria Cantwell
   party: minority
-  rank: 9
+  rank: 8
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEG03:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Jeff Flake
   party: majority
   rank: 4
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Cory Gardner
   party: majority
   rank: 6
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 7
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 8
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Bill Cassidy
   party: majority
   rank: 9
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 10
+  bioguide: C001047
+  thomas: '01676'
 - name: Lisa Murkowski
   party: majority
   rank: 11
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Joe Manchin, III
   party: minority
-  rank: 4
-  thomas: '01983'
+  rank: 3
   bioguide: M001183
+  thomas: '01983'
 - name: Martin Heinrich
   party: minority
-  rank: 5
-  thomas: '01937'
+  rank: 4
   bioguide: H001046
+  thomas: '01937'
 - name: Mazie K. Hirono
   party: minority
-  rank: 6
-  thomas: '01844'
+  rank: 5
   bioguide: H001042
+  thomas: '01844'
 - name: Catherine Cortez Masto
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C001113
+- name: Tina Smith
+  party: minority
+  rank: 7
+  bioguide: S001203
 - name: Maria Cantwell
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEG04:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Mike Lee
   party: majority
   rank: 3
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Cory Gardner
   party: majority
   rank: 4
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Lamar Alexander
   party: majority
   rank: 5
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: John Hoeven
   party: majority
   rank: 6
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Rob Portman
   party: majority
   rank: 7
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
-- name: Mazie K. Hirono
+  thomas: '01694'
+- name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01844'
-  bioguide: H001042
+  bioguide: K000383
+  thomas: '02185'
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Debbie Stabenow
   party: minority
   rank: 3
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
-- name: Angus S. King, Jr.
+  thomas: '01937'
+- name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '02185'
-  bioguide: K000383
+  bioguide: H001042
+  thomas: '01844'
 - name: Tammy Duckworth
   party: minority
   rank: 6
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Maria Cantwell
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEG07:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Bill Cassidy
   party: majority
   rank: 5
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 6
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
+- name: Shelley Moore Capito
+  party: majority
+  rank: 7
+  bioguide: C001047
+  thomas: '01676'
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
-- name: Angus S. King, Jr.
+  thomas: '01694'
+- name: Catherine Cortez Masto
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02185'
-  bioguide: K000383
+  bioguide: C001113
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Joe Manchin, III
   party: minority
-  rank: 5
-  thomas: '01983'
+  rank: 4
   bioguide: M001183
+  thomas: '01983'
 - name: Tammy Duckworth
   party: minority
-  rank: 6
-  thomas: '02123'
+  rank: 5
   bioguide: D000622
+  thomas: '02123'
 - name: Maria Cantwell
   party: minority
-  rank: 7
+  rank: 6
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 SSEV:
 - name: John Barrasso
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Shelley Moore Capito
   party: majority
   rank: 3
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Roger F. Wicker
   party: majority
   rank: 5
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 6
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 7
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Mike Rounds
   party: majority
   rank: 8
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Joni Ernst
   party: majority
   rank: 9
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Dan Sullivan
   party: majority
   rank: 10
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Richard C. Shelby
   party: majority
   rank: 11
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Cory A. Booker
   party: minority
   rank: 7
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Edward J. Markey
   party: minority
   rank: 8
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
-- name: Kamala D. Harris
+  thomas: '02123'
+- name: Chris Van Hollen
   party: minority
   rank: 10
-  bioguide: H001075
+  bioguide: V000128
+  thomas: '01729'
 SSEV08:
 - name: James M. Inhofe
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Shelley Moore Capito
   party: majority
   rank: 2
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Roger F. Wicker
   party: majority
   rank: 4
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Joni Ernst
   party: majority
   rank: 7
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Dan Sullivan
   party: majority
   rank: 8
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Richard C. Shelby
   party: majority
   rank: 9
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: John Barrasso
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
-- name: Kamala D. Harris
-  party: minority
-  rank: 8
-  bioguide: H001075
+  thomas: '02123'
 - name: Thomas R. Carper
   party: minority
-  rank: 9
+  rank: 8
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 SSEV09:
 - name: Mike Rounds
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Dan Sullivan
   party: majority
   rank: 4
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: John Barrasso
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
-- name: Kamala D. Harris
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H001075
+  thomas: '01881'
 - name: Bernard Sanders
   party: minority
-  rank: 2
-  thomas: '01010'
+  rank: 1
   bioguide: S000033
+  thomas: '01010'
 - name: Cory A. Booker
   party: minority
-  rank: 3
-  thomas: '02194'
+  rank: 2
   bioguide: B001288
+  thomas: '02194'
 - name: Thomas R. Carper
   party: minority
-  rank: 4
+  rank: 3
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 SSEV10:
 - name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Roger F. Wicker
   party: majority
   rank: 4
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: Joni Ernst
   party: majority
   rank: 7
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: Richard C. Shelby
   party: majority
   rank: 8
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: John Barrasso
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Sheldon Whitehouse
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Thomas R. Carper
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 SSEV15:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Shelley Moore Capito
   party: majority
   rank: 3
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Roger F. Wicker
   party: majority
   rank: 4
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Mike Rounds
   party: majority
   rank: 6
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Dan Sullivan
   party: majority
   rank: 7
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Richard C. Shelby
   party: majority
   rank: 8
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: John Barrasso
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Tammy Duckworth
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
   title: Ranking Member
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
+  thomas: '01866'
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Edward J. Markey
   party: minority
   rank: 7
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Thomas R. Carper
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 SSFI:
 - name: Orrin G. Hatch
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Pat Roberts
   party: majority
   rank: 4
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 5
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 6
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: John Thune
   party: majority
   rank: 7
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 8
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 9
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 10
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Patrick J. Toomey
   party: majority
   rank: 11
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Dean Heller
   party: majority
   rank: 12
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Tim Scott
   party: majority
   rank: 13
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Bill Cassidy
   party: majority
   rank: 14
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Maria Cantwell
   party: minority
   rank: 3
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Bill Nelson
   party: minority
   rank: 4
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Robert Menendez
   party: minority
   rank: 5
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Thomas R. Carper
   party: minority
   rank: 6
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 7
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Sherrod Brown
   party: minority
   rank: 8
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Michael F. Bennet
   party: minority
   rank: 9
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 10
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Mark R. Warner
   party: minority
   rank: 11
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Claire McCaskill
   party: minority
   rank: 12
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 13
+  bioguide: W000802
+  thomas: '01823'
 SSFI02:
 - name: Bill Cassidy
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Rob Portman
   party: majority
   rank: 2
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Orrin G. Hatch
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Ron Wyden
   party: minority
   rank: 3
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI10:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 6
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 7
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 8
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Dean Heller
   party: majority
   rank: 9
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Bill Cassidy
   party: majority
   rank: 10
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Orrin G. Hatch
   party: majority
   rank: 11
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Maria Cantwell
   party: minority
   rank: 3
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Thomas R. Carper
   party: minority
   rank: 4
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Sherrod Brown
   party: minority
   rank: 6
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Mark R. Warner
   party: minority
   rank: 7
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Ron Wyden
   party: minority
   rank: 8
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 9
+  bioguide: W000802
+  thomas: '01823'
 SSFI11:
 - name: Rob Portman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Mike Crapo
   party: majority
   rank: 2
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 5
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: John Thune
   party: majority
   rank: 6
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Richard Burr
   party: majority
   rank: 7
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 8
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Patrick J. Toomey
   party: majority
   rank: 9
-  thomas: '02085'
   bioguide: T000461
+  thomas: '02085'
 - name: Tim Scott
   party: majority
   rank: 10
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Orrin G. Hatch
   party: majority
   rank: 11
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Benjamin L. Cardin
   party: minority
   rank: 3
-  thomas: '00174'
   bioguide: C000141
+  thomas: '00174'
 - name: Claire McCaskill
   party: minority
   rank: 4
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Robert Menendez
   party: minority
   rank: 5
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Michael F. Bennet
   party: minority
   rank: 6
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 7
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Maria Cantwell
   party: minority
   rank: 8
-  thomas: '00172'
   bioguide: C000127
-- name: Ron Wyden
+  thomas: '00172'
+- name: Sheldon Whitehouse
   party: minority
   rank: 9
+  bioguide: W000802
+  thomas: '01823'
+- name: Ron Wyden
+  party: minority
+  rank: 10
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI12:
 - name: Dean Heller
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Cornyn
   party: majority
   rank: 5
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Richard Burr
   party: majority
   rank: 6
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Tim Scott
   party: majority
   rank: 7
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Bill Cassidy
   party: majority
   rank: 8
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Orrin G. Hatch
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01965'
   bioguide: B001267
+  thomas: '01965'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
+  thomas: '00172'
 - name: Bill Nelson
   party: minority
   rank: 3
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Robert Menendez
   party: minority
   rank: 4
-  thomas: '00791'
   bioguide: M000639
+  thomas: '00791'
 - name: Thomas R. Carper
   party: minority
   rank: 5
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
-- name: Ron Wyden
+  thomas: '01897'
+- name: Sheldon Whitehouse
   party: minority
   rank: 7
+  bioguide: W000802
+  thomas: '01823'
+- name: Ron Wyden
+  party: minority
+  rank: 8
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFI13:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
+  thomas: '01534'
 - name: Dean Heller
   party: majority
   rank: 6
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Orrin G. Hatch
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
+  thomas: '01531'
 - name: Bill Nelson
   party: minority
   rank: 3
-  thomas: '00859'
   bioguide: N000032
+  thomas: '00859'
 - name: Claire McCaskill
   party: minority
   rank: 4
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Ron Wyden
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 6
+  bioguide: C000141
+  thomas: '00174'
 SSFI14:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
+  thomas: '01247'
 SSFR:
 - name: Bob Corker
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 4
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Jeff Flake
   party: majority
   rank: 5
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 6
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Barrasso
   party: majority
   rank: 8
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 9
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rob Portman
   party: majority
   rank: 10
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 11
-  thomas: '02082'
   bioguide: P000603
-- name: Benjamin L. Cardin
+  thomas: '02082'
+- name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00174'
-  bioguide: C000141
-- name: Robert Menendez
+  bioguide: M000639
+  thomas: '00791'
+- name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00791'
-  bioguide: M000639
+  bioguide: C000141
+  thomas: '00174'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Christopher Murphy
   party: minority
   rank: 6
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Tim Kaine
   party: minority
   rank: 7
-  thomas: '02176'
   bioguide: K000384
+  thomas: '02176'
 - name: Edward J. Markey
   party: minority
   rank: 8
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Jeff Merkley
   party: minority
   rank: 9
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Cory A. Booker
   party: minority
   rank: 10
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 SSFR01:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: John Barrasso
   party: majority
   rank: 3
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Edward J. Markey
   party: minority
   rank: 2
-  thomas: '00735'
   bioguide: M000133
-- name: Robert Menendez
+  thomas: '00735'
+- name: Benjamin L. Cardin
   party: minority
   rank: 3
-  thomas: '00791'
-  bioguide: M000639
+  bioguide: C000141
+  thomas: '00174'
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
-- name: Benjamin L. Cardin
+  thomas: '01901'
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: M000639
+  thomas: '00791'
 SSFR02:
 - name: Cory Gardner
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: John Barrasso
   party: majority
   rank: 4
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 5
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Jeff Merkley
   party: minority
   rank: 2
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Christopher Murphy
   party: minority
   rank: 3
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
-- name: Benjamin L. Cardin
+  thomas: '02176'
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: M000639
+  thomas: '00791'
 SSFR06:
 - name: Marco Rubio
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 2
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Jeff Flake
   party: majority
   rank: 3
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 4
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: Johnny Isakson
   party: majority
   rank: 5
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
-- name: Robert Menendez
+  thomas: '01825'
+- name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00791'
-  bioguide: M000639
+  bioguide: C000141
+  thomas: '00174'
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
-- name: Benjamin L. Cardin
+  thomas: '02176'
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: M000639
+  thomas: '00791'
 SSFR07:
 - name: James E. Risch
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 2
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Ron Johnson
   party: majority
   rank: 3
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Todd Young
   party: majority
   rank: 4
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Rob Portman
   party: majority
   rank: 5
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02176'
   bioguide: K000384
-- name: Robert Menendez
+  thomas: '02176'
+- name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00791'
-  bioguide: M000639
+  bioguide: C000141
+  thomas: '00174'
 - name: Christopher Murphy
   party: minority
   rank: 3
-  title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
+  thomas: '01837'
 - name: Cory A. Booker
   party: minority
   rank: 4
-  thomas: '02194'
   bioguide: B001288
-- name: Benjamin L. Cardin
+  thomas: '02194'
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: M000639
+  thomas: '00791'
 SSFR09:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Todd Young
   party: majority
   rank: 2
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: John Barrasso
   party: majority
   rank: 3
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Cory A. Booker
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Christopher A. Coons
   party: minority
   rank: 2
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
-- name: Benjamin L. Cardin
+  thomas: '01900'
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: M000639
+  thomas: '00791'
 SSFR14:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
   bioguide: S001181
+  thomas: '01901'
 - name: Christopher A. Coons
   party: minority
   rank: 2
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Cory A. Booker
   party: minority
   rank: 3
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Tom Udall
   party: minority
   rank: 4
-  thomas: '01567'
   bioguide: U000039
-- name: Benjamin L. Cardin
+  thomas: '01567'
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: M000639
+  thomas: '00791'
 SSFR15:
 - name: Todd Young
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Jeff Flake
   party: majority
   rank: 2
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Cory Gardner
   party: majority
   rank: 3
-  thomas: '01998'
   bioguide: G000562
+  thomas: '01998'
 - name: John Barrasso
   party: majority
   rank: 4
-  thomas: '01881'
   bioguide: B001261
+  thomas: '01881'
 - name: Rob Portman
   party: majority
   rank: 5
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Bob Corker
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01825'
   bioguide: C001071
+  thomas: '01825'
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01900'
   bioguide: M001176
+  thomas: '01900'
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Christopher A. Coons
   party: minority
   rank: 3
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Edward J. Markey
   party: minority
   rank: 4
-  thomas: '00735'
   bioguide: M000133
-- name: Benjamin L. Cardin
+  thomas: '00735'
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: M000639
+  thomas: '00791'
 SSGA:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: John McCain
   party: majority
   rank: 2
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Rob Portman
   party: majority
   rank: 3
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Rand Paul
   party: majority
   rank: 4
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: James Lankford
   party: majority
   rank: 5
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Michael B. Enzi
   party: majority
   rank: 6
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Hoeven
   party: majority
   rank: 7
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Steve Daines
   party: majority
   rank: 8
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Claire McCaskill
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
-- name: Jon Tester
-  party: minority
-  rank: 3
-  thomas: '01829'
-  bioguide: T000464
+  thomas: '00179'
 - name: Heidi Heitkamp
   party: minority
-  rank: 4
-  thomas: '02174'
+  rank: 3
   bioguide: H001069
+  thomas: '02174'
 - name: Gary C. Peters
   party: minority
-  rank: 5
-  thomas: '01929'
+  rank: 4
   bioguide: P000595
+  thomas: '01929'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 6
+  rank: 5
   bioguide: H001076
 - name: Kamala D. Harris
   party: minority
-  rank: 7
+  rank: 6
   bioguide: H001075
+- name: Doug Jones
+  party: minority
+  rank: 7
+  bioguide: J000300
 SSGA01:
 - name: Rob Portman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: James Lankford
   party: majority
   rank: 2
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John McCain
   party: majority
   rank: 3
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Rand Paul
   party: majority
   rank: 4
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Ron Johnson
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00179'
   bioguide: C000174
-- name: Jon Tester
-  party: minority
-  rank: 2
-  thomas: '01829'
-  bioguide: T000464
+  thomas: '00179'
 - name: Heidi Heitkamp
   party: minority
-  rank: 3
-  thomas: '02174'
+  rank: 2
   bioguide: H001069
+  thomas: '02174'
 - name: Gary C. Peters
   party: minority
-  rank: 4
-  thomas: '01929'
+  rank: 3
   bioguide: P000595
+  thomas: '01929'
+- name: Margaret Wood Hassan
+  party: minority
+  rank: 4
+  bioguide: H001076
 - name: Claire McCaskill
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 SSGA18:
 - name: Rand Paul
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: James Lankford
   party: majority
   rank: 2
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: Michael B. Enzi
   party: majority
   rank: 3
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
+  thomas: '02079'
 - name: Ron Johnson
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01929'
   bioguide: P000595
-- name: Margaret Wood Hassan
-  party: minority
-  rank: 2
-  bioguide: H001076
+  thomas: '01929'
 - name: Kamala D. Harris
   party: minority
-  rank: 3
+  rank: 2
   bioguide: H001075
+- name: Doug Jones
+  party: minority
+  rank: 3
+  bioguide: J000300
 - name: Claire McCaskill
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 SSGA19:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02050'
   bioguide: L000575
+  thomas: '02050'
 - name: John McCain
   party: majority
   rank: 2
-  thomas: '00754'
   bioguide: M000303
+  thomas: '00754'
 - name: Rob Portman
   party: majority
   rank: 3
-  thomas: '00924'
   bioguide: P000449
+  thomas: '00924'
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
+  thomas: '02138'
 - name: Ron Johnson
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
+  thomas: '02086'
 - name: Heidi Heitkamp
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
+  thomas: '00179'
 - name: Margaret Wood Hassan
   party: minority
   rank: 3
@@ -18490,419 +18581,429 @@ SSGA19:
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01820'
   bioguide: M001170
+  thomas: '01820'
 SSHR:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Michael B. Enzi
   party: majority
   rank: 2
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Richard Burr
   party: majority
   rank: 3
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Susan M. Collins
   party: majority
   rank: 6
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Bill Cassidy
   party: majority
   rank: 7
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 8
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 9
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 10
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Lisa Murkowski
   party: majority
   rank: 11
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Tim Scott
   party: majority
   rank: 12
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 3
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Michael F. Bennet
   party: minority
-  rank: 5
-  thomas: '01965'
+  rank: 4
   bioguide: B001267
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 6
-  thomas: '01823'
-  bioguide: W000802
+  thomas: '01965'
 - name: Tammy Baldwin
   party: minority
-  rank: 7
-  thomas: '01558'
+  rank: 5
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
-  rank: 8
-  thomas: '01837'
+  rank: 6
   bioguide: M001169
+  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
-  rank: 9
-  thomas: '02182'
+  rank: 7
   bioguide: W000817
+  thomas: '02182'
 - name: Tim Kaine
   party: minority
-  rank: 10
-  thomas: '02176'
+  rank: 8
   bioguide: K000384
+  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 11
+  rank: 9
   bioguide: H001076
+- name: Tina Smith
+  party: minority
+  rank: 10
+  bioguide: S001203
+- name: Doug Jones
+  party: minority
+  rank: 11
+  bioguide: J000300
 SSHR09:
 - name: Rand Paul
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Lisa Murkowski
   party: majority
   rank: 2
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Richard Burr
   party: majority
   rank: 3
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Bill Cassidy
   party: majority
   rank: 4
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 5
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 6
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 7
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
+  thomas: '01828'
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Michael F. Bennet
   party: minority
-  rank: 4
-  thomas: '01965'
+  rank: 3
   bioguide: B001267
+  thomas: '01965'
 - name: Tim Kaine
   party: minority
-  rank: 5
-  thomas: '02176'
+  rank: 4
   bioguide: K000384
+  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 6
+  rank: 5
   bioguide: H001076
+- name: Tina Smith
+  party: minority
+  rank: 6
+  bioguide: S001203
 - name: Patty Murray
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 SSHR11:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Tim Scott
   party: majority
   rank: 3
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Richard Burr
   party: majority
   rank: 4
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Bill Cassidy
   party: majority
   rank: 6
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
+- name: Tammy Baldwin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001230
+  thomas: '01558'
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
-  thomas: '01828'
   bioguide: C001070
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  thomas: '01823'
-  bioguide: W000802
-- name: Tammy Baldwin
-  party: minority
-  rank: 4
-  thomas: '01558'
-  bioguide: B001230
+  thomas: '01828'
 - name: Christopher Murphy
   party: minority
-  rank: 5
-  thomas: '01837'
+  rank: 3
   bioguide: M001169
+  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
-  rank: 6
-  thomas: '02182'
+  rank: 4
   bioguide: W000817
+  thomas: '02182'
+- name: Tina Smith
+  party: minority
+  rank: 5
+  bioguide: S001203
+- name: Doug Jones
+  party: minority
+  rank: 6
+  bioguide: J000300
 - name: Patty Murray
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 SSHR12:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Richard Burr
   party: majority
   rank: 2
-  thomas: '00153'
   bioguide: B001135
+  thomas: '00153'
 - name: Susan M. Collins
   party: majority
   rank: 3
-  thomas: '01541'
   bioguide: C001035
+  thomas: '01541'
 - name: Bill Cassidy
   party: majority
   rank: 4
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Todd Young
   party: majority
   rank: 5
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Orrin G. Hatch
   party: majority
   rank: 6
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Pat Roberts
   party: majority
   rank: 7
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Tim Scott
   party: majority
   rank: 8
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Lisa Murkowski
   party: majority
   rank: 9
-  thomas: '01694'
   bioguide: M001153
+  thomas: '01694'
 - name: Lamar Alexander
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Michael F. Bennet
   party: minority
   rank: 2
-  thomas: '01965'
   bioguide: B001267
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  thomas: '01823'
-  bioguide: W000802
+  thomas: '01965'
 - name: Tammy Baldwin
   party: minority
-  rank: 4
-  thomas: '01558'
+  rank: 3
   bioguide: B001230
+  thomas: '01558'
 - name: Christopher Murphy
   party: minority
-  rank: 5
-  thomas: '01837'
+  rank: 4
   bioguide: M001169
+  thomas: '01837'
 - name: Elizabeth Warren
   party: minority
-  rank: 6
-  thomas: '02182'
+  rank: 5
   bioguide: W000817
+  thomas: '02182'
 - name: Tim Kaine
   party: minority
-  rank: 7
-  thomas: '02176'
+  rank: 6
   bioguide: K000384
+  thomas: '02176'
 - name: Margaret Wood Hassan
   party: minority
-  rank: 8
+  rank: 7
   bioguide: H001076
+- name: Doug Jones
+  party: minority
+  rank: 8
+  bioguide: J000300
 - name: Patty Murray
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 SSJU:
 - name: Chuck Grassley
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Lindsey Graham
   party: majority
   rank: 3
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: John Cornyn
   party: majority
   rank: 4
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Mike Lee
   party: majority
   rank: 5
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Ted Cruz
   party: majority
   rank: 6
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Jeff Flake
   party: majority
   rank: 8
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Mike Crapo
   party: majority
   rank: 9
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Thom Tillis
   party: majority
   rank: 10
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 11
@@ -18911,98 +19012,112 @@ SSJU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Amy Klobuchar
   party: minority
   rank: 5
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Christopher A. Coons
   party: minority
-  rank: 7
-  thomas: '01984'
+  rank: 6
   bioguide: C001088
+  thomas: '01984'
 - name: Richard Blumenthal
   party: minority
-  rank: 8
-  thomas: '02076'
+  rank: 7
   bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
-  rank: 9
-  thomas: '01844'
+  rank: 8
   bioguide: H001042
+  thomas: '01844'
+- name: Cory A. Booker
+  party: minority
+  rank: 9
+  bioguide: B001288
+  thomas: '02194'
+- name: Kamala D. Harris
+  party: minority
+  rank: 10
+  bioguide: H001075
 SSJU01:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Orrin G. Hatch
   party: majority
   rank: 3
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
+  thomas: '00452'
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Richard Blumenthal
   party: minority
-  rank: 4
-  thomas: '02076'
+  rank: 3
   bioguide: B001277
+  thomas: '02076'
+- name: Cory A. Booker
+  party: minority
+  rank: 4
+  bioguide: B001288
+  thomas: '02194'
 SSJU04:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Thom Tillis
   party: majority
   rank: 2
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: John Kennedy
   party: majority
   rank: 3
@@ -19010,217 +19125,270 @@ SSJU04:
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Jeff Flake
   party: majority
   rank: 6
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Mike Crapo
   party: majority
   rank: 7
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Mike Lee
   party: majority
   rank: 8
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Richard Blumenthal
   party: minority
-  rank: 6
-  thomas: '02076'
+  rank: 5
   bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
-  rank: 7
-  thomas: '01844'
+  rank: 6
   bioguide: H001042
+  thomas: '01844'
+- name: Cory A. Booker
+  party: minority
+  rank: 7
+  bioguide: B001288
+  thomas: '02194'
 SSJU21:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: John Cornyn
   party: majority
   rank: 2
-  thomas: '01692'
   bioguide: C001056
+  thomas: '01692'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: Ben Sasse
   party: majority
   rank: 4
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
-- name: Richard Blumenthal
+  thomas: '00452'
+- name: John Kennedy
+  party: majority
+  rank: 6
+  bioguide: K000393
+- name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02076'
-  bioguide: B001277
+  bioguide: H001042
+  thomas: '01844'
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 3
+  bioguide: W000802
+  thomas: '01823'
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
+- name: Kamala D. Harris
+  party: minority
+  rank: 5
+  bioguide: H001075
 SSJU22:
 - name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00452'
   bioguide: G000359
-- name: John Cornyn
+  thomas: '00452'
+- name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '01692'
-  bioguide: C001056
-- name: Ted Cruz
+  bioguide: G000386
+  thomas: '00457'
+- name: Orrin G. Hatch
   party: majority
   rank: 3
-  thomas: '02175'
-  bioguide: C001098
-- name: Ben Sasse
+  bioguide: H000338
+  thomas: '01351'
+- name: John Cornyn
   party: majority
   rank: 4
-  thomas: '02289'
-  bioguide: S001197
-- name: John Kennedy
+  bioguide: C001056
+  thomas: '01692'
+- name: Ted Cruz
   party: majority
   rank: 5
+  bioguide: C001098
+  thomas: '02175'
+- name: Ben Sasse
+  party: majority
+  rank: 6
+  bioguide: S001197
+  thomas: '02289'
+- name: John Kennedy
+  party: majority
+  rank: 7
   bioguide: K000393
 - name: Sheldon Whitehouse
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01823'
   bioguide: W000802
-- name: Richard J. Durbin
+  thomas: '01823'
+- name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '00326'
-  bioguide: D000563
-- name: Amy Klobuchar
+  bioguide: F000062
+  thomas: '01332'
+- name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '01826'
-  bioguide: K000367
-- name: Christopher A. Coons
+  bioguide: D000563
+  thomas: '00326'
+- name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01984'
+  bioguide: K000367
+  thomas: '01826'
+- name: Christopher A. Coons
+  party: minority
+  rank: 5
   bioguide: C001088
+  thomas: '01984'
+- name: Cory A. Booker
+  party: minority
+  rank: 6
+  bioguide: B001288
+  thomas: '02194'
 SSJU23:
 - name: Jeff Flake
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Orrin G. Hatch
   party: majority
   rank: 2
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Mike Lee
   party: majority
   rank: 3
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Mike Crapo
   party: majority
   rank: 5
-  thomas: '00250'
   bioguide: C000880
-- name: John Kennedy
+  thomas: '00250'
+- name: Ben Sasse
   party: majority
   rank: 6
+  bioguide: S001197
+  thomas: '02289'
+- name: John Kennedy
+  party: majority
+  rank: 7
   bioguide: K000393
+- name: Christopher A. Coons
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001088
+  thomas: '01984'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
-- name: Christopher A. Coons
+  thomas: '01823'
+- name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '01984'
-  bioguide: C001088
+  bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
+- name: Kamala D. Harris
+  party: minority
+  rank: 6
+  bioguide: H001075
 SSJU25:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02289'
   bioguide: S001197
+  thomas: '02289'
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
+  thomas: '00457'
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
+  thomas: '00250'
 - name: John Kennedy
   party: majority
   rank: 4
@@ -19228,147 +19396,151 @@ SSJU25:
 - name: Orrin G. Hatch
   party: majority
   rank: 5
-  thomas: '01351'
   bioguide: H000338
+  thomas: '01351'
 - name: Mike Lee
   party: majority
   rank: 6
-  thomas: '02080'
   bioguide: L000577
+  thomas: '02080'
 - name: Jeff Flake
   party: majority
   rank: 7
-  thomas: '01633'
   bioguide: F000444
+  thomas: '01633'
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
-- name: Christopher A. Coons
+  thomas: '02291'
+- name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01984'
-  bioguide: C001088
+  bioguide: B001277
+  thomas: '02076'
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
+  thomas: '01823'
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
-- name: Richard Blumenthal
+  thomas: '01826'
+- name: Christopher A. Coons
   party: minority
-  rank: 6
-  thomas: '02076'
-  bioguide: B001277
+  rank: 5
+  bioguide: C001088
+  thomas: '01984'
 - name: Mazie K. Hirono
   party: minority
-  rank: 7
-  thomas: '01844'
+  rank: 6
   bioguide: H001042
+  thomas: '01844'
+- name: Kamala D. Harris
+  party: minority
+  rank: 7
+  bioguide: H001075
 SSRA:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01049'
   bioguide: S000320
+  thomas: '01049'
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
+  thomas: '01395'
 - name: Thad Cochran
   party: majority
   rank: 3
-  thomas: '00213'
   bioguide: C000567
+  thomas: '00213'
 - name: Lamar Alexander
   party: majority
   rank: 4
-  thomas: '01695'
   bioguide: A000360
+  thomas: '01695'
 - name: Pat Roberts
   party: majority
   rank: 5
-  thomas: '00968'
   bioguide: R000307
+  thomas: '00968'
 - name: Roy Blunt
   party: majority
   rank: 6
-  thomas: '01464'
   bioguide: B000575
+  thomas: '01464'
 - name: Ted Cruz
   party: majority
   rank: 7
-  thomas: '02175'
   bioguide: C001098
+  thomas: '02175'
 - name: Shelley Moore Capito
   party: majority
   rank: 8
-  thomas: '01676'
   bioguide: C001047
+  thomas: '01676'
 - name: Roger F. Wicker
   party: majority
   rank: 9
-  thomas: '01226'
   bioguide: W000437
+  thomas: '01226'
 - name: Deb Fischer
   party: majority
   rank: 10
-  thomas: '02179'
   bioguide: F000463
+  thomas: '02179'
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01826'
   bioguide: K000367
+  thomas: '01826'
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
+  thomas: '01332'
 - name: Charles E. Schumer
   party: minority
   rank: 3
-  thomas: '01036'
   bioguide: S000148
+  thomas: '01036'
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
+  thomas: '00326'
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
+  thomas: '01567'
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
+  thomas: '01897'
 - name: Patrick J. Leahy
   party: minority
   rank: 7
-  thomas: '01383'
   bioguide: L000174
+  thomas: '01383'
 - name: Angus S. King, Jr.
   party: minority
   rank: 8
-  thomas: '02185'
   bioguide: K000383
+  thomas: '02185'
 - name: Catherine Cortez Masto
   party: minority
   rank: 9
@@ -19378,173 +19550,173 @@ SSSB:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01896'
   bioguide: R000584
+  thomas: '01896'
 - name: Marco Rubio
   party: majority
   rank: 2
-  thomas: '02084'
   bioguide: R000595
+  thomas: '02084'
 - name: Rand Paul
   party: majority
   rank: 3
-  thomas: '02082'
   bioguide: P000603
+  thomas: '02082'
 - name: Tim Scott
   party: majority
   rank: 4
-  thomas: '02056'
   bioguide: S001184
+  thomas: '02056'
 - name: Joni Ernst
   party: majority
   rank: 5
-  thomas: '02283'
   bioguide: E000295
+  thomas: '02283'
 - name: James M. Inhofe
   party: majority
   rank: 6
-  thomas: '00583'
   bioguide: I000024
+  thomas: '00583'
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
+  thomas: '02019'
 - name: Michael B. Enzi
   party: majority
   rank: 8
-  thomas: '01542'
   bioguide: E000285
+  thomas: '01542'
 - name: Mike Rounds
   party: majority
   rank: 9
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: John Kennedy
   party: majority
   rank: 10
   bioguide: K000393
-- name: Jeanne Shaheen
+- name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
-  bioguide: S001181
+  bioguide: C000141
+  thomas: '00174'
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
-- name: Benjamin L. Cardin
+  thomas: '00172'
+- name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '00174'
-  bioguide: C000141
+  bioguide: S001181
+  thomas: '01901'
 - name: Heidi Heitkamp
   party: minority
   rank: 4
-  thomas: '02174'
   bioguide: H001069
+  thomas: '02174'
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
+  thomas: '00735'
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
+  thomas: '02194'
 - name: Christopher A. Coons
   party: minority
   rank: 7
-  thomas: '01984'
   bioguide: C001088
+  thomas: '01984'
 - name: Mazie K. Hirono
   party: minority
   rank: 8
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
+  thomas: '02123'
 SSVA:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
+  thomas: '01608'
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
+  thomas: '01507'
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
+  thomas: '01687'
 - name: Dean Heller
   party: majority
   rank: 4
-  thomas: '01863'
   bioguide: H001041
+  thomas: '01863'
 - name: Bill Cassidy
   party: majority
   rank: 5
-  thomas: '01925'
   bioguide: C001075
+  thomas: '01925'
 - name: Mike Rounds
   party: majority
   rank: 6
-  thomas: '02288'
   bioguide: R000605
+  thomas: '02288'
 - name: Thom Tillis
   party: majority
   rank: 7
-  thomas: '02291'
   bioguide: T000476
+  thomas: '02291'
 - name: Dan Sullivan
   party: majority
   rank: 8
-  thomas: '02290'
   bioguide: S001198
+  thomas: '02290'
 - name: Jon Tester
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01829'
   bioguide: T000464
+  thomas: '01829'
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
+  thomas: '01409'
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
+  thomas: '01010'
 - name: Sherrod Brown
   party: minority
   rank: 4
-  thomas: '00136'
   bioguide: B000944
+  thomas: '00136'
 - name: Richard Blumenthal
   party: minority
   rank: 5
-  thomas: '02076'
   bioguide: B001277
+  thomas: '02076'
 - name: Mazie K. Hirono
   party: minority
   rank: 6
-  thomas: '01844'
   bioguide: H001042
+  thomas: '01844'
 - name: Joe Manchin, III
   party: minority
   rank: 7
-  thomas: '01983'
   bioguide: M001183
+  thomas: '01983'


### PR DESCRIPTION
- Some chair/ranking member details have changed since the last time it was run. One example was the HSBU, whose ranking member before this update was listed as someone who is now a Senator.
- For some reason the Thomas codes appeared in a different position than before, so this commit looks way more substantial than it really is.
- There were several sanity check warnings about name mismatches, which were in regard to punctuation and a middle initial. Full output:
    ```
    Name mismatch: John Curtis (in our file) vs John R. Curtis (on the Clerk page)
    Name mismatch: A. Drew Ferguson IV (in our file) vs A. Drew Ferguson, IV (on the Clerk page)
    Name mismatch: A. Drew Ferguson IV (in our file) vs A. Drew Ferguson, IV (on the Clerk page)
    Name mismatch: A. Drew Ferguson IV (in our file) vs A. Drew Ferguson, IV (on the Clerk page)
    Name mismatch: A. Drew Ferguson IV (in our file) vs A. Drew Ferguson, IV (on the Clerk page)
    ```
    Wasn't sure if I should address these by manually updating the yaml, but if so let me know and I'll add that commit to this PR.