### PR TITLE
Remove duplicate Twitter account for Rand Paul

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -995,7 +995,6 @@
     youtube_id: UCeM9I-20oWUs8daIIpsNHoQ
     instagram: senatorrandpaul
     instagram_id: 541357095
-    twitter: RandPaul
 - id:
     bioguide: P000601
     thomas: '02035'


### PR DESCRIPTION
Both #579 and #591 added Rand Paul's Twitter account, but they were added in different places, so Git did not automatically remove the duplicate addition. Remove it so the lints can pass.