### PR TITLE
Fixing capitalization and adding twitter account

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -978,6 +978,7 @@
     thomas: '02082'
     govtrack: 412492
   social:
+    twitter: RandPaul
     facebook: SenatorRandPaul
     youtube: SenatorRandPaul
     youtube_id: UCeM9I-20oWUs8daIIpsNHoQ
@@ -4710,8 +4711,8 @@
     govtrack: 412657
     thomas: '02272'
   social:
-    facebook: repdonbeyer
-    twitter: repdonbeyer
+    facebook: RepDonBeyer
+    twitter: RepDonBeyer
     twitter_id: 2962868158
     instagram: repdonbeyer
     youtube_id: UCPJGVbOVcAVGiBwq8qr_T9w


### PR DESCRIPTION
Fixing capitalization for Don Beyer's social media Twitter and Facebook accounts (repdonbeyer -> RepDonBeyer) and adding Rand Paul's twitter handle (@RandPaul)