### PR TITLE
SenBennetCo twitter account was renamed, RepIlhanOmar disappeared

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -2458,10 +2458,10 @@
     thomas: '01965'
     govtrack: 412330
   social:
-    twitter: SenBennetCo
     facebook: senbennetco
     youtube: SenatorBennet
     youtube_id: UCXB3cljpMwTyCUyLr2ZVLow
+    twitter: SenatorBennet
     twitter_id: 224285242
     instagram: SenBennetCO
 - id:
@@ -4773,10 +4773,6 @@
     bioguide: M001207
   social:
     twitter: RepDMP
-- id:
-    bioguide: O000173
-  social:
-    twitter: RepIlhanOmar
 - id:
     bioguide: J000302
   social:


### PR DESCRIPTION
Not sure if RepIlhanOmar was never the right name or if it was made private or deleted.