### PR TITLE
Don't require build success for deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/python:3.5-browsers
     steps:
       # Set up.
-      - checkout      
+      - checkout
       - run: sudo pip install -r scripts/requirements.txt
 
       # Run tests.
@@ -31,8 +31,6 @@ workflows:
     jobs:
       - build
       - deploy:
-          requires:
-            - build
           filters:
             branches:
               only: master


### PR DESCRIPTION
Oftentimes, the lint will fail for some reason or another, but we should still deploy the latest changes to GitHub pages. Remove the requirement that the build step must succeed for deploy to occur.