### PR TITLE
Fix indentation of FEC ID for lint

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40824,7 +40824,7 @@
     govtrack: 412743
     votesmart: 20784
     fec:
-      - S8MS00261
+    - S8MS00261
     cspan: 113208
     wikipedia: Cindy Hyde-Smith
     ballotpedia: Cindy Hyde-Smith


### PR DESCRIPTION
The lint didn't like the extra indentation for Hyde-Smith's FEC ID, so remove it.