### PR TITLE
Fix two Senate URLs

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -3552,7 +3552,7 @@
     class: 1
     party: Republican
     state_rank: junior
-    url: https://blackburn.house.gov/
+    url: https://www.blackburn.senate.gov
 - id:
     bioguide: B000574
     thomas: '00099'
@@ -30519,7 +30519,7 @@
     class: 1
     party: Republican
     state_rank: junior
-    url: https://cramer.house.gov/
+    url: https://www.cramer.senate.gov
 - id:
     bioguide: F000463
     thomas: '02179'


### PR DESCRIPTION
Two new Senators accidentally had their old House URLs put in for their Senate term. Fix these two URLs to point to their new Senate URLs.