### PR TITLE
Nov 2018 Special Election Results - Smith, Morelle, Hern

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -41112,3 +41112,47 @@
     address: 1203 Longworth House Office Building; Washington DC 20515-3512
     office: 1203 Longworth House Office Building
     phone: 202-225-5355
+- id:
+    bioguide: H001082
+    fec:
+    - H8OK01157
+    govtrack: 412748
+    wikipedia: Kevin Hern
+    wikidata: Q58333614
+    ballotpedia: Kevin Hern
+  name:
+    first: Kevin
+    middle: R.
+    last: Hern
+  bio:
+    gender: M
+    birthday: '1961-12-04'
+  terms:
+  - type: rep
+    start: '2018-11-13'
+    end: '2019-01-03'
+    state: OK
+    district: 1
+    party: Republican
+- id:
+    bioguide: M001206
+    fec:
+    - H8NY25105
+    govtrack: 412749
+    wikipedia: Joseph D. Morelle
+    wikidata: Q6285623
+    ballotpedia: Joseph Morelle
+  name:
+    first: Joseph
+    middle: D.
+    last: Morelle
+  bio:
+    gender: M
+    birthday: '1957-04-29'
+  terms:
+  - type: rep
+    start: '2018-11-13'
+    end: '2019-01-03'
+    state: NY
+    district: 25
+    party: Democrat

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40899,7 +40899,7 @@
   terms:
   - type: sen
     start: '2018-04-09'
-    end: '2018-11-06'
+    end: '2018-11-27'
     how: appointment
     end-type: special-election
     state: MS

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40868,6 +40868,18 @@
     phone: 202-224-5641
     url: https://www.smith.senate.gov
     contact_form: https://www.smith.senate.gov/content/contact-senator
+  - type: sen
+    start: '2018-11-07'
+    end: '2021-01-03'
+    state: MN
+    class: 2
+    party: Democrat
+    state_rank: junior
+    address: 309 Hart Senate Office Building Washington DC 20510
+    office: 309 Hart Senate Office Building
+    phone: 202-224-5641
+    url: https://www.smith.senate.gov
+    contact_form: https://www.smith.senate.gov/content/contact-senator
 - id:
     bioguide: H001079
     lis: S395


### PR DESCRIPTION
I've started a branch (and this PR) for special election results.

According to https://ballotpedia.org/Special_elections_to_the_115th_United_States_Congress_(2017-2018) and other sources there were six special elections plus one election (OK-1) that included simultaneously filling a vacancy:

| Contest | Result |
| --------- | -------- |
| MN (senate) | Smith |
| MS (senate) | runoff |
| MI-13 | Jones |
| NY-25 | Morelle |
| OK-1 | Hern |
| PA-7 | no data on CNN |
| PA-15 | no data on CNN |

Sen. Smith (MN) won reelection and so the one commit in this PR adds a term for her. I set the end/start dates to Nov 6/7 for now. I imagine she will be sworn in again later this month, and in that case we should update the turnover dates to that date, I think, and then merge the change, maybe?

The MI-13 and NY-25 results seem to be in, but since they're new members I haven't done anything for them yet, and we'll wait until they're sworn in before we make the change anyway.