### PR TITLE
mark Sen. Sanders as having always caucused with the Democrats

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -964,42 +964,49 @@
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
   - type: rep
     start: '1993-01-05'
     end: '1995-01-03'
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
   - type: rep
     start: '1995-01-04'
     end: '1997-01-03'
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
   - type: rep
     start: '1997-01-07'
     end: '1999-01-03'
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
   - type: rep
     start: '1999-01-06'
     end: '2001-01-03'
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
   - type: rep
     start: '2001-01-03'
     end: '2003-01-03'
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
   - type: rep
     start: '2003-01-07'
     end: '2005-01-03'
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
     url: http://bernie.house.gov
   - type: rep
     start: '2005-01-04'
@@ -1007,6 +1014,7 @@
     state: VT
     district: 0
     party: Independent
+    caucus: Democrat
     url: http://bernie.house.gov
   - type: sen
     start: '2007-01-04'
@@ -1014,6 +1022,7 @@
     state: VT
     class: 1
     party: Independent
+    caucus: Democrat
     url: http://sanders.senate.gov/
     address: 332 DIRKSEN SENATE OFFICE BUILDING WASHINGTON DC 20510
     phone: 202-224-5141


### PR DESCRIPTION
Recently-ish we added the `caucus` field to indicate the party Independents caucus with. We currently have it set for Sen. Sanders's current term, Sen. King (who is in his first term), and MP's delegate Rep. Sablan's previous term (he's currently a Democrat but was an Independent).

This PR sets it for all of Sanders's previous terms so that his party+caucus affiliation is consistent for all of his terms, and it makes it so all terms in legislators-current with `party: Independent` have `caucus:` set.