### PR TITLE
Updated office address for Dave Joyce (OH-14)

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -7390,15 +7390,15 @@
     govtrack: 412566
     thomas: '02154'
   offices:
-  - id: J000295-painesville
-    address: 1 Victoria Pl.
-    suite: Room 320
-    city: Painesville
+  - id: J000295-mentor
+    address: 8500 Station St
+    suite: Suite 390
+    city: Mentor
     state: OH
-    zip: '44077'
-    latitude: 41.7245406
-    longitude: -81.2427281
-    fax: 440-352-3622
+    zip: '44060'
+    latitude: 41.679062
+    longitude: -81.335902
+    fax: 440-266-9004
     phone: 440-352-3939
   - id: J000295-twinsburg
     address: 10075 Ravenna Road


### PR DESCRIPTION
Dave Joyce (OH-14) moved his office from Painesville, Ohio to Mentor, Ohio. 

Old address: 
1 Victoria Pl. Room 320 
Painesville, OH 44077

New address: 
8500 Station St, Suite 390 
Mentor, OH. 44060 

URL proof: https://joyce.house.gov/my-office-locations/ 

h/t @shannonturner for the tip.
