### PR TITLE
Use https for House Committee urls. Fix (some) RSS links.

### DIFF
--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -1,7 +1,7 @@
 - type: house
   name: House Committee on Agriculture
-  url: http://agriculture.house.gov/
-  minority_url: http://democrats.agriculture.house.gov/
+  url: https://agriculture.house.gov/
+  minority_url: https://democrats-agriculture.house.gov/
   thomas_id: HSAG
   house_committee_id: AG
   subcommittees:
@@ -31,15 +31,15 @@
     phone: (202) 225-2171
   address: 1301 LHOB; Washington, DC 20515-6001
   phone: (202) 225-2171
-  rss_url: http://agriculture.house.gov/rss.xml
-  minority_rss_url: http://democrats.agriculture.house.gov/Rss.aspx?GroupID=1
+  rss_url: https://agriculture.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-agriculture.house.gov/Rss.aspx?GroupID=1
   jurisdiction: The House Committee on Agriculture has legislative jurisdiction over
     agriculture, food, rural development, and forestry.
   jurisdiction_source: https://agriculture.house.gov/issuesinfocus/
 - type: house
   name: House Committee on Appropriations
-  url: http://appropriations.house.gov/
-  minority_url: http://democrats.appropriations.house.gov
+  url: https://appropriations.house.gov/
+  minority_url: https://democrats-appropriations.house.gov
   thomas_id: HSAP
   house_committee_id: AP
   subcommittees:
@@ -94,8 +94,8 @@
     phone: (202) 225-2141
   address: H305 CAPITOL; Washington, DC 20515-6015
   phone: (202) 225-2771
-  rss_url: http://appropriations.house.gov/news/rss.aspx
-  minority_rss_url: http://democrats.appropriations.house.gov/rss.xml
+  rss_url: https://appropriations.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-appropriations.house.gov/rss.xml
   jurisdiction: The House Committee on Appropriations is responsible for legislation
     allocating federal funds prior to expenditure from the treasury. Appropriations
     are generally limited to the levels set by the Budget Resolution drafted by the
@@ -105,8 +105,8 @@
   jurisdiction_source: https://appropriations.house.gov/about/
 - type: house
   name: House Committee on Armed Services
-  url: http://armedservices.house.gov/
-  minority_url: http://democrats.armedservices.house.gov/
+  url: https://armedservices.house.gov/
+  minority_url: https://democrats-armedservices.house.gov/
   thomas_id: HSAS
   house_committee_id: AS
   subcommittees:
@@ -140,15 +140,15 @@
     phone: (202) 226-2843
   address: 2216 RHOB; Washington, DC 20515-6035
   phone: (202) 225-4151
-  rss_url: http://armedservices.house.gov/index.cfm/rss/feed
-  minority_rss_url: http://democrats.armedservices.house.gov/index.cfm/rss/feed
+  rss_url: https://armedservices.house.gov/index.cfm/rss/feed
+  minority_rss_url: https://democrats-armedservices.house.gov/index.cfm/rss/feed
   jurisdiction: The House Committee on Armed Services has legislative jurisdiction
     over military and defense.
   jurisdiction_source: https://armedservices.house.gov/about
 - type: house
   name: House Committee on Financial Services
-  url: http://financialservices.house.gov/
-  minority_url: http://democrats.financialservices.house.gov/
+  url: https://financialservices.house.gov/
+  minority_url: https://democrats-financialservices.house.gov/
   thomas_id: HSBA
   house_committee_id: BA
   subcommittees:
@@ -178,8 +178,8 @@
     phone: (202) 225-7502
   address: 2129 RHOB; Washington, DC 20515-6050
   phone: (202) 225-7502
-  rss_url: http://financialservices.house.gov/news/rss.aspx
-  minority_rss_url: http://democrats.financialservices.house.gov/Rss.aspx?GroupID=1
+  rss_url: https://financialservices.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-financialservices.house.gov/news/rss.aspx
   jurisdiction: The House Financial Services Committee has jurisdiction over issues
     pertaining to the economy, the banking system, housing, insurance, and securities
     and exchanges. Additionally, the Committee also has jurisdiction over monetary
@@ -190,14 +190,14 @@
   jurisdiction_source: https://financialservices.house.gov/about/
 - type: house
   name: House Committee on the Budget
-  url: http://budget.house.gov/
-  minority_url: http://democrats.budget.house.gov/
+  url: https://budget.house.gov/
+  minority_url: https://democrats-budget.house.gov/
   thomas_id: HSBU
   house_committee_id: BU
   address: B234 LHOB; Washington, DC 20515-6065
   phone: (202) 226-7270
-  rss_url: http://budget.house.gov/news/rss.aspx
-  minority_rss_url: http://democrats.budget.house.gov/rss.xml
+  rss_url: https://budget.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-budget.house.gov/rss.xml
   jurisdiction: The House Committee on the Budget is responsible for drafting a concurrent
     resolution on the budget for congressional action on spending, revenue, and debt-limit
     legislation. The Budget Resolution must be jointly agreed to by both the House
@@ -208,8 +208,8 @@
   jurisdiction_source: https://budget.house.gov/about/
 - type: house
   name: House Committee on Education and the Workforce
-  url: http://edworkforce.house.gov/
-  minority_url: http://democrats.edworkforce.house.gov/
+  url: https://edworkforce.house.gov/
+  minority_url: https://democrats-edworkforce.house.gov/
   thomas_id: HSED
   house_committee_id: ED
   subcommittees:
@@ -231,16 +231,16 @@
     phone: (202) 225-4527
   address: 2176 RHOB; Washington, DC 20515-6100
   phone: (202) 225-4527
-  rss_url: http://edworkforce.house.gov/news/rss.aspx
-  minority_rss_url: http://democrats.edworkforce.house.gov/rss.xml
+  rss_url: https://edworkforce.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-edworkforce.house.gov/rss.xml
   jurisdiction: The House Committee on Education and the Workforce has legislative
     jurisdiction over matters related to higher and lower education, workforce development
     and protections, and health, employment, labor, and pensions.
   jurisdiction_source: https://edworkforce.house.gov/committee/subcommitteesjurisdictions.htm
 - type: house
   name: House Committee on Foreign Affairs
-  url: http://foreignaffairs.house.gov/
-  minority_url: http://democrats.foreignaffairs.house.gov/
+  url: https://foreignaffairs.house.gov/
+  minority_url: https://democrats-foreignaffairs.house.gov/
   thomas_id: HSFA
   house_committee_id: FA
   subcommittees:
@@ -270,7 +270,7 @@
     phone: (202) 226-9980
   address: 2170 RHOB; Washington, DC 20515-6128
   phone: (202) 225-5021
-  rss_url: http://foreignaffairs.house.gov/rss.xml
+  rss_url: https://foreignaffairs.house.gov/rss.xml
   jurisdiction: The House Committee on Foreign Affairs considers legislation that
     impacts the diplomatic community, which includes the Department of State, the
     Agency for International Development, the Peace Corps, the United Nations, and
@@ -278,8 +278,8 @@
   jurisdiction_source: https://foreignaffairs.house.gov/about/
 - type: house
   name: House Committee on Oversight and Government Reform
-  url: http://oversight.house.gov/
-  minority_url: http://democrats.oversight.house.gov/
+  url: https://oversight.house.gov/
+  minority_url: https://democrats-oversight.house.gov/
   thomas_id: HSGO
   house_committee_id: GO
   subcommittees:
@@ -309,8 +309,8 @@
     phone: (202) 225-5074
   address: 2157 RHOB; Washington, DC 20515-6143
   phone: (202) 225-5074
-  rss_url: http://oversight.house.gov/feed/rss/
-  minority_rss_url: http://democrats.oversight.house.gov/rss.xml
+  rss_url: https://oversight.house.gov/feed/
+  minority_rss_url: https://democrats-oversight.house.gov/rss.xml
   jurisdiction: The House Committee on Oversight and Government Reform oversees the
     federal government and all of its agencies to ensure efficiency, effectiveness,
     and accountability. The Committee oversees government operations, health care,
@@ -319,14 +319,14 @@
   jurisdiction_source: https://oversight.house.gov/about/
 - type: house
   name: House Committee on House Administration
-  url: http://cha.house.gov/
-  minority_url: http://democrats.cha.house.gov/
+  url: https://cha.house.gov/
+  minority_url: https://democrats-cha.house.gov/
   thomas_id: HSHA
   house_committee_id: HA
   address: 1309 LHOB; Washington, DC 20515-6157
   phone: (202) 225-8281
-  rss_url: http://cha.house.gov/rss.xml
-  minority_rss_url: http://democrats.cha.house.gov/rss.xml
+  rss_url: https://cha.house.gov/rss.xml
+  minority_rss_url: https://democrats-cha.house.gov/rss.xml
   jurisdiction: The Committee on House Administration has legislative jurisdiction
     over the federal elections and the day-to-day operations of the House. The Committee's
     jurisdiction over federal elections requires it to consider proposals to amend
@@ -337,8 +337,8 @@
   jurisdiction_source: https://cha.house.gov/about
 - type: house
   name: House Committee on Homeland Security
-  url: http://homeland.house.gov/
-  minority_url: http://chsdemocrats.house.gov/
+  url: https://homeland.house.gov/
+  minority_url: https://democrats-homeland.house.gov/
   thomas_id: HSHM
   house_committee_id: HM
   subcommittees:
@@ -368,7 +368,7 @@
     phone: (202) 226-8417
   address: 176 FHOB; Washington, DC 20515-6480
   phone: (202) 226-8417
-  rss_url: http://homeland.house.gov/rss.xml
+  rss_url: https://homeland.house.gov/rss.xml
   jurisdiction: The House Committee on Homeland Security has jurisdiction over matters
     related to national defense. It has six subcommittees on border and maritime security;
     counterterrorism and intelligence; cybersecurity and infrastructure protection;
@@ -378,8 +378,8 @@
   jurisdiction_source: https://homeland.house.gov/subcommittee/full_committee/
 - type: house
   name: House Committee on Energy and Commerce
-  url: http://energycommerce.house.gov/
-  minority_url: http://democrats.energycommerce.house.gov/
+  url: https://energycommerce.house.gov/
+  minority_url: https://democrats-energycommerce.house.gov/
   thomas_id: HSIF
   house_committee_id: IF
   subcommittees:
@@ -409,7 +409,7 @@
     phone: (202) 225-2927
   address: 2125 RHOB; Washington, DC 20515-6115
   phone: (202) 225-2927
-  rss_url: http://energycommerce.house.gov/rss.aspx
+  rss_url: https://energycommerce.house.gov/rss.aspx
   jurisdiction: The House Committee on Energy and Commerce has legislative jurisdiction
     on matters related to telecommunications, consumer protection, food and drug safety,
     public health research, environmental quality, energy policy, and interstate and
@@ -421,8 +421,8 @@
   jurisdiction_source: https://energycommerce.house.gov/committee-history/
 - type: house
   name: House Committee on Natural Resources
-  url: http://naturalresources.house.gov/
-  minority_url: http://democrats.naturalresources.house.gov/
+  url: https://naturalresources.house.gov/
+  minority_url: https://democrats-naturalresources.house.gov/
   thomas_id: HSII
   house_committee_id: II
   subcommittees:
@@ -452,16 +452,16 @@
     phone: (202) 225-7107
   address: 1324 LHOB; Washington, DC 20515-6201
   phone: (202) 225-2761
-  rss_url: http://naturalresources.house.gov/news.xml
-  minority_rss_url: http://democrats.naturalresources.house.gov/rss.xml
+  rss_url: https://naturalresources.house.gov/news.xml
+  minority_rss_url: https://democrats-naturalresources.house.gov/rss.xml
   jurisdiction: The House Committee on Natural Resources considers legislation about
     American energy production, mineral lands and mining, fisheries and wildlife,
     public lands, oceans, Native Americans, irrigation and reclamation.
   jurisdiction_source: https://naturalresources.house.gov/about/
 - type: house
   name: House Permanent Select Committee on Intelligence
-  url: http://intelligence.house.gov/
-  minority_url: http://democrats.intelligence.house.gov/
+  url: https://intelligence.house.gov/
+  minority_url: https://democrats-intelligence.house.gov/
   thomas_id: HLIG
   house_committee_id: IG
   subcommittees:
@@ -495,8 +495,8 @@
     phone: (202) 225-4121
   address: HVC304 CAPITOL; Washington, DC 20515-6415
   phone: (202) 225-4121
-  rss_url: http://intelligence.house.gov/rss.xml
-  minority_rss_url: http://democrats.intelligence.house.gov/rss.xml
+  rss_url: https://intelligence.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-intelligence.house.gov/news/rss.aspx
   jurisdiction: The United States House Permanent Select Committee on Intelligence
     (HPSCI) is a committee of the United States House of Representatives, currently
     chaired by Congressman Devin Nunes (California). Created in 1977, HPSCI is charged
@@ -506,8 +506,8 @@
   jurisdiction_source: https://intelligence.house.gov/about/history-and-jurisdiction.htm
 - type: house
   name: House Committee on the Judiciary
-  url: http://judiciary.house.gov/
-  minority_url: http://democrats.judiciary.house.gov/
+  url: https://judiciary.house.gov/
+  minority_url: https://democrats-judiciary.house.gov/
   thomas_id: HSJU
   house_committee_id: JU
   subcommittees:
@@ -533,7 +533,7 @@
     phone: (202) 226-7680
   address: 2138 RHOB; Washington, DC 20515-6216
   phone: (202) 225-3951
-  minority_rss_url: http://democrats.judiciary.house.gov/rss.xml
+  minority_rss_url: https://democrats-judiciary.house.gov/rss.xml
   jurisdiction: The Committee on the Judiciary has jurisdiction over matters relating
     to the administration of justice in federal courts, administrative bodies, and
     law enforcement agencies. Its role in impeachment proceedings has also brought
@@ -544,8 +544,8 @@
   jurisdiction_source: https://judiciary.house.gov/about-the-committee/
 - type: house
   name: House Committee on Transportation and Infrastructure
-  url: http://transportation.house.gov/
-  minority_url: http://democrats.transportation.house.gov/
+  url: https://transportation.house.gov/
+  minority_url: https://democrats-transportation.house.gov/
   thomas_id: HSPW
   house_committee_id: PW
   subcommittees:
@@ -575,8 +575,8 @@
     phone: (202) 225-4360
   address: 2165 RHOB; Washington, DC 20515-6256
   phone: (202) 225-9446
-  rss_url: http://transportation.house.gov/rss.xml
-  minority_rss_url: http://democrats.transportation.house.gov/rss.xml
+  rss_url: https://transportation.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-transportation.house.gov/rss.xml
   jurisdiction: 'The Transportation and Infrastructure Committee has jurisdiction
     over all modes of transportation: aviation, maritime and waterborne transportation,
     highways, bridges, mass transit, and railroads. The Committee also has jurisdiction
@@ -588,8 +588,8 @@
   jurisdiction_source: https://transportation.house.gov/about/history.htm
 - type: house
   name: House Committee on Rules
-  url: http://rules.house.gov/
-  minority_url: http://democrats.rules.house.gov/
+  url: https://rules.house.gov/
+  minority_url: https://democrats-rules.house.gov/
   thomas_id: HSRU
   house_committee_id: RU
   subcommittees:
@@ -603,7 +603,7 @@
     phone: (202) 225-9191
   address: H312 CAPITOL; Washington, DC 20515-6269
   phone: (202) 225-9191
-  minority_rss_url: http://democrats.rules.house.gov/rss.xml
+  minority_rss_url: https://democrats-rules.house.gov/rss.xml
   jurisdiction: The House Committee on Rules is commonly known as “The Speaker’s Committee”
     because it is the mechanism that the Speaker uses to maintain control of the House
     Floor. Because of the vast power wielded by the Rules Committee, its ratio has
@@ -615,8 +615,8 @@
   jurisdiction_source: https://rules.house.gov/about
 - type: house
   name: House Committee on Small Business
-  url: http://smallbusiness.house.gov/
-  minority_url: http://democrats.smallbusiness.house.gov/
+  url: https://smallbusiness.house.gov/
+  minority_url: https://democrats-smallbusiness.house.gov/
   thomas_id: HSSM
   house_committee_id: SM
   subcommittees:
@@ -642,8 +642,8 @@
     phone: (202) 225-5821
   address: 2361 RHOB; Washington, DC 20515-6315
   phone: (202) 225-5821
-  rss_url: http://smallbusiness.house.gov/news/rss.aspx
-  minority_rss_url: http://democrats.smallbusiness.house.gov/rss.xml
+  rss_url: https://smallbusiness.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-smallbusiness.house.gov/rss.xml
   jurisdiction: The House Small Business Committee was established to protect and
     assist small businesses.  As such, the Committee has jurisdiction over matters
     related to small business financial aid, regulatory flexibility, and paperwork
@@ -652,12 +652,12 @@
   jurisdiction_source: https://smallbusiness.house.gov/about/rulesandjurisdiction.htm
 - type: house
   name: House Committee on Ethics
-  url: http://ethics.house.gov/
+  url: https://ethics.house.gov/
   thomas_id: HSSO
   house_committee_id: SO
   address: 1015 LHOB; Washington, DC 20515-6328
   phone: (202) 225-7103
-  rss_url: http://ethics.house.gov/rss.xml
+  rss_url: https://ethics.house.gov/rss.xml
   jurisdiction: The House Committee on Ethics has the jurisdiction to administer travel,
     gift, financial disclosure, outside income, and other regulations; advise members
     and staff; issue advisory opinions and investigate potential ethics violations.
@@ -668,8 +668,8 @@
   jurisdiction_source: https://ethics.house.gov/about/committee-history
 - type: house
   name: House Committee on Science, Space, and Technology
-  url: http://science.house.gov/
-  minority_url: http://democrats.science.house.gov/
+  url: https://science.house.gov/
+  minority_url: https://democrats-science.house.gov/
   thomas_id: HSSY
   house_committee_id: SY
   subcommittees:
@@ -695,8 +695,8 @@
     phone: (202) 225-6371
   address: 2321 RHOB; Washington, DC 20515-6301
   phone: (202) 225-6371
-  rss_url: http://science.house.gov/rss.xml
-  minority_rss_url: http://democrats.science.house.gov/rss.xml
+  rss_url: https://science.house.gov/rss.xml
+  minority_rss_url: https://democrats-science.house.gov/rss.xml
   jurisdiction: The Committee on Science, Space, and Technology has a jurisdiction
     over a range of matters related to energy research and development, federally
     owned or operated non-military energy laboratories, astronautical research and
@@ -708,8 +708,8 @@
   jurisdiction_source: https://science.house.gov/about/jurisdiction
 - type: house
   name: House Committee on Veterans' Affairs
-  url: http://veterans.house.gov/
-  minority_url: http://democrats.veterans.house.gov/
+  url: https://veterans.house.gov/
+  minority_url: https://democrats-veterans.house.gov/
   thomas_id: HSVR
   house_committee_id: VR
   subcommittees:
@@ -731,8 +731,8 @@
     phone: (202) 225-3569
   address: 335 CHOB; Washington, DC 20515-6335
   phone: (202) 225-3527
-  rss_url: http://veterans.house.gov/rss.xml
-  minority_rss_url: http://democrats.veterans.house.gov/rss.xml
+  rss_url: https://veterans.house.gov/news/rss.aspx
+  minority_rss_url: https://democrats-veterans.house.gov/rss.xml
   jurisdiction: The House Committee on Veterans' Affairs is the authorizing committee
     for the Department of Veterans Affairs (VA). The committee is responsible for
     recommending legislation expanding, curtailing, or fine-tuning existing laws relating
@@ -743,8 +743,8 @@
   jurisdiction_source: https://veterans.house.gov/about/history.htm
 - type: house
   name: House Committee on Ways and Means
-  url: http://waysandmeans.house.gov/
-  minority_url: http://democrats.waysandmeans.house.gov/
+  url: https://waysandmeans.house.gov/
+  minority_url: https://democrats-waysandmeans.house.gov/
   thomas_id: HSWM
   house_committee_id: WM
   subcommittees:
@@ -774,7 +774,7 @@
     phone: (202) 225-6649
   address: 1102 LHOB; Washington, DC 20515-6348
   phone: (202) 225-3625
-  minority_rss_url: http://democrats.waysandmeans.house.gov/rss.xml
+  minority_rss_url: https://democrats-waysandmeans.house.gov/rss.xml
   jurisdiction: The Committee on Ways and Means is the chief tax-writing committee
     in the House of Representatives. The Committee derives a large share of its jurisdiction
     from Article I, Section VII of the U.S. Constitution, which declares, “All Bills


### PR DESCRIPTION
Some RSS links are broken and do not appear to have replacements.
Energy/Commerce's jurisdiction source is also broken, but their new jurisdiction page is less thorough, so I left it alone.