### PR TITLE
116th legislator wikipedia ids

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -38032,6 +38032,7 @@
     fec:
     - H8AZ09040
     govtrack: 412753
+    wikipedia: Greg Stanton
   name:
     first: Greg
     last: Stanton
@@ -38054,6 +38055,7 @@
     fec:
     - H8CA10126
     govtrack: 412754
+    wikipedia: Josh Harder
   name:
     first: Josh
     last: Harder
@@ -38076,6 +38078,7 @@
     fec:
     - H8CA10167
     govtrack: 412755
+    wikipedia: TJ Cox
   name:
     first: TJ
     last: Cox
@@ -38098,6 +38101,7 @@
     fec:
     - H8CA25074
     govtrack: 412756
+    wikipedia: Katie Hill (politician)
   name:
     first: Katie
     last: Hill
@@ -38120,6 +38124,7 @@
     fec:
     - H8CA39174
     govtrack: 412757
+    wikipedia: Gil Cisneros
   name:
     first: Gilbert
     middle: Ray
@@ -38143,6 +38148,7 @@
     fec:
     - H8CA45130
     govtrack: 412758
+    wikipedia: Katie Porter
   name:
     first: Katie
     last: Porter
@@ -38165,6 +38171,7 @@
     fec:
     - H8CA48035
     govtrack: 412759
+    wikipedia: Harley Rouda
   name:
     first: Harley
     last: Rouda
@@ -38187,6 +38194,7 @@
     fec:
     - H8CA49058
     govtrack: 412760
+    wikipedia: Mike Levin
   name:
     first: Mike
     last: Levin
@@ -38209,6 +38217,7 @@
     fec:
     - H8CO02178
     govtrack: 412761
+    wikipedia: Joe Neguse
   name:
     first: Joe
     last: Neguse
@@ -38231,6 +38240,7 @@
     fec:
     - H8CO06229
     govtrack: 412762
+    wikipedia: Jason Crow
   name:
     first: Jason
     last: Crow
@@ -38253,6 +38263,7 @@
     fec:
     - H8CT05245
     govtrack: 412763
+    wikipedia: Jahana Hayes
   name:
     first: Jahana
     last: Hayes
@@ -38275,6 +38286,7 @@
     fec:
     - H8FL06148
     govtrack: 412764
+    wikipedia: Michael Waltz
   name:
     first: Michael
     last: Waltz
@@ -38297,6 +38309,7 @@
     fec:
     - H8FL15230
     govtrack: 412765
+    wikipedia: Ross Spano
   name:
     first: Ross
     last: Spano
@@ -38319,6 +38332,7 @@
     fec:
     - H8FL17053
     govtrack: 412766
+    wikipedia: Greg Steube
   name:
     first: W.
     middle: Gregory
@@ -38342,6 +38356,7 @@
     fec:
     - H8FL26039
     govtrack: 412767
+    wikipedia: Debbie Mucarsel-Powell
   name:
     first: Debbie
     last: Mucarsel-Powell
@@ -38364,6 +38379,7 @@
     fec:
     - H8FL27193
     govtrack: 412768
+    wikipedia: Donna Shalala
   name:
     first: Donna
     middle: E.
@@ -38387,6 +38403,7 @@
     fec:
     - H8GA06393
     govtrack: 412769
+    wikipedia: Lucy McBath
   name:
     first: Lucy
     last: McBath
@@ -38409,6 +38426,7 @@
     fec:
     - H8GU01020
     govtrack: 412770
+    wikipedia: Michael San Nicolas
   name:
     first: Michael
     middle: F. Q.
@@ -38432,6 +38450,7 @@
     fec:
     - H8IA01094
     govtrack: 412771
+    wikipedia: Abby Finkenauer
   name:
     first: Abby
     last: Finkenauer
@@ -38454,6 +38473,7 @@
     fec:
     - H8IA03124
     govtrack: 412772
+    wikipedia: Cindy Axne
   name:
     first: Cynthia
     last: Axne
@@ -38476,6 +38496,7 @@
     fec:
     - H8ID01124
     govtrack: 412773
+    wikipedia: Russ Fulcher
   name:
     first: Russ
     last: Fulcher
@@ -38498,6 +38519,7 @@
     fec:
     - H8IL04134
     govtrack: 412774
+    wikipedia: Jesús "Chuy" García
   name:
     first: Jesús
     middle: G.
@@ -38521,6 +38543,7 @@
     fec:
     - H8IL06139
     govtrack: 412775
+    wikipedia: Sean Casten
   name:
     first: Sean
     last: Casten
@@ -38543,6 +38566,7 @@
     fec:
     - H8IL14174
     govtrack: 412776
+    wikipedia: Lauren Underwood
   name:
     first: Lauren
     last: Underwood
@@ -38565,6 +38589,7 @@
     fec:
     - H8IN04199
     govtrack: 412777
+    wikipedia: Jim Baird (American politician)
   name:
     first: James
     middle: R.
@@ -38588,6 +38613,7 @@
     fec:
     - H8IN06129
     govtrack: 412778
+    wikipedia: Greg Pence
   name:
     first: Greg
     last: Pence
@@ -38610,6 +38636,7 @@
     fec:
     - H8KS02199
     govtrack: 412779
+    wikipedia: Steve Watkins (politician)
   name:
     first: Steven
     middle: C.
@@ -38633,6 +38660,7 @@
     fec:
     - H8KS03155
     govtrack: 412780
+    wikipedia: Sharice Davids
   name:
     first: Sharice
     last: Davids
@@ -38655,6 +38683,7 @@
     fec:
     - H8MA03106
     govtrack: 412781
+    wikipedia: Lori Trahan
   name:
     first: Lori
     last: Trahan
@@ -38677,6 +38706,7 @@
     fec:
     - H8MA07032
     govtrack: 412782
+    wikipedia: Ayanna Pressley
   name:
     first: Ayanna
     last: Pressley
@@ -38699,6 +38729,7 @@
     fec:
     - H8MD06168
     govtrack: 412783
+    wikipedia: David Trone
   name:
     first: David
     middle: J.
@@ -38722,6 +38753,7 @@
     fec:
     - H8MI08102
     govtrack: 412784
+    wikipedia: Elissa Slotkin
   name:
     first: Elissa
     last: Slotkin
@@ -38744,6 +38776,7 @@
     fec:
     - H8MI09118
     govtrack: 412785
+    wikipedia: Andy Levin
   name:
     first: Andy
     last: Levin
@@ -38766,6 +38799,7 @@
     fec:
     - H8MI11254
     govtrack: 412786
+    wikipedia: Haley Stevens
   name:
     first: Haley
     middle: M.
@@ -38789,6 +38823,7 @@
     fec:
     - H8MI13250
     govtrack: 412787
+    wikipedia: Rashida Tlaib
   name:
     first: Rashida
     last: Tlaib
@@ -38811,6 +38846,7 @@
     fec:
     - H0MN01045
     govtrack: 412788
+    wikipedia: Jim Hagedorn
   name:
     first: Jim
     last: Hagedorn
@@ -38833,6 +38869,7 @@
     fec:
     - H6MN02131
     govtrack: 412789
+    wikipedia: Angie Craig
   name:
     first: Angie
     last: Craig
@@ -38855,6 +38892,7 @@
     fec:
     - H8MN03143
     govtrack: 412790
+    wikipedia: Dean Phillips
   name:
     first: Dean
     last: Phillips
@@ -38877,6 +38915,7 @@
     fec:
     - H8MN05239
     govtrack: 412791
+    wikipedia: Ilhan Omar
   name:
     first: Ilhan
     last: Omar
@@ -38899,6 +38938,7 @@
     fec:
     - H8MN08043
     govtrack: 412792
+    wikipedia: Pete Stauber
   name:
     first: Pete
     last: Stauber
@@ -38921,6 +38961,7 @@
     fec:
     - H8MS03125
     govtrack: 412793
+    wikipedia: Michael Guest (politician)
   name:
     first: Michael
     last: Guest
@@ -38943,6 +38984,7 @@
     fec:
     - H8ND00096
     govtrack: 412794
+    wikipedia: Kelly Armstrong
   name:
     first: Kelly
     last: Armstrong
@@ -38965,6 +39007,7 @@
     fec:
     - H8NH01210
     govtrack: 412795
+    wikipedia: Chris Pappas (politician)
   name:
     first: Chris
     last: Pappas
@@ -38987,6 +39030,7 @@
     fec:
     - H8NJ02166
     govtrack: 412796
+    wikipedia: Jeff Van Drew
   name:
     first: Jefferson
     last: Van Drew
@@ -39009,6 +39053,7 @@
     fec:
     - H8NJ03206
     govtrack: 412797
+    wikipedia: Andy Kim (politician)
   name:
     first: Andy
     last: Kim
@@ -39031,6 +39076,7 @@
     fec:
     - H8NJ07223
     govtrack: 412798
+    wikipedia: Tom Malinowski
   name:
     first: Tom
     last: Malinowski
@@ -39053,6 +39099,7 @@
     fec:
     - H8NJ11142
     govtrack: 412799
+    wikipedia: Mikie Sherrill
   name:
     first: Mikie
     last: Sherrill
@@ -39075,6 +39122,7 @@
     fec:
     - H8NM01331
     govtrack: 412800
+    wikipedia: Deb Haaland
   name:
     first: Debra
     middle: A.
@@ -39098,6 +39146,7 @@
     fec:
     - H8NM02248
     govtrack: 412801
+    wikipedia: Xochitl Torres Small
   name:
     first: Xochitl
     last: Torres Small
@@ -39120,6 +39169,7 @@
     fec:
     - H8NV03200
     govtrack: 412802
+    wikipedia: Susie Lee
   name:
     first: Susie
     last: Lee
@@ -39142,6 +39192,7 @@
     fec:
     - H8NY11113
     govtrack: 412803
+    wikipedia: Max Rose (politician)
   name:
     first: Max
     last: Rose
@@ -39164,6 +39215,7 @@
     fec:
     - H8NY15148
     govtrack: 412804
+    wikipedia: Alexandria Ocasio-Cortez
   name:
     first: Alexandria
     last: Ocasio-Cortez
@@ -39186,6 +39238,7 @@
     fec:
     - H8NY19181
     govtrack: 412805
+    wikipedia: Antonio Delgado (politician)
   name:
     first: Antonio
     last: Delgado
@@ -39208,6 +39261,7 @@
     fec:
     - H8NY22151
     govtrack: 412806
+    wikipedia: Anthony Brindisi
   name:
     first: Anthony
     last: Brindisi
@@ -39252,6 +39306,7 @@
     fec:
     - H8OK05109
     govtrack: 412808
+    wikipedia: Kendra Horn
   name:
     first: Kendra
     middle: S.
@@ -39275,6 +39330,7 @@
     fec:
     - H8PA04116
     govtrack: 412809
+    wikipedia: Madeleine Dean
   name:
     first: Madeleine
     last: Dean
@@ -39297,6 +39353,7 @@
     fec:
     - H8PA06087
     govtrack: 412810
+    wikipedia: Chrissy Houlahan
   name:
     first: Chrissy
     last: Houlahan
@@ -39319,6 +39376,7 @@
     fec:
     - H8PA10147
     govtrack: 412811
+    wikipedia: Dan Meuser
   name:
     first: Daniel
     last: Meuser
@@ -39341,6 +39399,7 @@
     fec:
     - H8PA13125
     govtrack: 412812
+    wikipedia: John Joyce (American politician)
   name:
     first: John
     last: Joyce
@@ -39363,6 +39422,7 @@
     fec:
     - H8PA18199
     govtrack: 412813
+    wikipedia: Guy Reschenthaler
   name:
     first: Guy
     last: Reschenthaler
@@ -39385,6 +39445,7 @@
     fec:
     - H8SC01116
     govtrack: 412814
+    wikipedia: Joe Cunningham (American politician)
   name:
     first: Joe
     last: Cunningham
@@ -39407,6 +39468,7 @@
     fec:
     - H8SC04250
     govtrack: 412815
+    wikipedia: William Timmons (politician)
   name:
     first: William
     middle: R.
@@ -39430,6 +39492,7 @@
     fec:
     - H8SD01055
     govtrack: 412816
+    wikipedia: Dusty Johnson
   name:
     first: Dusty
     last: Johnson
@@ -39452,6 +39515,7 @@
     fec:
     - H8TN02119
     govtrack: 412817
+    wikipedia: Tim Burchett
   name:
     first: Tim
     last: Burchett
@@ -39474,6 +39538,7 @@
     fec:
     - H8TN06094
     govtrack: 412818
+    wikipedia: John Rose (Tennessee politician)
   name:
     first: John
     middle: W.
@@ -39497,6 +39562,7 @@
     fec:
     - H8TN07076
     govtrack: 412819
+    wikipedia: Mark E. Green
   name:
     first: Mark
     middle: E.
@@ -39520,6 +39586,7 @@
     fec:
     - H8TX02166
     govtrack: 412820
+    wikipedia: Dan Crenshaw
   name:
     first: Dan
     last: Crenshaw
@@ -39542,6 +39609,7 @@
     fec:
     - H8TX03123
     govtrack: 412821
+    wikipedia: Van Taylor
   name:
     first: Van
     last: Taylor
@@ -39564,6 +39632,7 @@
     fec:
     - H8TX05144
     govtrack: 412822
+    wikipedia: Lance Gooden
   name:
     first: Lance
     last: Gooden
@@ -39586,6 +39655,7 @@
     fec:
     - H8TX06233
     govtrack: 412823
+    wikipedia: Ron Wright (politician)
   name:
     first: Ron
     last: Wright
@@ -39608,6 +39678,7 @@
     fec:
     - H8TX07140
     govtrack: 412824
+    wikipedia: Lizzie Pannill Fletcher
   name:
     first: Lizzie
     last: Fletcher
@@ -39630,6 +39701,7 @@
     fec:
     - H8TX16109
     govtrack: 412825
+    wikipedia: Veronica Escobar
   name:
     first: Veronica
     last: Escobar
@@ -39652,6 +39724,7 @@
     fec:
     - H8TX21307
     govtrack: 412826
+    wikipedia: Chip Roy
   name:
     first: Chip
     last: Roy
@@ -39674,6 +39747,7 @@
     fec:
     - H8TX29052
     govtrack: 412827
+    wikipedia: Sylvia Garcia
   name:
     first: Sylvia
     middle: R.
@@ -39697,6 +39771,7 @@
     fec:
     - H8TX32098
     govtrack: 412828
+    wikipedia: Colin Allred
   name:
     first: Colin
     middle: Z.
@@ -39720,6 +39795,7 @@
     fec:
     - H8UT04053
     govtrack: 412829
+    wikipedia: Ben McAdams
   name:
     first: Ben
     last: McAdams
@@ -39742,6 +39818,7 @@
     fec:
     - H8VA02111
     govtrack: 412830
+    wikipedia: Elaine Luria
   name:
     first: Elaine
     middle: G.
@@ -39765,6 +39842,7 @@
     fec:
     - H8VA05171
     govtrack: 412831
+    wikipedia: Denver Riggleman
   name:
     first: Denver
     last: Riggleman
@@ -39787,6 +39865,7 @@
     fec:
     - H8VA06104
     govtrack: 412832
+    wikipedia: Ben Cline
   name:
     first: Ben
     last: Cline
@@ -39809,6 +39888,7 @@
     fec:
     - H8VA07094
     govtrack: 412833
+    wikipedia: Abigail Spanberger
   name:
     first: Abigail
     middle: Davis
@@ -39832,6 +39912,7 @@
     fec:
     - H8VA10106
     govtrack: 412834
+    wikipedia: Jennifer Wexton
   name:
     first: Jennifer
     last: Wexton
@@ -39854,6 +39935,7 @@
     fec:
     - H8WA08189
     govtrack: 412835
+    wikipedia: Kim Schrier
   name:
     first: Kim
     last: Schrier
@@ -39876,6 +39958,7 @@
     fec:
     - H8WI01156
     govtrack: 412836
+    wikipedia: Bryan Steil
   name:
     first: Bryan
     last: Steil
@@ -39898,6 +39981,7 @@
     fec:
     - H8WV03097
     govtrack: 412837
+    wikipedia: Carol Miller (politician)
   name:
     first: Carol
     middle: D.
@@ -40066,6 +40150,7 @@
     fec:
     - H8ME02185
     govtrack: 412842
+    wikipedia: Jared Golden
   name:
     first: Jared
     middle: Forrest


### PR DESCRIPTION
Pretty much like you'd expect: added `wikipedia` IDs for all the incoming congresspeople I could find on Wikipedia.

Example:

```yaml
- id:
    bioguide: D000630
    fec:
    - H8NY19181
    govtrack: 412805
    wikipedia: Antonio Delgado (politician)
  name:
    first: Antonio
    last: Delgado
```