### PR TITLE
Remove accent from Robert Menendez's last name.

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -652,7 +652,7 @@
     google_entity_id: kg:/m/033d3p
   name:
     first: Robert
-    last: Menéndez
+    last: Menendez
     nickname: Bob
     official_full: Robert Menendez
   other_names:


### PR DESCRIPTION
#492

For consistency with official full name, and other public sources.