### PR TITLE
remove the old religion data

### DIFF
--- a/executive.yaml
+++ b/executive.yaml
@@ -1500,7 +1500,6 @@
   bio:
     birthday: '1942-11-20'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: viceprez
     start: '2009-01-20'

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -23,7 +23,6 @@
   bio:
     birthday: '1952-11-09'
     gender: M
-    religion: Lutheran
   terms:
   - type: rep
     start: '1993-01-05'
@@ -133,7 +132,6 @@
   bio:
     birthday: '1958-10-13'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1993-01-05'
@@ -213,7 +211,6 @@
   bio:
     birthday: '1943-10-05'
     gender: M
-    religion: Jewish
   terms:
   - type: rep
     start: '1987-01-06'
@@ -341,7 +338,6 @@
   bio:
     birthday: '1947-01-23'
     gender: M
-    religion: Presbyterian
   terms:
   - type: rep
     start: '1983-01-03'
@@ -509,7 +505,6 @@
   bio:
     birthday: '1933-06-22'
     gender: F
-    religion: Jewish
   terms:
   - type: sen
     start: '1992-11-10'
@@ -660,7 +655,6 @@
   bio:
     birthday: '1954-01-01'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1993-01-05'
@@ -779,7 +773,6 @@
   bio:
     birthday: '1941-09-08'
     gender: M
-    religion: Jewish
   terms:
   - type: rep
     start: '1991-01-03'
@@ -907,7 +900,6 @@
   bio:
     birthday: '1950-04-29'
     gender: F
-    religion: United Methodist
   terms:
   - type: rep
     start: '1997-01-07'
@@ -1184,7 +1176,6 @@
   bio:
     birthday: '1951-07-05'
     gender: M
-    religion: Southern Baptist
   terms:
   - type: rep
     start: '1995-01-04'
@@ -1293,7 +1284,6 @@
   bio:
     birthday: '1940-07-03'
     gender: M
-    religion: Presbyterian
   terms:
   - type: sen
     start: '2003-01-07'
@@ -1355,7 +1345,6 @@
   bio:
     birthday: '1952-12-07'
     gender: F
-    religion: Catholic
   terms:
   - type: sen
     start: '1997-01-07'
@@ -1421,7 +1410,6 @@
   bio:
     birthday: '1952-02-02'
     gender: M
-    religion: Church of Christ
   leadership_roles:
   - title: Minority Whip
     chamber: senate
@@ -1503,7 +1491,6 @@
   bio:
     birthday: '1944-11-21'
     gender: M
-    religion: Roman Catholic
   leadership_roles:
   - title: Minority Whip
     chamber: senate
@@ -1641,7 +1628,6 @@
   bio:
     birthday: '1944-02-01'
     gender: M
-    religion: Presbyterian
   terms:
   - type: sen
     start: '1997-01-07'
@@ -1710,7 +1696,6 @@
   bio:
     birthday: '1955-07-09'
     gender: M
-    religion: Southern Baptist
   terms:
   - type: rep
     start: '1995-01-04'
@@ -1798,7 +1783,6 @@
   bio:
     birthday: '1934-11-17'
     gender: M
-    religion: Presbyterian
   terms:
   - type: rep
     start: '1987-01-06'
@@ -1894,7 +1878,6 @@
   bio:
     birthday: '1942-02-20'
     gender: M
-    religion: Baptist
   leadership_roles:
   - title: Minority Leader
     chamber: senate
@@ -2053,7 +2036,6 @@
   bio:
     birthday: '1949-11-12'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1991-01-03'
@@ -2189,7 +2171,6 @@
   bio:
     birthday: '1936-04-20'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '1981-01-05'
@@ -2359,7 +2340,6 @@
   bio:
     birthday: '1948-05-18'
     gender: M
-    religion: Latter Day Saints
   terms:
   - type: rep
     start: '1999-01-06'
@@ -2705,7 +2685,6 @@
   bio:
     birthday: '1965-07-22'
     gender: M
-    religion: Protestant
   terms:
   - type: rep
     start: '1997-01-07'
@@ -3273,7 +3252,6 @@
   bio:
     birthday: '1951-07-13'
     gender: M
-    religion: Latter Day Saints
   terms:
   - type: rep
     start: '2003-01-07'
@@ -3388,7 +3366,6 @@
   bio:
     birthday: '1947-02-04'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1993-01-05'
@@ -3534,7 +3511,6 @@
   bio:
     birthday: '1952-06-06'
     gender: F
-    religion: Presbyterian
   terms:
   - type: rep
     start: '2003-01-07'
@@ -3839,7 +3815,6 @@
   bio:
     birthday: '1950-01-10'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1997-01-07'
@@ -4026,7 +4001,6 @@
   bio:
     birthday: '1955-04-11'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1997-01-07'
@@ -4425,7 +4399,6 @@
   bio:
     birthday: '1950-12-23'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '2003-01-07'
@@ -4542,7 +4515,6 @@
   bio:
     birthday: '1955-11-30'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '1995-01-04'
@@ -4636,7 +4608,6 @@
   bio:
     birthday: '1947-04-27'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '2004-07-21'
@@ -4749,7 +4720,6 @@
   bio:
     birthday: '1953-06-08'
     gender: M
-    religion: Protestant
   terms:
   - type: rep
     start: '1993-01-05'
@@ -4896,7 +4866,6 @@
   bio:
     birthday: '1953-11-26'
     gender: F
-    religion: Presbyterian
   terms:
   - type: rep
     start: '2001-01-03'
@@ -5099,7 +5068,6 @@
   bio:
     birthday: '1941-11-06'
     gender: M
-    religion: Christian
   terms:
   - type: rep
     start: '2003-01-07'
@@ -5385,7 +5353,6 @@
   bio:
     birthday: '1953-01-22'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1995-01-04'
@@ -5795,7 +5762,6 @@
   bio:
     birthday: '1956-07-27'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2001-01-03'
@@ -6021,7 +5987,6 @@
   bio:
     birthday: '1940-07-21'
     gender: M
-    religion: African Methodist Episcopal
   terms:
   - type: rep
     start: '1993-01-05'
@@ -6266,7 +6231,6 @@
   bio:
     birthday: '1949-04-28'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '2003-01-07'
@@ -6382,7 +6346,6 @@
   bio:
     birthday: '1948-06-11'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '2005-01-04'
@@ -6578,7 +6541,6 @@
   bio:
     birthday: '1954-06-19'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '1983-01-03'
@@ -6934,7 +6896,6 @@
   bio:
     birthday: '1951-05-20'
     gender: M
-    religion: Latter Day Saints
   terms:
   - type: rep
     start: '1993-01-05'
@@ -7102,7 +7063,6 @@
   bio:
     birthday: '1955-09-19'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '2005-01-04'
@@ -7209,7 +7169,6 @@
   bio:
     birthday: '1951-01-18'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1996-04-16'
@@ -7348,7 +7307,6 @@
   bio:
     birthday: '1941-09-06'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1997-01-07'
@@ -7480,7 +7438,6 @@
   bio:
     birthday: '1944-04-13'
     gender: F
-    religion: Jewish
   terms:
   - type: rep
     start: '2001-01-03'
@@ -7598,7 +7555,6 @@
   bio:
     birthday: '1947-05-27'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1987-01-06'
@@ -7758,7 +7714,6 @@
   bio:
     birthday: '1957-07-29'
     gender: F
-    religion: Presbyterian
   terms:
   - type: rep
     start: '1997-01-07'
@@ -7891,7 +7846,6 @@
   bio:
     birthday: '1943-03-02'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1991-01-03'
@@ -8217,7 +8171,6 @@
   bio:
     birthday: '1961-09-25'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '2003-01-07'
@@ -8334,7 +8287,6 @@
   bio:
     birthday: '1946-10-06'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '1995-01-04'
@@ -8475,7 +8427,6 @@
   bio:
     birthday: '1953-08-05'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1995-01-04'
@@ -8781,7 +8732,6 @@
   bio:
     birthday: '1947-02-18'
     gender: M
-    religion: Jewish
   terms:
   - type: rep
     start: '1989-01-03'
@@ -8933,7 +8883,6 @@
   bio:
     birthday: '1942-12-13'
     gender: F
-    religion: Catholic
   terms:
   - type: rep
     start: '1993-01-05'
@@ -9351,7 +9300,6 @@
   bio:
     birthday: '1943-06-29'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2005-01-04'
@@ -9796,7 +9744,6 @@
   bio:
     birthday: '1953-08-18'
     gender: M
-    religion: Unknown
   terms:
   - type: rep
     start: '2005-01-04'
@@ -9986,7 +9933,6 @@
   bio:
     birthday: '1943-01-18'
     gender: F
-    religion: Methodist
   terms:
   - type: rep
     start: '1997-01-07'
@@ -10121,7 +10067,6 @@
   bio:
     birthday: '1933-09-17'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1975-01-14'
@@ -10224,7 +10169,6 @@
   bio:
     birthday: '1963-11-07'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '2001-01-03'
@@ -10436,7 +10380,6 @@
   bio:
     birthday: '1947-09-01'
     gender: M
-    religion: Unknown
   terms:
   - type: rep
     start: '2005-01-04'
@@ -10628,7 +10571,6 @@
   bio:
     birthday: '1948-02-19'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2003-01-07'
@@ -11002,7 +10944,6 @@
   bio:
     birthday: '1936-09-05'
     gender: M
-    religion: African Methodist Episcopal
   terms:
   - type: rep
     start: '1993-01-05'
@@ -11631,7 +11572,6 @@
   bio:
     birthday: '1939-06-14'
     gender: M
-    religion: Baptist
   leadership_roles:
   - title: Minority Whip
     chamber: house
@@ -12019,7 +11959,6 @@
   bio:
     birthday: '1944-12-28'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '1999-01-06'
@@ -12097,7 +12036,6 @@
   bio:
     birthday: '1950-01-12'
     gender: F
-    religion: Seventh Day Adventist
   terms:
   - type: rep
     start: '1995-01-04'
@@ -12319,7 +12257,6 @@
   bio:
     birthday: '1935-12-03'
     gender: F
-    religion: Baptist
   terms:
   - type: rep
     start: '1993-01-05'
@@ -12619,7 +12556,6 @@
   bio:
     birthday: '1943-02-10'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1995-01-04'
@@ -12858,7 +12794,6 @@
   bio:
     birthday: '1946-06-17'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1983-01-03'
@@ -13201,7 +13136,6 @@
   bio:
     birthday: '1963-03-16'
     gender: M
-    religion: Lutheran
   terms:
   - type: rep
     start: '1997-01-07'
@@ -13335,7 +13269,6 @@
   bio:
     birthday: '1944-04-05'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1993-01-05'
@@ -13480,7 +13413,6 @@
   bio:
     birthday: '1949-05-28'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2003-01-07'
@@ -14319,7 +14251,6 @@
   bio:
     birthday: '1940-03-31'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: sen
     start: '1975-01-14'
@@ -14409,7 +14340,6 @@
   bio:
     birthday: '1946-07-16'
     gender: F
-    religion: Baptist
   terms:
   - type: rep
     start: '1998-04-07'
@@ -14592,7 +14522,6 @@
   bio:
     birthday: '1940-02-21'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1987-01-06'
@@ -14962,7 +14891,6 @@
   bio:
     birthday: '1947-12-21'
     gender: F
-    religion: Lutheran
   terms:
   - type: rep
     start: '1995-01-04'
@@ -15184,7 +15112,6 @@
   bio:
     birthday: '1937-07-05'
     gender: F
-    religion: Jewish
   terms:
   - type: rep
     start: '1989-01-03'
@@ -15341,7 +15268,6 @@
   bio:
     birthday: '1960-01-06'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1993-05-10'
@@ -15790,7 +15716,6 @@
   bio:
     birthday: '1946-02-19'
     gender: F
-    religion: Presbyterian
   terms:
   - type: rep
     start: '1993-01-05'
@@ -15934,7 +15859,6 @@
   bio:
     birthday: '1951-02-23'
     gender: M
-    religion: Nazarene
   terms:
   - type: rep
     start: '2005-01-04'
@@ -16044,7 +15968,6 @@
   bio:
     birthday: '1946-07-11'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1975-01-14'
@@ -16460,7 +16383,6 @@
   bio:
     birthday: '1962-01-14'
     gender: M
-    religion: Unknown
   terms:
   - type: rep
     start: '2005-01-04'
@@ -16655,7 +16577,6 @@
   bio:
     birthday: '1954-07-12'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2001-01-03'
@@ -16776,7 +16697,6 @@
   bio:
     birthday: '1959-11-20'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1997-01-07'
@@ -17302,7 +17222,6 @@
   bio:
     birthday: '1953-09-25'
     gender: M
-    religion: African Methodist Episcopal
   terms:
   - type: rep
     start: '1997-01-07'
@@ -17434,7 +17353,6 @@
   bio:
     birthday: '1951-04-18'
     gender: F
-    religion: Unknown
   terms:
   - type: rep
     start: '2005-01-04'
@@ -17542,7 +17460,6 @@
   bio:
     birthday: '1954-05-29'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '1997-01-07'
@@ -17643,7 +17560,6 @@
   bio:
     birthday: '1957-05-22'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: sen
     start: '2003-01-07'
@@ -17795,7 +17711,6 @@
   bio:
     birthday: '1950-10-11'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: sen
     start: '1993-01-05'
@@ -17868,7 +17783,6 @@
   bio:
     birthday: '1947-06-13'
     gender: M
-    religion: Jewish
   terms:
   - type: rep
     start: '1992-11-03'
@@ -18018,7 +17932,6 @@
   bio:
     birthday: '1936-12-04'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1999-01-06'
@@ -18144,7 +18057,6 @@
   bio:
     birthday: '1949-02-14'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1989-01-03'
@@ -18299,7 +18211,6 @@
   bio:
     birthday: '1937-06-13'
     gender: F
-    religion: Episcopalian
   terms:
   - type: rep
     start: '1991-01-03'
@@ -18450,7 +18361,6 @@
   bio:
     birthday: '1973-10-01'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2003-01-07'
@@ -18742,7 +18652,6 @@
   bio:
     birthday: '1951-10-30'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1987-01-06'
@@ -18905,7 +18814,6 @@
   bio:
     birthday: '1937-01-25'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1997-01-07'
@@ -19092,7 +19000,6 @@
   bio:
     birthday: '1940-03-26'
     gender: F
-    religion: Roman Catholic
   leadership_roles:
   - title: Minority Leader
     chamber: house
@@ -19446,7 +19353,6 @@
   bio:
     birthday: '1944-06-29'
     gender: M
-    religion: Lutheran
   terms:
   - type: rep
     start: '1991-01-03'
@@ -19693,7 +19599,6 @@
   bio:
     birthday: '1955-12-19'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '1993-05-04'
@@ -19882,7 +19787,6 @@
   bio:
     birthday: '1940-08-17'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1987-01-06'
@@ -20480,7 +20384,6 @@
   bio:
     birthday: '1937-12-31'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '1981-01-05'
@@ -20772,7 +20675,6 @@
   bio:
     birthday: '1941-06-12'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1993-01-05'
@@ -20971,7 +20873,6 @@
   bio:
     birthday: '1946-01-31'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '2003-01-07'
@@ -21086,7 +20987,6 @@
   bio:
     birthday: '1946-11-23'
     gender: M
-    religion: Protestant
   terms:
   - type: rep
     start: '1993-01-05'
@@ -21231,7 +21131,6 @@
   bio:
     birthday: '1973-07-16'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2003-01-07'
@@ -21661,7 +21560,6 @@
   bio:
     birthday: '1944-05-26'
     gender: F
-    religion: Jewish
   terms:
   - type: rep
     start: '1999-01-06'
@@ -22003,7 +21901,6 @@
   bio:
     birthday: '1950-11-23'
     gender: M
-    religion: Jewish
   leadership_roles:
   - title: Minority Leader
     chamber: senate
@@ -22295,7 +22192,6 @@
   bio:
     birthday: '1945-06-27'
     gender: M
-    religion: Baptist
   terms:
   - type: rep
     start: '2003-01-07'
@@ -22411,7 +22307,6 @@
   bio:
     birthday: '1947-04-30'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '1993-01-05'
@@ -22637,7 +22532,6 @@
   bio:
     birthday: '1943-06-14'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '1979-01-15'
@@ -22824,7 +22718,6 @@
   bio:
     birthday: '1943-10-24'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1989-01-03'
@@ -23067,7 +22960,6 @@
   bio:
     birthday: '1934-05-06'
     gender: M
-    religion: Presbyterian
   terms:
   - type: rep
     start: '1979-01-15'
@@ -23177,7 +23069,6 @@
   bio:
     birthday: '1954-10-24'
     gender: M
-    religion: Jewish
   terms:
   - type: rep
     start: '1997-01-07'
@@ -23310,7 +23201,6 @@
   bio:
     birthday: '1958-02-21'
     gender: M
-    religion: Lutheran
   terms:
   - type: rep
     start: '1997-01-07'
@@ -23444,7 +23334,6 @@
   bio:
     birthday: '1950-09-08'
     gender: M
-    religion: Latter Day Saints
   terms:
   - type: rep
     start: '1999-01-06'
@@ -23675,7 +23564,6 @@
   bio:
     birthday: '1965-06-15'
     gender: M
-    religion: Christian
   terms:
   - type: rep
     start: '1997-01-07'
@@ -23907,7 +23795,6 @@
   bio:
     birthday: '1953-03-04'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1981-01-05'
@@ -24269,7 +24156,6 @@
   bio:
     birthday: '1969-01-28'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '2003-01-07'
@@ -24386,7 +24272,6 @@
   bio:
     birthday: '1948-01-28'
     gender: M
-    religion: Methodist
   terms:
   - type: rep
     start: '1993-04-13'
@@ -24530,7 +24415,6 @@
   bio:
     birthday: '1951-01-24'
     gender: M
-    religion: Catholic
   terms:
   - type: rep
     start: '1999-01-06'
@@ -24748,7 +24632,6 @@
   bio:
     birthday: '1958-07-15'
     gender: M
-    religion: Presbyterian
   terms:
   - type: rep
     start: '1995-01-04'
@@ -25328,7 +25211,6 @@
   bio:
     birthday: '1953-04-23'
     gender: M
-    religion: Protestant
   terms:
   - type: rep
     start: '1987-01-06'
@@ -25492,7 +25374,6 @@
   bio:
     birthday: '1959-01-10'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '2003-01-07'
@@ -25596,7 +25477,6 @@
   bio:
     birthday: '1953-03-28'
     gender: F
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1993-01-05'
@@ -25737,7 +25617,6 @@
   bio:
     birthday: '1949-08-13'
     gender: M
-    religion: Roman Catholic
   terms:
   - type: rep
     start: '1985-01-03'
@@ -25997,7 +25876,6 @@
   bio:
     birthday: '1957-01-10'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '1999-01-06'
@@ -26123,7 +26001,6 @@
   bio:
     birthday: '1966-09-27'
     gender: F
-    religion: Jewish
   terms:
   - type: rep
     start: '2005-01-04'
@@ -26229,7 +26106,6 @@
   bio:
     birthday: '1938-08-15'
     gender: F
-    religion: Christian
   terms:
   - type: rep
     start: '1991-01-03'
@@ -26565,7 +26441,6 @@
   bio:
     birthday: '1947-07-31'
     gender: M
-    religion: Presbyterian
   terms:
   - type: rep
     start: '2001-12-18'
@@ -26771,7 +26646,6 @@
   bio:
     birthday: '1959-02-03'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '2007-12-13'
@@ -27040,7 +26914,6 @@
   bio:
     birthday: '1949-05-03'
     gender: M
-    religion: Jewish
   terms:
   - type: rep
     start: '1981-01-05'
@@ -27258,7 +27131,6 @@
   bio:
     birthday: '1933-06-09'
     gender: M
-    religion: Episcopalian
   terms:
   - type: rep
     start: '1973-03-06'
@@ -37930,7 +37802,6 @@
   bio:
     birthday: '1952-09-27'
     gender: M
-    religion: Protestant
   terms:
   - type: rep
     start: '2003-01-07'

--- a/test/validate.py
+++ b/test/validate.py
@@ -61,7 +61,6 @@ name_keys = { "first", "middle", "nickname", "last", "suffix", "official_full" }
 
 # bio keys
 bio_keys = { "gender", "birthday" }
-old_allowed_other_bio_keys = { "religion" }
 
 # get today as a date instance
 def now():
@@ -198,7 +197,7 @@ def check_name(name, context, is_other_names=False):
 
 def check_bio(bio, is_current_legislator, context):
   for key, value in bio.items():
-    if key not in (bio_keys | old_allowed_other_bio_keys):
+    if key not in bio_keys:
       error(context, "%s is not a valid key in bio." % key)
     elif not isinstance(value, str):
       error(context, rtyaml.dump({ key: value }) + " has an invalid data type.")


### PR DESCRIPTION
This data came from my original import from GovTrack's legislator database, and the religion field probably came from my original import of data from the MIT Media Lab's Government Information Awareness project in 2003. The field was never maintained. To avoid confusion over an unmaintained field, per #657 and 9101feaae3ec45418d9e0806df656df7b74ff22e, this PR removes it.