### PR TITLE
committee membership ID order

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -2060,129 +2060,134 @@ HSAS:
   bioguide: R000575
 - name: Bill Shuster
   party: majority
-  rank: 9
+  rank: 8
   thomas: '01681'
   bioguide: S001154
 - name: K. Michael Conaway
   party: majority
-  rank: 10
+  rank: 9
   thomas: '01805'
   bioguide: C001062
 - name: Doug Lamborn
   party: majority
-  rank: 11
+  rank: 10
   thomas: '01834'
   bioguide: L000564
 - name: Robert J. Wittman
   party: majority
-  rank: 12
+  rank: 11
   thomas: '01886'
   bioguide: W000804
 - name: Duncan Hunter
   party: majority
-  rank: 13
+  rank: 12
   thomas: '01909'
   bioguide: H001048
 - name: Mike Coffman
   party: majority
-  rank: 14
+  rank: 13
   thomas: '01912'
   bioguide: C001077
 - name: Vicky Hartzler
   party: majority
-  rank: 15
+  rank: 14
   thomas: '02032'
   bioguide: H001053
 - name: Austin Scott
   party: majority
-  rank: 16
+  rank: 15
   thomas: '02009'
   bioguide: S001189
 - name: Mo Brooks
   party: majority
-  rank: 17
+  rank: 16
   thomas: '01987'
   bioguide: B001274
 - name: Paul Cook
   party: majority
-  rank: 18
+  rank: 17
   thomas: '02103'
   bioguide: C001094
 - name: Jim Bridenstine
   party: majority
-  rank: 19
+  rank: 18
   thomas: '02155'
   bioguide: B001283
 - name: Brad R. Wenstrup
   party: majority
-  rank: 20
+  rank: 19
   thomas: '02152'
   bioguide: W000815
 - name: Bradley Byrne
   party: majority
-  rank: 21
+  rank: 20
   thomas: '02197'
   bioguide: B001289
 - name: Sam Graves
   party: majority
-  rank: 22
+  rank: 21
   thomas: '01656'
   bioguide: G000546
 - name: Elise M. Stefanik
   party: majority
-  rank: 23
+  rank: 22
   thomas: '02263'
   bioguide: S001196
 - name: Martha McSally
   party: majority
-  rank: 24
+  rank: 23
   thomas: '02225'
   bioguide: M001197
 - name: Stephen Knight
   party: majority
-  rank: 25
+  rank: 24
   thomas: '02228'
   bioguide: K000387
 - name: Steve Russell
   party: majority
-  rank: 26
+  rank: 25
   thomas: '02265'
   bioguide: R000604
 - name: Scott DesJarlais
   party: majority
-  rank: 27
+  rank: 26
   thomas: '02062'
   bioguide: D000616
 - name: Ralph Lee Abraham
   party: majority
-  rank: 28
+  rank: 27
   thomas: '02244'
   bioguide: A000374
 - name: Trent Kelly
   party: majority
-  rank: 29
+  rank: 28
   thomas: '02294'
   bioguide: K000388
 - name: Mike Gallagher
   party: majority
-  rank: 30
+  rank: 29
   bioguide: G000579
 - name: Matt Gaetz
   party: majority
-  rank: 31
+  rank: 30
   bioguide: G000578
 - name: Don Bacon
   party: majority
-  rank: 32
+  rank: 31
   bioguide: B001298
 - name: Jim Banks
   party: majority
-  rank: 33
+  rank: 32
   bioguide: B001299
 - name: Liz Cheney
   party: majority
-  rank: 34
+  rank: 33
   bioguide: C001109
+- name: Jody B. Hice
+  party: majority
+  rank: 34
+  thomas: '02237'
+  bioguide: H001071
 - name: Adam Smith
   party: minority
   rank: 1
@@ -2691,14 +2696,19 @@ HSAS26:
   bioguide: L000554
 - name: Doug Lamborn
   party: majority
-  rank: 9
+  rank: 8
   thomas: '01834'
   bioguide: L000564
 - name: Austin Scott
   party: majority
-  rank: 10
+  rank: 9
   thomas: '02009'
   bioguide: S001189
+- name: Jody B. Hice
+  party: majority
+  rank: 10
+  thomas: '02237'
+  bioguide: H001071
 - name: James R. Langevin
   party: minority
   rank: 1
@@ -2850,44 +2860,49 @@ HSAS29:
   bioguide: R000575
 - name: Doug Lamborn
   party: majority
-  rank: 3
+  rank: 2
   thomas: '01834'
   bioguide: L000564
 - name: Duncan Hunter
   party: majority
-  rank: 4
+  rank: 3
   thomas: '01909'
   bioguide: H001048
 - name: Mo Brooks
   party: majority
-  rank: 5
+  rank: 4
   thomas: '01987'
   bioguide: B001274
 - name: Jim Bridenstine
   party: majority
-  rank: 6
+  rank: 5
   thomas: '02155'
   bioguide: B001283
 - name: Michael R. Turner
   party: majority
-  rank: 7
+  rank: 6
   thomas: '01741'
   bioguide: T000463
 - name: Mike Coffman
   party: majority
-  rank: 8
+  rank: 7
   thomas: '01912'
   bioguide: C001077
 - name: Bradley Byrne
   party: majority
-  rank: 9
+  rank: 8
   thomas: '02197'
   bioguide: B001289
 - name: Sam Graves
   party: majority
-  rank: 10
+  rank: 9
   thomas: '01656'
   bioguide: G000546
+- name: Jody B. Hice
+  party: majority
+  rank: 10
+  thomas: '02237'
+  bioguide: H001071
 - name: Jim Cooper
   party: minority
   rank: 1
@@ -4017,47 +4032,47 @@ HSBA20:
   bioguide: W000187
   title: Ex Officio
 HSBU:
-- name: Diane Black
+- name: Steve Womack
   party: majority
   rank: 1
   title: Chair
+  thomas: '01991'
+  bioguide: W000809
+- name: Diane Black
+  party: majority
+  rank: 2
   thomas: '02063'
   bioguide: B001273
 - name: Mario Diaz-Balart
   party: majority
-  rank: 2
+  rank: 3
   thomas: '01717'
   bioguide: D000600
 - name: Tom Cole
   party: majority
-  rank: 3
+  rank: 4
   thomas: '01742'
   bioguide: C001053
 - name: Tom McClintock
   party: majority
-  rank: 4
+  rank: 5
   thomas: '01908'
   bioguide: M001177
 - name: Todd Rokita
   party: majority
-  rank: 5
+  rank: 6
   thomas: '02017'
   bioguide: R000592
 - name: Rob Woodall
   party: majority
-  rank: 6
+  rank: 7
   thomas: '02008'
   bioguide: W000810
 - name: Mark Sanford
   party: majority
-  rank: 7
+  rank: 8
   thomas: '01012'
   bioguide: S000051
-- name: Steve Womack
-  party: majority
-  rank: 8
-  thomas: '01991'
-  bioguide: W000809
 - name: Dave Brat
   party: majority
   rank: 9
@@ -4865,6 +4880,10 @@ HSFA:
   party: majority
   rank: 25
   bioguide: G000580
+- name: John Curtis
+  party: majority
+  rank: 26
+  bioguide: C001114
 - name: Eliot L. Engel
   party: minority
   rank: 1
@@ -5043,6 +5062,12 @@ HSFA05:
   thomas: '02122'
   bioguide: G000571
 HSFA07:
+- name: Paul Cook
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '02103'
+  bioguide: C001094
 - name: Christopher H. Smith
   party: majority
   rank: 2
@@ -5134,39 +5159,38 @@ HSFA13:
   rank: 5
   thomas: '02142'
   bioguide: M001187
-- name: Paul Cook
-  party: majority
-  rank: 6
-  thomas: '02103'
-  bioguide: C001094
 - name: Adam Kinzinger
   party: majority
-  rank: 7
+  rank: 6
   thomas: '02014'
   bioguide: K000378
 - name: Lee M. Zeldin
   party: majority
-  rank: 8
+  rank: 7
   thomas: '02261'
   bioguide: Z000017
 - name: Daniel M. Donovan, Jr.
   party: majority
-  rank: 9
+  rank: 8
   thomas: '02293'
   bioguide: D000625
 - name: Ann Wagner
   party: majority
-  rank: 10
+  rank: 9
   thomas: '02137'
   bioguide: W000812
 - name: Brian J. Mast
   party: majority
-  rank: 11
+  rank: 10
   bioguide: M001199
 - name: Brian K. Fitzpatrick
   party: majority
-  rank: 12
+  rank: 11
   bioguide: F000466
+- name: John Curtis
+  party: majority
+  rank: 12
+  bioguide: C001114
 - name: Theodore E. Deutch
   party: minority
   rank: 1
@@ -5247,6 +5271,10 @@ HSFA14:
   party: majority
   rank: 7
   bioguide: F000466
+- name: John Curtis
+  party: majority
+  rank: 8
+  bioguide: C001114
 - name: Gregory W. Meeks
   party: minority
   rank: 1
@@ -6104,6 +6132,10 @@ HSHM:
   party: majority
   rank: 17
   bioguide: E000298
+- name: Don Bacon
+  party: majority
+  rank: 18
+  bioguide: B001298
 - name: Bennie G. Thompson
   party: minority
   rank: 1
@@ -6289,18 +6321,14 @@ HSHM08:
   party: majority
   rank: 4
   bioguide: G000579
-- name: Clay Higgins
-  party: majority
-  rank: 5
-  bioguide: H001077
-- name: Thomas A. Garrett, Jr.
-  party: majority
-  rank: 6
-  bioguide: G000580
 - name: Brian K. Fitzpatrick
   party: majority
-  rank: 7
+  rank: 5
   bioguide: F000466
+- name: Don Bacon
+  party: majority
+  rank: 6
+  bioguide: B001298
 - name: Michael T. McCaul
   party: majority
   rank: 8
@@ -6349,9 +6377,13 @@ HSHM09:
   party: majority
   rank: 3
   bioguide: H001077
-- name: Ron Estes
+- name: Thomas A. Garrett, Jr.
   party: majority
   rank: 4
+  bioguide: G000580
+- name: Ron Estes
+  party: majority
+  rank: 5
   bioguide: E000298
 - name: Michael T. McCaul
   party: majority
@@ -6410,6 +6442,10 @@ HSHM11:
   party: majority
   rank: 6
   bioguide: R000609
+- name: Don Bacon
+  party: majority
+  rank: 7
+  bioguide: B001298
 - name: Michael T. McCaul
   party: majority
   rank: 8
@@ -6777,6 +6813,12 @@ HSIF:
   thomas: '02251'
   bioguide: D000624
 HSIF02:
+- name: Gregg Harper
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01933'
+  bioguide: H001045
 - name: H. Morgan Griffith
   party: majority
   rank: 2
@@ -6959,6 +7001,11 @@ HSIF03:
   rank: 17
   thomas: '01855'
   bioguide: W000798
+- name: Jeff Duncan
+  party: majority
+  rank: 18
+  thomas: '02057'
+  bioguide: D000615
 - name: Greg Walden
   party: majority
   rank: 19
@@ -7070,59 +7117,64 @@ HSIF14:
   rank: 6
   thomas: '01748'
   bioguide: B001243
-- name: Cathy McMorris Rodgers
+- name: Robert E. Latta
   party: majority
   rank: 7
+  thomas: '01885'
+  bioguide: L000566
+- name: Cathy McMorris Rodgers
+  party: majority
+  rank: 8
   thomas: '01809'
   bioguide: M001159
 - name: Leonard Lance
   party: majority
-  rank: 8
+  rank: 9
   thomas: '01936'
   bioguide: L000567
 - name: H. Morgan Griffith
   party: majority
-  rank: 9
+  rank: 10
   thomas: '02070'
   bioguide: G000568
 - name: Gus M. Bilirakis
   party: majority
-  rank: 10
+  rank: 11
   thomas: '01838'
   bioguide: B001257
 - name: Billy Long
   party: majority
-  rank: 11
+  rank: 12
   thomas: '02033'
   bioguide: L000576
 - name: Larry Bucshon
   party: majority
-  rank: 12
+  rank: 13
   thomas: '02018'
   bioguide: B001275
 - name: Susan W. Brooks
   party: majority
-  rank: 13
+  rank: 14
   thomas: '02129'
   bioguide: B001284
 - name: Markwayne Mullin
   party: majority
-  rank: 14
+  rank: 15
   thomas: '02156'
   bioguide: M001190
 - name: Richard Hudson
   party: majority
-  rank: 15
+  rank: 16
   thomas: '02140'
   bioguide: H001067
 - name: Chris Collins
   party: majority
-  rank: 16
+  rank: 17
   thomas: '02151'
   bioguide: C001092
 - name: Earl L. "Buddy" Carter
   party: majority
-  rank: 17
+  rank: 18
   thomas: '02236'
   bioguide: C001103
 - name: Greg Walden
@@ -7371,11 +7423,11 @@ HSIF17:
   title: Chair
   thomas: '01885'
   bioguide: L000566
-- name: Gregg Harper
+- name: Adam Kinzinger
   party: majority
   rank: 2
-  thomas: '01933'
-  bioguide: H001045
+  thomas: '02014'
+  bioguide: K000378
   title: Vice Chair
 - name: Fred Upton
   party: majority
@@ -7402,36 +7454,36 @@ HSIF17:
   rank: 7
   thomas: '02074'
   bioguide: M001180
-- name: Adam Kinzinger
-  party: majority
-  rank: 8
-  thomas: '02014'
-  bioguide: K000378
 - name: Gus M. Bilirakis
   party: majority
-  rank: 9
+  rank: 8
   thomas: '01838'
   bioguide: B001257
 - name: Larry Bucshon
   party: majority
-  rank: 10
+  rank: 9
   thomas: '02018'
   bioguide: B001275
 - name: Markwayne Mullin
   party: majority
-  rank: 11
+  rank: 10
   thomas: '02156'
   bioguide: M001190
 - name: Mimi Walters
   party: majority
-  rank: 12
+  rank: 11
   thomas: '02232'
   bioguide: W000820
 - name: Ryan A. Costello
   party: majority
-  rank: 13
+  rank: 12
   thomas: '02266'
   bioguide: C001106
+- name: Jeff Duncan
+  party: majority
+  rank: 13
+  thomas: '02057'
+  bioguide: D000615
 - name: Greg Walden
   party: majority
   rank: 14
@@ -7553,6 +7605,11 @@ HSIF18:
   rank: 12
   thomas: '02236'
   bioguide: C001103
+- name: Jeff Duncan
+  party: majority
+  rank: 13
+  thomas: '02057'
+  bioguide: D000615
 - name: Greg Walden
   party: majority
   rank: 14
@@ -7703,36 +7760,35 @@ HSII:
   rank: 18
   thomas: '02222'
   bioguide: R000600
-- name: Darin LaHood
-  party: majority
-  rank: 19
-  thomas: '02295'
-  bioguide: L000585
 - name: Daniel Webster
   party: majority
-  rank: 20
+  rank: 19
   thomas: '02002'
   bioguide: W000806
 - name: Jack Bergman
   party: majority
-  rank: 21
+  rank: 20
   bioguide: B001301
 - name: Liz Cheney
   party: majority
-  rank: 22
+  rank: 21
   bioguide: C001109
 - name: Mike Johnson
   party: majority
-  rank: 23
+  rank: 22
   bioguide: J000299
 - name: Jenniffer González-Colón
   party: majority
-  rank: 24
+  rank: 23
   bioguide: G000582
 - name: Greg Gianforte
   party: majority
-  rank: 25
+  rank: 24
   bioguide: G000584
+- name: John Curtis
+  party: majority
+  rank: 25
+  bioguide: C001114
 - name: Raúl M. Grijalva
   party: minority
   rank: 1
@@ -7871,18 +7927,13 @@ HSII06:
   rank: 10
   thomas: '02237'
   bioguide: H001071
-- name: Darin LaHood
-  party: majority
-  rank: 11
-  thomas: '02295'
-  bioguide: L000585
 - name: Jack Bergman
   party: majority
-  rank: 12
+  rank: 11
   bioguide: B001301
 - name: Liz Cheney
   party: majority
-  rank: 13
+  rank: 12
   bioguide: C001109
 - name: Rob Bishop
   party: majority
@@ -7971,27 +8022,22 @@ HSII10:
   rank: 7
   thomas: '02224'
   bioguide: W000821
-- name: Darin LaHood
-  party: majority
-  rank: 8
-  thomas: '02295'
-  bioguide: L000585
 - name: Daniel Webster
   party: majority
-  rank: 9
+  rank: 8
   thomas: '02002'
   bioguide: W000806
 - name: Jack Bergman
   party: majority
-  rank: 10
+  rank: 9
   bioguide: B001301
 - name: Liz Cheney
   party: majority
-  rank: 11
+  rank: 10
   bioguide: C001109
 - name: Greg Gianforte
   party: majority
-  rank: 12
+  rank: 11
   bioguide: G000584
 - name: Rob Bishop
   party: majority
@@ -8242,18 +8288,13 @@ HSII24:
   rank: 5
   thomas: '02222'
   bioguide: R000600
-- name: Darin LaHood
-  party: majority
-  rank: 6
-  thomas: '02295'
-  bioguide: L000585
 - name: Jack Bergman
   party: majority
-  rank: 7
+  rank: 6
   bioguide: B001301
 - name: Jenniffer González-Colón
   party: majority
-  rank: 8
+  rank: 7
   bioguide: G000582
 - name: Rob Bishop
   party: majority
@@ -8331,162 +8372,167 @@ HSJU:
   bioguide: K000362
 - name: Louie Gohmert
   party: majority
-  rank: 8
+  rank: 7
   thomas: '01801'
   bioguide: G000552
 - name: Jim Jordan
   party: majority
-  rank: 9
+  rank: 8
   thomas: '01868'
   bioguide: J000289
 - name: Ted Poe
   party: majority
-  rank: 10
+  rank: 9
   thomas: '01802'
   bioguide: P000592
 - name: Tom Marino
   party: majority
-  rank: 11
+  rank: 10
   thomas: '02053'
   bioguide: M001179
 - name: Trey Gowdy
   party: majority
-  rank: 12
+  rank: 11
   thomas: '02058'
   bioguide: G000566
 - name: Raúl R. Labrador
   party: majority
-  rank: 13
+  rank: 12
   thomas: '02011'
   bioguide: L000573
 - name: Blake Farenthold
   party: majority
-  rank: 14
+  rank: 13
   thomas: '02067'
   bioguide: F000460
 - name: Doug Collins
   party: majority
-  rank: 15
+  rank: 14
   thomas: '02121'
   bioguide: C001093
 - name: Ron DeSantis
   party: majority
-  rank: 16
+  rank: 15
   thomas: '02116'
   bioguide: D000621
 - name: Ken Buck
   party: majority
-  rank: 17
+  rank: 16
   thomas: '02233'
   bioguide: B001297
 - name: John Ratcliffe
   party: majority
-  rank: 18
+  rank: 17
   thomas: '02268'
   bioguide: R000601
 - name: Martha Roby
   party: majority
-  rank: 19
+  rank: 18
   thomas: '01986'
   bioguide: R000591
 - name: Matt Gaetz
   party: majority
-  rank: 20
+  rank: 19
   bioguide: G000578
 - name: Mike Johnson
   party: majority
-  rank: 21
+  rank: 20
   bioguide: J000299
 - name: Andy Biggs
   party: majority
-  rank: 22
+  rank: 21
   bioguide: B001302
 - name: John H. Rutherford
   party: majority
-  rank: 23
+  rank: 22
   bioguide: R000609
 - name: Karen C. Handel
   party: majority
-  rank: 24
+  rank: 23
   bioguide: H001078
 - name: Jerrold Nadler
   party: minority
-  rank: 2
+  rank: 1
+  title: Ranking Member
   thomas: '00850'
   bioguide: N000002
 - name: Zoe Lofgren
   party: minority
-  rank: 3
+  rank: 2
   thomas: '00701'
   bioguide: L000397
 - name: Sheila Jackson Lee
   party: minority
-  rank: 4
+  rank: 3
   thomas: '00588'
   bioguide: J000032
 - name: Steve Cohen
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01878'
   bioguide: C001068
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
-  rank: 6
+  rank: 5
   thomas: '01843'
   bioguide: J000288
 - name: Theodore E. Deutch
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01976'
   bioguide: D000610
 - name: Luis V. Gutiérrez
   party: minority
-  rank: 8
+  rank: 7
   thomas: '00478'
   bioguide: G000535
 - name: Karen Bass
   party: minority
-  rank: 9
+  rank: 8
   thomas: '01996'
   bioguide: B001270
 - name: Cedric L. Richmond
   party: minority
-  rank: 10
+  rank: 9
   thomas: '02023'
   bioguide: R000588
 - name: Hakeem S. Jeffries
   party: minority
-  rank: 11
+  rank: 10
   thomas: '02149'
   bioguide: J000294
 - name: David N. Cicilline
   party: minority
-  rank: 12
+  rank: 11
   thomas: '02055'
   bioguide: C001084
 - name: Eric Swalwell
   party: minority
-  rank: 13
+  rank: 12
   thomas: '02104'
   bioguide: S001193
 - name: Ted Lieu
   party: minority
-  rank: 14
+  rank: 13
   thomas: '02230'
   bioguide: L000582
 - name: Jamie Raskin
   party: minority
-  rank: 15
+  rank: 14
   bioguide: R000606
 - name: Pramila Jayapal
   party: minority
-  rank: 16
+  rank: 15
   bioguide: J000298
 - name: Bradley Scott Schneider
   party: minority
-  rank: 17
+  rank: 16
   thomas: '02124'
   bioguide: S001190
+- name: Val Butler Demings
+  party: minority
+  rank: 17
+  bioguide: D000627
 HSJU01:
 - name: Raúl R. Labrador
   party: majority
@@ -8547,11 +8593,10 @@ HSJU01:
   rank: 4
   thomas: '00588'
   bioguide: J000032
-- name: David N. Cicilline
+- name: Jamie Raskin
   party: minority
   rank: 5
-  thomas: '02055'
-  bioguide: C001084
+  bioguide: R000606
 HSJU03:
 - name: Darrell E. Issa
   party: majority
@@ -8577,19 +8622,24 @@ HSJU03:
   bioguide: C000266
 - name: Jim Jordan
   party: majority
-  rank: 6
+  rank: 5
   thomas: '01868'
   bioguide: J000289
 - name: Ted Poe
   party: majority
-  rank: 7
+  rank: 6
   thomas: '01802'
   bioguide: P000592
 - name: Tom Marino
   party: majority
-  rank: 8
+  rank: 7
   thomas: '02053'
   bioguide: M001179
+- name: Trey Gowdy
+  party: majority
+  rank: 8
+  thomas: '02058'
+  bioguide: G000566
 - name: Raúl R. Labrador
   party: majority
   rank: 9
@@ -8613,72 +8663,66 @@ HSJU03:
   party: majority
   rank: 13
   bioguide: B001302
-- name: Trey Gowdy
-  party: majority
-  rank: 14
-  thomas: '02058'
-  bioguide: G000566
-- name: Jerrold Nadler
+- name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00850'
-  bioguide: N000002
-- name: Henry C. "Hank" Johnson, Jr.
-  party: minority
-  rank: 2
   thomas: '01843'
   bioguide: J000288
 - name: Theodore E. Deutch
   party: minority
-  rank: 3
+  rank: 2
   thomas: '01976'
   bioguide: D000610
 - name: Karen Bass
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01996'
   bioguide: B001270
 - name: Cedric L. Richmond
   party: minority
-  rank: 5
+  rank: 4
   thomas: '02023'
   bioguide: R000588
 - name: Hakeem S. Jeffries
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02149'
   bioguide: J000294
 - name: Eric Swalwell
   party: minority
-  rank: 7
+  rank: 6
   thomas: '02104'
   bioguide: S001193
 - name: Ted Lieu
   party: minority
-  rank: 8
+  rank: 7
   thomas: '02230'
   bioguide: L000582
 - name: Bradley Scott Schneider
   party: minority
-  rank: 9
+  rank: 8
   thomas: '02124'
   bioguide: S001190
 - name: Zoe Lofgren
   party: minority
-  rank: 10
+  rank: 9
   thomas: '00701'
   bioguide: L000397
 - name: Steve Cohen
   party: minority
-  rank: 11
+  rank: 10
   thomas: '01878'
   bioguide: C001068
-- name: Luis V. Gutiérrez
+- name: David N. Cicilline
+  party: minority
+  rank: 11
+  thomas: '02055'
+  bioguide: C001084
+- name: Pramila Jayapal
   party: minority
   rank: 12
-  thomas: '00478'
-  bioguide: G000535
+  bioguide: J000298
 HSJU05:
 - name: Tom Marino
   party: majority
@@ -8736,15 +8780,15 @@ HSJU05:
   rank: 3
   thomas: '02104'
   bioguide: S001193
-- name: Pramila Jayapal
-  party: minority
-  rank: 4
-  bioguide: J000298
 - name: Bradley Scott Schneider
   party: minority
-  rank: 5
+  rank: 4
   thomas: '02124'
   bioguide: S001190
+- name: Val Butler Demings
+  party: minority
+  rank: 5
+  bioguide: D000627
 HSJU08:
 - name: F. James Sensenbrenner, Jr.
   party: majority
@@ -8797,11 +8841,10 @@ HSJU08:
   title: Ranking Member
   thomas: '00588'
   bioguide: J000032
-- name: Theodore E. Deutch
+- name: Val Butler Demings
   party: minority
   rank: 2
-  thomas: '01976'
-  bioguide: D000610
+  bioguide: D000627
 - name: Karen Bass
   party: minority
   rank: 3
@@ -8841,12 +8884,12 @@ HSJU10:
   title: Vice Chair
 - name: Louie Gohmert
   party: majority
-  rank: 4
+  rank: 3
   thomas: '01801'
   bioguide: G000552
 - name: Karen C. Handel
   party: majority
-  rank: 5
+  rank: 4
   bioguide: H001078
 - name: Steve Cohen
   party: minority
@@ -8858,11 +8901,11 @@ HSJU10:
   party: minority
   rank: 2
   bioguide: R000606
-- name: Jerrold Nadler
+- name: Theodore E. Deutch
   party: minority
   rank: 3
-  thomas: '00850'
-  bioguide: N000002
+  thomas: '01976'
+  bioguide: D000610
 HSPW:
 - name: Bill Shuster
   party: majority
@@ -9041,131 +9084,131 @@ HSPW:
   rank: 2
   thomas: '00868'
   bioguide: N000147
-- name: Jerrold Nadler
-  party: minority
-  rank: 3
-  thomas: '00850'
-  bioguide: N000002
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 4
+  rank: 3
   thomas: '00599'
   bioguide: J000126
 - name: Elijah E. Cummings
   party: minority
-  rank: 5
+  rank: 4
   thomas: '00256'
   bioguide: C000984
 - name: Rick Larsen
   party: minority
-  rank: 6
+  rank: 5
   thomas: '01675'
   bioguide: L000560
 - name: Michael E. Capuano
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01564'
   bioguide: C001037
 - name: Grace F. Napolitano
   party: minority
-  rank: 8
+  rank: 7
   thomas: '01602'
   bioguide: N000179
 - name: Daniel Lipinski
   party: minority
-  rank: 9
+  rank: 8
   thomas: '01781'
   bioguide: L000563
 - name: Steve Cohen
   party: minority
-  rank: 10
+  rank: 9
   thomas: '01878'
   bioguide: C001068
 - name: Albio Sires
   party: minority
-  rank: 11
+  rank: 10
   thomas: '01818'
   bioguide: S001165
 - name: John Garamendi
   party: minority
-  rank: 12
+  rank: 11
   thomas: '01973'
   bioguide: G000559
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
-  rank: 13
+  rank: 12
   thomas: '01843'
   bioguide: J000288
 - name: André Carson
   party: minority
-  rank: 14
+  rank: 13
   thomas: '01889'
   bioguide: C001072
 - name: Richard M. Nolan
   party: minority
-  rank: 15
+  rank: 14
   thomas: '00867'
   bioguide: N000127
 - name: Dina Titus
   party: minority
-  rank: 16
+  rank: 15
   thomas: '01940'
   bioguide: T000468
 - name: Sean Patrick Maloney
   party: minority
-  rank: 17
+  rank: 16
   thomas: '02150'
   bioguide: M001185
 - name: Elizabeth H. Esty
   party: minority
-  rank: 18
+  rank: 17
   thomas: '02114'
   bioguide: E000293
 - name: Lois Frankel
   party: minority
-  rank: 19
+  rank: 18
   thomas: '02119'
   bioguide: F000462
 - name: Cheri Bustos
   party: minority
-  rank: 20
+  rank: 19
   thomas: '02127'
   bioguide: B001286
 - name: Jared Huffman
   party: minority
-  rank: 21
+  rank: 20
   thomas: '02101'
   bioguide: H001068
 - name: Julia Brownley
   party: minority
-  rank: 22
+  rank: 21
   thomas: '02106'
   bioguide: B001285
 - name: Frederica S. Wilson
   party: minority
-  rank: 23
+  rank: 22
   thomas: '02004'
   bioguide: W000808
 - name: Donald M. Payne, Jr.
   party: minority
-  rank: 24
+  rank: 23
   thomas: '02097'
   bioguide: P000604
 - name: Alan S. Lowenthal
   party: minority
-  rank: 25
+  rank: 24
   thomas: '02111'
   bioguide: L000579
 - name: Brenda L. Lawrence
   party: minority
-  rank: 26
+  rank: 25
   thomas: '02252'
   bioguide: L000581
 - name: Mark DeSaulnier
   party: minority
-  rank: 27
+  rank: 26
   thomas: '02227'
   bioguide: D000623
+- name: Stacey E. Plaskett
+  party: minority
+  rank: 27
+  thomas: '02274'
+  bioguide: P000610
 HSPW02:
 - name: Garret Graves
   party: majority
@@ -9713,104 +9756,99 @@ HSPW12:
   title: Ranking Member
   thomas: '00868'
   bioguide: N000147
-- name: Jerrold Nadler
-  party: minority
-  rank: 2
-  thomas: '00850'
-  bioguide: N000002
 - name: Steve Cohen
   party: minority
-  rank: 3
+  rank: 2
   thomas: '01878'
   bioguide: C001068
 - name: Albio Sires
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01818'
   bioguide: S001165
 - name: Richard M. Nolan
   party: minority
-  rank: 5
+  rank: 4
   thomas: '00867'
   bioguide: N000127
 - name: Dina Titus
   party: minority
-  rank: 6
+  rank: 5
   thomas: '01940'
   bioguide: T000468
 - name: Sean Patrick Maloney
   party: minority
-  rank: 7
+  rank: 6
   thomas: '02150'
   bioguide: M001185
 - name: Elizabeth H. Esty
   party: minority
-  rank: 8
+  rank: 7
   thomas: '02114'
   bioguide: E000293
 - name: Jared Huffman
   party: minority
-  rank: 9
+  rank: 8
   thomas: '02101'
   bioguide: H001068
 - name: Julia Brownley
   party: minority
-  rank: 10
+  rank: 9
   thomas: '02106'
   bioguide: B001285
 - name: Alan S. Lowenthal
   party: minority
-  rank: 11
+  rank: 10
   thomas: '02111'
   bioguide: L000579
 - name: Brenda L. Lawrence
   party: minority
-  rank: 12
+  rank: 11
   thomas: '02252'
   bioguide: L000581
 - name: Mark DeSaulnier
   party: minority
-  rank: 13
+  rank: 12
   thomas: '02227'
   bioguide: D000623
 - name: Eddie Bernice Johnson
   party: minority
-  rank: 14
+  rank: 13
   thomas: '00599'
   bioguide: J000126
 - name: Michael E. Capuano
   party: minority
-  rank: 15
+  rank: 14
   thomas: '01564'
   bioguide: C001037
 - name: Grace F. Napolitano
   party: minority
-  rank: 16
+  rank: 15
   thomas: '01602'
   bioguide: N000179
 - name: Daniel Lipinski
   party: minority
-  rank: 17
+  rank: 16
   thomas: '01781'
   bioguide: L000563
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
-  rank: 18
+  rank: 17
   thomas: '01843'
   bioguide: J000288
 - name: Lois Frankel
   party: minority
-  rank: 19
+  rank: 18
   thomas: '02119'
   bioguide: F000462
 - name: Cheri Bustos
   party: minority
-  rank: 20
+  rank: 19
   thomas: '02127'
   bioguide: B001286
 - name: Frederica S. Wilson
   party: minority
-  rank: 21
+  rank: 20
   thomas: '02004'
   bioguide: W000808
 HSPW13:
@@ -9976,64 +10014,59 @@ HSPW14:
   rank: 2
   thomas: '02097'
   bioguide: P000604
-- name: Jerrold Nadler
-  party: minority
-  rank: 3
-  thomas: '00850'
-  bioguide: N000002
 - name: Elijah E. Cummings
   party: minority
-  rank: 4
+  rank: 3
   thomas: '00256'
   bioguide: C000984
 - name: Steve Cohen
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01878'
   bioguide: C001068
 - name: Albio Sires
   party: minority
-  rank: 6
+  rank: 5
   thomas: '01818'
   bioguide: S001165
 - name: John Garamendi
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01973'
   bioguide: G000559
 - name: André Carson
   party: minority
-  rank: 8
+  rank: 7
   thomas: '01889'
   bioguide: C001072
 - name: Richard M. Nolan
   party: minority
-  rank: 9
+  rank: 8
   thomas: '00867'
   bioguide: N000127
 - name: Elizabeth H. Esty
   party: minority
-  rank: 10
+  rank: 9
   thomas: '02114'
   bioguide: E000293
 - name: Cheri Bustos
   party: minority
-  rank: 11
+  rank: 10
   thomas: '02127'
   bioguide: B001286
 - name: Frederica S. Wilson
   party: minority
-  rank: 12
+  rank: 11
   thomas: '02004'
   bioguide: W000808
 - name: Mark DeSaulnier
   party: minority
-  rank: 13
+  rank: 12
   thomas: '02227'
   bioguide: D000623
 - name: Daniel Lipinski
   party: minority
-  rank: 14
+  rank: 13
   thomas: '01781'
   bioguide: L000563
 HSRU:
@@ -10228,22 +10261,22 @@ HSSM:
   party: majority
   rank: 10
   bioguide: G000582
-- name: Don Bacon
-  party: majority
-  rank: 11
-  bioguide: B001298
 - name: Brian K. Fitzpatrick
   party: majority
-  rank: 12
+  rank: 11
   bioguide: F000466
 - name: Roger W. Marshall
   party: majority
-  rank: 13
+  rank: 12
   bioguide: M001198
 - name: Ralph Norman
   party: majority
-  rank: 14
+  rank: 13
   bioguide: N000190
+- name: John Curtis
+  party: majority
+  rank: 14
+  bioguide: C001114
 - name: Nydia M. Velázquez
   party: minority
   rank: 1
@@ -10336,18 +10369,18 @@ HSSM24:
   rank: 2
   thomas: '02241'
   bioguide: B001294
-- name: Don Bacon
-  party: majority
-  rank: 3
-  bioguide: B001298
 - name: Roger W. Marshall
   party: majority
-  rank: 4
+  rank: 3
   bioguide: M001198
 - name: Ralph Norman
   party: majority
-  rank: 5
+  rank: 4
   bioguide: N000190
+- name: John Curtis
+  party: majority
+  rank: 5
+  bioguide: C001114
 - name: Alma S. Adams
   party: minority
   rank: 1
@@ -10380,10 +10413,10 @@ HSSM25:
   party: majority
   rank: 5
   bioguide: C001108
-- name: Don Bacon
+- name: John Curtis
   party: majority
   rank: 6
-  bioguide: B001298
+  bioguide: C001114
 - name: Bradley Scott Schneider
   party: minority
   rank: 1
@@ -10483,26 +10516,26 @@ HSSO:
   title: Chair
   thomas: '02129'
   bioguide: B001284
-- name: Patrick Meehan
-  party: majority
-  rank: 2
-  thomas: '02052'
-  bioguide: M001181
-- name: Trey Gowdy
-  party: majority
-  rank: 3
-  thomas: '02058'
-  bioguide: G000566
 - name: Kenny Marchant
   party: majority
-  rank: 4
+  rank: 2
   thomas: '01806'
   bioguide: M001158
 - name: Leonard Lance
   party: majority
-  rank: 5
+  rank: 3
   thomas: '01936'
   bioguide: L000567
+- name: Mimi Walters
+  party: majority
+  rank: 4
+  thomas: '02232'
+  bioguide: W000820
+- name: John Ratcliffe
+  party: majority
+  rank: 5
+  thomas: '02268'
+  bioguide: R000601
 - name: Theodore E. Deutch
   party: minority
   rank: 1
@@ -10545,6 +10578,7 @@ HSSY:
   rank: 3
   thomas: '00711'
   bioguide: L000491
+  title: Vice Chair
 - name: Mo Brooks
   party: majority
   rank: 4
@@ -10600,39 +10634,34 @@ HSSY:
   rank: 14
   thomas: '02244'
   bioguide: A000374
-- name: Darin LaHood
-  party: majority
-  rank: 15
-  thomas: '02295'
-  bioguide: L000585
 - name: Daniel Webster
   party: majority
-  rank: 16
+  rank: 15
   thomas: '02002'
   bioguide: W000806
 - name: Jim Banks
   party: majority
-  rank: 17
+  rank: 16
   bioguide: B001299
 - name: Andy Biggs
   party: majority
-  rank: 18
+  rank: 17
   bioguide: B001302
 - name: Roger W. Marshall
   party: majority
-  rank: 19
+  rank: 18
   bioguide: M001198
 - name: Neal P. Dunn
   party: majority
-  rank: 20
+  rank: 19
   bioguide: D000628
 - name: Clay Higgins
   party: majority
-  rank: 21
+  rank: 20
   bioguide: H001077
 - name: Ralph Norman
   party: majority
-  rank: 22
+  rank: 21
   bioguide: N000190
 - name: Eddie Bernice Johnson
   party: minority
@@ -10735,30 +10764,25 @@ HSSY15:
   rank: 4
   thomas: '02228'
   bioguide: K000387
-- name: Darin LaHood
-  party: majority
-  rank: 5
-  thomas: '02295'
-  bioguide: L000585
 - name: Ralph Lee Abraham
   party: majority
-  rank: 6
+  rank: 5
   thomas: '02244'
   bioguide: A000374
-  title: Vice Chair
 - name: Daniel Webster
   party: majority
-  rank: 7
+  rank: 6
   thomas: '02002'
   bioguide: W000806
 - name: Jim Banks
   party: majority
-  rank: 8
+  rank: 7
   bioguide: B001299
 - name: Roger W. Marshall
   party: majority
-  rank: 9
+  rank: 8
   bioguide: M001198
+  title: Vice Chair
 - name: Lamar Smith
   party: majority
   rank: 10
@@ -11041,19 +11065,14 @@ HSSY20:
   thomas: '02228'
   bioguide: K000387
   title: Vice Chair
-- name: Darin LaHood
-  party: majority
-  rank: 9
-  thomas: '02295'
-  bioguide: L000585
 - name: Daniel Webster
   party: majority
-  rank: 10
+  rank: 9
   thomas: '02002'
   bioguide: W000806
 - name: Neal P. Dunn
   party: majority
-  rank: 11
+  rank: 10
   bioguide: D000628
 - name: Lamar Smith
   party: majority
@@ -11108,12 +11127,12 @@ HSSY20:
   bioguide: J000126
   title: Ex Officio
 HSSY21:
-- name: Darin LaHood
+- name: Ralph Lee Abraham
   party: majority
   rank: 1
   title: Chair
-  thomas: '02295'
-  bioguide: L000585
+  thomas: '02244'
+  bioguide: A000374
 - name: Bill Posey
   party: majority
   rank: 2
@@ -11133,11 +11152,11 @@ HSSY21:
   party: majority
   rank: 5
   bioguide: M001198
-  title: Vice Chair
 - name: Clay Higgins
   party: majority
   rank: 6
   bioguide: H001077
+  title: Vice Chair
 - name: Ralph Norman
   party: majority
   rank: 7
@@ -11496,104 +11515,109 @@ HSWM:
   bioguide: N000181
 - name: David G. Reichert
   party: majority
-  rank: 5
+  rank: 4
   thomas: '01810'
   bioguide: R000578
 - name: Peter J. Roskam
   party: majority
-  rank: 6
+  rank: 5
   thomas: '01848'
   bioguide: R000580
 - name: Vern Buchanan
   party: majority
-  rank: 7
+  rank: 6
   thomas: '01840'
   bioguide: B001260
 - name: Adrian Smith
   party: majority
-  rank: 8
+  rank: 7
   thomas: '01860'
   bioguide: S001172
 - name: Lynn Jenkins
   party: majority
-  rank: 9
+  rank: 8
   thomas: '01921'
   bioguide: J000290
 - name: Erik Paulsen
   party: majority
-  rank: 10
+  rank: 9
   thomas: '01930'
   bioguide: P000594
 - name: Kenny Marchant
   party: majority
-  rank: 11
+  rank: 10
   thomas: '01806'
   bioguide: M001158
 - name: Diane Black
   party: majority
-  rank: 12
+  rank: 11
   thomas: '02063'
   bioguide: B001273
 - name: Tom Reed
   party: majority
-  rank: 13
+  rank: 12
   thomas: '01982'
   bioguide: R000585
 - name: Mike Kelly
   party: majority
-  rank: 14
+  rank: 13
   thomas: '02051'
   bioguide: K000376
 - name: James B. Renacci
   party: majority
-  rank: 15
+  rank: 14
   thomas: '02048'
   bioguide: R000586
 - name: Patrick Meehan
   party: majority
-  rank: 16
+  rank: 15
   thomas: '02052'
   bioguide: M001181
 - name: Kristi L. Noem
   party: majority
-  rank: 17
+  rank: 16
   thomas: '02060'
   bioguide: N000184
 - name: George Holding
   party: majority
-  rank: 18
+  rank: 17
   thomas: '02143'
   bioguide: H001065
 - name: Jason Smith
   party: majority
-  rank: 19
+  rank: 18
   thomas: '02191'
   bioguide: S001195
 - name: Tom Rice
   party: majority
-  rank: 20
+  rank: 19
   thomas: '02160'
   bioguide: R000597
 - name: David Schweikert
   party: majority
-  rank: 21
+  rank: 20
   thomas: '01994'
   bioguide: S001183
 - name: Jackie Walorski
   party: majority
-  rank: 22
+  rank: 21
   thomas: '02128'
   bioguide: W000813
 - name: Carlos Curbelo
   party: majority
-  rank: 23
+  rank: 22
   thomas: '02235'
   bioguide: C001107
 - name: Mike Bishop
   party: majority
-  rank: 24
+  rank: 23
   thomas: '02249'
   bioguide: B001293
+- name: Darin LaHood
+  party: majority
+  rank: 24
+  thomas: '02295'
+  bioguide: L000585
 - name: Richard E. Neal
   party: minority
   rank: 1
@@ -11682,36 +11706,36 @@ HSWM01:
   title: Chair
   thomas: '00603'
   bioguide: J000174
-- name: Tom Rice
-  party: majority
-  rank: 2
-  thomas: '02160'
-  bioguide: R000597
-- name: David Schweikert
-  party: majority
-  rank: 3
-  thomas: '01994'
-  bioguide: S001183
 - name: Vern Buchanan
   party: majority
-  rank: 4
+  rank: 2
   thomas: '01840'
   bioguide: B001260
 - name: Mike Kelly
   party: majority
-  rank: 5
+  rank: 3
   thomas: '02051'
   bioguide: K000376
-- name: James B. Renacci
+- name: George Holding
   party: majority
-  rank: 6
-  thomas: '02048'
-  bioguide: R000586
+  rank: 4
+  thomas: '02143'
+  bioguide: H001065
 - name: Jason Smith
   party: majority
-  rank: 7
+  rank: 5
   thomas: '02191'
   bioguide: S001195
+- name: Tom Rice
+  party: majority
+  rank: 6
+  thomas: '02160'
+  bioguide: R000597
+- name: David Schweikert
+  party: majority
+  rank: 7
+  thomas: '01994'
+  bioguide: S001183
 - name: John B. Larson
   party: minority
   rank: 1
@@ -11734,6 +11758,12 @@ HSWM01:
   thomas: '01757'
   bioguide: S001156
 HSWM02:
+- name: Peter J. Roskam
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01848'
+  bioguide: R000580
 - name: Sam Johnson
   party: majority
   rank: 2
@@ -11744,46 +11774,46 @@ HSWM02:
   rank: 3
   thomas: '01710'
   bioguide: N000181
-- name: Peter J. Roskam
-  party: majority
-  rank: 4
-  thomas: '01848'
-  bioguide: R000580
 - name: Vern Buchanan
   party: majority
-  rank: 5
+  rank: 4
   thomas: '01840'
   bioguide: B001260
 - name: Adrian Smith
   party: majority
-  rank: 6
+  rank: 5
   thomas: '01860'
   bioguide: S001172
 - name: Lynn Jenkins
   party: majority
-  rank: 7
+  rank: 6
   thomas: '01921'
   bioguide: J000290
 - name: Kenny Marchant
   party: majority
-  rank: 8
+  rank: 7
   thomas: '01806'
   bioguide: M001158
 - name: Diane Black
   party: majority
-  rank: 9
+  rank: 8
   thomas: '02063'
   bioguide: B001273
 - name: Erik Paulsen
   party: majority
-  rank: 10
+  rank: 9
   thomas: '01930'
   bioguide: P000594
 - name: Tom Reed
   party: majority
-  rank: 11
+  rank: 10
   thomas: '01982'
   bioguide: R000585
+- name: Mike Kelly
+  party: majority
+  rank: 11
+  thomas: '02051'
+  bioguide: K000376
 - name: Sander M. Levin
   party: minority
   rank: 1
@@ -11827,36 +11857,36 @@ HSWM03:
   title: Chair
   thomas: '01860'
   bioguide: S001172
-- name: Jason Smith
-  party: majority
-  rank: 2
-  thomas: '02191'
-  bioguide: S001195
 - name: Jackie Walorski
   party: majority
-  rank: 3
+  rank: 2
   thomas: '02128'
   bioguide: W000813
 - name: Carlos Curbelo
   party: majority
-  rank: 4
+  rank: 3
   thomas: '02235'
   bioguide: C001107
 - name: Mike Bishop
   party: majority
-  rank: 5
+  rank: 4
   thomas: '02249'
   bioguide: B001293
-- name: David G. Reichert
+- name: David Schweikert
+  party: majority
+  rank: 5
+  thomas: '01994'
+  bioguide: S001183
+- name: Darin LaHood
   party: majority
   rank: 6
-  thomas: '01810'
-  bioguide: R000578
-- name: Tom Reed
+  thomas: '02295'
+  bioguide: L000585
+- name: David G. Reichert
   party: majority
   rank: 7
-  thomas: '01982'
-  bioguide: R000585
+  thomas: '01810'
+  bioguide: R000578
 - name: Danny K. Davis
   party: minority
   rank: 1
@@ -11890,46 +11920,46 @@ HSWM04:
   rank: 2
   thomas: '01710'
   bioguide: N000181
-- name: Lynn Jenkins
-  party: majority
-  rank: 3
-  thomas: '01921'
-  bioguide: J000290
 - name: Erik Paulsen
   party: majority
-  rank: 4
+  rank: 3
   thomas: '01930'
   bioguide: P000594
 - name: Mike Kelly
   party: majority
-  rank: 5
+  rank: 4
   thomas: '02051'
   bioguide: K000376
 - name: Patrick Meehan
   party: majority
-  rank: 6
+  rank: 5
   thomas: '02052'
   bioguide: M001181
 - name: Tom Reed
   party: majority
-  rank: 7
+  rank: 6
   thomas: '01982'
   bioguide: R000585
 - name: Kristi L. Noem
   party: majority
-  rank: 8
+  rank: 7
   thomas: '02060'
   bioguide: N000184
 - name: George Holding
   party: majority
-  rank: 9
+  rank: 8
   thomas: '02143'
   bioguide: H001065
 - name: Tom Rice
   party: majority
-  rank: 10
+  rank: 9
   thomas: '02160'
   bioguide: R000597
+- name: Kenny Marchant
+  party: majority
+  rank: 10
+  thomas: '01806'
+  bioguide: M001158
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 1
@@ -11962,47 +11992,57 @@ HSWM04:
   thomas: '01794'
   bioguide: H001038
 HSWM05:
-- name: Peter J. Roskam
+- name: Vern Buchanan
   party: majority
   rank: 1
   title: Chair
+  thomas: '01840'
+  bioguide: B001260
+- name: Peter J. Roskam
+  party: majority
+  rank: 2
   thomas: '01848'
   bioguide: R000580
 - name: David G. Reichert
   party: majority
-  rank: 2
+  rank: 3
   thomas: '01810'
   bioguide: R000578
-- name: Mike Kelly
-  party: majority
-  rank: 4
-  thomas: '02051'
-  bioguide: K000376
 - name: James B. Renacci
   party: majority
-  rank: 5
+  rank: 4
   thomas: '02048'
   bioguide: R000586
 - name: Kristi L. Noem
   party: majority
-  rank: 6
+  rank: 5
   thomas: '02060'
   bioguide: N000184
+- name: Mike Kelly
+  party: majority
+  rank: 6
+  thomas: '02051'
+  bioguide: K000376
 - name: George Holding
   party: majority
   rank: 7
   thomas: '02143'
   bioguide: H001065
-- name: Kenny Marchant
-  party: majority
-  rank: 8
-  thomas: '01806'
-  bioguide: M001158
 - name: Patrick Meehan
   party: majority
-  rank: 9
+  rank: 8
   thomas: '02052'
   bioguide: M001181
+- name: Jason Smith
+  party: majority
+  rank: 9
+  thomas: '02191'
+  bioguide: S001195
+- name: Tom Rice
+  party: majority
+  rank: 10
+  thomas: '02160'
+  bioguide: R000597
 - name: Lloyd Doggett
   party: minority
   rank: 1
@@ -12035,12 +12075,12 @@ HSWM05:
   thomas: '00099'
   bioguide: B000574
 HSWM06:
-- name: Vern Buchanan
+- name: Lynn Jenkins
   party: majority
   rank: 1
   title: Chair
-  thomas: '01840'
-  bioguide: B001260
+  thomas: '01921'
+  bioguide: J000290
 - name: David Schweikert
   party: majority
   rank: 2
@@ -12061,16 +12101,16 @@ HSWM06:
   rank: 5
   thomas: '02249'
   bioguide: B001293
-- name: Patrick Meehan
+- name: Darin LaHood
   party: majority
   rank: 6
-  thomas: '02052'
-  bioguide: M001181
-- name: George Holding
+  thomas: '02295'
+  bioguide: L000585
+- name: Tom Reed
   party: majority
   rank: 7
-  thomas: '02143'
-  bioguide: H001065
+  thomas: '01982'
+  bioguide: R000585
 - name: John Lewis
   party: minority
   rank: 1
@@ -12401,7 +12441,7 @@ JSTX:
 - name: Orrin G. Hatch
   party: majority
   rank: 1
-  title: Vice Chairman
+  title: Chairman
   thomas: '01351'
   bioguide: H000338
   chamber: senate
@@ -12579,18 +12619,22 @@ SLIA:
   bioguide: T000464
 - name: Brian Schatz
   party: minority
-  rank: 5
+  rank: 4
   thomas: '02173'
   bioguide: S001194
 - name: Heidi Heitkamp
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02174'
   bioguide: H001069
 - name: Catherine Cortez Masto
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C001113
+- name: Tina Smith
+  party: minority
+  rank: 7
+  bioguide: S001203
 SLIN:
 - name: Richard Burr
   party: majority
@@ -12750,35 +12794,34 @@ SPAG:
   rank: 2
   thomas: '00859'
   bioguide: N000032
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  thomas: '01823'
-  bioguide: W000802
 - name: Kirsten E. Gillibrand
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01866'
   bioguide: G000555
 - name: Richard Blumenthal
   party: minority
-  rank: 5
+  rank: 4
   thomas: '02076'
   bioguide: B001277
 - name: Joe Donnelly
   party: minority
-  rank: 6
+  rank: 5
   thomas: '01850'
   bioguide: D000607
 - name: Elizabeth Warren
   party: minority
-  rank: 7
+  rank: 6
   thomas: '02182'
   bioguide: W000817
 - name: Catherine Cortez Masto
   party: minority
-  rank: 8
+  rank: 7
   bioguide: C001113
+- name: Doug Jones
+  party: minority
+  rank: 8
+  bioguide: J000300
 SSAF:
 - name: Pat Roberts
   party: majority
@@ -12831,6 +12874,11 @@ SSAF:
   rank: 10
   thomas: '02286'
   bioguide: P000612
+- name: Deb Fischer
+  party: majority
+  rank: 11
+  thomas: '02179'
+  bioguide: F000463
 - name: Debbie Stabenow
   party: minority
   rank: 1
@@ -12877,11 +12925,10 @@ SSAF:
   rank: 9
   thomas: '01828'
   bioguide: C001070
-- name: Chris Van Hollen
+- name: Tina Smith
   party: minority
   rank: 10
-  thomas: '01729'
-  bioguide: V000128
+  bioguide: S001203
 SSAF13:
 - name: John Boozman
   party: majority
@@ -12951,14 +12998,9 @@ SSAF13:
   rank: 5
   thomas: '01850'
   bioguide: D000607
-- name: Chris Van Hollen
-  party: minority
-  rank: 6
-  thomas: '01729'
-  bioguide: V000128
 - name: Debbie Stabenow
   party: minority
-  rank: 7
+  rank: 6
   title: Ex Officio
   thomas: '01531'
   bioguide: S000770
@@ -12991,7 +13033,7 @@ SSAF14:
   bioguide: G000386
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 6
   title: Ex Officio
   thomas: '00968'
   bioguide: R000307
@@ -13061,76 +13103,70 @@ SSAF15:
   bioguide: D000618
 - name: Pat Roberts
   party: majority
-  rank: 8
+  rank: 7
   title: Ex Officio
   thomas: '00968'
   bioguide: R000307
-- name: Chris Van Hollen
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01729'
-  bioguide: V000128
 - name: Sherrod Brown
   party: minority
-  rank: 2
+  rank: 1
   thomas: '00136'
   bioguide: B000944
 - name: Amy Klobuchar
   party: minority
-  rank: 3
+  rank: 2
   thomas: '01826'
   bioguide: K000367
 - name: Michael F. Bennet
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01965'
   bioguide: B001267
 - name: Joe Donnelly
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01850'
   bioguide: D000607
 - name: Heidi Heitkamp
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02174'
   bioguide: H001069
 - name: Debbie Stabenow
   party: minority
-  rank: 7
+  rank: 6
   title: Ex Officio
   thomas: '01531'
   bioguide: S000770
 SSAF16:
 - name: Mitch McConnell
   party: majority
-  rank: 2
+  rank: 1
   thomas: '01395'
   bioguide: M000355
 - name: John Boozman
   party: majority
-  rank: 3
+  rank: 2
   thomas: '01687'
   bioguide: B001236
 - name: John Hoeven
   party: majority
-  rank: 4
+  rank: 3
   thomas: '02079'
   bioguide: H001061
 - name: Joni Ernst
   party: majority
-  rank: 5
+  rank: 4
   thomas: '02283'
   bioguide: E000295
 - name: David Perdue
   party: majority
-  rank: 6
+  rank: 5
   thomas: '02286'
   bioguide: P000612
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 6
   title: Ex Officio
   thomas: '00968'
   bioguide: R000307
@@ -13155,14 +13191,9 @@ SSAF16:
   rank: 4
   thomas: '01866'
   bioguide: G000555
-- name: Chris Van Hollen
-  party: minority
-  rank: 5
-  thomas: '01729'
-  bioguide: V000128
 - name: Debbie Stabenow
   party: minority
-  rank: 6
+  rank: 5
   title: Ex Officio
   thomas: '01531'
   bioguide: S000770
@@ -14433,6 +14464,11 @@ SSAS:
   rank: 13
   thomas: '02289'
   bioguide: S001197
+- name: Tim Scott
+  party: majority
+  rank: 14
+  thomas: '02056'
+  bioguide: S001184
 - name: Jack Reed
   party: minority
   rank: 1
@@ -14526,6 +14562,11 @@ SSAS13:
   rank: 5
   thomas: '02290'
   bioguide: S001198
+- name: Tim Scott
+  party: majority
+  rank: 6
+  thomas: '02056'
+  bioguide: S001184
 - name: John McCain
   party: majority
   rank: 7
@@ -14668,7 +14709,7 @@ SSAS15:
   bioguide: P000612
 - name: John McCain
   party: majority
-  rank: 6
+  rank: 5
   title: Ex Officio
   thomas: '00754'
   bioguide: M000303
@@ -14836,9 +14877,14 @@ SSAS20:
   rank: 5
   thomas: '02175'
   bioguide: C001098
-- name: John McCain
+- name: Tim Scott
   party: majority
   rank: 6
+  thomas: '02056'
+  bioguide: S001184
+- name: John McCain
+  party: majority
+  rank: 7
   title: Ex Officio
   thomas: '00754'
   bioguide: M000303
@@ -14990,6 +15036,11 @@ SSBK:
   party: majority
   rank: 12
   bioguide: K000393
+- name: Jerry Moran
+  party: majority
+  rank: 13
+  thomas: '01507'
+  bioguide: M000934
 - name: Sherrod Brown
   party: minority
   rank: 1
@@ -15045,6 +15096,10 @@ SSBK:
   party: minority
   rank: 11
   bioguide: C001113
+- name: Doug Jones
+  party: minority
+  rank: 12
+  bioguide: J000300
 SSBK04:
 - name: Dean Heller
   party: majority
@@ -15476,6 +15531,11 @@ SSBU:
   rank: 11
   thomas: '01687'
   bioguide: B001236
+- name: Tom Cotton
+  party: majority
+  rank: 12
+  thomas: '02098'
+  bioguide: C001095
 - name: Bernard Sanders
   party: minority
   rank: 1
@@ -15634,39 +15694,39 @@ SSCM:
   rank: 6
   thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 7
-  thomas: '02194'
-  bioguide: B001288
 - name: Tom Udall
   party: minority
-  rank: 8
+  rank: 7
   thomas: '01567'
   bioguide: U000039
 - name: Gary C. Peters
   party: minority
-  rank: 9
+  rank: 8
   thomas: '01929'
   bioguide: P000595
 - name: Tammy Baldwin
   party: minority
-  rank: 10
+  rank: 9
   thomas: '01558'
   bioguide: B001230
 - name: Tammy Duckworth
   party: minority
-  rank: 11
+  rank: 10
   thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
-  rank: 12
+  rank: 11
   bioguide: H001076
 - name: Catherine Cortez Masto
   party: minority
-  rank: 13
+  rank: 12
   bioguide: C001113
+- name: Jon Tester
+  party: minority
+  rank: 13
+  thomas: '01829'
+  bioguide: T000464
 SSCM01:
 - name: Roy Blunt
   party: majority
@@ -15761,35 +15821,35 @@ SSCM01:
   rank: 5
   thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 6
-  thomas: '02194'
-  bioguide: B001288
 - name: Tom Udall
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01567'
   bioguide: U000039
 - name: Gary C. Peters
   party: minority
-  rank: 8
+  rank: 7
   thomas: '01929'
   bioguide: P000595
 - name: Tammy Baldwin
   party: minority
-  rank: 9
+  rank: 8
   thomas: '01558'
   bioguide: B001230
 - name: Tammy Duckworth
   party: minority
-  rank: 10
+  rank: 9
   thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
-  rank: 11
+  rank: 10
   bioguide: H001076
+- name: Jon Tester
+  party: minority
+  rank: 11
+  thomas: '01829'
+  bioguide: T000464
 - name: Bill Nelson
   party: minority
   rank: 12
@@ -15865,32 +15925,27 @@ SSCM20:
   rank: 3
   thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 4
-  thomas: '02194'
-  bioguide: B001288
 - name: Tom Udall
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01567'
   bioguide: U000039
 - name: Tammy Duckworth
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
-  rank: 7
+  rank: 6
   bioguide: H001076
 - name: Catherine Cortez Masto
   party: minority
-  rank: 8
+  rank: 7
   bioguide: C001113
 - name: Bill Nelson
   party: minority
-  rank: 9
+  rank: 8
   title: Ex Officio
   thomas: '00859'
   bioguide: N000032
@@ -15942,12 +15997,12 @@ SSCM22:
   title: Ex Officio
   thomas: '01534'
   bioguide: T000250
-- name: Gary C. Peters
+- name: Tammy Baldwin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01929'
-  bioguide: P000595
+  thomas: '01558'
+  bioguide: B001230
 - name: Maria Cantwell
   party: minority
   rank: 2
@@ -15968,19 +16023,14 @@ SSCM22:
   rank: 5
   thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
+- name: Gary C. Peters
   party: minority
   rank: 6
-  thomas: '02194'
-  bioguide: B001288
-- name: Tammy Baldwin
-  party: minority
-  rank: 7
-  thomas: '01558'
-  bioguide: B001230
+  thomas: '01929'
+  bioguide: P000595
 - name: Bill Nelson
   party: minority
-  rank: 8
+  rank: 7
   title: Ex Officio
   thomas: '00859'
   bioguide: N000032
@@ -16116,12 +16166,12 @@ SSCM25:
   title: Ex Officio
   thomas: '01534'
   bioguide: T000250
-- name: Cory A. Booker
+- name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02194'
-  bioguide: B001288
+  thomas: '01929'
+  bioguide: P000595
 - name: Maria Cantwell
   party: minority
   rank: 2
@@ -16261,39 +16311,39 @@ SSCM26:
   rank: 5
   thomas: '00735'
   bioguide: M000133
-- name: Cory A. Booker
-  party: minority
-  rank: 6
-  thomas: '02194'
-  bioguide: B001288
 - name: Tom Udall
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01567'
   bioguide: U000039
 - name: Gary C. Peters
   party: minority
-  rank: 8
+  rank: 7
   thomas: '01929'
   bioguide: P000595
 - name: Tammy Baldwin
   party: minority
-  rank: 9
+  rank: 8
   thomas: '01558'
   bioguide: B001230
 - name: Tammy Duckworth
   party: minority
-  rank: 10
+  rank: 9
   thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
-  rank: 11
+  rank: 10
   bioguide: H001076
 - name: Catherine Cortez Masto
   party: minority
-  rank: 12
+  rank: 11
   bioguide: C001113
+- name: Jon Tester
+  party: minority
+  rank: 12
+  thomas: '01829'
+  bioguide: T000464
 - name: Bill Nelson
   party: minority
   rank: 13
@@ -16357,6 +16407,11 @@ SSEG:
   rank: 11
   thomas: '00924'
   bioguide: P000449
+- name: Shelley Moore Capito
+  party: majority
+  rank: 12
+  thomas: '01676'
+  bioguide: C001047
 - name: Maria Cantwell
   party: minority
   rank: 1
@@ -16380,33 +16435,37 @@ SSEG:
   bioguide: S000770
 - name: Joe Manchin, III
   party: minority
-  rank: 6
+  rank: 5
   thomas: '01983'
   bioguide: M001183
 - name: Martin Heinrich
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01937'
   bioguide: H001046
 - name: Mazie K. Hirono
   party: minority
-  rank: 8
+  rank: 7
   thomas: '01844'
   bioguide: H001042
 - name: Angus S. King, Jr.
   party: minority
-  rank: 9
+  rank: 8
   thomas: '02185'
   bioguide: K000383
 - name: Tammy Duckworth
   party: minority
-  rank: 10
+  rank: 9
   thomas: '02123'
   bioguide: D000622
 - name: Catherine Cortez Masto
   party: minority
-  rank: 11
+  rank: 10
   bioguide: C001113
+- name: Tina Smith
+  party: minority
+  rank: 11
+  bioguide: S001203
 SSEG01:
 - name: Cory Gardner
   party: majority
@@ -16449,6 +16508,11 @@ SSEG01:
   rank: 8
   thomas: '00924'
   bioguide: P000449
+- name: Shelley Moore Capito
+  party: majority
+  rank: 9
+  thomas: '01676'
+  bioguide: C001047
 - name: Lisa Murkowski
   party: majority
   rank: 10
@@ -16473,26 +16537,26 @@ SSEG01:
   bioguide: S000033
 - name: Martin Heinrich
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01937'
   bioguide: H001046
 - name: Angus S. King, Jr.
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02185'
   bioguide: K000383
 - name: Tammy Duckworth
   party: minority
-  rank: 7
+  rank: 6
   thomas: '02123'
   bioguide: D000622
-- name: Catherine Cortez Masto
+- name: Tina Smith
   party: minority
-  rank: 8
-  bioguide: C001113
+  rank: 7
+  bioguide: S001203
 - name: Maria Cantwell
   party: minority
-  rank: 9
+  rank: 8
   title: Ex Officio
   thomas: '00172'
   bioguide: C000127
@@ -16543,6 +16607,11 @@ SSEG03:
   rank: 9
   thomas: '01925'
   bioguide: C001075
+- name: Shelley Moore Capito
+  party: majority
+  rank: 10
+  thomas: '01676'
+  bioguide: C001047
 - name: Lisa Murkowski
   party: majority
   rank: 11
@@ -16562,23 +16631,27 @@ SSEG03:
   bioguide: S000770
 - name: Joe Manchin, III
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01983'
   bioguide: M001183
 - name: Martin Heinrich
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01937'
   bioguide: H001046
 - name: Mazie K. Hirono
   party: minority
-  rank: 6
+  rank: 5
   thomas: '01844'
   bioguide: H001042
 - name: Catherine Cortez Masto
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C001113
+- name: Tina Smith
+  party: minority
+  rank: 7
+  bioguide: S001203
 - name: Maria Cantwell
   party: minority
   rank: 8
@@ -16628,12 +16701,12 @@ SSEG04:
   title: Ex Officio
   thomas: '01694'
   bioguide: M001153
-- name: Mazie K. Hirono
+- name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01844'
-  bioguide: H001042
+  thomas: '02185'
+  bioguide: K000383
 - name: Bernard Sanders
   party: minority
   rank: 2
@@ -16649,11 +16722,11 @@ SSEG04:
   rank: 4
   thomas: '01937'
   bioguide: H001046
-- name: Angus S. King, Jr.
+- name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '02185'
-  bioguide: K000383
+  thomas: '01844'
+  bioguide: H001042
 - name: Tammy Duckworth
   party: minority
   rank: 6
@@ -16697,18 +16770,22 @@ SSEG07:
   rank: 6
   thomas: '00924'
   bioguide: P000449
+- name: Shelley Moore Capito
+  party: majority
+  rank: 7
+  thomas: '01676'
+  bioguide: C001047
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
   thomas: '01694'
   bioguide: M001153
-- name: Angus S. King, Jr.
+- name: Catherine Cortez Masto
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02185'
-  bioguide: K000383
+  bioguide: C001113
 - name: Ron Wyden
   party: minority
   rank: 2
@@ -16721,17 +16798,17 @@ SSEG07:
   bioguide: S000033
 - name: Joe Manchin, III
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01983'
   bioguide: M001183
 - name: Tammy Duckworth
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02123'
   bioguide: D000622
 - name: Maria Cantwell
   party: minority
-  rank: 7
+  rank: 6
   title: Ex Officio
   thomas: '00172'
   bioguide: C000127
@@ -16838,10 +16915,11 @@ SSEV:
   rank: 9
   thomas: '02123'
   bioguide: D000622
-- name: Kamala D. Harris
+- name: Chris Van Hollen
   party: minority
   rank: 10
-  bioguide: H001075
+  thomas: '01729'
+  bioguide: V000128
 SSEV08:
 - name: James M. Inhofe
   party: majority
@@ -16931,13 +17009,9 @@ SSEV08:
   rank: 7
   thomas: '02123'
   bioguide: D000622
-- name: Kamala D. Harris
-  party: minority
-  rank: 8
-  bioguide: H001075
 - name: Thomas R. Carper
   party: minority
-  rank: 9
+  rank: 8
   title: Ex Officio
   thomas: '00179'
   bioguide: C000174
@@ -16969,24 +17043,19 @@ SSEV09:
   title: Ex Officio
   thomas: '01881'
   bioguide: B001261
-- name: Kamala D. Harris
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H001075
 - name: Bernard Sanders
   party: minority
-  rank: 2
+  rank: 1
   thomas: '01010'
   bioguide: S000033
 - name: Cory A. Booker
   party: minority
-  rank: 3
+  rank: 2
   thomas: '02194'
   bioguide: B001288
 - name: Thomas R. Carper
   party: minority
-  rank: 4
+  rank: 3
   title: Ex Officio
   thomas: '00179'
   bioguide: C000174
@@ -17304,6 +17373,11 @@ SSFI:
   rank: 12
   thomas: '01820'
   bioguide: M001170
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 13
+  thomas: '01823'
+  bioguide: W000802
 SSFI02:
 - name: Bill Cassidy
   party: majority
@@ -17448,6 +17522,11 @@ SSFI10:
   rank: 8
   thomas: '01247'
   bioguide: W000779
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 9
+  thomas: '01823'
+  bioguide: W000802
 SSFI11:
 - name: Rob Portman
   party: majority
@@ -17547,9 +17626,14 @@ SSFI11:
   rank: 8
   thomas: '00172'
   bioguide: C000127
-- name: Ron Wyden
+- name: Sheldon Whitehouse
   party: minority
   rank: 9
+  thomas: '01823'
+  bioguide: W000802
+- name: Ron Wyden
+  party: minority
+  rank: 10
   title: Ex Officio
   thomas: '01247'
   bioguide: W000779
@@ -17632,9 +17716,14 @@ SSFI12:
   rank: 6
   thomas: '01897'
   bioguide: W000805
-- name: Ron Wyden
+- name: Sheldon Whitehouse
   party: minority
   rank: 7
+  thomas: '01823'
+  bioguide: W000802
+- name: Ron Wyden
+  party: minority
+  rank: 8
   title: Ex Officio
   thomas: '01247'
   bioguide: W000779
@@ -17703,6 +17792,11 @@ SSFI13:
   title: Ex Officio
   thomas: '01247'
   bioguide: W000779
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 6
+  thomas: '00174'
+  bioguide: C000141
 SSFI14:
 - name: Tim Scott
   party: majority
@@ -17778,17 +17872,17 @@ SSFR:
   rank: 11
   thomas: '02082'
   bioguide: P000603
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00174'
-  bioguide: C000141
-- name: Robert Menendez
-  party: minority
-  rank: 2
   thomas: '00791'
   bioguide: M000639
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 2
+  thomas: '00174'
+  bioguide: C000141
 - name: Jeanne Shaheen
   party: minority
   rank: 3
@@ -17873,22 +17967,22 @@ SSFR01:
   rank: 2
   thomas: '00735'
   bioguide: M000133
-- name: Robert Menendez
+- name: Benjamin L. Cardin
   party: minority
   rank: 3
-  thomas: '00791'
-  bioguide: M000639
+  thomas: '00174'
+  bioguide: C000141
 - name: Jeanne Shaheen
   party: minority
   rank: 4
   thomas: '01901'
   bioguide: S001181
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '00791'
+  bioguide: M000639
 SSFR02:
 - name: Cory Gardner
   party: majority
@@ -17943,12 +18037,12 @@ SSFR02:
   rank: 4
   thomas: '02176'
   bioguide: K000384
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '00791'
+  bioguide: M000639
 SSFR06:
 - name: Marco Rubio
   party: majority
@@ -17982,12 +18076,12 @@ SSFR06:
   title: Ex Officio
   thomas: '01825'
   bioguide: C001071
-- name: Robert Menendez
+- name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00791'
-  bioguide: M000639
+  thomas: '00174'
+  bioguide: C000141
 - name: Tom Udall
   party: minority
   rank: 2
@@ -18003,12 +18097,12 @@ SSFR06:
   rank: 4
   thomas: '02176'
   bioguide: K000384
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '00791'
+  bioguide: M000639
 SSFR07:
 - name: James E. Risch
   party: majority
@@ -18048,15 +18142,14 @@ SSFR07:
   title: Ranking Member
   thomas: '02176'
   bioguide: K000384
-- name: Robert Menendez
+- name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00791'
-  bioguide: M000639
+  thomas: '00174'
+  bioguide: C000141
 - name: Christopher Murphy
   party: minority
   rank: 3
-  title: Ranking Member
   thomas: '01837'
   bioguide: M001169
 - name: Cory A. Booker
@@ -18064,12 +18157,12 @@ SSFR07:
   rank: 4
   thomas: '02194'
   bioguide: B001288
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '00791'
+  bioguide: M000639
 SSFR09:
 - name: Jeff Flake
   party: majority
@@ -18124,12 +18217,12 @@ SSFR09:
   rank: 4
   thomas: '01900'
   bioguide: M001176
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '00791'
+  bioguide: M000639
 SSFR14:
 - name: Johnny Isakson
   party: majority
@@ -18184,12 +18277,12 @@ SSFR14:
   rank: 4
   thomas: '01567'
   bioguide: U000039
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '00791'
+  bioguide: M000639
 SSFR15:
 - name: Todd Young
   party: majority
@@ -18244,12 +18337,12 @@ SSFR15:
   rank: 4
   thomas: '00735'
   bioguide: M000133
-- name: Benjamin L. Cardin
+- name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '00791'
+  bioguide: M000639
 SSGA:
 - name: Ron Johnson
   party: majority
@@ -18303,29 +18396,28 @@ SSGA:
   rank: 2
   thomas: '00179'
   bioguide: C000174
-- name: Jon Tester
-  party: minority
-  rank: 3
-  thomas: '01829'
-  bioguide: T000464
 - name: Heidi Heitkamp
   party: minority
-  rank: 4
+  rank: 3
   thomas: '02174'
   bioguide: H001069
 - name: Gary C. Peters
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01929'
   bioguide: P000595
 - name: Margaret Wood Hassan
   party: minority
-  rank: 6
+  rank: 5
   bioguide: H001076
 - name: Kamala D. Harris
   party: minority
-  rank: 7
+  rank: 6
   bioguide: H001075
+- name: Doug Jones
+  party: minority
+  rank: 7
+  bioguide: J000300
 SSGA01:
 - name: Rob Portman
   party: majority
@@ -18365,21 +18457,20 @@ SSGA01:
   title: Ranking Member
   thomas: '00179'
   bioguide: C000174
-- name: Jon Tester
-  party: minority
-  rank: 2
-  thomas: '01829'
-  bioguide: T000464
 - name: Heidi Heitkamp
   party: minority
-  rank: 3
+  rank: 2
   thomas: '02174'
   bioguide: H001069
 - name: Gary C. Peters
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01929'
   bioguide: P000595
+- name: Margaret Wood Hassan
+  party: minority
+  rank: 4
+  bioguide: H001076
 - name: Claire McCaskill
   party: minority
   rank: 5
@@ -18420,14 +18511,14 @@ SSGA18:
   title: Ranking Member
   thomas: '01929'
   bioguide: P000595
-- name: Margaret Wood Hassan
-  party: minority
-  rank: 2
-  bioguide: H001076
 - name: Kamala D. Harris
   party: minority
-  rank: 3
+  rank: 2
   bioguide: H001075
+- name: Doug Jones
+  party: minority
+  rank: 3
+  bioguide: J000300
 - name: Claire McCaskill
   party: minority
   rank: 4
@@ -18572,38 +18663,41 @@ SSHR:
   bioguide: C001070
 - name: Michael F. Bennet
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01965'
   bioguide: B001267
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 6
-  thomas: '01823'
-  bioguide: W000802
 - name: Tammy Baldwin
   party: minority
-  rank: 7
+  rank: 5
   thomas: '01558'
   bioguide: B001230
 - name: Christopher Murphy
   party: minority
-  rank: 8
+  rank: 6
   thomas: '01837'
   bioguide: M001169
 - name: Elizabeth Warren
   party: minority
-  rank: 9
+  rank: 7
   thomas: '02182'
   bioguide: W000817
 - name: Tim Kaine
   party: minority
-  rank: 10
+  rank: 8
   thomas: '02176'
   bioguide: K000384
 - name: Margaret Wood Hassan
   party: minority
-  rank: 11
+  rank: 9
   bioguide: H001076
+- name: Tina Smith
+  party: minority
+  rank: 10
+  bioguide: S001203
+- name: Doug Jones
+  party: minority
+  rank: 11
+  bioguide: J000300
 SSHR09:
 - name: Rand Paul
   party: majority
@@ -18660,18 +18754,22 @@ SSHR09:
   bioguide: S000033
 - name: Michael F. Bennet
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01965'
   bioguide: B001267
 - name: Tim Kaine
   party: minority
-  rank: 5
+  rank: 4
   thomas: '02176'
   bioguide: K000384
 - name: Margaret Wood Hassan
   party: minority
-  rank: 6
+  rank: 5
   bioguide: H001076
+- name: Tina Smith
+  party: minority
+  rank: 6
+  bioguide: S001203
 - name: Patty Murray
   party: minority
   rank: 7
@@ -18721,31 +18819,35 @@ SSHR11:
   title: Ex Officio
   thomas: '01695'
   bioguide: A000360
+- name: Tammy Baldwin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01558'
+  bioguide: B001230
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
   thomas: '01828'
   bioguide: C001070
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  thomas: '01823'
-  bioguide: W000802
-- name: Tammy Baldwin
-  party: minority
-  rank: 4
-  thomas: '01558'
-  bioguide: B001230
 - name: Christopher Murphy
   party: minority
-  rank: 5
+  rank: 3
   thomas: '01837'
   bioguide: M001169
 - name: Elizabeth Warren
   party: minority
-  rank: 6
+  rank: 4
   thomas: '02182'
   bioguide: W000817
+- name: Tina Smith
+  party: minority
+  rank: 5
+  bioguide: S001203
+- name: Doug Jones
+  party: minority
+  rank: 6
+  bioguide: J000300
 - name: Patty Murray
   party: minority
   rank: 7
@@ -18816,35 +18918,34 @@ SSHR12:
   rank: 2
   thomas: '01965'
   bioguide: B001267
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  thomas: '01823'
-  bioguide: W000802
 - name: Tammy Baldwin
   party: minority
-  rank: 4
+  rank: 3
   thomas: '01558'
   bioguide: B001230
 - name: Christopher Murphy
   party: minority
-  rank: 5
+  rank: 4
   thomas: '01837'
   bioguide: M001169
 - name: Elizabeth Warren
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02182'
   bioguide: W000817
 - name: Tim Kaine
   party: minority
-  rank: 7
+  rank: 6
   thomas: '02176'
   bioguide: K000384
 - name: Margaret Wood Hassan
   party: minority
-  rank: 8
+  rank: 7
   bioguide: H001076
+- name: Doug Jones
+  party: minority
+  rank: 8
+  bioguide: J000300
 - name: Patty Murray
   party: minority
   rank: 9
@@ -18935,19 +19036,28 @@ SSJU:
   bioguide: K000367
 - name: Christopher A. Coons
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01984'
   bioguide: C001088
 - name: Richard Blumenthal
   party: minority
-  rank: 8
+  rank: 7
   thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
-  rank: 9
+  rank: 8
   thomas: '01844'
   bioguide: H001042
+- name: Cory A. Booker
+  party: minority
+  rank: 9
+  thomas: '02194'
+  bioguide: B001288
+- name: Kamala D. Harris
+  party: minority
+  rank: 10
+  bioguide: H001075
 SSJU01:
 - name: Mike Lee
   party: majority
@@ -18988,9 +19098,14 @@ SSJU01:
   bioguide: L000174
 - name: Richard Blumenthal
   party: minority
-  rank: 4
+  rank: 3
   thomas: '02076'
   bioguide: B001277
+- name: Cory A. Booker
+  party: minority
+  rank: 4
+  thomas: '02194'
+  bioguide: B001288
 SSJU04:
 - name: John Cornyn
   party: majority
@@ -19055,14 +19170,19 @@ SSJU04:
   bioguide: K000367
 - name: Richard Blumenthal
   party: minority
-  rank: 6
+  rank: 5
   thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01844'
   bioguide: H001042
+- name: Cory A. Booker
+  party: minority
+  rank: 7
+  thomas: '02194'
+  bioguide: B001288
 SSJU21:
 - name: Ted Cruz
   party: majority
@@ -19090,22 +19210,35 @@ SSJU21:
   rank: 5
   thomas: '00452'
   bioguide: G000359
-- name: Richard Blumenthal
+- name: John Kennedy
+  party: majority
+  rank: 6
+  bioguide: K000393
+- name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02076'
-  bioguide: B001277
+  thomas: '01844'
+  bioguide: H001042
 - name: Richard J. Durbin
   party: minority
   rank: 2
   thomas: '00326'
   bioguide: D000563
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 3
+  thomas: '01823'
+  bioguide: W000802
 - name: Christopher A. Coons
   party: minority
   rank: 4
   thomas: '01984'
   bioguide: C001088
+- name: Kamala D. Harris
+  party: minority
+  rank: 5
+  bioguide: H001075
 SSJU22:
 - name: Lindsey Graham
   party: majority
@@ -19113,24 +19246,34 @@ SSJU22:
   title: Chairman
   thomas: '00452'
   bioguide: G000359
-- name: John Cornyn
+- name: Chuck Grassley
   party: majority
   rank: 2
+  thomas: '00457'
+  bioguide: G000386
+- name: Orrin G. Hatch
+  party: majority
+  rank: 3
+  thomas: '01351'
+  bioguide: H000338
+- name: John Cornyn
+  party: majority
+  rank: 4
   thomas: '01692'
   bioguide: C001056
 - name: Ted Cruz
   party: majority
-  rank: 3
+  rank: 5
   thomas: '02175'
   bioguide: C001098
 - name: Ben Sasse
   party: majority
-  rank: 4
+  rank: 6
   thomas: '02289'
   bioguide: S001197
 - name: John Kennedy
   party: majority
-  rank: 5
+  rank: 7
   bioguide: K000393
 - name: Sheldon Whitehouse
   party: minority
@@ -19138,21 +19281,31 @@ SSJU22:
   title: Ranking Member
   thomas: '01823'
   bioguide: W000802
-- name: Richard J. Durbin
+- name: Dianne Feinstein
   party: minority
   rank: 2
+  thomas: '01332'
+  bioguide: F000062
+- name: Richard J. Durbin
+  party: minority
+  rank: 3
   thomas: '00326'
   bioguide: D000563
 - name: Amy Klobuchar
   party: minority
-  rank: 3
+  rank: 4
   thomas: '01826'
   bioguide: K000367
 - name: Christopher A. Coons
   party: minority
-  rank: 4
+  rank: 5
   thomas: '01984'
   bioguide: C001088
+- name: Cory A. Booker
+  party: minority
+  rank: 6
+  thomas: '02194'
+  bioguide: B001288
 SSJU23:
 - name: Jeff Flake
   party: majority
@@ -19180,10 +19333,21 @@ SSJU23:
   rank: 5
   thomas: '00250'
   bioguide: C000880
-- name: John Kennedy
+- name: Ben Sasse
   party: majority
   rank: 6
+  thomas: '02289'
+  bioguide: S001197
+- name: John Kennedy
+  party: majority
+  rank: 7
   bioguide: K000393
+- name: Christopher A. Coons
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01984'
+  bioguide: C001088
 - name: Patrick J. Leahy
   party: minority
   rank: 2
@@ -19194,16 +19358,20 @@ SSJU23:
   rank: 3
   thomas: '01823'
   bioguide: W000802
-- name: Christopher A. Coons
+- name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '01984'
-  bioguide: C001088
+  thomas: '02076'
+  bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
   rank: 5
   thomas: '01844'
   bioguide: H001042
+- name: Kamala D. Harris
+  party: minority
+  rank: 6
+  bioguide: H001075
 SSJU25:
 - name: Ben Sasse
   party: majority
@@ -19245,12 +19413,12 @@ SSJU25:
   rank: 8
   thomas: '02291'
   bioguide: T000476
-- name: Christopher A. Coons
+- name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01984'
-  bioguide: C001088
+  thomas: '02076'
+  bioguide: B001277
 - name: Patrick J. Leahy
   party: minority
   rank: 2
@@ -19266,16 +19434,20 @@ SSJU25:
   rank: 4
   thomas: '01826'
   bioguide: K000367
-- name: Richard Blumenthal
+- name: Christopher A. Coons
   party: minority
-  rank: 6
-  thomas: '02076'
-  bioguide: B001277
+  rank: 5
+  thomas: '01984'
+  bioguide: C001088
 - name: Mazie K. Hirono
   party: minority
-  rank: 7
+  rank: 6
   thomas: '01844'
   bioguide: H001042
+- name: Kamala D. Harris
+  party: minority
+  rank: 7
+  bioguide: H001075
 SSRA:
 - name: Richard C. Shelby
   party: majority
@@ -19424,22 +19596,22 @@ SSSB:
   party: majority
   rank: 10
   bioguide: K000393
-- name: Jeanne Shaheen
+- name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
-  bioguide: S001181
+  thomas: '00174'
+  bioguide: C000141
 - name: Maria Cantwell
   party: minority
   rank: 2
   thomas: '00172'
   bioguide: C000127
-- name: Benjamin L. Cardin
+- name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '00174'
-  bioguide: C000141
+  thomas: '01901'
+  bioguide: S001181
 - name: Heidi Heitkamp
   party: minority
   rank: 4

--- a/scripts/committee_membership.py
+++ b/scripts/committee_membership.py
@@ -275,8 +275,8 @@ def run():
   # this limits the IDs from going out of control in this file, while
   # preserving us flexibility to be inclusive of IDs in the main leg files
   def ids_from(moc):
-    ids = {}
-    for id in ["bioguide", "thomas"]:
+    ids = OrderedDict()
+    for id in ["thomas", "bioguide"]:
       if id in moc:
         ids[id] = moc[id]
     if len(ids) == 0:


### PR DESCRIPTION
For some reason, running committee_membership.py now suddenly reverses the thomas and bioguide ID fields compared to the order that we have in the YAML file, creating spurious diffs.

We were using a dict to pass this information, and dicts have been unordered (though that changes in CPython 3.6, though I'm running 3.5 so that wasn't the problem), so the order was only lucky to be stable until now. It's surprising we got this far without seeing them flip.

Changing it to an OrderedDict should guarantee the order that we want.

This PR also updates the committee-membership-current.yaml data file after running the script.
  
See #546.