### PR TITLE
116th Congress Committee Assignments

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -435,6 +435,99 @@ HSAG03:
   bioguide: F000455
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+- name: James P. McGovern
+  party: majority
+  rank: 2
+  bioguide: M000312
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Alma S. Adams
+  party: majority
+  rank: 3
+  bioguide: A000370
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jahana Hayes
+  party: majority
+  rank: 4
+  bioguide: H001081
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Kim Schrier
+  party: majority
+  rank: 5
+  bioguide: S001216
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jefferson Van Drew
+  party: majority
+  rank: 6
+  bioguide: V000133
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Al Lawson, Jr.
+  party: majority
+  rank: 7
+  bioguide: L000586
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jimmy Panetta
+  party: majority
+  rank: 8
+  bioguide: P000613
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Collin C. Peterson
+  party: majority
+  rank: 9
+  title: Ex Officio
+  bioguide: P000258
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Dusty Johnson
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: J000301
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Scott DesJarlais
+  party: minority
+  rank: 2
+  bioguide: D000616
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Rodney Davis
+  party: minority
+  rank: 3
+  bioguide: D000619
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Ted S. Yoho
+  party: minority
+  rank: 4
+  bioguide: Y000065
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Don Bacon
+  party: minority
+  rank: 5
+  bioguide: B001298
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jim Hagedorn
+  party: minority
+  rank: 6
+  bioguide: H001088
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: K. Michael Conaway
+  party: minority
+  rank: 7
+  title: Ex Officio
+  bioguide: C001062
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
 HSAG14:
 - name: Stacey E. Plaskett
   party: majority
@@ -443,6 +536,141 @@ HSAG14:
   bioguide: P000610
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+- name: Antonio Delgado
+  party: majority
+  rank: 2
+  bioguide: D000630
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: T.J. Cox
+  party: majority
+  rank: 3
+  bioguide: C001124
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Josh Harder
+  party: majority
+  rank: 4
+  bioguide: H001090
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Anthony Brindisi
+  party: majority
+  rank: 5
+  bioguide: B001308
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jefferson Van Drew
+  party: majority
+  rank: 6
+  bioguide: V000133
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Kim Schrier
+  party: majority
+  rank: 7
+  bioguide: S001216
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Chellie Pingree
+  party: majority
+  rank: 8
+  bioguide: P000597
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Salud Carbajal
+  party: majority
+  rank: 9
+  bioguide: C001112
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jimmy Panetta
+  party: majority
+  rank: 10
+  bioguide: P000613
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Sean Patrick Maloney
+  party: majority
+  rank: 11
+  bioguide: M001185
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Al Lawson, Jr.
+  party: majority
+  rank: 12
+  bioguide: L000586
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Collin C. Peterson
+  party: majority
+  rank: 13
+  title: Ex Officio
+  bioguide: P000258
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Neal P. Dunn
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000628
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Glenn Thompson
+  party: minority
+  rank: 2
+  bioguide: T000467
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Vicky Hartzler
+  party: minority
+  rank: 3
+  bioguide: H001053
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Doug LaMalfa
+  party: minority
+  rank: 4
+  bioguide: L000578
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Rodney Davis
+  party: minority
+  rank: 5
+  bioguide: D000619
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Ted S. Yoho
+  party: minority
+  rank: 6
+  bioguide: Y000065
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Mike Bost
+  party: minority
+  rank: 7
+  bioguide: B001295
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: James Comer
+  party: minority
+  rank: 8
+  bioguide: C001108
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: James Baird
+  party: minority
+  rank: 9
+  bioguide: B001307
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: K. Michael Conaway
+  party: minority
+  rank: 10
+  title: Ex Officio
+  bioguide: C001062
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
 HSAG15:
 - name: Abigail Spanberger
   party: majority
@@ -451,6 +679,69 @@ HSAG15:
   bioguide: S001209
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+- name: Marcia L. Fudge
+  party: majority
+  rank: 2
+  bioguide: F000455
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Tom O’Halleran
+  party: majority
+  rank: 3
+  bioguide: O000171
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Chellie Pingree
+  party: majority
+  rank: 4
+  bioguide: P000597
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Cindy Axne
+  party: majority
+  rank: 5
+  bioguide: A000378
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Collin C. Peterson
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: P000258
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Doug LaMalfa
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000578
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Rick W. Allen
+  party: minority
+  rank: 2
+  bioguide: A000372
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Ralph Lee Abraham
+  party: minority
+  rank: 3
+  bioguide: A000374
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Trent Kelly
+  party: minority
+  rank: 4
+  bioguide: K000388
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: K. Michael Conaway
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: C001062
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
 HSAG16:
 - name: Filemon Vela
   party: majority
@@ -459,6 +750,75 @@ HSAG16:
   bioguide: V000132
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+- name: Angie Craig
+  party: majority
+  rank: 2
+  bioguide: C001119
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: David Scott
+  party: majority
+  rank: 3
+  bioguide: S001157
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Al Lawson, Jr.
+  party: majority
+  rank: 4
+  bioguide: L000586
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jefferson Van Drew
+  party: majority
+  rank: 5
+  bioguide: V000133
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Collin C. Peterson
+  party: majority
+  rank: 6
+  title: Ex Officio
+  bioguide: P000258
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Glenn Thompson
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: T000467
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Austin Scott
+  party: minority
+  rank: 2
+  bioguide: S001189
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Eric A. "Rick" Crawford
+  party: minority
+  rank: 3
+  bioguide: C001087
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Rick W. Allen
+  party: minority
+  rank: 4
+  bioguide: A000372
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Ralph Lee Abraham
+  party: minority
+  rank: 5
+  bioguide: A000374
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: K. Michael Conaway
+  party: minority
+  rank: 6
+  title: Ex Officio
+  bioguide: C001062
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
 HSAG22:
 - name: David Scott
   party: majority
@@ -467,6 +827,123 @@ HSAG22:
   bioguide: S001157
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+- name: Jefferson Van Drew
+  party: majority
+  rank: 2
+  bioguide: V000133
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Filemon Vela
+  party: majority
+  rank: 3
+  bioguide: V000132
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Stacey E. Plaskett
+  party: majority
+  rank: 4
+  bioguide: P000610
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Abigail Spanberger
+  party: majority
+  rank: 5
+  bioguide: S001209
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Antonio Delgado
+  party: majority
+  rank: 6
+  bioguide: D000630
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Angie Craig
+  party: majority
+  rank: 7
+  bioguide: C001119
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Sean Patrick Maloney
+  party: majority
+  rank: 8
+  bioguide: M001185
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Ann Kirkpatrick
+  party: majority
+  rank: 9
+  bioguide: K000368
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Cindy Axne
+  party: majority
+  rank: 10
+  bioguide: A000378
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Collin C. Peterson
+  party: majority
+  rank: 11
+  title: Ex Officio
+  bioguide: P000258
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Austin Scott
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001189
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Eric A. "Rick" Crawford
+  party: minority
+  rank: 2
+  bioguide: C001087
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Mike Bost
+  party: minority
+  rank: 3
+  bioguide: B001295
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: David Rouzer
+  party: minority
+  rank: 4
+  bioguide: R000603
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Roger W. Marshall
+  party: minority
+  rank: 5
+  bioguide: M001198
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Neal P. Dunn
+  party: minority
+  rank: 6
+  bioguide: D000628
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Dusty Johnson
+  party: minority
+  rank: 7
+  bioguide: J000301
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: James Baird
+  party: minority
+  rank: 8
+  bioguide: B001307
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: K. Michael Conaway
+  party: minority
+  rank: 9
+  title: Ex Officio
+  bioguide: C001062
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
 HSAG29:
 - name: Jim Costa
   party: majority
@@ -475,6 +952,129 @@ HSAG29:
   bioguide: C001059
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+- name: Anthony Brindisi
+  party: majority
+  rank: 2
+  bioguide: B001308
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jahana Hayes
+  party: majority
+  rank: 3
+  bioguide: H001081
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: T.J. Cox
+  party: majority
+  rank: 4
+  bioguide: C001124
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Angie Craig
+  party: majority
+  rank: 5
+  bioguide: C001119
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Josh Harder
+  party: majority
+  rank: 6
+  bioguide: H001090
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Filemon Vela
+  party: majority
+  rank: 7
+  bioguide: V000132
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Stacey E. Plaskett
+  party: majority
+  rank: 8
+  bioguide: P000610
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Salud Carbajal
+  party: majority
+  rank: 9
+  bioguide: C001112
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Cheri Bustos
+  party: majority
+  rank: 10
+  bioguide: B001286
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Collin C. Peterson
+  party: majority
+  rank: 11
+  title: Ex Officio
+  bioguide: P000258
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: David Rouzer
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000603
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Glenn Thompson
+  party: minority
+  rank: 2
+  bioguide: T000467
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Scott DesJarlais
+  party: minority
+  rank: 3
+  bioguide: D000616
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Vicky Hartzler
+  party: minority
+  rank: 4
+  bioguide: H001053
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Trent Kelly
+  party: minority
+  rank: 5
+  bioguide: K000388
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: James Comer
+  party: minority
+  rank: 6
+  bioguide: C001108
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Roger W. Marshall
+  party: minority
+  rank: 7
+  bioguide: M001198
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Don Bacon
+  party: minority
+  rank: 8
+  bioguide: B001298
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: Jim Hagedorn
+  party: minority
+  rank: 9
+  bioguide: H001088
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
+- name: K. Michael Conaway
+  party: minority
+  rank: 10
+  title: Ex Officio
+  bioguide: C001062
+  start_date: '2019-02-06'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1365
 HSAP:
 - name: Kay Granger
   party: minority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -1,3617 +1,3271 @@
 HLIG:
-- name: Devin Nunes
+- name: Adam B. Schiff
   party: majority
   rank: 1
   title: Chair
-  thomas: '01710'
-  bioguide: N000181
-- name: K. Michael Conaway
-  party: majority
-  rank: 2
-  thomas: '01805'
-  bioguide: C001062
-- name: Peter T. King
-  party: majority
-  rank: 3
-  thomas: '00635'
-  bioguide: K000210
-- name: Michael R. Turner
-  party: majority
-  rank: 7
-  thomas: '01741'
-  bioguide: T000463
-- name: Brad R. Wenstrup
-  party: majority
-  rank: 8
-  thomas: '02152'
-  bioguide: W000815
-- name: Chris Stewart
-  party: majority
-  rank: 9
-  thomas: '02168'
-  bioguide: S001192
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 10
-  thomas: '01989'
-  bioguide: C001087
-- name: Elise M. Stefanik
-  party: majority
-  rank: 12
-  thomas: '02263'
-  bioguide: S001196
-- name: Will Hurd
-  party: majority
-  rank: 13
-  thomas: '02269'
-  bioguide: H001073
-- name: Adam B. Schiff
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '01635'
   bioguide: S001150
 - name: James A. Himes
-  party: minority
+  party: majority
   rank: 2
   thomas: '01913'
   bioguide: H001047
 - name: Terri A. Sewell
-  party: minority
+  party: majority
   rank: 3
   thomas: '01988'
   bioguide: S001185
 - name: André Carson
-  party: minority
+  party: majority
   rank: 4
   thomas: '01889'
   bioguide: C001072
 - name: Jackie Speier
-  party: minority
+  party: majority
   rank: 5
   thomas: '01890'
   bioguide: S001175
 - name: Mike Quigley
-  party: minority
+  party: majority
   rank: 6
   thomas: '01967'
   bioguide: Q000023
 - name: Eric Swalwell
-  party: minority
+  party: majority
   rank: 7
   thomas: '02104'
   bioguide: S001193
 - name: Joaquin Castro
-  party: minority
+  party: majority
   rank: 8
   thomas: '02163'
   bioguide: C001091
 - name: Denny Heck
-  party: minority
+  party: majority
   rank: 9
   thomas: '02170'
   bioguide: H001064
-HLIG01:
-- name: K. Michael Conaway
+- name: Peter Welch
   party: majority
+  rank: 10
+  thomas: '01879'
+  bioguide: W000800
+- name: Sean Patrick Maloney
+  party: majority
+  rank: 11
+  thomas: '02150'
+  bioguide: M001185
+- name: Val Butler Demings
+  party: majority
+  rank: 12
+  bioguide: D000627
+- name: Raja Krishnamoorthi
+  party: majority
+  rank: 13
+  bioguide: K000391
+- name: Devin Nunes
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01710'
+  bioguide: N000181
+- name: K. Michael Conaway
+  party: minority
   rank: 2
   thomas: '01805'
   bioguide: C001062
 - name: Peter T. King
-  party: majority
+  party: minority
   rank: 3
   thomas: '00635'
   bioguide: K000210
-- name: Chris Stewart
-  party: majority
-  rank: 6
-  thomas: '02168'
-  bioguide: S001192
-- name: Eric Swalwell
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02104'
-  bioguide: S001193
-- name: James A. Himes
-  party: minority
-  rank: 2
-  thomas: '01913'
-  bioguide: H001047
-- name: Joaquin Castro
-  party: minority
-  rank: 3
-  thomas: '02163'
-  bioguide: C001091
-- name: Denny Heck
-  party: minority
-  rank: 4
-  thomas: '02170'
-  bioguide: H001064
-HLIG02:
-- name: K. Michael Conaway
-  party: majority
-  rank: 2
-  thomas: '01805'
-  bioguide: C001062
 - name: Michael R. Turner
-  party: majority
+  party: minority
   rank: 4
   thomas: '01741'
   bioguide: T000463
-- name: Elise M. Stefanik
-  party: majority
-  rank: 6
-  thomas: '02263'
-  bioguide: S001196
-- name: James A. Himes
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01913'
-  bioguide: H001047
-- name: Terri A. Sewell
-  party: minority
-  rank: 2
-  thomas: '01988'
-  bioguide: S001185
-- name: Jackie Speier
-  party: minority
-  rank: 3
-  thomas: '01890'
-  bioguide: S001175
-- name: Mike Quigley
-  party: minority
-  rank: 4
-  thomas: '01967'
-  bioguide: Q000023
-HLIG03:
-- name: Peter T. King
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '00635'
-  bioguide: K000210
 - name: Brad R. Wenstrup
-  party: majority
-  rank: 3
-  thomas: '02152'
-  bioguide: W000815
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 4
-  thomas: '01989'
-  bioguide: C001087
-- name: Will Hurd
-  party: majority
-  rank: 6
-  thomas: '02269'
-  bioguide: H001073
-- name: André Carson
   party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01889'
-  bioguide: C001072
-- name: Jackie Speier
-  party: minority
-  rank: 2
-  thomas: '01890'
-  bioguide: S001175
-- name: Mike Quigley
-  party: minority
-  rank: 3
-  thomas: '01967'
-  bioguide: Q000023
-- name: Eric Swalwell
-  party: minority
-  rank: 4
-  thomas: '02104'
-  bioguide: S001193
-HLIG04:
-- name: Chris Stewart
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02168'
-  bioguide: S001192
-- name: Michael R. Turner
-  party: majority
-  rank: 2
-  thomas: '01741'
-  bioguide: T000463
-- name: Brad R. Wenstrup
-  party: majority
-  rank: 3
-  thomas: '02152'
-  bioguide: W000815
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 4
-  thomas: '01989'
-  bioguide: C001087
-- name: Elise M. Stefanik
-  party: majority
   rank: 5
+  thomas: '02152'
+  bioguide: W000815
+- name: Chris Stewart
+  party: minority
+  rank: 6
+  thomas: '02168'
+  bioguide: S001192
+- name: Eric A. "Rick" Crawford
+  party: minority
+  rank: 7
+  thomas: '01989'
+  bioguide: C001087
+- name: Elise M. Stefanik
+  party: minority
+  rank: 8
   thomas: '02263'
   bioguide: S001196
 - name: Will Hurd
-  party: majority
-  rank: 6
+  party: minority
+  rank: 9
   thomas: '02269'
   bioguide: H001073
-- name: Terri A. Sewell
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01988'
-  bioguide: S001185
-- name: André Carson
-  party: minority
-  rank: 2
-  thomas: '01889'
-  bioguide: C001072
-- name: Joaquin Castro
-  party: minority
-  rank: 3
-  thomas: '02163'
-  bioguide: C001091
-- name: Denny Heck
-  party: minority
-  rank: 4
-  thomas: '02170'
-  bioguide: H001064
 HSAG:
 - name: K. Michael Conaway
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
+  title: Ranking Member
   thomas: '01805'
   bioguide: C001062
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Glenn Thompson
+  party: minority
+  rank: 2
+  thomas: '01952'
+  bioguide: T000467
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Frank D. Lucas
-  party: majority
+  party: minority
   rank: 3
   thomas: '00711'
   bioguide: L000491
-- name: Steve King
-  party: majority
-  rank: 4
-  thomas: '01724'
-  bioguide: K000362
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mike Rogers
-  party: majority
-  rank: 5
+  party: minority
+  rank: 4
   thomas: '01704'
   bioguide: R000575
-- name: Glenn Thompson
-  party: majority
-  rank: 6
-  thomas: '01952'
-  bioguide: T000467
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bob Gibbs
-  party: majority
-  rank: 7
+  party: minority
+  rank: 5
   thomas: '02049'
   bioguide: G000563
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Austin Scott
-  party: majority
-  rank: 8
+  party: minority
+  rank: 6
   thomas: '02009'
   bioguide: S001189
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 9
+  party: minority
+  rank: 7
   thomas: '01989'
   bioguide: C001087
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Scott DesJarlais
-  party: majority
-  rank: 10
+  party: minority
+  rank: 8
   thomas: '02062'
   bioguide: D000616
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Vicky Hartzler
-  party: majority
-  rank: 11
+  party: minority
+  rank: 9
   thomas: '02032'
   bioguide: H001053
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Doug LaMalfa
-  party: majority
-  rank: 13
+  party: minority
+  rank: 10
   thomas: '02100'
   bioguide: L000578
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Rodney Davis
-  party: majority
-  rank: 14
+  party: minority
+  rank: 11
   thomas: '02126'
   bioguide: D000619
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ted S. Yoho
-  party: majority
-  rank: 15
+  party: minority
+  rank: 12
   thomas: '02115'
   bioguide: Y000065
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Rick W. Allen
-  party: majority
-  rank: 16
+  party: minority
+  rank: 13
   thomas: '02239'
   bioguide: A000372
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mike Bost
-  party: majority
-  rank: 17
+  party: minority
+  rank: 14
   thomas: '02243'
   bioguide: B001295
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: David Rouzer
-  party: majority
-  rank: 18
+  party: minority
+  rank: 15
   thomas: '02256'
   bioguide: R000603
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ralph Lee Abraham
-  party: majority
-  rank: 19
+  party: minority
+  rank: 16
   thomas: '02244'
   bioguide: A000374
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Trent Kelly
-  party: majority
-  rank: 20
+  party: minority
+  rank: 17
   thomas: '02294'
   bioguide: K000388
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: James Comer
-  party: majority
-  rank: 21
-  bioguide: C001108
-- name: Roger W. Marshall
-  party: majority
-  rank: 22
-  bioguide: M001198
-- name: Don Bacon
-  party: majority
-  rank: 23
-  bioguide: B001298
-- name: Neal P. Dunn
-  party: majority
-  rank: 25
-  bioguide: D000628
-- name: Jodey C. Arrington
-  party: majority
-  rank: 26
-  bioguide: A000375
-- name: Collin C. Peterson
   party: minority
+  rank: 18
+  bioguide: C001108
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Roger W. Marshall
+  party: minority
+  rank: 19
+  bioguide: M001198
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Don Bacon
+  party: minority
+  rank: 20
+  bioguide: B001298
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Neal P. Dunn
+  party: minority
+  rank: 21
+  bioguide: D000628
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Dusty Johnson
+  party: minority
+  rank: 22
+  bioguide: J000301
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: James Baird
+  party: minority
+  rank: 23
+  bioguide: B001307
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jim Hagedorn
+  party: minority
+  rank: 24
+  bioguide: H001088
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Collin C. Peterson
+  party: majority
   rank: 1
-  title: Ranking Member
+  title: Chair
   thomas: '00910'
   bioguide: P000258
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: David Scott
-  party: minority
+  party: majority
   rank: 2
   thomas: '01722'
   bioguide: S001157
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Jim Costa
-  party: minority
+  party: majority
   rank: 3
   thomas: '01774'
   bioguide: C001059
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Marcia L. Fudge
-  party: minority
-  rank: 5
+  party: majority
+  rank: 4
   thomas: '01895'
   bioguide: F000455
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: James P. McGovern
-  party: minority
-  rank: 6
+  party: majority
+  rank: 5
   thomas: '01504'
   bioguide: M000312
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Filemon Vela
-  party: minority
-  rank: 7
+  party: majority
+  rank: 6
   thomas: '02167'
   bioguide: V000132
-- name: Ann M. Kuster
-  party: minority
-  rank: 9
-  thomas: '02145'
-  bioguide: K000382
-- name: Cheri Bustos
-  party: minority
-  rank: 11
-  thomas: '02127'
-  bioguide: B001286
-- name: Sean Patrick Maloney
-  party: minority
-  rank: 12
-  thomas: '02150'
-  bioguide: M001185
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Stacey E. Plaskett
-  party: minority
-  rank: 13
+  party: majority
+  rank: 7
   thomas: '02274'
   bioguide: P000610
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Alma S. Adams
-  party: minority
-  rank: 14
+  party: majority
+  rank: 8
   thomas: '02201'
   bioguide: A000370
-- name: Dwight Evans
-  party: minority
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Abigail Spanberger
+  party: majority
+  rank: 9
+  bioguide: S001209
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jahana Hayes
+  party: majority
+  rank: 10
+  bioguide: H001081
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Antonio Delgado
+  party: majority
+  rank: 11
+  bioguide: D000630
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: T.J. Cox
+  party: majority
+  rank: 12
+  bioguide: C001124
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Angie Craig
+  party: majority
+  rank: 13
+  bioguide: C001119
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Anthony Brindisi
+  party: majority
+  rank: 14
+  bioguide: B001308
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jefferson Van Drew
+  party: majority
   rank: 15
-  bioguide: E000296
-- name: Al Lawson, Jr.
-  party: minority
+  bioguide: V000133
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Josh Harder
+  party: majority
   rank: 16
-  bioguide: L000586
-- name: Tom O’Halleran
-  party: minority
+  bioguide: H001090
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Kim Schrier
+  party: majority
   rank: 17
-  bioguide: O000171
-- name: Jimmy Panetta
-  party: minority
+  bioguide: S001216
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Chellie Pingree
+  party: majority
   rank: 18
-  bioguide: P000613
-- name: Darren Soto
-  party: minority
+  bioguide: P000597
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Cheri Bustos
+  party: majority
   rank: 19
-  bioguide: S001200
-- name: Lisa Blunt Rochester
-  party: minority
-  rank: 20
-  bioguide: B001303
-HSAG03:
-- name: Glenn Thompson
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01952'
-  bioguide: T000467
-- name: Steve King
-  party: majority
-  rank: 2
-  thomas: '01724'
-  bioguide: K000362
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 3
-  thomas: '01989'
-  bioguide: C001087
-- name: Scott DesJarlais
-  party: majority
-  rank: 4
-  thomas: '02062'
-  bioguide: D000616
-- name: Vicky Hartzler
-  party: majority
-  rank: 5
-  thomas: '02032'
-  bioguide: H001053
-- name: Rodney Davis
-  party: majority
-  rank: 6
-  thomas: '02126'
-  bioguide: D000619
-- name: Ted S. Yoho
-  party: majority
-  rank: 7
-  thomas: '02115'
-  bioguide: Y000065
-- name: David Rouzer
-  party: majority
-  rank: 8
-  thomas: '02256'
-  bioguide: R000603
-- name: James Comer
-  party: majority
-  rank: 9
-  bioguide: C001108
-- name: Roger W. Marshall
-  party: majority
-  rank: 10
-  bioguide: M001198
-- name: Jodey C. Arrington
-  party: majority
-  rank: 12
-  bioguide: A000375
-- name: James P. McGovern
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01504'
-  bioguide: M000312
-- name: Alma S. Adams
-  party: minority
-  rank: 2
-  thomas: '02201'
-  bioguide: A000370
-- name: Dwight Evans
-  party: minority
-  rank: 3
-  bioguide: E000296
-- name: Marcia L. Fudge
-  party: minority
-  rank: 4
-  thomas: '01895'
-  bioguide: F000455
-- name: Al Lawson, Jr.
-  party: minority
-  rank: 6
-  bioguide: L000586
-- name: Jimmy Panetta
-  party: minority
-  rank: 7
-  bioguide: P000613
-- name: Darren Soto
-  party: minority
-  rank: 8
-  bioguide: S001200
-- name: Sean Patrick Maloney
-  party: minority
-  rank: 9
-  thomas: '02150'
-  bioguide: M001185
-HSAG14:
-- name: Rodney Davis
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02126'
-  bioguide: D000619
-- name: Bob Gibbs
-  party: majority
-  rank: 2
-  thomas: '02049'
-  bioguide: G000563
-- name: Ted S. Yoho
-  party: majority
-  rank: 4
-  thomas: '02115'
-  bioguide: Y000065
-- name: David Rouzer
-  party: majority
-  rank: 5
-  thomas: '02256'
-  bioguide: R000603
-- name: Don Bacon
-  party: majority
-  rank: 6
-  bioguide: B001298
-- name: Neal P. Dunn
-  party: majority
-  rank: 7
-  bioguide: D000628
-- name: Jodey C. Arrington
-  party: majority
-  rank: 8
-  bioguide: A000375
-- name: Al Lawson, Jr.
-  party: minority
-  rank: 2
-  bioguide: L000586
-- name: Jimmy Panetta
-  party: minority
-  rank: 3
-  bioguide: P000613
-- name: Jim Costa
-  party: minority
-  rank: 4
-  thomas: '01774'
-  bioguide: C001059
-- name: James P. McGovern
-  party: minority
-  rank: 5
-  thomas: '01504'
-  bioguide: M000312
-- name: Lisa Blunt Rochester
-  party: minority
-  rank: 6
-  bioguide: B001303
-HSAG15:
-- name: Frank D. Lucas
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '00711'
-  bioguide: L000491
-- name: Glenn Thompson
-  party: majority
-  rank: 2
-  thomas: '01952'
-  bioguide: T000467
-- name: Doug LaMalfa
-  party: majority
-  rank: 4
-  thomas: '02100'
-  bioguide: L000578
-- name: Rick W. Allen
-  party: majority
-  rank: 5
-  thomas: '02239'
-  bioguide: A000372
-- name: Mike Bost
-  party: majority
-  rank: 6
-  thomas: '02243'
-  bioguide: B001295
-- name: Ralph Lee Abraham
-  party: majority
-  rank: 7
-  thomas: '02244'
-  bioguide: A000374
-- name: Trent Kelly
-  party: majority
-  rank: 8
-  thomas: '02294'
-  bioguide: K000388
-- name: Marcia L. Fudge
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01895'
-  bioguide: F000455
-- name: Ann M. Kuster
-  party: minority
-  rank: 3
-  thomas: '02145'
-  bioguide: K000382
-- name: Tom O’Halleran
-  party: minority
-  rank: 5
-  bioguide: O000171
-- name: Filemon Vela
-  party: minority
-  rank: 6
-  thomas: '02167'
-  bioguide: V000132
-HSAG16:
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01989'
-  bioguide: C001087
-- name: Frank D. Lucas
-  party: majority
-  rank: 2
-  thomas: '00711'
-  bioguide: L000491
-- name: Mike Rogers
-  party: majority
-  rank: 3
-  thomas: '01704'
-  bioguide: R000575
-- name: Bob Gibbs
-  party: majority
-  rank: 4
-  thomas: '02049'
-  bioguide: G000563
-- name: Austin Scott
-  party: majority
-  rank: 5
-  thomas: '02009'
-  bioguide: S001189
-- name: Scott DesJarlais
-  party: majority
-  rank: 6
-  thomas: '02062'
-  bioguide: D000616
-- name: Rick W. Allen
-  party: majority
-  rank: 7
-  thomas: '02239'
-  bioguide: A000372
-- name: Mike Bost
-  party: majority
-  rank: 8
-  thomas: '02243'
-  bioguide: B001295
-- name: Ralph Lee Abraham
-  party: majority
-  rank: 9
-  thomas: '02244'
-  bioguide: A000374
-- name: Don Bacon
-  party: majority
-  rank: 10
-  bioguide: B001298
-- name: Neal P. Dunn
-  party: majority
-  rank: 11
-  bioguide: D000628
-- name: Jodey C. Arrington
-  party: majority
-  rank: 12
-  bioguide: A000375
-- name: Cheri Bustos
-  party: minority
-  rank: 3
   thomas: '02127'
   bioguide: B001286
-- name: Lisa Blunt Rochester
-  party: minority
-  rank: 4
-  bioguide: B001303
-- name: David Scott
-  party: minority
-  rank: 5
-  thomas: '01722'
-  bioguide: S001157
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Sean Patrick Maloney
-  party: minority
-  rank: 6
-  thomas: '02150'
-  bioguide: M001185
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 7
-  thomas: '02274'
-  bioguide: P000610
-- name: Al Lawson, Jr.
-  party: minority
-  rank: 8
-  bioguide: L000586
-- name: Tom O’Halleran
-  party: minority
-  rank: 9
-  bioguide: O000171
-HSAG22:
-- name: Austin Scott
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02009'
-  bioguide: S001189
-- name: Mike Rogers
-  party: majority
-  rank: 3
-  thomas: '01704'
-  bioguide: R000575
-- name: Doug LaMalfa
-  party: majority
-  rank: 4
-  thomas: '02100'
-  bioguide: L000578
-- name: Rodney Davis
-  party: majority
-  rank: 5
-  thomas: '02126'
-  bioguide: D000619
-- name: James Comer
-  party: majority
-  rank: 6
-  bioguide: C001108
-- name: Roger W. Marshall
-  party: majority
-  rank: 7
-  bioguide: M001198
-- name: David Scott
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01722'
-  bioguide: S001157
-- name: Sean Patrick Maloney
-  party: minority
-  rank: 2
-  thomas: '02150'
-  bioguide: M001185
-- name: Ann M. Kuster
-  party: minority
-  rank: 3
-  thomas: '02145'
-  bioguide: K000382
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 4
-  thomas: '02274'
-  bioguide: P000610
-- name: Tom O’Halleran
-  party: minority
-  rank: 5
-  bioguide: O000171
-- name: Darren Soto
-  party: minority
-  rank: 6
-  bioguide: S001200
-HSAG29:
-- name: David Rouzer
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02256'
-  bioguide: R000603
-- name: Steve King
-  party: majority
-  rank: 3
-  thomas: '01724'
-  bioguide: K000362
-- name: Scott DesJarlais
-  party: majority
-  rank: 4
-  thomas: '02062'
-  bioguide: D000616
-- name: Vicky Hartzler
-  party: majority
-  rank: 5
-  thomas: '02032'
-  bioguide: H001053
-- name: Ted S. Yoho
-  party: majority
-  rank: 6
-  thomas: '02115'
-  bioguide: Y000065
-- name: Trent Kelly
-  party: majority
-  rank: 7
-  thomas: '02294'
-  bioguide: K000388
-- name: Roger W. Marshall
-  party: majority
-  rank: 8
-  bioguide: M001198
-- name: Jim Costa
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01774'
-  bioguide: C001059
-- name: Filemon Vela
-  party: minority
-  rank: 2
-  thomas: '02167'
-  bioguide: V000132
-- name: Cheri Bustos
-  party: minority
-  rank: 3
-  thomas: '02127'
-  bioguide: B001286
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 4
-  thomas: '02274'
-  bioguide: P000610
-- name: Dwight Evans
-  party: minority
-  rank: 5
-  bioguide: E000296
-HSAP:
-- name: Harold Rogers
-  party: majority
-  rank: 2
-  thomas: '00977'
-  bioguide: R000395
-- name: Robert B. Aderholt
-  party: majority
-  rank: 3
-  thomas: '01460'
-  bioguide: A000055
-- name: Kay Granger
-  party: majority
-  rank: 4
-  thomas: '01487'
-  bioguide: G000377
-- name: Michael K. Simpson
-  party: majority
-  rank: 5
-  thomas: '01590'
-  bioguide: S001148
-- name: John R. Carter
-  party: majority
-  rank: 7
-  thomas: '01752'
-  bioguide: C001051
-- name: Ken Calvert
-  party: majority
-  rank: 8
-  thomas: '00165'
-  bioguide: C000059
-- name: Tom Cole
-  party: majority
-  rank: 9
-  thomas: '01742'
-  bioguide: C001053
-- name: Mario Diaz-Balart
-  party: majority
-  rank: 10
-  thomas: '01717'
-  bioguide: D000600
-- name: Tom Graves
-  party: majority
-  rank: 11
-  thomas: '01979'
-  bioguide: G000560
-- name: Steve Womack
-  party: majority
-  rank: 13
-  thomas: '01991'
-  bioguide: W000809
-- name: Jeff Fortenberry
-  party: majority
-  rank: 14
-  thomas: '01793'
-  bioguide: F000449
-- name: Charles J. "Chuck" Fleischmann
-  party: majority
-  rank: 16
-  thomas: '02061'
-  bioguide: F000459
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 17
-  thomas: '02071'
-  bioguide: H001056
-- name: David P. Joyce
-  party: majority
-  rank: 18
-  thomas: '02154'
-  bioguide: J000295
-- name: Andy Harris
   party: majority
   rank: 20
-  thomas: '02026'
-  bioguide: H001052
-- name: Martha Roby
+  thomas: '02150'
+  bioguide: M001185
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Salud Carbajal
   party: majority
   rank: 21
-  thomas: '01986'
-  bioguide: R000591
-- name: Mark E. Amodei
+  bioguide: C001112
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Al Lawson, Jr.
   party: majority
   rank: 22
-  thomas: '02090'
-  bioguide: A000369
-- name: Chris Stewart
+  bioguide: L000586
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Tom O’Halleran
   party: majority
   rank: 23
-  thomas: '02168'
-  bioguide: S001192
-- name: Steven M. Palazzo
+  bioguide: O000171
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jimmy Panetta
+  party: majority
+  rank: 24
+  bioguide: P000613
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Ann Kirkpatrick
   party: majority
   rank: 25
-  thomas: '02035'
-  bioguide: P000601
-- name: Dan Newhouse
+  bioguide: K000368
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Cindy Axne
   party: majority
   rank: 26
-  thomas: '02275'
-  bioguide: N000189
-- name: John R. Moolenaar
+  bioguide: A000378
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+HSAG03:
+- name: Marcia L. Fudge
   party: majority
-  rank: 27
-  thomas: '02248'
-  bioguide: M001194
-- name: John H. Rutherford
+  rank: 1
+  title: Chair
+  thomas: '01895'
+  bioguide: F000455
+  start_date: '2019-01-24'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+HSAG14:
+- name: Stacey E. Plaskett
   party: majority
-  rank: 29
-  bioguide: R000609
-- name: Nita M. Lowey
+  rank: 1
+  title: Chair
+  thomas: '02274'
+  bioguide: P000610
+  start_date: '2019-01-24'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+HSAG15:
+- name: Abigail Spanberger
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: S001209
+  start_date: '2019-01-24'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+HSAG16:
+- name: Filemon Vela
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '02167'
+  bioguide: V000132
+  start_date: '2019-01-24'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+HSAG22:
+- name: David Scott
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01722'
+  bioguide: S001157
+  start_date: '2019-01-24'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+HSAG29:
+- name: Jim Costa
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01774'
+  bioguide: C001059
+  start_date: '2019-01-24'
+  source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
+HSAP:
+- name: Kay Granger
   party: minority
   rank: 1
   title: Ranking Member
+  thomas: '01487'
+  bioguide: G000377
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
+- name: Harold Rogers
+  party: minority
+  rank: 2
+  thomas: '00977'
+  bioguide: R000395
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Robert B. Aderholt
+  party: minority
+  rank: 3
+  thomas: '01460'
+  bioguide: A000055
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael K. Simpson
+  party: minority
+  rank: 4
+  thomas: '01590'
+  bioguide: S001148
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John R. Carter
+  party: minority
+  rank: 5
+  thomas: '01752'
+  bioguide: C001051
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ken Calvert
+  party: minority
+  rank: 6
+  thomas: '00165'
+  bioguide: C000059
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Tom Cole
+  party: minority
+  rank: 7
+  thomas: '01742'
+  bioguide: C001053
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mario Diaz-Balart
+  party: minority
+  rank: 8
+  thomas: '01717'
+  bioguide: D000600
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Tom Graves
+  party: minority
+  rank: 9
+  thomas: '01979'
+  bioguide: G000560
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Steve Womack
+  party: minority
+  rank: 10
+  thomas: '01991'
+  bioguide: W000809
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jeff Fortenberry
+  party: minority
+  rank: 11
+  thomas: '01793'
+  bioguide: F000449
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Charles J. "Chuck" Fleischmann
+  party: minority
+  rank: 12
+  thomas: '02061'
+  bioguide: F000459
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jaime Herrera Beutler
+  party: minority
+  rank: 13
+  thomas: '02071'
+  bioguide: H001056
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: David P. Joyce
+  party: minority
+  rank: 14
+  thomas: '02154'
+  bioguide: J000295
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Andy Harris
+  party: minority
+  rank: 15
+  thomas: '02026'
+  bioguide: H001052
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Martha Roby
+  party: minority
+  rank: 16
+  thomas: '01986'
+  bioguide: R000591
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark E. Amodei
+  party: minority
+  rank: 17
+  thomas: '02090'
+  bioguide: A000369
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Chris Stewart
+  party: minority
+  rank: 18
+  thomas: '02168'
+  bioguide: S001192
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Steven M. Palazzo
+  party: minority
+  rank: 19
+  thomas: '02035'
+  bioguide: P000601
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Dan Newhouse
+  party: minority
+  rank: 20
+  thomas: '02275'
+  bioguide: N000189
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John R. Moolenaar
+  party: minority
+  rank: 21
+  thomas: '02248'
+  bioguide: M001194
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John H. Rutherford
+  party: minority
+  rank: 22
+  bioguide: R000609
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Will Hurd
+  party: minority
+  rank: 23
+  thomas: '02269'
+  bioguide: H001073
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Nita M. Lowey
+  party: majority
+  rank: 1
+  title: Chair
   thomas: '00709'
   bioguide: L000480
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
 - name: Marcy Kaptur
-  party: minority
+  party: majority
   rank: 2
   thomas: '00616'
   bioguide: K000009
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Peter J. Visclosky
-  party: minority
+  party: majority
   rank: 3
   thomas: '01188'
   bioguide: V000108
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: José E. Serrano
-  party: minority
+  party: majority
   rank: 4
   thomas: '01042'
   bioguide: S000248
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Rosa L. DeLauro
-  party: minority
+  party: majority
   rank: 5
   thomas: '00281'
   bioguide: D000216
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: David E. Price
-  party: minority
+  party: majority
   rank: 6
   thomas: '00930'
   bioguide: P000523
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Lucille Roybal-Allard
-  party: minority
+  party: majority
   rank: 7
   thomas: '00997'
   bioguide: R000486
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Sanford D. Bishop, Jr.
-  party: minority
+  party: majority
   rank: 8
   thomas: '00091'
   bioguide: B000490
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Barbara Lee
-  party: minority
+  party: majority
   rank: 9
   thomas: '01501'
   bioguide: L000551
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Betty McCollum
-  party: minority
+  party: majority
   rank: 10
   thomas: '01653'
   bioguide: M001143
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Tim Ryan
-  party: minority
+  party: majority
   rank: 11
   thomas: '01756'
   bioguide: R000577
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: C. A. Dutch Ruppersberger
-  party: minority
+  party: majority
   rank: 12
   thomas: '01728'
   bioguide: R000576
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Debbie Wasserman Schultz
-  party: minority
+  party: majority
   rank: 13
   thomas: '01777'
   bioguide: W000797
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Henry Cuellar
-  party: minority
+  party: majority
   rank: 14
   thomas: '01807'
   bioguide: C001063
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Chellie Pingree
-  party: minority
+  party: majority
   rank: 15
   thomas: '01927'
   bioguide: P000597
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mike Quigley
-  party: minority
+  party: majority
   rank: 16
   thomas: '01967'
   bioguide: Q000023
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Derek Kilmer
-  party: minority
+  party: majority
   rank: 17
   thomas: '02169'
   bioguide: K000381
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Matt Cartwright
-  party: minority
+  party: majority
   rank: 18
   thomas: '02159'
   bioguide: C001090
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Grace Meng
-  party: minority
+  party: majority
   rank: 19
   thomas: '02148'
   bioguide: M001188
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mark Pocan
-  party: minority
+  party: majority
   rank: 20
   thomas: '02171'
   bioguide: P000607
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Katherine M. Clark
-  party: minority
+  party: majority
   rank: 21
   thomas: '02196'
   bioguide: C001101
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Pete Aguilar
-  party: minority
+  party: majority
   rank: 22
   thomas: '02229'
   bioguide: A000371
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Lois Frankel
+  party: majority
+  rank: 23
+  thomas: '02119'
+  bioguide: F000462
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Cheri Bustos
+  party: majority
+  rank: 24
+  thomas: '02127'
+  bioguide: B001286
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Bonnie Watson Coleman
+  party: majority
+  rank: 25
+  thomas: '02259'
+  bioguide: W000822
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Brenda L. Lawrence
+  party: majority
+  rank: 26
+  thomas: '02252'
+  bioguide: L000581
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Norma J. Torres
+  party: majority
+  rank: 27
+  thomas: '02231'
+  bioguide: T000474
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Charlie Crist
+  party: majority
+  rank: 28
+  bioguide: C001111
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ann Kirkpatrick
+  party: majority
+  rank: 29
+  bioguide: K000368
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ed Case
+  party: majority
+  rank: 30
+  bioguide: C001055
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 HSAP01:
-- name: Robert B. Aderholt
+- name: Sanford D. Bishop, Jr.
   party: majority
   rank: 1
   title: Chair
-  thomas: '01460'
-  bioguide: A000055
-- name: Andy Harris
-  party: majority
-  rank: 5
-  thomas: '02026'
-  bioguide: H001052
-- name: Steven M. Palazzo
-  party: majority
-  rank: 7
-  thomas: '02035'
-  bioguide: P000601
-- name: Sanford D. Bishop, Jr.
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '00091'
   bioguide: B000490
 - name: Rosa L. DeLauro
-  party: minority
+  party: majority
   rank: 2
   thomas: '00281'
   bioguide: D000216
 - name: Chellie Pingree
-  party: minority
+  party: majority
   rank: 3
   thomas: '01927'
   bioguide: P000597
 - name: Mark Pocan
-  party: minority
+  party: majority
   rank: 4
   thomas: '02171'
   bioguide: P000607
+- name: Barbara Lee
+  party: majority
+  rank: 5
+  thomas: '01501'
+  bioguide: L000551
+- name: Betty McCollum
+  party: majority
+  rank: 6
+  thomas: '01653'
+  bioguide: M001143
+- name: Henry Cuellar
+  party: majority
+  rank: 7
+  thomas: '01807'
+  bioguide: C001063
 HSAP02:
-- name: Kay Granger
+- name: Peter J. Visclosky
   party: majority
   rank: 1
   title: Chair
-  thomas: '01487'
-  bioguide: G000377
-- name: Harold Rogers
-  party: majority
-  rank: 2
-  thomas: '00977'
-  bioguide: R000395
-- name: Ken Calvert
-  party: majority
-  rank: 3
-  thomas: '00165'
-  bioguide: C000059
-  title: Vice Chair
-- name: Tom Cole
-  party: majority
-  rank: 4
-  thomas: '01742'
-  bioguide: C001053
-- name: Steve Womack
-  party: majority
-  rank: 5
-  thomas: '01991'
-  bioguide: W000809
-- name: Robert B. Aderholt
-  party: majority
-  rank: 6
-  thomas: '01460'
-  bioguide: A000055
-- name: John R. Carter
-  party: majority
-  rank: 7
-  thomas: '01752'
-  bioguide: C001051
-- name: Mario Diaz-Balart
-  party: majority
-  rank: 8
-  thomas: '01717'
-  bioguide: D000600
-- name: Tom Graves
-  party: majority
-  rank: 9
-  thomas: '01979'
-  bioguide: G000560
-- name: Martha Roby
-  party: majority
-  rank: 10
-  thomas: '01986'
-  bioguide: R000591
-- name: Peter J. Visclosky
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '01188'
   bioguide: V000108
 - name: Betty McCollum
-  party: minority
+  party: majority
   rank: 2
   thomas: '01653'
   bioguide: M001143
 - name: Tim Ryan
-  party: minority
+  party: majority
   rank: 3
   thomas: '01756'
   bioguide: R000577
 - name: C. A. Dutch Ruppersberger
-  party: minority
+  party: majority
   rank: 4
   thomas: '01728'
   bioguide: R000576
 - name: Marcy Kaptur
-  party: minority
+  party: majority
   rank: 5
   thomas: '00616'
   bioguide: K000009
 - name: Henry Cuellar
-  party: minority
+  party: majority
   rank: 6
   thomas: '01807'
   bioguide: C001063
+- name: Derek Kilmer
+  party: majority
+  rank: 7
+  thomas: '02169'
+  bioguide: K000381
+- name: Pete Aguilar
+  party: majority
+  rank: 8
+  thomas: '02229'
+  bioguide: A000371
+- name: Cheri Bustos
+  party: majority
+  rank: 9
+  thomas: '02127'
+  bioguide: B001286
+- name: Charlie Crist
+  party: majority
+  rank: 10
+  bioguide: C001111
+- name: Ann Kirkpatrick
+  party: majority
+  rank: 11
+  bioguide: K000368
 HSAP04:
-- name: Harold Rogers
+- name: Nita M. Lowey
   party: majority
   rank: 1
   title: Chair
-  thomas: '00977'
-  bioguide: R000395
-- name: Kay Granger
-  party: majority
-  rank: 2
-  thomas: '01487'
-  bioguide: G000377
-- name: Mario Diaz-Balart
-  party: majority
-  rank: 3
-  thomas: '01717'
-  bioguide: D000600
-- name: Jeff Fortenberry
-  party: majority
-  rank: 5
-  thomas: '01793'
-  bioguide: F000449
-- name: Chris Stewart
-  party: majority
-  rank: 6
-  thomas: '02168'
-  bioguide: S001192
-- name: John H. Rutherford
-  party: majority
-  rank: 7
-  bioguide: R000609
-- name: Nita M. Lowey
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '00709'
   bioguide: L000480
 - name: Barbara Lee
-  party: minority
+  party: majority
   rank: 2
   thomas: '01501'
   bioguide: L000551
-- name: C. A. Dutch Ruppersberger
-  party: minority
-  rank: 3
-  thomas: '01728'
-  bioguide: R000576
 - name: Grace Meng
-  party: minority
-  rank: 4
+  party: majority
+  rank: 3
   thomas: '02148'
   bioguide: M001188
 - name: David E. Price
-  party: minority
-  rank: 5
+  party: majority
+  rank: 4
   thomas: '00930'
   bioguide: P000523
+- name: Lois Frankel
+  party: majority
+  rank: 5
+  thomas: '02119'
+  bioguide: F000462
+- name: Norma J. Torres
+  party: majority
+  rank: 6
+  thomas: '02231'
+  bioguide: T000474
 HSAP06:
-- name: Ken Calvert
+- name: Betty McCollum
   party: majority
   rank: 1
   title: Chair
-  thomas: '00165'
-  bioguide: C000059
-- name: Michael K. Simpson
-  party: majority
-  rank: 2
-  thomas: '01590'
-  bioguide: S001148
-- name: Tom Cole
-  party: majority
-  rank: 3
-  thomas: '01742'
-  bioguide: C001053
-- name: David P. Joyce
-  party: majority
-  rank: 4
-  thomas: '02154'
-  bioguide: J000295
-- name: Chris Stewart
-  party: majority
-  rank: 5
-  thomas: '02168'
-  bioguide: S001192
-  title: Vice Chair
-- name: Mark E. Amodei
-  party: majority
-  rank: 6
-  thomas: '02090'
-  bioguide: A000369
-- name: Betty McCollum
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '01653'
   bioguide: M001143
 - name: Chellie Pingree
-  party: minority
+  party: majority
   rank: 2
   thomas: '01927'
   bioguide: P000597
 - name: Derek Kilmer
-  party: minority
+  party: majority
   rank: 3
   thomas: '02169'
   bioguide: K000381
-- name: Marcy Kaptur
-  party: minority
+- name: José E. Serrano
+  party: majority
   rank: 4
-  thomas: '00616'
-  bioguide: K000009
+  thomas: '01042'
+  bioguide: S000248
+- name: Mike Quigley
+  party: majority
+  rank: 5
+  thomas: '01967'
+  bioguide: Q000023
+- name: Bonnie Watson Coleman
+  party: majority
+  rank: 6
+  thomas: '02259'
+  bioguide: W000822
+- name: Brenda L. Lawrence
+  party: majority
+  rank: 7
+  thomas: '02252'
+  bioguide: L000581
 HSAP07:
-- name: Tom Cole
+- name: Rosa L. DeLauro
   party: majority
   rank: 1
   title: Chair
-  thomas: '01742'
-  bioguide: C001053
-- name: Michael K. Simpson
-  party: majority
-  rank: 2
-  thomas: '01590'
-  bioguide: S001148
-- name: Steve Womack
-  party: majority
-  rank: 3
-  thomas: '01991'
-  bioguide: W000809
-  title: Vice Chair
-- name: Charles J. "Chuck" Fleischmann
-  party: majority
-  rank: 4
-  thomas: '02061'
-  bioguide: F000459
-- name: Andy Harris
-  party: majority
-  rank: 5
-  thomas: '02026'
-  bioguide: H001052
-- name: Martha Roby
-  party: majority
-  rank: 6
-  thomas: '01986'
-  bioguide: R000591
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 7
-  thomas: '02071'
-  bioguide: H001056
-- name: John R. Moolenaar
-  party: majority
-  rank: 8
-  thomas: '02248'
-  bioguide: M001194
-- name: Rosa L. DeLauro
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '00281'
   bioguide: D000216
 - name: Lucille Roybal-Allard
-  party: minority
+  party: majority
   rank: 2
   thomas: '00997'
   bioguide: R000486
 - name: Barbara Lee
-  party: minority
+  party: majority
   rank: 3
   thomas: '01501'
   bioguide: L000551
 - name: Mark Pocan
-  party: minority
+  party: majority
   rank: 4
   thomas: '02171'
   bioguide: P000607
 - name: Katherine M. Clark
-  party: minority
+  party: majority
   rank: 5
   thomas: '02196'
   bioguide: C001101
+- name: Lois Frankel
+  party: majority
+  rank: 6
+  thomas: '02119'
+  bioguide: F000462
+- name: Cheri Bustos
+  party: majority
+  rank: 7
+  thomas: '02127'
+  bioguide: B001286
+- name: Bonnie Watson Coleman
+  party: majority
+  rank: 8
+  thomas: '02259'
+  bioguide: W000822
 HSAP10:
-- name: Michael K. Simpson
+- name: Marcy Kaptur
   party: majority
   rank: 1
   title: Chair
-  thomas: '01590'
-  bioguide: S001148
-- name: Ken Calvert
-  party: majority
-  rank: 2
-  thomas: '00165'
-  bioguide: C000059
-- name: Charles J. "Chuck" Fleischmann
-  party: majority
-  rank: 3
-  thomas: '02061'
-  bioguide: F000459
-  title: Vice Chair
-- name: Jeff Fortenberry
-  party: majority
-  rank: 4
-  thomas: '01793'
-  bioguide: F000449
-- name: Kay Granger
-  party: majority
-  rank: 5
-  thomas: '01487'
-  bioguide: G000377
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 6
-  thomas: '02071'
-  bioguide: H001056
-- name: David P. Joyce
-  party: majority
-  rank: 7
-  thomas: '02154'
-  bioguide: J000295
-- name: Dan Newhouse
-  party: majority
-  rank: 8
-  thomas: '02275'
-  bioguide: N000189
-- name: Marcy Kaptur
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '00616'
   bioguide: K000009
 - name: Peter J. Visclosky
-  party: minority
+  party: majority
   rank: 2
   thomas: '01188'
   bioguide: V000108
 - name: Debbie Wasserman Schultz
-  party: minority
+  party: majority
   rank: 3
   thomas: '01777'
   bioguide: W000797
-- name: Pete Aguilar
-  party: minority
-  rank: 4
-  thomas: '02229'
-  bioguide: A000371
-- name: José E. Serrano
-  party: minority
-  rank: 5
-  thomas: '01042'
-  bioguide: S000248
-HSAP15:
-- name: Charles J. "Chuck" Fleischmann
-  party: majority
-  rank: 3
-  thomas: '02061'
-  bioguide: F000459
-- name: Andy Harris
+- name: Ann Kirkpatrick
   party: majority
   rank: 4
-  thomas: '02026'
-  bioguide: H001052
-- name: Steven M. Palazzo
+  bioguide: K000368
+- name: Derek Kilmer
   party: majority
   rank: 5
-  thomas: '02035'
-  bioguide: P000601
-  title: Vice Chair
-- name: Dan Newhouse
+  thomas: '02169'
+  bioguide: K000381
+- name: Mark Pocan
   party: majority
   rank: 6
-  thomas: '02275'
-  bioguide: N000189
+  thomas: '02171'
+  bioguide: P000607
+- name: Lois Frankel
+  party: majority
+  rank: 7
+  thomas: '02119'
+  bioguide: F000462
+HSAP15:
 - name: Lucille Roybal-Allard
-  party: minority
+  party: majority
   rank: 1
-  title: Ranking Member
+  title: Chair
   thomas: '00997'
   bioguide: R000486
 - name: Henry Cuellar
-  party: minority
+  party: majority
   rank: 2
   thomas: '01807'
   bioguide: C001063
-- name: David E. Price
-  party: minority
-  rank: 3
-  thomas: '00930'
-  bioguide: P000523
 - name: C. A. Dutch Ruppersberger
-  party: minority
-  rank: 4
+  party: majority
+  rank: 3
   thomas: '01728'
   bioguide: R000576
+- name: David E. Price
+  party: majority
+  rank: 4
+  thomas: '00930'
+  bioguide: P000523
+- name: Debbie Wasserman Schultz
+  party: majority
+  rank: 5
+  thomas: '01777'
+  bioguide: W000797
+- name: Grace Meng
+  party: majority
+  rank: 6
+  thomas: '02148'
+  bioguide: M001188
+- name: Pete Aguilar
+  party: majority
+  rank: 7
+  thomas: '02229'
+  bioguide: A000371
 HSAP18:
-- name: John R. Carter
+- name: Debbie Wasserman Schultz
   party: majority
   rank: 1
   title: Chair
-  thomas: '01752'
-  bioguide: C001051
-- name: Steve Womack
-  party: majority
-  rank: 4
-  thomas: '01991'
-  bioguide: W000809
-- name: John H. Rutherford
-  party: majority
-  rank: 6
-  bioguide: R000609
-- name: Debbie Wasserman Schultz
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '01777'
   bioguide: W000797
 - name: Sanford D. Bishop, Jr.
-  party: minority
+  party: majority
   rank: 2
   thomas: '00091'
   bioguide: B000490
-- name: Barbara Lee
-  party: minority
+- name: Ed Case
+  party: majority
   rank: 3
-  thomas: '01501'
-  bioguide: L000551
+  bioguide: C001055
 - name: Tim Ryan
-  party: minority
+  party: majority
   rank: 4
   thomas: '01756'
   bioguide: R000577
-HSAP19:
-- name: Harold Rogers
-  party: majority
-  rank: 2
-  thomas: '00977'
-  bioguide: R000395
-- name: Robert B. Aderholt
-  party: majority
-  rank: 3
-  thomas: '01460'
-  bioguide: A000055
-- name: John R. Carter
-  party: majority
-  rank: 4
-  thomas: '01752'
-  bioguide: C001051
-- name: Martha Roby
+- name: Chellie Pingree
   party: majority
   rank: 5
-  thomas: '01986'
-  bioguide: R000591
-- name: Steven M. Palazzo
+  thomas: '01927'
+  bioguide: P000597
+- name: Matt Cartwright
   party: majority
   rank: 6
-  thomas: '02035'
-  bioguide: P000601
-- name: José E. Serrano
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01042'
-  bioguide: S000248
-- name: Derek Kilmer
-  party: minority
-  rank: 2
-  thomas: '02169'
-  bioguide: K000381
-- name: Matt Cartwright
-  party: minority
-  rank: 3
   thomas: '02159'
   bioguide: C001090
-- name: Grace Meng
-  party: minority
-  rank: 4
-  thomas: '02148'
-  bioguide: M001188
-HSAP20:
-- name: Mario Diaz-Balart
+- name: Cheri Bustos
+  party: majority
+  rank: 7
+  thomas: '02127'
+  bioguide: B001286
+HSAP19:
+- name: José E. Serrano
   party: majority
   rank: 1
   title: Chair
-  thomas: '01717'
-  bioguide: D000600
-- name: David P. Joyce
+  thomas: '01042'
+  bioguide: S000248
+- name: Matt Cartwright
   party: majority
   rank: 2
-  thomas: '02154'
-  bioguide: J000295
-  title: Vice Chair
-- name: Tom Graves
+  thomas: '02159'
+  bioguide: C001090
+- name: Grace Meng
+  party: majority
+  rank: 3
+  thomas: '02148'
+  bioguide: M001188
+- name: Brenda L. Lawrence
+  party: majority
+  rank: 4
+  thomas: '02252'
+  bioguide: L000581
+- name: Charlie Crist
+  party: majority
+  rank: 5
+  bioguide: C001111
+- name: Ed Case
   party: majority
   rank: 6
-  thomas: '01979'
-  bioguide: G000560
-- name: John H. Rutherford
+  bioguide: C001055
+- name: Marcy Kaptur
   party: majority
   rank: 7
-  bioguide: R000609
-- name: David E. Price
+  thomas: '00616'
+  bioguide: K000009
+HSAP20:
+- name: Mario Diaz-Balart
   party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01717'
+  bioguide: D000600
+- name: David E. Price
+  party: majority
   rank: 1
   title: Ranking Member
   thomas: '00930'
   bioguide: P000523
 - name: Mike Quigley
-  party: minority
+  party: majority
   rank: 2
   thomas: '01967'
   bioguide: Q000023
 - name: Katherine M. Clark
-  party: minority
+  party: majority
   rank: 3
   thomas: '02196'
   bioguide: C001101
-- name: Pete Aguilar
-  party: minority
+- name: Bonnie Watson Coleman
+  party: majority
   rank: 4
+  thomas: '02259'
+  bioguide: W000822
+- name: Brenda L. Lawrence
+  party: majority
+  rank: 5
+  thomas: '02252'
+  bioguide: L000581
+- name: Norma J. Torres
+  party: majority
+  rank: 6
+  thomas: '02231'
+  bioguide: T000474
+- name: Pete Aguilar
+  party: majority
+  rank: 7
   thomas: '02229'
   bioguide: A000371
 HSAP23:
-- name: Tom Graves
+- name: Mike Quigley
   party: majority
   rank: 1
   title: Chair
-  thomas: '01979'
-  bioguide: G000560
-- name: Jaime Herrera Beutler
-  party: majority
-  rank: 3
-  thomas: '02071'
-  bioguide: H001056
-  title: Vice Chair
-- name: Mark E. Amodei
-  party: majority
-  rank: 4
-  thomas: '02090'
-  bioguide: A000369
-- name: Chris Stewart
-  party: majority
-  rank: 5
-  thomas: '02168'
-  bioguide: S001192
-- name: John R. Moolenaar
-  party: majority
-  rank: 7
-  thomas: '02248'
-  bioguide: M001194
-- name: Mike Quigley
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '01967'
   bioguide: Q000023
 - name: José E. Serrano
-  party: minority
+  party: majority
   rank: 2
   thomas: '01042'
   bioguide: S000248
 - name: Matt Cartwright
-  party: minority
+  party: majority
   rank: 3
   thomas: '02159'
   bioguide: C001090
 - name: Sanford D. Bishop, Jr.
-  party: minority
+  party: majority
   rank: 4
   thomas: '00091'
   bioguide: B000490
+- name: Norma J. Torres
+  party: majority
+  rank: 5
+  thomas: '02231'
+  bioguide: T000474
+- name: Charlie Crist
+  party: majority
+  rank: 6
+  bioguide: C001111
+- name: Ann Kirkpatrick
+  party: majority
+  rank: 7
+  bioguide: K000368
 HSAP24:
-- name: Jeff Fortenberry
+- name: Tim Ryan
   party: majority
   rank: 1
   title: Chair
-  thomas: '01793'
-  bioguide: F000449
-- name: Mark E. Amodei
-  party: majority
-  rank: 2
-  thomas: '02090'
-  bioguide: A000369
-  title: Vice Chair
-- name: Dan Newhouse
-  party: majority
-  rank: 3
-  thomas: '02275'
-  bioguide: N000189
-- name: John R. Moolenaar
-  party: majority
-  rank: 4
-  thomas: '02248'
-  bioguide: M001194
-- name: Tim Ryan
-  party: minority
-  rank: 1
-  title: Ranking Member
   thomas: '01756'
   bioguide: R000577
-- name: Betty McCollum
-  party: minority
+- name: C. A. Dutch Ruppersberger
+  party: majority
   rank: 2
-  thomas: '01653'
-  bioguide: M001143
-- name: Debbie Wasserman Schultz
-  party: minority
+  thomas: '01728'
+  bioguide: R000576
+- name: Katherine M. Clark
+  party: majority
   rank: 3
-  thomas: '01777'
-  bioguide: W000797
+  thomas: '02196'
+  bioguide: C001101
+- name: Ed Case
+  party: majority
+  rank: 4
+  bioguide: C001055
 HSAS:
 - name: Mac Thornberry
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
+  title: Ranking Member
   thomas: '01155'
   bioguide: T000238
-- name: Walter B. Jones
-  party: majority
-  rank: 2
-  thomas: '00612'
-  bioguide: J000255
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Joe Wilson
-  party: majority
-  rank: 3
+  party: minority
+  rank: 2
   thomas: '01688'
   bioguide: W000795
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Rob Bishop
-  party: majority
-  rank: 5
-  thomas: '01753'
-  bioguide: B001250
-- name: Michael R. Turner
-  party: majority
-  rank: 6
-  thomas: '01741'
-  bioguide: T000463
-- name: Mike Rogers
-  party: majority
-  rank: 7
-  thomas: '01704'
-  bioguide: R000575
-- name: K. Michael Conaway
-  party: majority
-  rank: 9
-  thomas: '01805'
-  bioguide: C001062
-- name: Doug Lamborn
-  party: majority
-  rank: 10
-  thomas: '01834'
-  bioguide: L000564
-- name: Robert J. Wittman
-  party: majority
-  rank: 11
-  thomas: '01886'
-  bioguide: W000804
-- name: Vicky Hartzler
-  party: majority
-  rank: 13
-  thomas: '02032'
-  bioguide: H001053
-- name: Austin Scott
-  party: majority
-  rank: 14
-  thomas: '02009'
-  bioguide: S001189
-- name: Mo Brooks
-  party: majority
-  rank: 15
-  thomas: '01987'
-  bioguide: B001274
-- name: Paul Cook
-  party: majority
-  rank: 16
-  thomas: '02103'
-  bioguide: C001094
-- name: Bradley Byrne
-  party: majority
-  rank: 17
-  thomas: '02197'
-  bioguide: B001289
-- name: Sam Graves
-  party: majority
-  rank: 18
-  thomas: '01656'
-  bioguide: G000546
-- name: Elise M. Stefanik
-  party: majority
-  rank: 19
-  thomas: '02263'
-  bioguide: S001196
-- name: Scott DesJarlais
-  party: majority
-  rank: 23
-  thomas: '02062'
-  bioguide: D000616
-- name: Ralph Lee Abraham
-  party: majority
-  rank: 24
-  thomas: '02244'
-  bioguide: A000374
-- name: Trent Kelly
-  party: majority
-  rank: 25
-  thomas: '02294'
-  bioguide: K000388
-- name: Mike Gallagher
-  party: majority
-  rank: 26
-  bioguide: G000579
-- name: Matt Gaetz
-  party: majority
-  rank: 27
-  bioguide: G000578
-- name: Don Bacon
-  party: majority
-  rank: 28
-  bioguide: B001298
-- name: Jim Banks
-  party: majority
-  rank: 29
-  bioguide: B001299
-- name: Liz Cheney
-  party: majority
-  rank: 30
-  bioguide: C001109
-- name: Jody B. Hice
-  party: majority
-  rank: 31
-  thomas: '02237'
-  bioguide: H001071
-- name: Paul Mitchell
-  party: majority
-  rank: 32
-  bioguide: M001201
-- name: Adam Smith
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01528'
-  bioguide: S000510
-- name: Susan A. Davis
   party: minority
   rank: 3
-  thomas: '01641'
-  bioguide: D000598
-- name: James R. Langevin
+  thomas: '01753'
+  bioguide: B001250
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael R. Turner
   party: minority
   rank: 4
-  thomas: '01668'
-  bioguide: L000559
-- name: Rick Larsen
+  thomas: '01741'
+  bioguide: T000463
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mike Rogers
   party: minority
   rank: 5
-  thomas: '01675'
-  bioguide: L000560
-- name: Jim Cooper
+  thomas: '01704'
+  bioguide: R000575
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: K. Michael Conaway
   party: minority
   rank: 6
-  thomas: '00231'
-  bioguide: C000754
-- name: Joe Courtney
+  thomas: '01805'
+  bioguide: C001062
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Doug Lamborn
+  party: minority
+  rank: 7
+  thomas: '01834'
+  bioguide: L000564
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Robert J. Wittman
   party: minority
   rank: 8
-  thomas: '01836'
-  bioguide: C001069
-- name: John Garamendi
+  thomas: '01886'
+  bioguide: W000804
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Vicky Hartzler
+  party: minority
+  rank: 9
+  thomas: '02032'
+  bioguide: H001053
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Austin Scott
   party: minority
   rank: 10
-  thomas: '01973'
-  bioguide: G000559
-- name: Jackie Speier
+  thomas: '02009'
+  bioguide: S001189
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mo Brooks
   party: minority
   rank: 11
-  thomas: '01890'
-  bioguide: S001175
-- name: Marc A. Veasey
+  thomas: '01987'
+  bioguide: B001274
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Paul Cook
   party: minority
   rank: 12
-  thomas: '02166'
-  bioguide: V000131
-- name: Tulsi Gabbard
+  thomas: '02103'
+  bioguide: C001094
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bradley Byrne
   party: minority
   rank: 13
-  thomas: '02122'
-  bioguide: G000571
-- name: Donald Norcross
+  thomas: '02197'
+  bioguide: B001289
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Sam Graves
+  party: minority
+  rank: 14
+  thomas: '01656'
+  bioguide: G000546
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Elise M. Stefanik
   party: minority
   rank: 15
-  thomas: '02202'
-  bioguide: N000188
-- name: Ruben Gallego
+  thomas: '02263'
+  bioguide: S001196
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Scott DesJarlais
   party: minority
   rank: 16
-  thomas: '02226'
-  bioguide: G000574
-- name: Seth Moulton
+  thomas: '02062'
+  bioguide: D000616
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ralph Lee Abraham
   party: minority
   rank: 17
-  thomas: '02246'
-  bioguide: M001196
-- name: Jacky Rosen
+  thomas: '02244'
+  bioguide: A000374
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Trent Kelly
+  party: minority
+  rank: 18
+  thomas: '02294'
+  bioguide: K000388
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mike Gallagher
+  party: minority
+  rank: 19
+  bioguide: G000579
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Matt Gaetz
   party: minority
   rank: 20
-  bioguide: R000608
-- name: A. Donald McEachin
+  bioguide: G000578
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Don Bacon
   party: minority
   rank: 21
-  bioguide: M001200
-- name: Salud O. Carbajal
+  bioguide: B001298
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jim Banks
   party: minority
   rank: 22
-  bioguide: C001112
-- name: Anthony G. Brown
+  bioguide: B001299
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Liz Cheney
   party: minority
   rank: 23
-  bioguide: B001304
-- name: Stephanie N. Murphy
+  bioguide: C001109
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Paul Mitchell
   party: minority
   rank: 24
-  bioguide: M001202
-- name: Ro Khanna
+  bioguide: M001201
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jack Bergman
   party: minority
   rank: 25
-  bioguide: K000389
-- name: Tom O’Halleran
+  bioguide: B001301
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael Waltz
   party: minority
   rank: 26
-  bioguide: O000171
-- name: Thomas R. Suozzi
-  party: minority
-  rank: 27
-  bioguide: S001201
-- name: Jimmy Panetta
-  party: minority
-  rank: 28
-  bioguide: P000613
-HSAS02:
-- name: Walter B. Jones
-  party: majority
-  rank: 2
-  thomas: '00612'
-  bioguide: J000255
-- name: Don Bacon
-  party: majority
-  rank: 4
-  bioguide: B001298
-- name: Ralph Lee Abraham
-  party: majority
-  rank: 6
-  thomas: '02244'
-  bioguide: A000374
-- name: Trent Kelly
-  party: majority
-  rank: 7
-  thomas: '02294'
-  bioguide: K000388
-- name: Jackie Speier
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01890'
-  bioguide: S001175
-- name: Ruben Gallego
-  party: minority
-  rank: 4
-  thomas: '02226'
-  bioguide: G000574
-- name: Jacky Rosen
-  party: minority
-  rank: 6
-  bioguide: R000608
-HSAS03:
-- name: Joe Wilson
+  bioguide: W000823
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Adam Smith
   party: majority
   rank: 1
   title: Chair
-  thomas: '01688'
-  bioguide: W000795
-- name: Rob Bishop
+  thomas: '01528'
+  bioguide: S000510
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Susan A. Davis
   party: majority
   rank: 2
-  thomas: '01753'
-  bioguide: B001250
-- name: Austin Scott
+  thomas: '01641'
+  bioguide: D000598
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: James R. Langevin
   party: majority
   rank: 3
-  thomas: '02009'
-  bioguide: S001189
-- name: Mike Rogers
+  thomas: '01668'
+  bioguide: L000559
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Rick Larsen
+  party: majority
+  rank: 4
+  thomas: '01675'
+  bioguide: L000560
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jim Cooper
   party: majority
   rank: 5
-  thomas: '01704'
-  bioguide: R000575
-- name: Vicky Hartzler
+  thomas: '00231'
+  bioguide: C000754
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Joe Courtney
   party: majority
   rank: 6
-  thomas: '02032'
-  bioguide: H001053
-- name: Elise M. Stefanik
-  party: majority
-  rank: 7
-  thomas: '02263'
-  bioguide: S001196
-- name: Scott DesJarlais
-  party: majority
-  rank: 9
-  thomas: '02062'
-  bioguide: D000616
-- name: Trent Kelly
-  party: majority
-  rank: 10
-  thomas: '02294'
-  bioguide: K000388
-- name: Mike Gallagher
-  party: majority
-  rank: 11
-  bioguide: G000579
-- name: Joe Courtney
-  party: minority
-  rank: 2
   thomas: '01836'
   bioguide: C001069
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: John Garamendi
+  party: majority
+  rank: 7
+  thomas: '01973'
+  bioguide: G000559
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jackie Speier
+  party: majority
+  rank: 8
+  thomas: '01890'
+  bioguide: S001175
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Tulsi Gabbard
-  party: minority
-  rank: 3
+  party: majority
+  rank: 9
   thomas: '02122'
   bioguide: G000571
-- name: A. Donald McEachin
-  party: minority
-  rank: 5
-  bioguide: M001200
-- name: Salud O. Carbajal
-  party: minority
-  rank: 6
-  bioguide: C001112
-- name: Anthony G. Brown
-  party: minority
-  rank: 7
-  bioguide: B001304
-- name: Stephanie N. Murphy
-  party: minority
-  rank: 8
-  bioguide: M001202
-- name: Ro Khanna
-  party: minority
-  rank: 9
-  bioguide: K000389
-HSAS06:
-- name: Vicky Hartzler
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02032'
-  bioguide: H001053
-- name: K. Michael Conaway
-  party: majority
-  rank: 2
-  thomas: '01805'
-  bioguide: C001062
-- name: Matt Gaetz
-  party: majority
-  rank: 3
-  bioguide: G000578
-- name: Jim Banks
-  party: majority
-  rank: 4
-  bioguide: B001299
-- name: Liz Cheney
-  party: majority
-  rank: 5
-  bioguide: C001109
-- name: Austin Scott
-  party: majority
-  rank: 6
-  thomas: '02009'
-  bioguide: S001189
-- name: Seth Moulton
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02246'
-  bioguide: M001196
-- name: Tom O’Halleran
-  party: minority
-  rank: 2
-  bioguide: O000171
-- name: Thomas R. Suozzi
-  party: minority
-  rank: 3
-  bioguide: S001201
-- name: Jimmy Panetta
-  party: minority
-  rank: 4
-  bioguide: P000613
-HSAS25:
-- name: Michael R. Turner
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01741'
-  bioguide: T000463
-- name: Paul Cook
-  party: majority
-  rank: 3
-  thomas: '02103'
-  bioguide: C001094
-  title: Vice Chair
-- name: Sam Graves
-  party: majority
-  rank: 4
-  thomas: '01656'
-  bioguide: G000546
-- name: Trent Kelly
-  party: majority
-  rank: 7
-  thomas: '02294'
-  bioguide: K000388
-- name: Matt Gaetz
-  party: majority
-  rank: 8
-  bioguide: G000578
-- name: Don Bacon
-  party: majority
-  rank: 9
-  bioguide: B001298
-- name: Jim Banks
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Donald Norcross
   party: majority
   rank: 10
-  bioguide: B001299
-- name: Walter B. Jones
+  thomas: '02202'
+  bioguide: N000188
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ruben Gallego
   party: majority
   rank: 11
-  thomas: '00612'
-  bioguide: J000255
-- name: Rob Bishop
+  thomas: '02226'
+  bioguide: G000574
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Seth Moulton
   party: majority
   rank: 12
-  thomas: '01753'
-  bioguide: B001250
-- name: Robert J. Wittman
-  party: majority
-  rank: 13
-  thomas: '01886'
-  bioguide: W000804
-- name: Mo Brooks
-  party: majority
-  rank: 14
-  thomas: '01987'
-  bioguide: B001274
-- name: James R. Langevin
-  party: minority
-  rank: 2
-  thomas: '01668'
-  bioguide: L000559
-- name: Jim Cooper
-  party: minority
-  rank: 3
-  thomas: '00231'
-  bioguide: C000754
-- name: Marc A. Veasey
-  party: minority
-  rank: 4
-  thomas: '02166'
-  bioguide: V000131
-- name: Ruben Gallego
-  party: minority
-  rank: 5
-  thomas: '02226'
-  bioguide: G000574
-- name: Jacky Rosen
-  party: minority
-  rank: 6
-  bioguide: R000608
-- name: Salud O. Carbajal
-  party: minority
-  rank: 7
-  bioguide: C001112
-- name: Anthony G. Brown
-  party: minority
-  rank: 8
-  bioguide: B001304
-- name: Tom O’Halleran
-  party: minority
-  rank: 9
-  bioguide: O000171
-- name: Thomas R. Suozzi
-  party: minority
-  rank: 10
-  bioguide: S001201
-- name: Jimmy Panetta
-  party: minority
-  rank: 11
-  bioguide: P000613
-HSAS26:
-- name: Elise M. Stefanik
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02263'
-  bioguide: S001196
-- name: Ralph Lee Abraham
-  party: majority
-  rank: 3
-  thomas: '02244'
-  bioguide: A000374
-- name: Liz Cheney
-  party: majority
-  rank: 4
-  bioguide: C001109
-  title: Vice Chair
-- name: Joe Wilson
-  party: majority
-  rank: 5
-  thomas: '01688'
-  bioguide: W000795
-- name: Doug Lamborn
-  party: majority
-  rank: 7
-  thomas: '01834'
-  bioguide: L000564
-- name: Austin Scott
-  party: majority
-  rank: 8
-  thomas: '02009'
-  bioguide: S001189
-- name: Jody B. Hice
-  party: majority
-  rank: 9
-  thomas: '02237'
-  bioguide: H001071
-- name: James R. Langevin
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01668'
-  bioguide: L000559
-- name: Rick Larsen
-  party: minority
-  rank: 2
-  thomas: '01675'
-  bioguide: L000560
-- name: Jim Cooper
-  party: minority
-  rank: 3
-  thomas: '00231'
-  bioguide: C000754
-- name: Jackie Speier
-  party: minority
-  rank: 4
-  thomas: '01890'
-  bioguide: S001175
-- name: Marc A. Veasey
-  party: minority
-  rank: 5
-  thomas: '02166'
-  bioguide: V000131
-- name: Tulsi Gabbard
-  party: minority
-  rank: 6
-  thomas: '02122'
-  bioguide: G000571
-- name: Stephanie N. Murphy
-  party: minority
-  rank: 8
-  bioguide: M001202
-HSAS28:
-- name: Robert J. Wittman
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01886'
-  bioguide: W000804
-- name: K. Michael Conaway
-  party: majority
-  rank: 2
-  thomas: '01805'
-  bioguide: C001062
-- name: Vicky Hartzler
-  party: majority
-  rank: 3
-  thomas: '02032'
-  bioguide: H001053
-- name: Bradley Byrne
-  party: majority
-  rank: 4
-  thomas: '02197'
-  bioguide: B001289
-  title: Vice Chair
-- name: Scott DesJarlais
-  party: majority
-  rank: 5
-  thomas: '02062'
-  bioguide: D000616
-- name: Mike Gallagher
-  party: majority
-  rank: 6
-  bioguide: G000579
-- name: Paul Cook
-  party: majority
-  rank: 7
-  thomas: '02103'
-  bioguide: C001094
-- name: Ralph Lee Abraham
-  party: majority
-  rank: 9
-  thomas: '02244'
-  bioguide: A000374
-- name: Paul Mitchell
-  party: majority
-  rank: 10
-  bioguide: M001201
-- name: Joe Courtney
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01836'
-  bioguide: C001069
-- name: Susan A. Davis
-  party: minority
-  rank: 2
-  thomas: '01641'
-  bioguide: D000598
-- name: James R. Langevin
-  party: minority
-  rank: 3
-  thomas: '01668'
-  bioguide: L000559
-- name: John Garamendi
-  party: minority
-  rank: 5
-  thomas: '01973'
-  bioguide: G000559
-- name: Donald Norcross
-  party: minority
-  rank: 6
-  thomas: '02202'
-  bioguide: N000188
-- name: Seth Moulton
-  party: minority
-  rank: 7
   thomas: '02246'
   bioguide: M001196
-- name: A. Donald McEachin
-  party: minority
-  rank: 9
-  bioguide: M001200
-HSAS29:
-- name: Mike Rogers
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Salud O. Carbajal
   party: majority
-  rank: 1
-  title: Chair
-  thomas: '01704'
-  bioguide: R000575
-- name: Doug Lamborn
+  rank: 13
+  bioguide: C001112
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Anthony G. Brown
   party: majority
-  rank: 2
-  thomas: '01834'
-  bioguide: L000564
-- name: Mo Brooks
+  rank: 14
+  bioguide: B001304
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ro Khanna
   party: majority
-  rank: 3
-  thomas: '01987'
-  bioguide: B001274
-- name: Michael R. Turner
+  rank: 15
+  bioguide: K000389
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: William R. Keating
   party: majority
-  rank: 4
-  thomas: '01741'
-  bioguide: T000463
-- name: Bradley Byrne
+  rank: 16
+  thomas: '02025'
+  bioguide: K000375
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Filemon Vela
   party: majority
-  rank: 6
-  thomas: '02197'
-  bioguide: B001289
-- name: Sam Graves
+  rank: 17
+  thomas: '02167'
+  bioguide: V000132
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Andy Kim
   party: majority
-  rank: 7
-  thomas: '01656'
-  bioguide: G000546
-- name: Jody B. Hice
+  rank: 18
+  bioguide: K000394
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Kendra S. Horn
   party: majority
-  rank: 8
-  thomas: '02237'
-  bioguide: H001071
-- name: Paul Mitchell
+  rank: 19
+  bioguide: H001083
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Gil Cisneros
   party: majority
-  rank: 9
-  bioguide: M001201
-- name: Jim Cooper
+  rank: 20
+  bioguide: C001123
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Chrissy Houlahan
+  party: majority
+  rank: 21
+  bioguide: H001085
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jason Crow
+  party: majority
+  rank: 22
+  bioguide: C001121
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Xochitl Torres Small
+  party: majority
+  rank: 23
+  bioguide: T000484
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Elissa Slotkin
+  party: majority
+  rank: 24
+  bioguide: S001208
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Mikie Sherrill
+  party: majority
+  rank: 25
+  bioguide: S001207
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Katie Hill
+  party: majority
+  rank: 26
+  bioguide: H001087
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Veronica Escobar
+  party: majority
+  rank: 27
+  bioguide: E000299
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Deb Haaland
+  party: majority
+  rank: 28
+  bioguide: H001080
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jared Golden
+  party: majority
+  rank: 29
+  bioguide: G000592
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Lori Trahan
+  party: majority
+  rank: 30
+  bioguide: T000482
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Elaine G. Luria
+  party: majority
+  rank: 31
+  bioguide: L000591
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+HSAS02:
+- name: Trent Kelly
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00231'
-  bioguide: C000754
+  thomas: '02294'
+  bioguide: K000388
+  start_date: '2019-01-23'
+  source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
+- name: Jackie Speier
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01890'
+  bioguide: S001175
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Susan A. Davis
-  party: minority
+  party: majority
   rank: 2
   thomas: '01641'
   bioguide: D000598
-- name: Rick Larsen
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Ruben Gallego
+  party: majority
+  rank: 3
+  thomas: '02226'
+  bioguide: G000574
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Gil Cisneros
+  party: majority
+  rank: 4
+  bioguide: C001123
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Veronica Escobar
+  party: majority
+  rank: 5
+  bioguide: E000299
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Deb Haaland
+  party: majority
+  rank: 6
+  bioguide: H001080
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Lori Trahan
+  party: majority
+  rank: 7
+  bioguide: T000482
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Elaine G. Luria
+  party: majority
+  rank: 8
+  bioguide: L000591
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+HSAS03:
+- name: Doug Lamborn
   party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01834'
+  bioguide: L000564
+  start_date: '2019-01-23'
+  source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
+- name: John Garamendi
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01973'
+  bioguide: G000559
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Tulsi Gabbard
+  party: majority
+  rank: 2
+  thomas: '02122'
+  bioguide: G000571
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Andy Kim
+  party: majority
+  rank: 3
+  bioguide: K000394
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Kendra S. Horn
+  party: majority
+  rank: 4
+  bioguide: H001083
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Chrissy Houlahan
+  party: majority
+  rank: 5
+  bioguide: H001085
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Jason Crow
+  party: majority
+  rank: 6
+  bioguide: C001121
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Xochitl Torres Small
+  party: majority
+  rank: 7
+  bioguide: T000484
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Elissa Slotkin
+  party: majority
+  rank: 8
+  bioguide: S001208
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Veronica Escobar
+  party: majority
+  rank: 9
+  bioguide: E000299
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Deb Haaland
+  party: majority
+  rank: 10
+  bioguide: H001080
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+HSAS25:
+- name: Vicky Hartzler
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '02032'
+  bioguide: H001053
+  start_date: '2019-01-23'
+  source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
+- name: Donald Norcross
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '02202'
+  bioguide: N000188
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: James R. Langevin
+  party: majority
+  rank: 2
+  thomas: '01668'
+  bioguide: L000559
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Joe Courtney
+  party: majority
+  rank: 3
+  thomas: '01836'
+  bioguide: C001069
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Ruben Gallego
+  party: majority
+  rank: 4
+  thomas: '02226'
+  bioguide: G000574
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Salud O. Carbajal
+  party: majority
+  rank: 5
+  bioguide: C001112
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Anthony G. Brown
+  party: majority
+  rank: 6
+  bioguide: B001304
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Filemon Vela
+  party: majority
+  rank: 7
+  thomas: '02167'
+  bioguide: V000132
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Xochitl Torres Small
+  party: majority
+  rank: 8
+  bioguide: T000484
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Mikie Sherrill
+  party: majority
+  rank: 9
+  bioguide: S001207
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Katie Hill
+  party: majority
+  rank: 10
+  bioguide: H001087
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Jared Golden
+  party: majority
+  rank: 11
+  bioguide: G000592
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+HSAS26:
+- name: Elise M. Stefanik
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '02263'
+  bioguide: S001196
+  start_date: '2019-01-23'
+  source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
+- name: James R. Langevin
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01668'
+  bioguide: L000559
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Rick Larsen
+  party: majority
+  rank: 2
+  thomas: '01675'
+  bioguide: L000560
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Jim Cooper
+  party: majority
+  rank: 3
+  thomas: '00231'
+  bioguide: C000754
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Tulsi Gabbard
+  party: majority
+  rank: 4
+  thomas: '02122'
+  bioguide: G000571
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Anthony G. Brown
+  party: majority
+  rank: 5
+  bioguide: B001304
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Ro Khanna
+  party: majority
+  rank: 6
+  bioguide: K000389
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: William R. Keating
+  party: majority
+  rank: 7
+  thomas: '02025'
+  bioguide: K000375
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Andy Kim
+  party: majority
+  rank: 8
+  bioguide: K000394
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Chrissy Houlahan
+  party: majority
+  rank: 9
+  bioguide: H001085
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Jason Crow
+  party: majority
+  rank: 10
+  bioguide: C001121
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Elissa Slotkin
+  party: majority
+  rank: 11
+  bioguide: S001208
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Lori Trahan
+  party: majority
+  rank: 12
+  bioguide: T000482
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+HSAS28:
+- name: Robert J. Wittman
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01886'
+  bioguide: W000804
+  start_date: '2019-01-23'
+  source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
+- name: Joe Courtney
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01836'
+  bioguide: C001069
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: James R. Langevin
+  party: majority
+  rank: 2
+  thomas: '01668'
+  bioguide: L000559
+- name: Jim Cooper
+  party: majority
+  rank: 3
+  thomas: '00231'
+  bioguide: C000754
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Donald Norcross
+  party: majority
+  rank: 4
+  thomas: '02202'
+  bioguide: N000188
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Seth Moulton
+  party: majority
+  rank: 5
+  thomas: '02246'
+  bioguide: M001196
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Filemon Vela
+  party: majority
+  rank: 6
+  thomas: '02167'
+  bioguide: V000132
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Gil Cisneros
+  party: majority
+  rank: 7
+  bioguide: C001123
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Mikie Sherrill
+  party: majority
+  rank: 8
+  bioguide: S001207
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Katie Hill
+  party: majority
+  rank: 9
+  bioguide: H001087
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Jared Golden
+  party: majority
+  rank: 10
+  bioguide: G000592
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Elaine G. Luria
+  party: majority
+  rank: 11
+  bioguide: L000591
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+HSAS29:
+- name: Michael R. Turner
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01741'
+  bioguide: T000463
+  start_date: '2019-01-23'
+  source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
+- name: Jim Cooper
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '00231'
+  bioguide: C000754
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Susan A. Davis
+  party: majority
+  rank: 2
+  thomas: '01641'
+  bioguide: D000598
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Rick Larsen
+  party: majority
   rank: 3
   thomas: '01675'
   bioguide: L000560
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: John Garamendi
-  party: minority
+  party: majority
   rank: 4
   thomas: '01973'
   bioguide: G000559
-- name: Donald Norcross
-  party: minority
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Jackie Speier
+  party: majority
+  rank: 5
+  thomas: '01890'
+  bioguide: S001175
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Seth Moulton
+  party: majority
   rank: 6
-  thomas: '02202'
-  bioguide: N000188
+  thomas: '02246'
+  bioguide: M001196
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Salud O. Carbajal
+  party: majority
+  rank: 7
+  bioguide: C001112
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Ro Khanna
-  party: minority
+  party: majority
   rank: 8
   bioguide: K000389
-HSBA:
-- name: Peter T. King
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: William R. Keating
   party: majority
+  rank: 9
+  thomas: '02025'
+  bioguide: K000375
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+- name: Kendra S. Horn
+  party: majority
+  rank: 10
+  bioguide: H001083
+  start_date: '2019-01-23'
+  source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
+HSBA:
+- name: Patrick T. McHenry
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01792'
+  bioguide: M001156
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
+- name: Peter T. King
+  party: minority
   rank: 2
   thomas: '00635'
   bioguide: K000210
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Frank D. Lucas
-  party: majority
-  rank: 4
+  party: minority
+  rank: 3
   thomas: '00711'
   bioguide: L000491
-- name: Patrick T. McHenry
-  party: majority
-  rank: 5
-  thomas: '01792'
-  bioguide: M001156
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bill Posey
-  party: majority
-  rank: 7
+  party: minority
+  rank: 4
   thomas: '01915'
   bioguide: P000599
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Blaine Luetkemeyer
-  party: majority
-  rank: 8
+  party: minority
+  rank: 5
   thomas: '01931'
   bioguide: L000569
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bill Huizenga
-  party: majority
-  rank: 9
+  party: minority
+  rank: 6
   thomas: '02028'
   bioguide: H001058
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Sean P. Duffy
-  party: majority
-  rank: 10
+  party: minority
+  rank: 7
   thomas: '02072'
   bioguide: D000614
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Steve Stivers
-  party: majority
-  rank: 11
+  party: minority
+  rank: 8
   thomas: '02047'
   bioguide: S001187
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ann Wagner
-  party: majority
-  rank: 15
+  party: minority
+  rank: 9
   thomas: '02137'
   bioguide: W000812
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Andy Barr
-  party: majority
-  rank: 16
+  party: minority
+  rank: 10
   thomas: '02131'
   bioguide: B001282
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Scott R. Tipton
-  party: majority
-  rank: 19
+  party: minority
+  rank: 11
   thomas: '01997'
   bioguide: T000470
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Roger Williams
-  party: majority
-  rank: 20
+  party: minority
+  rank: 12
   thomas: '02165'
   bioguide: W000816
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: J. French Hill
-  party: majority
-  rank: 23
+  party: minority
+  rank: 13
   thomas: '02223'
   bioguide: H001072
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Tom Emmer
-  party: majority
-  rank: 24
+  party: minority
+  rank: 14
   thomas: '02253'
   bioguide: E000294
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Lee M. Zeldin
-  party: majority
-  rank: 25
+  party: minority
+  rank: 15
   thomas: '02261'
   bioguide: Z000017
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Barry Loudermilk
-  party: majority
-  rank: 27
+  party: minority
+  rank: 16
   thomas: '02238'
   bioguide: L000583
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Alexander X. Mooney
-  party: majority
-  rank: 28
+  party: minority
+  rank: 17
   thomas: '02277'
   bioguide: M001195
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Warren Davidson
-  party: majority
-  rank: 30
+  party: minority
+  rank: 18
   thomas: '02296'
   bioguide: D000626
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ted Budd
-  party: majority
-  rank: 31
-  bioguide: B001305
-- name: David Kustoff
-  party: majority
-  rank: 32
-  bioguide: K000392
-- name: Trey Hollingsworth
-  party: majority
-  rank: 34
-  bioguide: H001074
-- name: Maxine Waters
   party: minority
+  rank: 19
+  bioguide: B001305
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: David Kustoff
+  party: minority
+  rank: 20
+  bioguide: K000392
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Trey Hollingsworth
+  party: minority
+  rank: 21
+  bioguide: H001074
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Anthony Gonzalez
+  party: minority
+  rank: 22
+  bioguide: G000588
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John W. Rose
+  party: minority
+  rank: 23
+  bioguide: R000612
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bryan Steil
+  party: minority
+  rank: 24
+  bioguide: S001213
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Lance Gooden
+  party: minority
+  rank: 25
+  bioguide: G000589
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Denver Riggleman
+  party: minority
+  rank: 26
+  bioguide: R000611
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Maxine Waters
+  party: majority
   rank: 1
-  title: Ranking Member
+  title: Chair
   thomas: '01205'
   bioguide: W000187
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
 - name: Carolyn B. Maloney
-  party: minority
+  party: majority
   rank: 2
   thomas: '00729'
   bioguide: M000087
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Nydia M. Velázquez
-  party: minority
+  party: majority
   rank: 3
   thomas: '01184'
   bioguide: V000081
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Brad Sherman
-  party: minority
+  party: majority
   rank: 4
   thomas: '01526'
   bioguide: S000344
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Gregory W. Meeks
-  party: minority
+  party: majority
   rank: 5
   thomas: '01506'
   bioguide: M001137
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Wm. Lacy Clay
-  party: minority
-  rank: 7
+  party: majority
+  rank: 6
   thomas: '01654'
   bioguide: C001049
-- name: Stephen F. Lynch
-  party: minority
-  rank: 8
-  thomas: '01686'
-  bioguide: L000562
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: David Scott
-  party: minority
-  rank: 9
+  party: majority
+  rank: 7
   thomas: '01722'
   bioguide: S001157
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Al Green
-  party: minority
-  rank: 10
+  party: majority
+  rank: 8
   thomas: '01803'
   bioguide: G000553
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Emanuel Cleaver
-  party: minority
-  rank: 11
+  party: majority
+  rank: 9
   thomas: '01790'
   bioguide: C001061
-- name: Gwen Moore
-  party: minority
-  rank: 12
-  thomas: '01811'
-  bioguide: M001160
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Ed Perlmutter
-  party: minority
-  rank: 14
+  party: majority
+  rank: 10
   thomas: '01835'
   bioguide: P000593
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: James A. Himes
-  party: minority
-  rank: 15
+  party: majority
+  rank: 11
   thomas: '01913'
   bioguide: H001047
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Bill Foster
-  party: minority
-  rank: 16
+  party: majority
+  rank: 12
   thomas: '01888'
   bioguide: F000454
-- name: Daniel T. Kildee
-  party: minority
-  rank: 17
-  thomas: '02134'
-  bioguide: K000380
-- name: Kyrsten Sinema
-  party: minority
-  rank: 19
-  thomas: '02099'
-  bioguide: S001191
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Joyce Beatty
-  party: minority
-  rank: 20
+  party: majority
+  rank: 13
   thomas: '02153'
   bioguide: B001281
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Denny Heck
-  party: minority
-  rank: 21
+  party: majority
+  rank: 14
   thomas: '02170'
   bioguide: H001064
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Juan Vargas
-  party: minority
-  rank: 22
+  party: majority
+  rank: 15
   thomas: '02112'
   bioguide: V000130
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Josh Gottheimer
-  party: minority
-  rank: 23
+  party: majority
+  rank: 16
   bioguide: G000583
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Vicente Gonzalez
-  party: minority
-  rank: 24
+  party: majority
+  rank: 17
   bioguide: G000581
-- name: Charlie Crist
-  party: minority
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Al Lawson, Jr.
+  party: majority
+  rank: 18
+  bioguide: L000586
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Michael San Nicolas
+  party: majority
+  rank: 19
+  bioguide: S001204
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Rashida Tlaib
+  party: majority
+  rank: 20
+  bioguide: T000481
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Katie Porter
+  party: majority
+  rank: 21
+  bioguide: P000618
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Cindy Axne
+  party: majority
+  rank: 22
+  bioguide: A000378
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Sean Casten
+  party: majority
+  rank: 23
+  bioguide: C001117
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Ayanna Pressley
+  party: majority
+  rank: 24
+  bioguide: P000617
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Ben McAdams
+  party: majority
   rank: 25
-  bioguide: C001111
+  bioguide: M001209
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Alexandria Ocasio-Cortez
+  party: majority
+  rank: 26
+  bioguide: O000172
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jennifer Wexton
+  party: majority
+  rank: 27
+  bioguide: W000825
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Stephen F. Lynch
+  party: majority
+  rank: 28
+  bioguide: L000562
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Tulsi Gabbard
+  party: majority
+  rank: 29
+  bioguide: G000571
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Alma S. Adams
+  party: majority
+  rank: 30
+  bioguide: A000370
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Madeleine Dean
+  party: majority
+  rank: 31
+  bioguide: D000631
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jesús G. García
+  party: majority
+  rank: 32
+  bioguide: G000586
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Sylvia R. Garcia
+  party: majority
+  rank: 33
+  bioguide: G000587
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Dean Phillips
+  party: majority
+  rank: 34
+  bioguide: P000616
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 HSBA01:
 - name: Scott R. Tipton
-  party: majority
+  party: minority
   rank: 5
   thomas: '01997'
   bioguide: T000470
-- name: Roger Williams
-  party: majority
-  rank: 6
-  thomas: '02165'
-  bioguide: W000816
-- name: J. French Hill
-  party: majority
-  rank: 9
-  thomas: '02223'
-  bioguide: H001072
-- name: Tom Emmer
-  party: majority
-  rank: 10
-  thomas: '02253'
-  bioguide: E000294
-- name: Lee M. Zeldin
-  party: majority
-  rank: 11
-  thomas: '02261'
-  bioguide: Z000017
-- name: Warren Davidson
-  party: majority
-  rank: 12
-  thomas: '02296'
-  bioguide: D000626
-- name: Ted Budd
-  party: majority
-  rank: 13
-  bioguide: B001305
-- name: David Kustoff
-  party: majority
-  rank: 14
-  bioguide: K000392
 - name: Ed Perlmutter
-  party: minority
+  party: majority
   rank: 1
   title: Ranking Member
   thomas: '01835'
   bioguide: P000593
 - name: Carolyn B. Maloney
-  party: minority
+  party: majority
   rank: 2
   thomas: '00729'
   bioguide: M000087
 - name: James A. Himes
-  party: minority
+  party: majority
   rank: 3
   thomas: '01913'
   bioguide: H001047
 - name: Bill Foster
-  party: minority
+  party: majority
   rank: 4
   thomas: '01888'
   bioguide: F000454
-- name: Daniel T. Kildee
-  party: minority
-  rank: 5
-  thomas: '02134'
-  bioguide: K000380
-- name: Kyrsten Sinema
-  party: minority
-  rank: 7
-  thomas: '02099'
-  bioguide: S001191
 - name: Juan Vargas
-  party: minority
+  party: majority
   rank: 8
   thomas: '02112'
   bioguide: V000130
 - name: Josh Gottheimer
-  party: minority
+  party: majority
   rank: 9
   bioguide: G000583
 - name: Stephen F. Lynch
-  party: minority
+  party: majority
   rank: 11
   thomas: '01686'
   bioguide: L000562
 - name: Maxine Waters
-  party: minority
+  party: majority
   rank: 12
   thomas: '01205'
   bioguide: W000187
   title: Ex Officio
 HSBA04:
 - name: Sean P. Duffy
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
+  title: Ranking Member
   thomas: '02072'
   bioguide: D000614
-- name: Bill Posey
-  party: majority
-  rank: 5
-  thomas: '01915'
-  bioguide: P000599
-- name: Blaine Luetkemeyer
-  party: majority
-  rank: 6
-  thomas: '01931'
-  bioguide: L000569
-- name: Steve Stivers
-  party: majority
-  rank: 7
-  thomas: '02047'
-  bioguide: S001187
-- name: Lee M. Zeldin
-  party: majority
-  rank: 10
-  thomas: '02261'
-  bioguide: Z000017
-- name: Ted Budd
-  party: majority
-  rank: 13
-  bioguide: B001305
-- name: Emanuel Cleaver
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01790'
-  bioguide: C001061
-- name: Nydia M. Velázquez
-  party: minority
-  rank: 2
-  thomas: '01184'
-  bioguide: V000081
+  start_date: '2019-01-24'
+  source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
 - name: Wm. Lacy Clay
-  party: minority
-  rank: 4
-  thomas: '01654'
-  bioguide: C001049
-- name: Brad Sherman
-  party: minority
-  rank: 5
-  thomas: '01526'
-  bioguide: S000344
-- name: Joyce Beatty
-  party: minority
-  rank: 6
-  thomas: '02153'
-  bioguide: B001281
-- name: Daniel T. Kildee
-  party: minority
-  rank: 7
-  thomas: '02134'
-  bioguide: K000380
-- name: Vicente Gonzalez
-  party: minority
-  rank: 10
-  bioguide: G000581
-- name: Maxine Waters
-  party: minority
-  rank: 11
-  thomas: '01205'
-  bioguide: W000187
-  title: Ex Officio
-HSBA09:
-- name: Ann Wagner
   party: majority
   rank: 1
   title: Chair
-  thomas: '02137'
-  bioguide: W000812
-- name: Scott R. Tipton
-  party: majority
-  rank: 2
-  thomas: '01997'
-  bioguide: T000470
-  title: Vice Chair
-- name: Peter T. King
-  party: majority
-  rank: 3
-  thomas: '00635'
-  bioguide: K000210
-- name: Patrick T. McHenry
-  party: majority
-  rank: 4
-  thomas: '01792'
-  bioguide: M001156
-- name: Lee M. Zeldin
-  party: majority
-  rank: 7
-  thomas: '02261'
-  bioguide: Z000017
-- name: Barry Loudermilk
-  party: majority
-  rank: 9
-  thomas: '02238'
-  bioguide: L000583
-- name: David Kustoff
-  party: majority
-  rank: 10
-  bioguide: K000392
-- name: Trey Hollingsworth
-  party: majority
-  rank: 12
-  bioguide: H001074
-- name: Al Green
+  thomas: '01654'
+  bioguide: C001049
+  start_date: '2019-01-24'
+  source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
+HSBA09:
+- name: Andy Barr
   party: minority
   rank: 1
   title: Ranking Member
+  thomas: '02131'
+  bioguide: B001282
+  start_date: '2019-01-24'
+  source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
+- name: Al Green
+  party: majority
+  rank: 1
+  title: Chair
   thomas: '01803'
   bioguide: G000553
-- name: Emanuel Cleaver
-  party: minority
-  rank: 3
-  thomas: '01790'
-  bioguide: C001061
-- name: Joyce Beatty
-  party: minority
-  rank: 4
-  thomas: '02153'
-  bioguide: B001281
-- name: Gwen Moore
-  party: minority
-  rank: 6
-  thomas: '01811'
-  bioguide: M001160
-- name: Josh Gottheimer
-  party: minority
-  rank: 7
-  bioguide: G000583
-- name: Vicente Gonzalez
-  party: minority
-  rank: 8
-  bioguide: G000581
-- name: Charlie Crist
-  party: minority
-  rank: 9
-  bioguide: C001111
-- name: Maxine Waters
-  party: minority
-  rank: 10
-  thomas: '01205'
-  bioguide: W000187
-  title: Ex Officio
+  start_date: '2019-01-24'
+  source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
 HSBA15:
 - name: Blaine Luetkemeyer
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
+  title: Ranking Member
   thomas: '01931'
   bioguide: L000569
-- name: Frank D. Lucas
-  party: majority
-  rank: 4
-  thomas: '00711'
-  bioguide: L000491
-- name: Bill Posey
-  party: majority
-  rank: 5
-  thomas: '01915'
-  bioguide: P000599
-- name: Andy Barr
-  party: majority
-  rank: 8
-  thomas: '02131'
-  bioguide: B001282
-- name: Scott R. Tipton
-  party: majority
-  rank: 9
-  thomas: '01997'
-  bioguide: T000470
-- name: Roger Williams
-  party: majority
-  rank: 10
-  thomas: '02165'
-  bioguide: W000816
-- name: Barry Loudermilk
-  party: majority
-  rank: 13
-  thomas: '02238'
-  bioguide: L000583
-- name: David Kustoff
-  party: majority
-  rank: 14
-  bioguide: K000392
-- name: Wm. Lacy Clay
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01654'
-  bioguide: C001049
-- name: Carolyn B. Maloney
-  party: minority
-  rank: 2
-  thomas: '00729'
-  bioguide: M000087
+  start_date: '2019-01-24'
+  source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
 - name: Gregory W. Meeks
-  party: minority
-  rank: 3
+  party: majority
+  rank: 1
+  title: Chair
   thomas: '01506'
   bioguide: M001137
-- name: David Scott
-  party: minority
-  rank: 4
-  thomas: '01722'
-  bioguide: S001157
-- name: Nydia M. Velázquez
-  party: minority
-  rank: 5
-  thomas: '01184'
-  bioguide: V000081
-- name: Al Green
-  party: minority
-  rank: 6
-  thomas: '01803'
-  bioguide: G000553
-- name: Denny Heck
-  party: minority
-  rank: 9
-  thomas: '02170'
-  bioguide: H001064
-- name: Gwen Moore
-  party: minority
-  rank: 10
-  thomas: '01811'
-  bioguide: M001160
-- name: Charlie Crist
-  party: minority
-  rank: 11
-  bioguide: C001111
-- name: Maxine Waters
-  party: minority
-  rank: 12
-  thomas: '01205'
-  bioguide: W000187
-  title: Ex Officio
+  start_date: '2019-01-24'
+  source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
 HSBA16:
 - name: Bill Huizenga
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02028'
-  bioguide: H001058
-- name: Peter T. King
-  party: majority
-  rank: 3
-  thomas: '00635'
-  bioguide: K000210
-- name: Patrick T. McHenry
-  party: majority
-  rank: 4
-  thomas: '01792'
-  bioguide: M001156
-- name: Sean P. Duffy
-  party: majority
-  rank: 5
-  thomas: '02072'
-  bioguide: D000614
-- name: Steve Stivers
-  party: majority
-  rank: 6
-  thomas: '02047'
-  bioguide: S001187
-- name: Ann Wagner
-  party: majority
-  rank: 7
-  thomas: '02137'
-  bioguide: W000812
-- name: J. French Hill
-  party: majority
-  rank: 10
-  thomas: '02223'
-  bioguide: H001072
-- name: Tom Emmer
-  party: majority
-  rank: 11
-  thomas: '02253'
-  bioguide: E000294
-- name: Alexander X. Mooney
-  party: majority
-  rank: 12
-  thomas: '02277'
-  bioguide: M001195
-- name: Warren Davidson
-  party: majority
-  rank: 14
-  thomas: '02296'
-  bioguide: D000626
-- name: Ted Budd
-  party: majority
-  rank: 15
-  bioguide: B001305
-- name: Trey Hollingsworth
-  party: majority
-  rank: 16
-  bioguide: H001074
-- name: Carolyn B. Maloney
   party: minority
   rank: 1
   title: Ranking Member
+  thomas: '02028'
+  bioguide: H001058
+  start_date: '2019-01-24'
+  source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
+- name: Carolyn B. Maloney
+  party: majority
+  rank: 1
+  title: Chair
   thomas: '00729'
   bioguide: M000087
-- name: Brad Sherman
-  party: minority
-  rank: 2
-  thomas: '01526'
-  bioguide: S000344
-- name: Stephen F. Lynch
-  party: minority
-  rank: 3
-  thomas: '01686'
-  bioguide: L000562
-- name: David Scott
-  party: minority
-  rank: 4
-  thomas: '01722'
-  bioguide: S001157
-- name: James A. Himes
-  party: minority
-  rank: 5
-  thomas: '01913'
-  bioguide: H001047
-- name: Bill Foster
-  party: minority
-  rank: 7
-  thomas: '01888'
-  bioguide: F000454
-- name: Gregory W. Meeks
-  party: minority
-  rank: 8
-  thomas: '01506'
-  bioguide: M001137
-- name: Kyrsten Sinema
-  party: minority
-  rank: 9
-  thomas: '02099'
-  bioguide: S001191
-- name: Juan Vargas
-  party: minority
-  rank: 10
-  thomas: '02112'
-  bioguide: V000130
-- name: Josh Gottheimer
-  party: minority
-  rank: 11
-  bioguide: G000583
-- name: Vicente Gonzalez
-  party: minority
-  rank: 12
-  bioguide: G000581
-- name: Maxine Waters
-  party: minority
-  rank: 13
-  thomas: '01205'
-  bioguide: W000187
-  title: Ex Officio
+  start_date: '2019-01-24'
+  source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
 HSBA20:
-- name: Andy Barr
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02131'
-  bioguide: B001282
-- name: Roger Williams
-  party: majority
-  rank: 2
-  thomas: '02165'
-  bioguide: W000816
-  title: Vice Chair
-- name: Frank D. Lucas
-  party: majority
-  rank: 3
-  thomas: '00711'
-  bioguide: L000491
-- name: Bill Huizenga
-  party: majority
-  rank: 4
-  thomas: '02028'
-  bioguide: H001058
-- name: J. French Hill
-  party: majority
-  rank: 7
-  thomas: '02223'
-  bioguide: H001072
-- name: Tom Emmer
-  party: majority
-  rank: 8
-  thomas: '02253'
-  bioguide: E000294
-- name: Alexander X. Mooney
-  party: majority
-  rank: 9
-  thomas: '02277'
-  bioguide: M001195
-- name: Warren Davidson
-  party: majority
-  rank: 10
-  thomas: '02296'
-  bioguide: D000626
-- name: Trey Hollingsworth
-  party: majority
-  rank: 12
-  bioguide: H001074
-- name: Gwen Moore
+- name: Steve Stivers
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01811'
-  bioguide: M001160
-- name: Gregory W. Meeks
-  party: minority
-  rank: 2
-  thomas: '01506'
-  bioguide: M001137
-- name: Bill Foster
-  party: minority
-  rank: 3
-  thomas: '01888'
-  bioguide: F000454
-- name: Brad Sherman
-  party: minority
-  rank: 4
-  thomas: '01526'
-  bioguide: S000344
-- name: Al Green
-  party: minority
-  rank: 5
-  thomas: '01803'
-  bioguide: G000553
-- name: Denny Heck
-  party: minority
-  rank: 6
-  thomas: '02170'
-  bioguide: H001064
-- name: Daniel T. Kildee
-  party: minority
-  rank: 7
-  thomas: '02134'
-  bioguide: K000380
-- name: Juan Vargas
-  party: minority
-  rank: 8
-  thomas: '02112'
-  bioguide: V000130
-- name: Charlie Crist
-  party: minority
-  rank: 9
-  bioguide: C001111
-- name: Maxine Waters
-  party: minority
-  rank: 10
-  thomas: '01205'
-  bioguide: W000187
-  title: Ex Officio
+  thomas: '02047'
+  bioguide: S001187
+  start_date: '2019-01-24'
+  source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
+- name: Emanuel Cleaver
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01790'
+  bioguide: C001061
+  start_date: '2019-01-24'
+  source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
 HSBU:
 - name: Steve Womack
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
+  title: Ranking Member
   thomas: '01991'
   bioguide: W000809
-- name: Mario Diaz-Balart
-  party: majority
-  rank: 3
-  thomas: '01717'
-  bioguide: D000600
-- name: Tom Cole
-  party: majority
-  rank: 4
-  thomas: '01742'
-  bioguide: C001053
-- name: Tom McClintock
-  party: majority
-  rank: 5
-  thomas: '01908'
-  bioguide: M001177
-- name: Rob Woodall
-  party: majority
-  rank: 7
-  thomas: '02008'
-  bioguide: W000810
-- name: Glenn Grothman
-  party: majority
-  rank: 10
-  thomas: '02276'
-  bioguide: G000576
-- name: Gary J. Palmer
-  party: majority
-  rank: 11
-  thomas: '02221'
-  bioguide: P000609
-- name: Bruce Westerman
-  party: majority
-  rank: 12
-  thomas: '02224'
-  bioguide: W000821
-- name: Bill Johnson
-  party: majority
-  rank: 14
-  thomas: '02046'
-  bioguide: J000292
-- name: Jason Smith
-  party: majority
-  rank: 15
-  thomas: '02191'
-  bioguide: S001195
-- name: Jack Bergman
-  party: majority
-  rank: 17
-  bioguide: B001301
-- name: Lloyd Smucker
-  party: majority
-  rank: 19
-  bioguide: S001199
-- name: Matt Gaetz
-  party: majority
-  rank: 20
-  bioguide: G000578
-- name: Jodey C. Arrington
-  party: majority
-  rank: 21
-  bioguide: A000375
-- name: A. Drew Ferguson IV
-  party: majority
-  rank: 22
-  bioguide: F000465
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
 - name: John A. Yarmuth
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01853'
-  bioguide: Y000062
-- name: Barbara Lee
-  party: minority
-  rank: 2
-  thomas: '01501'
-  bioguide: L000551
-- name: Seth Moulton
-  party: minority
-  rank: 4
-  thomas: '02246'
-  bioguide: M001196
-- name: Hakeem S. Jeffries
-  party: minority
-  rank: 5
-  thomas: '02149'
-  bioguide: J000294
-- name: Brian Higgins
-  party: minority
-  rank: 6
-  thomas: '01794'
-  bioguide: H001038
-- name: Suzan K. DelBene
-  party: minority
-  rank: 7
-  thomas: '02096'
-  bioguide: D000617
-- name: Debbie Wasserman Schultz
-  party: minority
-  rank: 8
-  thomas: '01777'
-  bioguide: W000797
-- name: Brendan F. Boyle
-  party: minority
-  rank: 9
-  thomas: '02267'
-  bioguide: B001296
-- name: Ro Khanna
-  party: minority
-  rank: 10
-  bioguide: K000389
-- name: Pramila Jayapal
-  party: minority
-  rank: 11
-  bioguide: J000298
-- name: Salud O. Carbajal
-  party: minority
-  rank: 12
-  bioguide: C001112
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 13
-  thomas: '00588'
-  bioguide: J000032
-- name: Janice D. Schakowsky
-  party: minority
-  rank: 14
-  thomas: '01588'
-  bioguide: S001145
-HSED:
-- name: Virginia Foxx
   party: majority
   rank: 1
   title: Chair
-  thomas: '01791'
-  bioguide: F000450
-- name: Joe Wilson
-  party: majority
-  rank: 2
-  thomas: '01688'
-  bioguide: W000795
-  title: Vice Chair
-- name: David P. Roe
-  party: majority
-  rank: 3
-  thomas: '01954'
-  bioguide: R000582
-- name: Glenn Thompson
-  party: majority
-  rank: 4
-  thomas: '01952'
-  bioguide: T000467
-- name: Tim Walberg
-  party: majority
-  rank: 5
-  thomas: '01855'
-  bioguide: W000798
-- name: Brett Guthrie
-  party: majority
-  rank: 6
-  thomas: '01922'
-  bioguide: G000558
-- name: Bradley Byrne
-  party: majority
-  rank: 10
-  thomas: '02197'
-  bioguide: B001289
-- name: Glenn Grothman
-  party: majority
-  rank: 12
-  thomas: '02276'
-  bioguide: G000576
-- name: Elise M. Stefanik
-  party: majority
-  rank: 13
-  thomas: '02263'
-  bioguide: S001196
-- name: Rick W. Allen
-  party: majority
-  rank: 14
-  thomas: '02239'
-  bioguide: A000372
-- name: Francis Rooney
-  party: majority
-  rank: 16
-  bioguide: R000607
-- name: Lloyd Smucker
-  party: majority
-  rank: 18
-  bioguide: S001199
-- name: A. Drew Ferguson IV
-  party: majority
-  rank: 19
-  bioguide: F000465
-- name: Ron Estes
-  party: majority
-  rank: 20
-  bioguide: E000298
-- name: Jim Banks
-  party: majority
-  rank: 22
-  bioguide: B001299
-- name: Robert C. "Bobby" Scott
+  thomas: '01853'
+  bioguide: Y000062
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
+HSED:
+- name: Virginia Foxx
   party: minority
   rank: 1
   title: Ranking Member
+  thomas: '01791'
+  bioguide: F000450
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: David P. Roe
+  party: minority
+  rank: 2
+  thomas: '01954'
+  bioguide: R000582
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Glenn Thompson
+  party: minority
+  rank: 3
+  thomas: '01952'
+  bioguide: T000467
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Tim Walberg
+  party: minority
+  rank: 4
+  thomas: '01855'
+  bioguide: W000798
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Brett Guthrie
+  party: minority
+  rank: 5
+  thomas: '01922'
+  bioguide: G000558
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bradley Byrne
+  party: minority
+  rank: 6
+  thomas: '02197'
+  bioguide: B001289
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Glenn Grothman
+  party: minority
+  rank: 7
+  thomas: '02276'
+  bioguide: G000576
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Elise M. Stefanik
+  party: minority
+  rank: 8
+  thomas: '02263'
+  bioguide: S001196
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Rick W. Allen
+  party: minority
+  rank: 9
+  thomas: '02239'
+  bioguide: A000372
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Francis Rooney
+  party: minority
+  rank: 10
+  bioguide: R000607
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Lloyd Smucker
+  party: minority
+  rank: 11
+  bioguide: S001199
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark Walker
+  party: minority
+  rank: 12
+  thomas: '02255'
+  bioguide: W000819
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jim Banks
+  party: minority
+  rank: 13
+  bioguide: B001299
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: James Comer
+  party: minority
+  rank: 14
+  bioguide: C001108
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ben Cline
+  party: minority
+  rank: 15
+  bioguide: C001118
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Russ Fulcher
+  party: minority
+  rank: 16
+  bioguide: F000469
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Van Taylor
+  party: minority
+  rank: 17
+  bioguide: T000479
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Steven C. Watkins
+  party: minority
+  rank: 18
+  bioguide: W000824
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ron Wright
+  party: minority
+  rank: 19
+  bioguide: W000827
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Daniel Meuser
+  party: minority
+  rank: 20
+  bioguide: M001204
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: William Timmons
+  party: minority
+  rank: 21
+  bioguide: T000480
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Dusty Johnson
+  party: minority
+  rank: 22
+  bioguide: J000301
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Robert C. "Bobby" Scott
+  party: majority
+  rank: 1
+  title: Chair
   thomas: '01037'
   bioguide: S000185
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Susan A. Davis
-  party: minority
+  party: majority
   rank: 2
   thomas: '01641'
   bioguide: D000598
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Raúl M. Grijalva
-  party: minority
+  party: majority
   rank: 3
   thomas: '01708'
   bioguide: G000551
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Joe Courtney
-  party: minority
+  party: majority
   rank: 4
   thomas: '01836'
   bioguide: C001069
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Marcia L. Fudge
-  party: minority
+  party: majority
   rank: 5
   thomas: '01895'
   bioguide: F000455
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Gregorio Kilili Camacho Sablan
-  party: minority
+  party: majority
   rank: 7
   thomas: '01962'
   bioguide: S001177
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Frederica S. Wilson
-  party: minority
+  party: majority
   rank: 8
   thomas: '02004'
   bioguide: W000808
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Suzanne Bonamici
-  party: minority
+  party: majority
   rank: 9
   thomas: '02092'
   bioguide: B001278
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mark Takano
-  party: minority
+  party: majority
   rank: 10
   thomas: '02110'
   bioguide: T000472
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Alma S. Adams
-  party: minority
+  party: majority
   rank: 11
   thomas: '02201'
   bioguide: A000370
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mark DeSaulnier
-  party: minority
+  party: majority
   rank: 12
   thomas: '02227'
   bioguide: D000623
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Donald Norcross
-  party: minority
+  party: majority
   rank: 13
   thomas: '02202'
   bioguide: N000188
-- name: Lisa Blunt Rochester
-  party: minority
-  rank: 14
-  bioguide: B001303
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Raja Krishnamoorthi
-  party: minority
-  rank: 15
+  party: majority
+  rank: 14
   bioguide: K000391
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Adriano Espaillat
-  party: minority
-  rank: 17
+  party: majority
+  rank: 15
   bioguide: E000297
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Pramila Jayapal
+  party: majority
+  rank: 16
+  bioguide: J000298
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Joseph D. Morelle
+  party: majority
+  rank: 17
+  bioguide: M001206
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Susan Wild
+  party: majority
+  rank: 18
+  bioguide: W000826
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Josh Harder
+  party: majority
+  rank: 19
+  bioguide: H001090
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Lucy McBath
+  party: majority
+  rank: 20
+  bioguide: M001208
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Kim Schrier
+  party: majority
+  rank: 21
+  bioguide: S001216
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Lauren Underwood
+  party: majority
+  rank: 22
+  bioguide: U000040
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jahana Hayes
+  party: majority
+  rank: 23
+  bioguide: H001081
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Donna E. Shalala
+  party: majority
+  rank: 24
+  bioguide: S001206
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Andy Levin
+  party: majority
+  rank: 25
+  bioguide: L000592
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ilhan Omar
+  party: majority
+  rank: 26
+  bioguide: O000173
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: David J. Trone
+  party: majority
+  rank: 27
+  bioguide: T000483
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Haley M. Stevens
+  party: majority
+  rank: 28
+  bioguide: S001215
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Susie Lee
+  party: majority
+  rank: 29
+  bioguide: L000590
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Lori Trahan
+  party: majority
+  rank: 30
+  bioguide: T000482
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Joaquin Castro
+  party: majority
+  rank: 31
+  bioguide: C001091
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 HSED02:
 - name: Tim Walberg
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
+  title: Ranking Member
   thomas: '01855'
   bioguide: W000798
-- name: Joe Wilson
-  party: majority
-  rank: 2
-  thomas: '01688'
-  bioguide: W000795
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: David P. Roe
-  party: majority
-  rank: 3
+  party: minority
+  rank: 2
   thomas: '01954'
   bioguide: R000582
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Rick W. Allen
-  party: majority
-  rank: 6
-  thomas: '02239'
-  bioguide: A000372
-- name: Francis Rooney
-  party: majority
-  rank: 8
-  bioguide: R000607
-- name: Lloyd Smucker
-  party: majority
-  rank: 9
-  bioguide: S001199
-- name: A. Drew Ferguson IV
-  party: majority
-  rank: 10
-  bioguide: F000465
-- name: Ron Estes
-  party: majority
-  rank: 11
-  bioguide: E000298
-- name: Jim Banks
-  party: majority
-  rank: 12
-  bioguide: B001299
-- name: Gregorio Kilili Camacho Sablan
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01962'
-  bioguide: S001177
-- name: Frederica S. Wilson
-  party: minority
-  rank: 2
-  thomas: '02004'
-  bioguide: W000808
-- name: Donald Norcross
   party: minority
   rank: 3
-  thomas: '02202'
-  bioguide: N000188
-- name: Lisa Blunt Rochester
+  thomas: '02239'
+  bioguide: A000372
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Francis Rooney
   party: minority
   rank: 4
-  bioguide: B001303
-- name: Adriano Espaillat
+  bioguide: R000607
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Jim Banks
+  party: minority
+  rank: 5
+  bioguide: B001299
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Russ Fulcher
   party: minority
   rank: 6
-  bioguide: E000297
-- name: Joe Courtney
+  bioguide: F000469
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Van Taylor
   party: minority
   rank: 7
-  thomas: '01836'
-  bioguide: C001069
-- name: Marcia L. Fudge
+  bioguide: T000479
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Steven C. Watkins
   party: minority
   rank: 8
-  thomas: '01895'
-  bioguide: F000455
-- name: Suzanne Bonamici
+  bioguide: W000824
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Ron Wright
   party: minority
   rank: 9
-  thomas: '02092'
-  bioguide: B001278
-HSED10:
-- name: Bradley Byrne
+  bioguide: W000827
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Daniel Meuser
+  party: minority
+  rank: 10
+  bioguide: M001204
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Dusty Johnson
+  party: minority
+  rank: 11
+  bioguide: J000301
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Frederica S. Wilson
   party: majority
   rank: 1
   title: Chair
-  thomas: '02197'
-  bioguide: B001289
-- name: Joe Wilson
+  thomas: '02004'
+  bioguide: W000808
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Joe Courtney
   party: majority
   rank: 2
-  thomas: '01688'
-  bioguide: W000795
-- name: Glenn Grothman
+  thomas: '01836'
+  bioguide: C001069
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Marcia L. Fudge
+  party: majority
+  rank: 3
+  thomas: '01895'
+  bioguide: F000455
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Donald Norcross
   party: majority
   rank: 4
-  thomas: '02276'
-  bioguide: G000576
-- name: Elise M. Stefanik
+  thomas: '02202'
+  bioguide: N000188
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Joseph D. Morelle
   party: majority
   rank: 5
-  thomas: '02263'
-  bioguide: S001196
-- name: Francis Rooney
+  bioguide: M001206
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Susan Wild
   party: majority
-  rank: 6
-  bioguide: R000607
-- name: A. Drew Ferguson IV
+  rank: 5
+  bioguide: W000826
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Josh Harder
   party: majority
   rank: 7
-  bioguide: F000465
-- name: Mark Takano
+  bioguide: H001090
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Lucy McBath
+  party: majority
+  rank: 8
+  bioguide: M001208
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Lauren Underwood
+  party: majority
+  rank: 9
+  bioguide: U000040
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Donna E. Shalala
+  party: majority
+  rank: 10
+  bioguide: S001206
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Andy Levin
+  party: majority
+  rank: 11
+  bioguide: L000592
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Haley M. Stevens
+  party: majority
+  rank: 12
+  bioguide: S001215
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Lori Trahan
+  party: majority
+  rank: 13
+  bioguide: T000482
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+HSED10:
+- name: Bradley Byrne
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02110'
-  bioguide: T000472
-- name: Raúl M. Grijalva
+  thomas: '02197'
+  bioguide: B001289
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Francis Rooney
   party: minority
   rank: 2
-  thomas: '01708'
-  bioguide: G000551
-- name: Alma S. Adams
+  bioguide: R000607
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Mark Walker
   party: minority
   rank: 3
+  thomas: '02255'
+  bioguide: W000819
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Ben Cline
+  party: minority
+  rank: 15
+  bioguide: C001118
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Ron Wright
+  party: minority
+  rank: 19
+  bioguide: W000827
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Alma S. Adams
+  party: majority
+  rank: 1
+  title: Chair
   thomas: '02201'
   bioguide: A000370
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Mark Takano
+  party: majority
+  rank: 2
+  thomas: '02110'
+  bioguide: T000472
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Mark DeSaulnier
   party: minority
-  rank: 4
+  rank: 3
   thomas: '02227'
   bioguide: D000623
-- name: Donald Norcross
-  party: minority
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Pramila Jayapal
+  party: majority
+  rank: 4
+  bioguide: J000298
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Susan Wild
+  party: majority
   rank: 5
-  thomas: '02202'
-  bioguide: N000188
-- name: Raja Krishnamoorthi
-  party: minority
+  bioguide: W000826
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Lucy McBath
+  party: majority
   rank: 6
-  bioguide: K000391
+  bioguide: M001208
+  start_date: '2019-01-15'
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Ilhan Omar
+  party: majority
+  rank: 7
+  bioguide: O000173
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Haley M. Stevens
+  party: majority
+  rank: 8
+  bioguide: S001215
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 HSED13:
 - name: Brett Guthrie
   party: majority
@@ -8113,61 +7767,67 @@ HSPW14:
   thomas: '01602'
   bioguide: N000179
 HSRU:
-- name: Tom Cole
-  party: majority
-  rank: 2
-  thomas: '01742'
-  bioguide: C001053
-- name: Rob Woodall
-  party: majority
-  rank: 3
-  thomas: '02008'
-  bioguide: W000810
-- name: Michael C. Burgess
-  party: majority
-  rank: 4
-  thomas: '01751'
-  bioguide: B001248
-- name: Doug Collins
-  party: majority
-  rank: 5
-  thomas: '02121'
-  bioguide: C001093
-- name: Bradley Byrne
-  party: majority
-  rank: 6
-  thomas: '02197'
-  bioguide: B001289
-- name: Dan Newhouse
-  party: majority
-  rank: 7
-  thomas: '02275'
-  bioguide: N000189
-- name: Ken Buck
-  party: majority
-  rank: 8
-  thomas: '02233'
-  bioguide: B001297
-- name: Liz Cheney
-  party: majority
-  rank: 9
-  bioguide: C001109
 - name: James P. McGovern
-  party: minority
+  party: majority
   rank: 1
-  title: Ranking Member
+  title: Chair
   thomas: '01504'
   bioguide: M000312
 - name: Alcee L. Hastings
-  party: minority
+  party: majority
   rank: 2
   thomas: '00511'
   bioguide: H000324
 - name: Norma J. Torres
-  party: minority
-  rank: 4
+  party: majority
+  rank: 3
   thomas: '02231'
   bioguide: T000474
+- name: Jamie Raskin
+  party: majority
+  rank: 4
+  bioguide: R000606
+- name: Mary Gay Scanlon
+  party: majority
+  rank: 5
+  bioguide: S001205
+- name: Joe Morelle
+  party: majority
+  rank: 6
+  bioguide: M001206
+- name: Donna Shalala
+  party: majority
+  rank: 7
+  bioguide: S001206
+- name: Doris O. Matsui
+  party: majority
+  rank: 8
+  thomas: '01814'
+  bioguide: M001163
+- name: Ed Perlmutter
+  party: majority
+  rank: 9
+  thomas: '01835'
+  bioguide: P000593
+- name: Tom Cole
+  party: minority
+  rank: 1
+  thomas: '01742'
+  bioguide: C001053
+- name: Rob Woodall
+  party: minority
+  rank: 2
+  thomas: '02008'
+  bioguide: W000810
+- name: Michael C. Burgess
+  party: minority
+  rank: 3
+  thomas: '01751'
+  bioguide: B001248
+- name: Debbie Lesko
+  party: minority
+  rank: 4
+  bioguide: L000589
 HSRU02:
 - name: Rob Woodall
   party: majority
@@ -10427,13 +10087,18 @@ SSAF:
   bioguide: G000555
 - name: Robert P. Casey, Jr.
   party: minority
-  rank: 9
+  rank: 7
   thomas: '01828'
   bioguide: C001070
 - name: Tina Smith
   party: minority
-  rank: 10
+  rank: 8
   bioguide: S001203
+- name: Richard J. Durbin
+  party: minority
+  rank: 9
+  thomas: '00326'
+  bioguide: D000563
 SSAF13:
 - name: John Boozman
   party: majority
@@ -11966,49 +11631,63 @@ SSAS:
   bioguide: R000122
 - name: Jeanne Shaheen
   party: minority
-  rank: 4
+  rank: 2
   thomas: '01901'
   bioguide: S001181
 - name: Kirsten E. Gillibrand
   party: minority
-  rank: 5
+  rank: 3
   thomas: '01866'
   bioguide: G000555
 - name: Richard Blumenthal
   party: minority
-  rank: 6
+  rank: 4
   thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
-  rank: 8
+  rank: 5
   thomas: '01844'
   bioguide: H001042
 - name: Tim Kaine
   party: minority
-  rank: 9
+  rank: 6
   thomas: '02176'
   bioguide: K000384
 - name: Angus S. King, Jr.
   party: minority
-  rank: 10
+  rank: 7
   thomas: '02185'
   bioguide: K000383
 - name: Martin Heinrich
   party: minority
-  rank: 11
+  rank: 8
   thomas: '01937'
   bioguide: H001046
 - name: Elizabeth Warren
   party: minority
-  rank: 12
+  rank: 9
   thomas: '02182'
   bioguide: W000817
 - name: Gary C. Peters
   party: minority
-  rank: 13
+  rank: 10
   thomas: '01929'
   bioguide: P000595
+- name: Joe Manchin, III
+  party: minority
+  rank: 11
+  thomas: '01983'
+  bioguide: M001183
+- name: Tammy Duckworth
+  party: minority
+  rank: 12
+  thomas: '02123'
+  bioguide: D000622
+- name: Doug Jones
+  party: minority
+  rank: 13
+  bioguide: J000300
 SSAS13:
 - name: Roger F. Wicker
   party: majority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -4,91 +4,126 @@ HLIG:
   rank: 1
   title: Chair
   bioguide: S001150
+  start_date: '2019-01-03'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=427
 - name: James A. Himes
   party: majority
   rank: 2
   bioguide: H001047
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Terri A. Sewell
   party: majority
   rank: 3
   bioguide: S001185
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: André Carson
   party: majority
   rank: 4
   bioguide: C001072
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Jackie Speier
   party: majority
   rank: 5
   bioguide: S001175
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Mike Quigley
   party: majority
   rank: 6
   bioguide: Q000023
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Eric Swalwell
   party: majority
   rank: 7
   bioguide: S001193
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Joaquin Castro
   party: majority
   rank: 8
   bioguide: C001091
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Denny Heck
   party: majority
   rank: 9
   bioguide: H001064
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Peter Welch
   party: majority
   rank: 10
   bioguide: W000800
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Sean Patrick Maloney
   party: majority
   rank: 11
   bioguide: M001185
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Val Butler Demings
   party: majority
   rank: 12
   bioguide: D000627
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Raja Krishnamoorthi
   party: majority
   rank: 13
   bioguide: K000391
+  start_date: '2019-01-16'
+  source: https://intelligence.house.gov/news/documentsingle.aspx?DocumentID=430
 - name: Devin Nunes
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: N000181
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 - name: K. Michael Conaway
   party: minority
   rank: 2
   bioguide: C001062
-- name: Peter T. King
-  party: minority
-  rank: 3
-  bioguide: K000210
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 - name: Michael R. Turner
   party: minority
-  rank: 4
+  rank: 3
   bioguide: T000463
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 - name: Brad R. Wenstrup
   party: minority
-  rank: 5
+  rank: 4
   bioguide: W000815
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 - name: Chris Stewart
   party: minority
-  rank: 6
+  rank: 5
   bioguide: S001192
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 - name: Eric A. "Rick" Crawford
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C001087
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 - name: Elise M. Stefanik
   party: minority
-  rank: 8
+  rank: 7
   bioguide: S001196
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 - name: Will Hurd
   party: minority
-  rank: 9
+  rank: 8
   bioguide: H001073
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
+- name: John Ratcliffe
+  party: minority
+  rank: 9
+  bioguide: R000601
+  source: https://republicans-intelligence.house.gov/about/hpsci-minority-members.htm
 HSAG:
 - name: K. Michael Conaway
   party: minority
@@ -2364,52 +2399,52 @@ HSBU:
   bioguide: J000294
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
-- name: Ro Khanna
+- name: Brian Higgins
   party: majority
   rank: 4
+  bioguide: H001038
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
+- name: Brendan F. Boyle
+  party: majority
+  rank: 5
+  bioguide: B001296
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
+- name: Ro Khanna
+  party: majority
+  rank: 6
   bioguide: K000389
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Rosa L. DeLauro
   party: majority
-  rank: 5
+  rank: 7
   bioguide: D000216
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Lloyd Doggett
   party: majority
-  rank: 6
+  rank: 8
   bioguide: D000399
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: David E. Price
   party: majority
-  rank: 7
+  rank: 9
   bioguide: P000523
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Janice D. Schakowsky
   party: majority
-  rank: 8
+  rank: 10
   bioguide: S001145
-  start_date: '2019-01-24'
-  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
-- name: Brian Higgins
-  party: majority
-  rank: 9
-  bioguide: H001038
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Daniel T. Kildee
   party: majority
-  rank: 10
-  bioguide: K000380
-  start_date: '2019-01-24'
-  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
-- name: Brendan F. Boyle
-  party: majority
   rank: 11
-  bioguide: B001296
+  bioguide: K000380
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Jimmy Panetta
@@ -2424,7 +2459,7 @@ HSBU:
   bioguide: M001206
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
-- name:
+- name: Steven Horsford
   party: majority
   rank: 14
   bioguide: H001066
@@ -2528,18 +2563,18 @@ HSED:
   bioguide: S001199
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
-- name: Mark Walker
-  party: minority
-  rank: 12
-  bioguide: W000819
-  start_date: '2019-01-23'
-  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Jim Banks
   party: minority
-  rank: 13
+  rank: 12
   bioguide: B001299
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark Walker
+  party: minority
+  rank: 13
+  bioguide: W000819
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/80/text
 - name: James Comer
   party: minority
   rank: 14
@@ -4606,6 +4641,36 @@ HSHA:
   bioguide: L000397
   start_date: '2019-01-09'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/31/text
+- name: Jamie Raskin
+  party: majority
+  rank: 2
+  bioguide: R000606
+  start_date: '2019-01-29'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
+- name: Susan A. Davis
+  party: majority
+  rank: 3
+  bioguide: D000598
+  start_date: '2019-01-29'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
+- name: G. K. Butterfield
+  party: majority
+  rank: 4
+  bioguide: B001251
+  start_date: '2019-01-29'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
+- name: Marcia L. Fudge
+  party: majority
+  rank: 5
+  bioguide: F000455
+  start_date: '2019-01-29'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
+- name: Pete Aguilar
+  party: majority
+  rank: 6
+  bioguide: A000371
+  start_date: '2019-01-29'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
 HSHM:
 - name: Mike Rogers
   party: minority
@@ -4613,18 +4678,18 @@ HSHM:
   bioguide: R000575
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
-- name: Michael T. McCaul
-  party: minority
-  rank: 2
-  bioguide: M001157
-  start_date: '2019-01-23'
-  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Peter T. King
   party: minority
-  rank: 3
+  rank: 2
   bioguide: K000210
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael T. McCaul
+  party: minority
+  rank: 3
+  bioguide: M001157
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/80/text
 - name: John Katko
   party: minority
   rank: 4
@@ -4637,18 +4702,18 @@ HSHM:
   bioguide: R000601
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
-- name: Clay Higgins
-  party: minority
-  rank: 6
-  bioguide: H001077
-  start_date: '2019-01-23'
-  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mark Walker
   party: minority
-  rank: 7
+  rank: 6
   bioguide: W000819
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Clay Higgins
+  party: minority
+  rank: 7
+  bioguide: H001077
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/80/text
 - name: Debbie Lesko
   party: minority
   rank: 8
@@ -9937,82 +10002,167 @@ HSWM04:
   start_date: '2019-01-16'
   source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
 HSWM05:
-- name: Vern Buchanan
+- name: Adrian Smith
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001172
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Tom Rice
+  party: minority
+  rank: 2
+  bioguide: R000597
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: David Schweikert
+  party: minority
+  rank: 3
+  bioguide: S001183
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Darin LaHood
+  party: minority
+  rank: 4
+  bioguide: L000585
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Jodey C. Arrington
+  party: minority
+  rank: 5
+  bioguide: A000375
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: A. Drew Ferguson IV
+  party: minority
+  rank: 6
+  bioguide: F000465
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Mike Thompson
   party: majority
   rank: 1
   title: Chair
-  bioguide: B001260
-- name: George Holding
+  bioguide: T000460
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Lloyd Doggett
+  party: majority
+  rank: 2
+  bioguide: D000399
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: John B. Larson
+  party: majority
+  rank: 3
+  bioguide: L000557
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Linda T. Sánchez
+  party: majority
+  rank: 4
+  bioguide: S001156
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Suzan K. DelBene
+  party: majority
+  rank: 5
+  bioguide: D000617
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Gwen Moore
   party: majority
   rank: 6
-  bioguide: H001065
-- name: Jason Smith
+  bioguide: M001160
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Brendan F. Boyle
   party: majority
   rank: 7
-  bioguide: S001195
-- name: Tom Rice
+  bioguide: B001296
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Donald S. Beyer, Jr.
   party: majority
   rank: 8
-  bioguide: R000597
-- name: David Schweikert
+  bioguide: B001292
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Thomas R. Suozzi
   party: majority
   rank: 9
-  bioguide: S001183
-- name: Lloyd Doggett
+  bioguide: S001201
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+HSWM06:
+- name: Mike Kelly
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: D000399
-- name: John B. Larson
-  party: minority
-  rank: 2
-  bioguide: L000557
-- name: Linda T. Sánchez
-  party: minority
-  rank: 3
-  bioguide: S001156
-- name: Mike Thompson
-  party: minority
-  rank: 4
-  bioguide: T000460
-- name: Suzan K. DelBene
-  party: minority
-  rank: 5
-  bioguide: D000617
-- name: Earl Blumenauer
-  party: minority
-  rank: 6
-  bioguide: B000574
-HSWM06:
+  bioguide: K000376
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
 - name: Jackie Walorski
-  party: majority
+  party: minority
   rank: 2
   bioguide: W000813
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
 - name: Darin LaHood
-  party: majority
-  rank: 5
-  bioguide: L000585
-- name: Brad R. Wenstrup
-  party: majority
-  rank: 6
-  bioguide: W000815
-- name: Kenny Marchant
-  party: majority
-  rank: 7
-  bioguide: M001158
-- name: John Lewis
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000287
-- name: Suzan K. DelBene
   party: minority
   rank: 3
-  bioguide: D000617
-- name: Earl Blumenauer
+  bioguide: L000585
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Brad R. Wenstrup
   party: minority
   rank: 4
-  bioguide: B000574
+  bioguide: W000815
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: John Lewis
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000287
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Linda T. Sánchez
+  party: majority
+  rank: 2
+  bioguide: S001156
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Suzan K. DelBene
+  party: majority
+  rank: 3
+  bioguide: D000617
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Judy Chu
+  party: majority
+  rank: 4
+  bioguide: C001080
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Gwen Moore
+  party: majority
+  rank: 5
+  bioguide: M001160
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Brendan F. Boyle
+  party: majority
+  rank: 6
+  bioguide: B001296
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Thomas R. Suozzi
+  party: majority
+  rank: 7
+  bioguide: S001201
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
 JCSE:
 - name: Roger F. Wicker
   party: majority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -10193,6 +10193,7 @@ JCSE:
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
+  title: Ranking Member
   bioguide: C000141
   chamber: senate
 - name: Sheldon Whitehouse
@@ -10210,32 +10211,6 @@ JCSE:
   rank: 4
   bioguide: S001181
   chamber: senate
-- name: Christopher H. Smith
-  party: majority
-  rank: 1
-  title: Co-Chairman
-  bioguide: S000522
-  chamber: house
-- name: Robert Aderholt
-  party: majority
-  rank: 3
-  bioguide: A000055
-  chamber: house
-- name: Michael C. Burgess
-  party: majority
-  rank: 4
-  bioguide: B001248
-  chamber: house
-- name: Alcee L. Hastings
-  party: minority
-  rank: 1
-  bioguide: H000324
-  chamber: house
-- name: Steve Cohen
-  party: minority
-  rank: 3
-  bioguide: C001068
-  chamber: house
 JSEC:
 - name: Mike Lee
   party: majority
@@ -10288,32 +10263,6 @@ JSEC:
   rank: 4
   bioguide: H001076
   chamber: senate
-- name: Kevin Brady
-  party: majority
-  rank: 1
-  bioguide: B000755
-  title: Chairman
-  chamber: house
-- name: Sean P. Duffy
-  party: majority
-  rank: 3
-  bioguide: D000614
-  chamber: house
-- name: Justin Amash
-  party: majority
-  rank: 4
-  bioguide: A000367
-  chamber: house
-- name: Carolyn B. Maloney
-  party: minority
-  rank: 1
-  bioguide: M000087
-  chamber: house
-- name: Elijah E. Cummings
-  party: minority
-  rank: 3
-  bioguide: C000984
-  chamber: house
 JSLC:
 - name: Roy Blunt
   party: majority
@@ -10341,16 +10290,6 @@ JSLC:
   rank: 2
   bioguide: L000174
   chamber: senate
-- name: Tom Cole
-  party: majority
-  rank: 3
-  bioguide: C001053
-  chamber: house
-- name: Zoe Lofgren
-  party: minority
-  rank: 2
-  bioguide: L000397
-  chamber: house
 JSPR:
 - name: Roy Blunt
   party: majority
@@ -10378,11 +10317,6 @@ JSPR:
   rank: 2
   bioguide: U000039
   chamber: senate
-- name: Juan Vargas
-  party: minority
-  rank: 2
-  bioguide: V000130
-  chamber: house
 JSTX:
 - name: Chuck Grassley
   party: majority
@@ -10404,11 +10338,6 @@ JSTX:
   rank: 2
   bioguide: S000770
   chamber: senate
-- name: Kevin Brady
-  party: majority
-  rank: 3
-  bioguide: B000755
-  chamber: house
 SCNC:
 - name: Chuck Grassley
   party: majority
@@ -10480,10 +10409,10 @@ SLIA:
   party: majority
   rank: 5
   bioguide: D000618
-- name: Mike Crapo
+- name: Martha McSally
   party: majority
   rank: 6
-  bioguide: C000880
+  bioguide: M001197
 - name: Jerry Moran
   party: majority
   rank: 7
@@ -10535,18 +10464,18 @@ SLIN:
   party: majority
   rank: 5
   bioguide: B000575
-- name: James Lankford
-  party: majority
-  rank: 6
-  bioguide: L000575
 - name: Tom Cotton
   party: majority
-  rank: 7
+  rank: 6
   bioguide: C001095
 - name: John Cornyn
   party: majority
-  rank: 8
+  rank: 7
   bioguide: C001056
+- name: Ben Sasse
+  party: majority
+  rank: 8
+  bioguide: S001197
 - name: Mitch McConnell
   party: majority
   rank: 9
@@ -10578,14 +10507,14 @@ SLIN:
   party: minority
   rank: 5
   bioguide: K000383
-- name: Joe Manchin, III
-  party: minority
-  rank: 6
-  bioguide: M001183
 - name: Kamala D. Harris
   party: minority
-  rank: 7
+  rank: 6
   bioguide: H001075
+- name: Michael F. Bennet
+  party: minority
+  rank: 7
+  bioguide: B001267
 - name: Charles E. Schumer
   party: minority
   rank: 8
@@ -10604,24 +10533,32 @@ SPAG:
   bioguide: C001035
 - name: Tim Scott
   party: majority
-  rank: 4
+  rank: 2
   bioguide: S001184
-- name: Thom Tillis
-  party: majority
-  rank: 5
-  bioguide: T000476
 - name: Richard Burr
   party: majority
-  rank: 7
+  rank: 3
   bioguide: B001135
+- name: Martha McSally
+  party: majority
+  rank: 4
+  bioguide: M001197
 - name: Marco Rubio
   party: majority
-  rank: 8
+  rank: 5
   bioguide: R000595
-- name: Deb Fischer
+- name: Josh Hawley
   party: majority
-  rank: 9
-  bioguide: F000463
+  rank: 6
+  bioguide: H001089
+- name: Mike Braun
+  party: majority
+  rank: 7
+  bioguide: B001310
+- name: Rick Scott
+  party: majority
+  rank: 8
+  bioguide: S001217
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
@@ -10629,192 +10566,244 @@ SPAG:
   bioguide: C001070
 - name: Kirsten E. Gillibrand
   party: minority
-  rank: 3
+  rank: 2
   bioguide: G000555
 - name: Richard Blumenthal
   party: minority
-  rank: 4
+  rank: 3
   bioguide: B001277
 - name: Elizabeth Warren
   party: minority
-  rank: 6
+  rank: 4
   bioguide: W000817
-- name: Catherine Cortez Masto
-  party: minority
-  rank: 7
-  bioguide: C001113
 - name: Doug Jones
   party: minority
-  rank: 8
+  rank: 5
   bioguide: J000300
+- name: Kyrsten Sinema
+  party: minority
+  rank: 6
+  bioguide: S001191
+- name: Jacky Rosen
+  party: minority
+  rank: 7
+  bioguide: R000608
 SSAF:
 - name: Pat Roberts
   party: majority
   rank: 1
   title: Chairman
   bioguide: R000307
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Hoeven
   party: majority
   rank: 4
   bioguide: H001061
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Joni Ernst
   party: majority
   rank: 5
   bioguide: E000295
-- name: Chuck Grassley
-  party: majority
-  rank: 6
-  bioguide: G000386
-- name: John Thune
-  party: majority
-  rank: 7
-  bioguide: T000250
-- name: Steve Daines
-  party: majority
-  rank: 8
-  bioguide: D000618
-- name: David Perdue
-  party: majority
-  rank: 9
-  bioguide: P000612
-- name: Deb Fischer
-  party: majority
-  rank: 10
-  bioguide: F000463
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Cindy Hyde-Smith
   party: majority
-  rank: 11
+  rank: 6
   bioguide: H001079
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mike Braun
+  party: majority
+  rank: 7
+  bioguide: B001310
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: David Perdue
+  party: majority
+  rank: 8
+  bioguide: P000612
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Chuck Grassley
+  party: majority
+  rank: 9
+  bioguide: G000386
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: John Thune
+  party: majority
+  rank: 10
+  bioguide: T000250
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Deb Fischer
+  party: majority
+  rank: 11
+  bioguide: F000463
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000770
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Sherrod Brown
   party: minority
   rank: 3
   bioguide: B000944
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Amy Klobuchar
   party: minority
   rank: 4
   bioguide: K000367
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Michael F. Bennet
   party: minority
   rank: 5
   bioguide: B001267
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
   bioguide: G000555
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 7
   bioguide: C001070
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tina Smith
   party: minority
   rank: 8
   bioguide: S001203
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard J. Durbin
   party: minority
   rank: 9
   bioguide: D000563
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSAF13:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
   bioguide: B001236
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: John Hoeven
   party: majority
   rank: 2
   bioguide: H001061
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Chuck Grassley
   party: majority
   rank: 3
   bioguide: G000386
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: John Thune
   party: majority
   rank: 4
   bioguide: T000250
-- name: Steve Daines
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
+- name: Cindy Hyde-Smith
   party: majority
   rank: 5
-  bioguide: D000618
+  bioguide: H001079
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: David Perdue
   party: majority
   rank: 6
   bioguide: P000612
-- name: Cindy Hyde-Smith
-  party: majority
-  rank: 7
-  bioguide: H001079
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Pat Roberts
   party: majority
-  rank: 8
+  rank: 7
   title: Ex Officio
   bioguide: R000307
 - name: Sherrod Brown
   party: minority
-  rank: 2
+  rank: 1
+  title: Ranking Member
   bioguide: B000944
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Michael F. Bennet
   party: minority
-  rank: 3
+  rank: 2
   bioguide: B001267
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Kirsten E. Gillibrand
   party: minority
-  rank: 4
+  rank: 3
   bioguide: G000555
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Tina Smith
   party: minority
-  rank: 6
+  rank: 4
   bioguide: S001203
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Debbie Stabenow
   party: minority
-  rank: 7
+  rank: 5
   title: Ex Officio
   bioguide: S000770
 SSAF14:
-- name: Steve Daines
+- name: Mitch McConnell
   party: majority
   rank: 1
   title: Chairman
-  bioguide: D000618
-- name: Mitch McConnell
-  party: majority
-  rank: 2
   bioguide: M000355
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: John Boozman
   party: majority
-  rank: 3
+  rank: 2
   bioguide: B001236
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Chuck Grassley
   party: majority
-  rank: 4
+  rank: 3
   bioguide: G000386
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: David Perdue
   party: majority
-  rank: 5
+  rank: 4
   bioguide: P000612
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Cindy Hyde-Smith
   party: majority
-  rank: 6
+  rank: 5
   bioguide: H001079
+  source: https://www.agriculture.senate.gov/about/subcommittees/#risk
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 6
   title: Ex Officio
   bioguide: R000307
 - name: Michael F. Bennet
@@ -10832,11 +10821,11 @@ SSAF14:
   bioguide: K000367
 - name: Robert P. Casey, Jr.
   party: minority
-  rank: 5
+  rank: 4
   bioguide: C001070
 - name: Debbie Stabenow
   party: minority
-  rank: 6
+  rank: 5
   title: Ex Officio
   bioguide: S000770
 SSAF15:
@@ -10857,21 +10846,17 @@ SSAF15:
   party: majority
   rank: 4
   bioguide: T000250
-- name: Steve Daines
-  party: majority
-  rank: 5
-  bioguide: D000618
 - name: Deb Fischer
   party: majority
-  rank: 6
+  rank: 5
   bioguide: F000463
 - name: Cindy Hyde-Smith
   party: majority
-  rank: 7
+  rank: 6
   bioguide: H001079
 - name: Pat Roberts
   party: majority
-  rank: 8
+  rank: 7
   title: Ex Officio
   bioguide: R000307
 - name: Tina Smith
@@ -10893,7 +10878,7 @@ SSAF15:
   bioguide: B001267
 - name: Debbie Stabenow
   party: minority
-  rank: 7
+  rank: 5
   title: Ex Officio
   bioguide: S000770
 SSAF16:
@@ -10975,13 +10960,9 @@ SSAF17:
   party: majority
   rank: 5
   bioguide: T000250
-- name: Steve Daines
-  party: majority
-  rank: 6
-  bioguide: D000618
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 6
   title: Ex Officio
   bioguide: R000307
 - name: Kirsten E. Gillibrand
@@ -10999,11 +10980,11 @@ SSAF17:
   bioguide: K000367
 - name: Robert P. Casey, Jr.
   party: minority
-  rank: 5
+  rank: 4
   bioguide: C001070
 - name: Debbie Stabenow
   party: minority
-  rank: 6
+  rank: 5
   title: Ex Officio
   bioguide: S000770
 SSAP:
@@ -11012,127 +10993,189 @@ SSAP:
   rank: 1
   title: Chairman
   bioguide: S000320
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Lamar Alexander
   party: majority
   rank: 3
   bioguide: A000360
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Susan M. Collins
   party: majority
   rank: 4
   bioguide: C001035
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Lisa Murkowski
   party: majority
   rank: 5
   bioguide: M001153
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Lindsey Graham
   party: majority
   rank: 6
   bioguide: G000359
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Roy Blunt
   party: majority
   rank: 7
   bioguide: B000575
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Jerry Moran
   party: majority
   rank: 8
   bioguide: M000934
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Hoeven
   party: majority
   rank: 9
   bioguide: H001061
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Boozman
   party: majority
   rank: 10
   bioguide: B001236
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Shelley Moore Capito
   party: majority
   rank: 11
   bioguide: C001047
-- name: James Lankford
-  party: majority
-  rank: 12
-  bioguide: L000575
-- name: Steve Daines
-  party: majority
-  rank: 13
-  bioguide: D000618
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Kennedy
   party: majority
-  rank: 14
+  rank: 12
   bioguide: K000393
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Cindy Hyde-Smith
+  party: majority
+  rank: 13
+  bioguide: H001079
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Steve Daines
+  party: majority
+  rank: 14
+  bioguide: D000618
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Marco Rubio
   party: majority
   rank: 15
   bioguide: R000595
-- name: Cindy Hyde-Smith
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: James Lankford
   party: majority
   rank: 16
-  bioguide: H001079
+  bioguide: L000575
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Patrick J. Leahy
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: L000174
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Dianne Feinstein
   party: minority
   rank: 3
   bioguide: F000062
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard J. Durbin
   party: minority
   rank: 4
   bioguide: D000563
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jack Reed
   party: minority
   rank: 5
   bioguide: R000122
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jon Tester
   party: minority
   rank: 6
   bioguide: T000464
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tom Udall
   party: minority
   rank: 7
   bioguide: U000039
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeanne Shaheen
   party: minority
   rank: 8
   bioguide: S001181
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeff Merkley
   party: minority
   rank: 9
   bioguide: M001176
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Christopher A. Coons
   party: minority
   rank: 10
   bioguide: C001088
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Brian Schatz
   party: minority
   rank: 11
   bioguide: S001194
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tammy Baldwin
   party: minority
   rank: 12
   bioguide: B001230
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Christopher Murphy
   party: minority
   rank: 13
   bioguide: M001169
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Joe Manchin, III
   party: minority
   rank: 14
   bioguide: M001183
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Chris Van Hollen
   party: minority
   rank: 15
   bioguide: V000128
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSAP01:
 - name: John Hoeven
   party: majority
@@ -11155,14 +11198,14 @@ SSAP01:
   party: majority
   rank: 5
   bioguide: M000934
-- name: Marco Rubio
-  party: majority
-  rank: 6
-  bioguide: R000595
 - name: Cindy Hyde-Smith
   party: majority
-  rank: 7
+  rank: 6
   bioguide: H001079
+- name: John Kennedy
+  party: majority
+  rank: 7
+  bioguide: K000393
 - name: Richard C. Shelby
   party: majority
   rank: 8
@@ -11223,18 +11266,18 @@ SSAP02:
   party: majority
   rank: 7
   bioguide: B000575
-- name: Steve Daines
-  party: majority
-  rank: 8
-  bioguide: D000618
 - name: Jerry Moran
   party: majority
-  rank: 9
+  rank: 8
   bioguide: M000934
 - name: John Hoeven
   party: majority
-  rank: 10
+  rank: 9
   bioguide: H001061
+- name: John Boozman
+  party: majority
+  rank: 10
+  bioguide: B001236
 - name: Richard J. Durbin
   party: minority
   rank: 1
@@ -11273,19 +11316,19 @@ SSAP02:
   rank: 9
   bioguide: B001230
 SSAP08:
-- name: Steve Daines
+- name: Cindy Hyde-Smith
   party: majority
   rank: 1
   title: Chairman
-  bioguide: D000618
-- name: Cindy Hyde-Smith
-  party: majority
-  rank: 2
   bioguide: H001079
 - name: Richard C. Shelby
   party: majority
-  rank: 3
+  rank: 2
   bioguide: S000320
+- name: James Lankford
+  party: majority
+  rank: 3
+  bioguide: L000575
 - name: Christopher Murphy
   party: minority
   rank: 1
@@ -11314,22 +11357,22 @@ SSAP14:
   party: majority
   rank: 3
   bioguide: M001153
-- name: John Boozman
-  party: majority
-  rank: 4
-  bioguide: B001236
 - name: John Hoeven
   party: majority
-  rank: 5
+  rank: 4
   bioguide: H001061
-- name: James Lankford
-  party: majority
-  rank: 6
-  bioguide: L000575
 - name: John Kennedy
   party: majority
-  rank: 7
+  rank: 5
   bioguide: K000393
+- name: Cindy Hyde-Smith
+  party: majority
+  rank: 6
+  bioguide: H001079
+- name: James Lankford
+  party: majority
+  rank: 7
+  bioguide: L000575
 - name: Jon Tester
   party: minority
   rank: 1
@@ -11385,14 +11428,14 @@ SSAP16:
   party: majority
   rank: 7
   bioguide: C001047
-- name: James Lankford
-  party: majority
-  rank: 8
-  bioguide: L000575
 - name: John Kennedy
   party: majority
-  rank: 9
+  rank: 8
   bioguide: K000393
+- name: Marco Rubio
+  party: majority
+  rank: 9
+  bioguide: R000595
 - name: Richard C. Shelby
   party: majority
   rank: 10
@@ -11449,22 +11492,22 @@ SSAP17:
   party: majority
   rank: 4
   bioguide: M000355
-- name: Steve Daines
-  party: majority
-  rank: 5
-  bioguide: D000618
 - name: Shelley Moore Capito
   party: majority
-  rank: 6
+  rank: 5
   bioguide: C001047
-- name: Marco Rubio
-  party: majority
-  rank: 7
-  bioguide: R000595
 - name: Cindy Hyde-Smith
   party: majority
-  rank: 8
+  rank: 6
   bioguide: H001079
+- name: Steve Daines
+  party: majority
+  rank: 7
+  bioguide: D000618
+- name: Marco Rubio
+  party: majority
+  rank: 8
+  bioguide: R000595
 - name: Richard C. Shelby
   party: majority
   rank: 9
@@ -11525,22 +11568,22 @@ SSAP18:
   party: majority
   rank: 6
   bioguide: C001047
-- name: James Lankford
-  party: majority
-  rank: 7
-  bioguide: L000575
 - name: John Kennedy
   party: majority
-  rank: 8
+  rank: 7
   bioguide: K000393
+- name: Cindy Hyde-Smith
+  party: majority
+  rank: 8
+  bioguide: H001079
 - name: Marco Rubio
   party: majority
   rank: 9
   bioguide: R000595
-- name: Cindy Hyde-Smith
+- name: James Lankford
   party: majority
   rank: 10
-  bioguide: H001079
+  bioguide: L000575
 - name: Patty Murray
   party: minority
   rank: 1
@@ -11609,14 +11652,14 @@ SSAP19:
   party: majority
   rank: 6
   bioguide: C001047
-- name: Jerry Moran
-  party: majority
-  rank: 7
-  bioguide: M000934
 - name: Marco Rubio
   party: majority
-  rank: 8
+  rank: 7
   bioguide: R000595
+- name: Steve Daines
+  party: majority
+  rank: 8
+  bioguide: D000618
 - name: Richard C. Shelby
   party: majority
   rank: 9
@@ -11674,22 +11717,22 @@ SSAP20:
   party: majority
   rank: 4
   bioguide: B001236
-- name: James Lankford
+- name: Jerry Moran
   party: majority
   rank: 5
+  bioguide: M000934
+- name: Marco Rubio
+  party: majority
+  rank: 6
+  bioguide: R000595
+- name: James Lankford
+  party: majority
+  rank: 7
   bioguide: L000575
 - name: Steve Daines
   party: majority
-  rank: 6
-  bioguide: D000618
-- name: Marco Rubio
-  party: majority
-  rank: 7
-  bioguide: R000595
-- name: Cindy Hyde-Smith
-  party: majority
   rank: 8
-  bioguide: H001079
+  bioguide: D000618
 - name: Richard C. Shelby
   party: majority
   rank: 9
@@ -11758,10 +11801,10 @@ SSAP22:
   party: majority
   rank: 8
   bioguide: K000393
-- name: James Lankford
+- name: Cindy Hyde-Smith
   party: majority
   rank: 9
-  bioguide: L000575
+  bioguide: H001079
 - name: Dianne Feinstein
   party: minority
   rank: 1
@@ -11801,11 +11844,11 @@ SSAP22:
   title: Ex Officio
   bioguide: L000174
 SSAP23:
-- name: James Lankford
+- name: John Kennedy
   party: majority
   rank: 1
   title: Chairman
-  bioguide: L000575
+  bioguide: K000393
 - name: Jerry Moran
   party: majority
   rank: 2
@@ -11818,10 +11861,10 @@ SSAP23:
   party: majority
   rank: 4
   bioguide: D000618
-- name: John Kennedy
+- name: James Lankford
   party: majority
   rank: 5
-  bioguide: K000393
+  bioguide: L000575
 - name: Richard C. Shelby
   party: majority
   rank: 6
@@ -11875,18 +11918,18 @@ SSAP24:
   party: majority
   rank: 6
   bioguide: C001047
-- name: Steve Daines
-  party: majority
-  rank: 7
-  bioguide: D000618
 - name: Lindsey Graham
   party: majority
-  rank: 8
+  rank: 7
   bioguide: G000359
 - name: John Hoeven
   party: majority
-  rank: 9
+  rank: 8
   bioguide: H001061
+- name: Steve Daines
+  party: majority
+  rank: 9
+  bioguide: D000618
 - name: Jack Reed
   party: minority
   rank: 1
@@ -11931,129 +11974,187 @@ SSAS:
   rank: 1
   title: Chairman
   bioguide: I000024
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Roger F. Wicker
   party: majority
   rank: 2
   bioguide: W000437
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Deb Fischer
   party: majority
   rank: 3
   bioguide: F000463
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tom Cotton
   party: majority
   rank: 4
   bioguide: C001095
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Rounds
   party: majority
   rank: 5
   bioguide: R000605
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Joni Ernst
   party: majority
   rank: 6
   bioguide: E000295
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Thom Tillis
   party: majority
   rank: 7
   bioguide: T000476
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Dan Sullivan
   party: majority
   rank: 8
   bioguide: S001198
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: David Perdue
   party: majority
   rank: 9
   bioguide: P000612
-- name: Ted Cruz
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Kevin Cramer
   party: majority
   rank: 10
-  bioguide: C001098
-- name: Lindsey Graham
+  bioguide: C001096
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Martha McSally
   party: majority
   rank: 11
-  bioguide: G000359
-- name: Ben Sasse
+  bioguide: M001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Rick Scott
   party: majority
   rank: 12
-  bioguide: S001197
-- name: Tim Scott
+  bioguide: S001217
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Marsha Blackburn
   party: majority
   rank: 13
-  bioguide: S001184
+  bioguide: B001243
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Josh Hawley
+  party: majority
+  rank: 14
+  bioguide: H001089
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: R000122
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeanne Shaheen
   party: minority
   rank: 2
   bioguide: S001181
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 3
   bioguide: G000555
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard Blumenthal
   party: minority
   rank: 4
   bioguide: B001277
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mazie K. Hirono
   party: minority
   rank: 5
   bioguide: H001042
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tim Kaine
   party: minority
   rank: 6
   bioguide: K000384
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Angus S. King, Jr.
   party: minority
   rank: 7
   bioguide: K000383
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Martin Heinrich
   party: minority
   rank: 8
   bioguide: H001046
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Elizabeth Warren
   party: minority
   rank: 9
   bioguide: W000817
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Gary C. Peters
   party: minority
   rank: 10
   bioguide: P000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Joe Manchin, III
   party: minority
   rank: 11
   bioguide: M001183
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tammy Duckworth
   party: minority
   rank: 12
   bioguide: D000622
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Doug Jones
   party: minority
   rank: 13
   bioguide: J000300
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSAS13:
-- name: Roger F. Wicker
+- name: David Perdue
   party: majority
   rank: 1
   title: Chairman
+  bioguide: P000612
+- name: Roger F. Wicker
+  party: majority
+  rank: 2
   bioguide: W000437
 - name: Tom Cotton
   party: majority
-  rank: 2
-  bioguide: C001095
-- name: Mike Rounds
-  party: majority
   rank: 3
-  bioguide: R000605
-- name: Thom Tillis
+  bioguide: C001095
+- name: Joni Ernst
   party: majority
   rank: 4
-  bioguide: T000476
-- name: Tim Scott
+  bioguide: E000295
+- name: Thom Tillis
   party: majority
   rank: 5
-  bioguide: S001184
+  bioguide: T000476
 - name: James M. Inhofe
   party: majority
   rank: 6
@@ -12103,17 +12204,21 @@ SSAS14:
   party: majority
   rank: 4
   bioguide: S001198
-- name: Ted Cruz
+- name: Kevin Cramer
   party: majority
   rank: 5
-  bioguide: C001098
-- name: Ben Sasse
+  bioguide: C001096
+- name: Martha McSally
   party: majority
   rank: 6
-  bioguide: S001197
-- name: James M. Inhofe
+  bioguide: M001197
+- name: Rick Scott
   party: majority
   rank: 7
+  bioguide: S001217
+- name: James M. Inhofe
+  party: majority
+  rank: 8
   title: Ex Officio
   bioguide: I000024
 - name: Angus S. King, Jr.
@@ -12123,16 +12228,24 @@ SSAS14:
   bioguide: K000383
 - name: Richard Blumenthal
   party: minority
-  rank: 3
+  rank: 2
   bioguide: B001277
 - name: Elizabeth Warren
   party: minority
-  rank: 5
+  rank: 3
   bioguide: W000817
 - name: Gary C. Peters
   party: minority
-  rank: 6
+  rank: 4
   bioguide: P000595
+- name: Tammy Duckworth
+  party: minority
+  rank: 5
+  bioguide: D000622
+- name: Doug Jones
+  party: minority
+  rank: 6
+  bioguide: J000300
 - name: Jack Reed
   party: minority
   rank: 7
@@ -12144,10 +12257,10 @@ SSAS15:
   rank: 1
   title: Chairman
   bioguide: S001198
-- name: Mike Rounds
+- name: Deb Fischer
   party: majority
   rank: 2
-  bioguide: R000605
+  bioguide: F000463
 - name: Joni Ernst
   party: majority
   rank: 3
@@ -12156,9 +12269,17 @@ SSAS15:
   party: majority
   rank: 4
   bioguide: P000612
-- name: James M. Inhofe
+- name: Martha McSally
   party: majority
   rank: 5
+  bioguide: M001197
+- name: Marsha Blackburn
+  party: majority
+  rank: 6
+  bioguide: B001243
+- name: James M. Inhofe
+  party: majority
+  rank: 7
   title: Ex Officio
   bioguide: I000024
 - name: Tim Kaine
@@ -12174,9 +12295,17 @@ SSAS15:
   party: minority
   rank: 3
   bioguide: H001042
-- name: Jack Reed
+- name: Tammy Duckworth
   party: minority
   rank: 4
+  bioguide: D000622
+- name: Doug Jones
+  party: minority
+  rank: 5
+  bioguide: J000300
+- name: Jack Reed
+  party: minority
+  rank: 6
   title: Ex Officio
   bioguide: R000122
 SSAS16:
@@ -12189,18 +12318,22 @@ SSAS16:
   party: majority
   rank: 2
   bioguide: C001095
-- name: Dan Sullivan
+- name: Mike Rounds
   party: majority
   rank: 3
-  bioguide: S001198
-- name: Ted Cruz
+  bioguide: R000605
+- name: Dan Sullivan
   party: majority
   rank: 4
-  bioguide: C001098
-- name: Lindsey Graham
+  bioguide: S001198
+- name: Kevin Cramer
   party: majority
   rank: 5
-  bioguide: G000359
+  bioguide: C001096
+- name: Josh Hawley
+  party: majority
+  rank: 6
+  bioguide: H001089
 - name: James M. Inhofe
   party: majority
   rank: 6
@@ -12208,16 +12341,25 @@ SSAS16:
   bioguide: I000024
 - name: Martin Heinrich
   party: minority
-  rank: 2
+  rank: 1
+  title: Ranking Member
   bioguide: H001046
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 2
+  bioguide: K000383
 - name: Elizabeth Warren
   party: minority
   rank: 3
   bioguide: W000817
-- name: Gary C. Peters
+- name: Joe Manchin, III
   party: minority
   rank: 4
-  bioguide: P000595
+  bioguide: M001183
+- name: Doug Jones
+  party: minority
+  rank: 5
+  bioguide: J000300
 - name: Jack Reed
   party: minority
   rank: 5
@@ -12229,18 +12371,18 @@ SSAS17:
   rank: 1
   title: Chairman
   bioguide: T000476
-- name: Joni Ernst
+- name: Mike Rounds
   party: majority
   rank: 2
-  bioguide: E000295
-- name: Lindsey Graham
+  bioguide: R000605
+- name: Martha McSally
   party: majority
   rank: 3
-  bioguide: G000359
-- name: Ben Sasse
+  bioguide: M001197
+- name: Rick Scott
   party: majority
   rank: 4
-  bioguide: S001197
+  bioguide: S001217
 - name: James M. Inhofe
   party: majority
   rank: 5
@@ -12253,8 +12395,12 @@ SSAS17:
   bioguide: G000555
 - name: Elizabeth Warren
   party: minority
-  rank: 3
+  rank: 2
   bioguide: W000817
+- name: Tammy Duckworth
+  party: minority
+  rank: 3
+  bioguide: D000622
 - name: Jack Reed
   party: minority
   rank: 4
@@ -12266,44 +12412,44 @@ SSAS20:
   rank: 1
   title: Chairman
   bioguide: E000295
-- name: Roger F. Wicker
-  party: majority
-  rank: 2
-  bioguide: W000437
 - name: Deb Fischer
   party: majority
-  rank: 3
+  rank: 2
   bioguide: F000463
-- name: David Perdue
+- name: Kevin Cramer
+  party: majority
+  rank: 3
+  bioguide: C001096
+- name: Marsha Blackburn
   party: majority
   rank: 4
-  bioguide: P000612
-- name: Ted Cruz
+  bioguide: B001243
+- name: Josh Hawley
   party: majority
   rank: 5
-  bioguide: C001098
-- name: Tim Scott
-  party: majority
-  rank: 6
-  bioguide: S001184
+  bioguide: H001089
 - name: James M. Inhofe
   party: majority
-  rank: 7
+  rank: 6
   title: Ex Officio
   bioguide: I000024
-- name: Martin Heinrich
+- name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: H001046
+  bioguide: P000595
 - name: Jeanne Shaheen
   party: minority
-  rank: 3
+  rank: 2
   bioguide: S001181
-- name: Gary C. Peters
+- name: Martin Heinrich
+  party: minority
+  rank: 3
+  bioguide: H001046
+- name: Mazie K. Hirono
   party: minority
   rank: 4
-  bioguide: P000595
+  bioguide: H001042
 - name: Jack Reed
   party: minority
   rank: 5
@@ -12315,35 +12461,44 @@ SSAS21:
   rank: 1
   title: Chairman
   bioguide: R000605
-- name: Deb Fischer
+- name: Roger F. Wicker
   party: majority
   rank: 2
-  bioguide: F000463
+  bioguide: W000437
 - name: David Perdue
   party: majority
   rank: 3
   bioguide: P000612
-- name: Lindsey Graham
+- name: Rick Scott
   party: majority
   rank: 4
-  bioguide: G000359
-- name: Ben Sasse
+  bioguide: S001217
+- name: Marsha Blackburn
   party: majority
   rank: 5
-  bioguide: S001197
+  bioguide: B001243
 - name: James M. Inhofe
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: I000024
+- name: Joe Manchin, III
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001183
 - name: Kirsten E. Gillibrand
   party: minority
-  rank: 3
+  rank: 2
   bioguide: G000555
 - name: Richard Blumenthal
   party: minority
-  rank: 4
+  rank: 3
   bioguide: B001277
+- name: Martin Heinrich
+  party: minority
+  rank: 4
+  bioguide: H001046
 - name: Jack Reed
   party: minority
   rank: 5
@@ -12355,726 +12510,1062 @@ SSBK:
   rank: 1
   title: Chairman
   bioguide: C000880
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Patrick J. Toomey
   party: majority
-  rank: 4
+  rank: 3
   bioguide: T000461
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tim Scott
   party: majority
-  rank: 6
+  rank: 4
   bioguide: S001184
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ben Sasse
   party: majority
-  rank: 7
+  rank: 5
   bioguide: S001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tom Cotton
   party: majority
-  rank: 8
+  rank: 6
   bioguide: C001095
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Rounds
   party: majority
-  rank: 9
+  rank: 7
   bioguide: R000605
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: David Perdue
   party: majority
-  rank: 10
+  rank: 8
   bioguide: P000612
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Thom Tillis
   party: majority
-  rank: 11
+  rank: 9
   bioguide: T000476
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Kennedy
   party: majority
-  rank: 12
+  rank: 10
   bioguide: K000393
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Martha McSally
+  party: majority
+  rank: 11
+  bioguide: M001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Jerry Moran
   party: majority
-  rank: 13
+  rank: 12
   bioguide: M000934
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Kevin Cramer
+  party: majority
+  rank: 13
+  bioguide: C001096
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B000944
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Robert Menendez
   party: minority
   rank: 3
   bioguide: M000639
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jon Tester
   party: minority
   rank: 4
   bioguide: T000464
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mark R. Warner
   party: minority
   rank: 5
   bioguide: W000805
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Elizabeth Warren
   party: minority
   rank: 6
   bioguide: W000817
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Brian Schatz
   party: minority
-  rank: 9
+  rank: 7
   bioguide: S001194
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Chris Van Hollen
   party: minority
-  rank: 10
+  rank: 8
   bioguide: V000128
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Catherine Cortez Masto
   party: minority
-  rank: 11
+  rank: 9
   bioguide: C001113
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Doug Jones
   party: minority
-  rank: 12
+  rank: 10
   bioguide: J000300
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Tina Smith
+  party: minority
+  rank: 11
+  bioguide: S001203
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Kyrsten Sinema
+  party: minority
+  rank: 12
+  bioguide: S001191
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSBK04:
+- name: Patrick J. Toomey
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: T000461
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
-- name: Patrick J. Toomey
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Martha McSally
   party: majority
-  rank: 4
-  bioguide: T000461
+  rank: 3
+  bioguide: M001197
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Tim Scott
   party: majority
-  rank: 5
+  rank: 4
   bioguide: S001184
-- name: Ben Sasse
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Tom Cotton
   party: majority
-  rank: 6
-  bioguide: S001197
+  rank: 5
+  bioguide: C001095
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mike Rounds
   party: majority
-  rank: 7
+  rank: 6
   bioguide: R000605
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: David Perdue
+  party: majority
+  rank: 7
+  bioguide: P000612
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Thom Tillis
   party: majority
   rank: 8
   bioguide: T000476
-- name: Jerry Moran
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: John Kennedy
   party: majority
   rank: 9
-  bioguide: M000934
+  bioguide: K000393
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mike Crapo
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: C000880
-- name: Mark R. Warner
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Chris Van Hollen
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: W000805
+  bioguide: V000128
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Robert Menendez
   party: minority
   rank: 3
   bioguide: M000639
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Jon Tester
   party: minority
   rank: 4
   bioguide: T000464
-- name: Elizabeth Warren
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Mark R. Warner
   party: minority
   rank: 5
-  bioguide: W000817
-- name: Chris Van Hollen
+  bioguide: W000805
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Elizabeth Warren
   party: minority
   rank: 6
-  bioguide: V000128
-- name: Catherine Cortez Masto
+  bioguide: W000817
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Tina Smith
   party: minority
   rank: 7
-  bioguide: C001113
-- name: Doug Jones
+  bioguide: S001203
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Kyrsten Sinema
   party: minority
   rank: 8
-  bioguide: J000300
+  bioguide: S001191
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Sherrod Brown
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: B000944
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 SSBK05:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
   bioguide: S001197
-- name: Tom Cotton
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Martha McSally
+  party: majority
+  rank: 2
+  bioguide: M001197
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Jerry Moran
   party: majority
   rank: 3
-  bioguide: C001095
-- name: Mike Rounds
+  bioguide: M000934
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Patrick J. Toomey
   party: majority
   rank: 4
-  bioguide: R000605
-- name: David Perdue
+  bioguide: T000461
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Tim Scott
   party: majority
   rank: 5
-  bioguide: P000612
+  bioguide: S001184
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mike Crapo
   party: majority
   rank: 6
   title: Ex Officio
   bioguide: C000880
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mark R. Warner
   party: minority
-  rank: 2
+  rank: 1
+  title: Ranking Member
   bioguide: W000805
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Brian Schatz
   party: minority
-  rank: 4
+  rank: 2
   bioguide: S001194
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Chris Van Hollen
+  party: minority
+  rank: 3
+  bioguide: V000128
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Kyrsten Sinema
+  party: minority
+  rank: 4
+  bioguide: S001191
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
   bioguide: B000944
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 SSBK08:
-- name: Patrick J. Toomey
+- name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
-  bioguide: T000461
-- name: Richard C. Shelby
+  bioguide: S001184
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Mike Rounds
   party: majority
   rank: 2
-  bioguide: S000320
-- name: Tim Scott
+  bioguide: R000605
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Thom Tillis
   party: majority
-  rank: 5
-  bioguide: S001184
-- name: Ben Sasse
-  party: majority
-  rank: 6
-  bioguide: S001197
-- name: Tom Cotton
-  party: majority
-  rank: 7
-  bioguide: C001095
-- name: David Perdue
-  party: majority
-  rank: 8
-  bioguide: P000612
+  rank: 3
+  bioguide: T000476
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: John Kennedy
   party: majority
-  rank: 9
+  rank: 4
   bioguide: K000393
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Jerry Moran
+  party: majority
+  rank: 5
+  bioguide: M000934
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Kevin Cramer
+  party: majority
+  rank: 6
+  bioguide: C001096
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Richard C. Shelby
+  party: majority
+  rank: 7
+  bioguide: S000320
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Patrick J. Toomey
+  party: majority
+  rank: 8
+  bioguide: T000461
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Ben Sasse
+  party: majority
+  rank: 9
+  bioguide: S001197
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mike Crapo
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: C000880
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Elizabeth Warren
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000817
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Jon Tester
   party: minority
   rank: 3
   bioguide: T000464
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mark R. Warner
   party: minority
   rank: 4
   bioguide: W000805
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Brian Schatz
   party: minority
-  rank: 6
+  rank: 5
   bioguide: S001194
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Chris Van Hollen
   party: minority
-  rank: 7
+  rank: 6
   bioguide: V000128
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Catherine Cortez Masto
   party: minority
-  rank: 8
+  rank: 7
   bioguide: C001113
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Doug Jones
+  party: minority
+  rank: 9
+  bioguide: J000300
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Sherrod Brown
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: B000944
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 SSBK09:
-- name: Tim Scott
+- name: David Perdue
   party: majority
   rank: 1
   title: Chairman
-  bioguide: S001184
+  bioguide: P000612
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Richard C. Shelby
   party: majority
   rank: 2
   bioguide: S000320
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Tom Cotton
+  party: majority
+  rank: 3
+  bioguide: C001095
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mike Rounds
   party: majority
   rank: 4
   bioguide: R000605
-- name: Thom Tillis
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Martha McSally
   party: majority
   rank: 5
-  bioguide: T000476
-- name: John Kennedy
-  party: majority
-  rank: 6
-  bioguide: K000393
+  bioguide: M001197
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Jerry Moran
   party: majority
-  rank: 7
+  rank: 6
   bioguide: M000934
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Kevin Cramer
+  party: majority
+  rank: 7
+  bioguide: C001096
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mike Crapo
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: C000880
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M000639
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Jack Reed
   party: minority
   rank: 2
   bioguide: R000122
-- name: Brian Schatz
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Elizabeth Warren
+  party: minority
+  rank: 3
+  bioguide: W000817
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Catherine Cortez Masto
   party: minority
   rank: 4
-  bioguide: S001194
-- name: Chris Van Hollen
-  party: minority
-  rank: 5
-  bioguide: V000128
+  bioguide: C001113
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Doug Jones
   party: minority
-  rank: 6
+  rank: 5
   bioguide: J000300
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Tina Smith
+  party: minority
+  rank: 6
+  bioguide: S001203
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Sherrod Brown
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: B000944
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 SSBK12:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001095
-- name: Patrick J. Toomey
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Kevin Cramer
   party: majority
   rank: 2
-  bioguide: T000461
-- name: David Perdue
+  bioguide: C001096
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Ben Sasse
   party: majority
   rank: 3
-  bioguide: P000612
-- name: Thom Tillis
+  bioguide: S001197
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: David Perdue
   party: majority
   rank: 4
-  bioguide: T000476
-- name: John Kennedy
+  bioguide: P000612
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Thom Tillis
   party: majority
   rank: 5
-  bioguide: K000393
-- name: Jerry Moran
+  bioguide: T000476
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: John Kennedy
   party: majority
   rank: 6
-  bioguide: M000934
+  bioguide: K000393
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Mike Crapo
   party: majority
   rank: 7
   title: Ex Officio
   bioguide: C000880
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Catherine Cortez Masto
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001113
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Robert Menendez
   party: minority
   rank: 2
   bioguide: M000639
-- name: Elizabeth Warren
-  party: minority
-  rank: 3
-  bioguide: W000817
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Doug Jones
   party: minority
-  rank: 5
+  rank: 3
   bioguide: J000300
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Tina Smith
+  party: minority
+  rank: 4
+  bioguide: S001203
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
+- name: Kyrsten Sinema
+  party: minority
+  rank: 5
+  bioguide: S001191
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 - name: Sherrod Brown
   party: minority
   rank: 6
   title: Ex Officio
   bioguide: B000944
+  start_date: '2019-01-18'
+  source: https://www.banking.senate.gov/newsroom/press/chairman-crapo-and-ranking-member-brown-announce-banking-subcommittee-assignments-for-the-116th-congress
 SSBU:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
   bioguide: E000285
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Lindsey Graham
   party: majority
   rank: 4
   bioguide: G000359
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Patrick J. Toomey
   party: majority
   rank: 5
   bioguide: T000461
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ron Johnson
   party: majority
   rank: 6
   bioguide: J000293
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: David Perdue
   party: majority
-  rank: 8
+  rank: 7
   bioguide: P000612
-- name: Cory Gardner
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mike Braun
+  party: majority
+  rank: 8
+  bioguide: B001310
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Rick Scott
   party: majority
   rank: 9
-  bioguide: G000562
+  bioguide: S001217
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Kennedy
   party: majority
   rank: 10
   bioguide: K000393
-- name: John Boozman
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Kevin Cramer
   party: majority
   rank: 11
-  bioguide: B001236
-- name: Tom Cotton
-  party: majority
-  rank: 12
-  bioguide: C001095
+  bioguide: C001096
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000033
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Ron Wyden
   party: minority
   rank: 3
   bioguide: W000779
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Debbie Stabenow
   party: minority
   rank: 4
   bioguide: S000770
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Sheldon Whitehouse
   party: minority
   rank: 5
   bioguide: W000802
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mark R. Warner
   party: minority
   rank: 6
   bioguide: W000805
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeff Merkley
   party: minority
   rank: 7
   bioguide: M001176
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tim Kaine
   party: minority
   rank: 8
   bioguide: K000384
-- name: Angus S. King, Jr.
-  party: minority
-  rank: 9
-  bioguide: K000383
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Chris Van Hollen
   party: minority
-  rank: 10
+  rank: 9
   bioguide: V000128
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kamala D. Harris
   party: minority
-  rank: 11
+  rank: 10
   bioguide: H001075
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSCM:
-- name: John Thune
+- name: Roger F. Wicker
   party: majority
   rank: 1
   title: Chairman
-  bioguide: T000250
-- name: Roger F. Wicker
+  bioguide: W000437
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: John Thune
   party: majority
   rank: 2
-  bioguide: W000437
+  bioguide: T000250
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Roy Blunt
   party: majority
   rank: 3
   bioguide: B000575
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ted Cruz
   party: majority
   rank: 4
   bioguide: C001098
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Deb Fischer
   party: majority
   rank: 5
   bioguide: F000463
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Jerry Moran
   party: majority
   rank: 6
   bioguide: M000934
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Dan Sullivan
   party: majority
   rank: 7
   bioguide: S001198
-- name: James M. Inhofe
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Cory Gardner
+  party: majority
+  rank: 8
+  bioguide: G000562
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Marsha Blackburn
   party: majority
   rank: 9
-  bioguide: I000024
-- name: Mike Lee
+  bioguide: B001243
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Shelley Moore Capito
   party: majority
   rank: 10
+  bioguide: C001047
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mike Lee
+  party: majority
+  rank: 11
   bioguide: L000577
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ron Johnson
   party: majority
-  rank: 11
-  bioguide: J000293
-- name: Shelley Moore Capito
-  party: majority
   rank: 12
-  bioguide: C001047
-- name: Cory Gardner
+  bioguide: J000293
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Todd Young
   party: majority
   rank: 13
-  bioguide: G000562
-- name: Todd Young
+  bioguide: Y000064
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Rick Scott
   party: majority
   rank: 14
-  bioguide: Y000064
-- name: Maria Cantwell
-  party: minority
-  rank: 2
-  bioguide: C000127
-- name: Amy Klobuchar
-  party: minority
-  rank: 3
-  bioguide: K000367
-- name: Richard Blumenthal
-  party: minority
-  rank: 4
-  bioguide: B001277
-- name: Brian Schatz
-  party: minority
-  rank: 5
-  bioguide: S001194
-- name: Edward J. Markey
-  party: minority
-  rank: 6
-  bioguide: M000133
-- name: Tom Udall
-  party: minority
-  rank: 7
-  bioguide: U000039
-- name: Gary C. Peters
-  party: minority
-  rank: 8
-  bioguide: P000595
-- name: Tammy Baldwin
-  party: minority
-  rank: 9
-  bioguide: B001230
-- name: Tammy Duckworth
-  party: minority
-  rank: 10
-  bioguide: D000622
-- name: Margaret Wood Hassan
-  party: minority
-  rank: 11
-  bioguide: H001076
-- name: Catherine Cortez Masto
-  party: minority
-  rank: 12
-  bioguide: C001113
-- name: Jon Tester
-  party: minority
-  rank: 13
-  bioguide: T000464
-SSCM01:
-- name: Roy Blunt
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: B000575
-- name: Roger F. Wicker
-  party: majority
-  rank: 2
-  bioguide: W000437
-- name: Ted Cruz
-  party: majority
-  rank: 3
-  bioguide: C001098
-- name: Deb Fischer
-  party: majority
-  rank: 4
-  bioguide: F000463
-- name: Jerry Moran
-  party: majority
-  rank: 5
-  bioguide: M000934
-- name: Dan Sullivan
-  party: majority
-  rank: 6
-  bioguide: S001198
-- name: James M. Inhofe
-  party: majority
-  rank: 8
-  bioguide: I000024
-- name: Mike Lee
-  party: majority
-  rank: 9
-  bioguide: L000577
-- name: Shelley Moore Capito
-  party: majority
-  rank: 10
-  bioguide: C001047
-- name: Cory Gardner
-  party: majority
-  rank: 11
-  bioguide: G000562
-- name: Todd Young
-  party: majority
-  rank: 12
-  bioguide: Y000064
-- name: John Thune
-  party: majority
-  rank: 13
-  title: Ex Officio
-  bioguide: T000250
+  bioguide: S001217
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000127
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Amy Klobuchar
   party: minority
   rank: 2
   bioguide: K000367
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard Blumenthal
   party: minority
   rank: 3
   bioguide: B001277
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Brian Schatz
   party: minority
   rank: 4
   bioguide: S001194
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Edward J. Markey
   party: minority
   rank: 5
   bioguide: M000133
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tom Udall
   party: minority
   rank: 6
   bioguide: U000039
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Gary C. Peters
   party: minority
   rank: 7
   bioguide: P000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tammy Baldwin
   party: minority
   rank: 8
   bioguide: B001230
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tammy Duckworth
   party: minority
   rank: 9
   bioguide: D000622
-- name: Margaret Wood Hassan
-  party: minority
-  rank: 10
-  bioguide: H001076
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jon Tester
   party: minority
-  rank: 11
+  rank: 10
   bioguide: T000464
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Kyrsten Sinema
+  party: minority
+  rank: 11
+  bioguide: S001191
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Jacky Rosen
+  party: minority
+  rank: 12
+  bioguide: R000608
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+SSCM01:
+- name: Ted Cruz
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: C001098
+- name: Marsha Blackburn
+  party: majority
+  rank: 2
+  bioguide: B001243
+- name: Roy Blunt
+  party: majority
+  rank: 3
+  bioguide: B000575
+- name: Shelley Moore Capito
+  party: majority
+  rank: 4
+  bioguide: C001047
+- name: Cory Gardner
+  party: majority
+  rank: 5
+  bioguide: G000562
+- name: Mike Lee
+  party: majority
+  rank: 6
+  bioguide: L000577
+- name: Jerry Moran
+  party: majority
+  rank: 7
+  bioguide: M000934
+- name: John Thune
+  party: majority
+  rank: 8
+  bioguide: T000250
+- name: Tammy Duckworth
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000622
+- name: Amy Klobuchar
+  party: minority
+  rank: 2
+  bioguide: K000367
+- name: Gary C. Peters
+  party: minority
+  rank: 3
+  bioguide: P000595
+- name: Jacky Rosen
+  party: minority
+  rank: 4
+  bioguide: R000608
+- name: Brian Schatz
+  party: minority
+  rank: 5
+  bioguide: S001194
+- name: Jon Tester
+  party: minority
+  rank: 6
+  bioguide: T000464
+- name: Tom Udall
+  party: minority
+  rank: 7
+  bioguide: U000039
 SSCM20:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
   bioguide: M000934
-- name: Roy Blunt
+- name: Marsha Blackburn
   party: majority
   rank: 2
-  bioguide: B000575
-- name: Ted Cruz
+  bioguide: B001243
+- name: Shelley Moore Capito
   party: majority
   rank: 3
-  bioguide: C001098
+  bioguide: C001047
 - name: Deb Fischer
   party: majority
   rank: 4
   bioguide: F000463
-- name: James M. Inhofe
+- name: Ron Johnson
   party: majority
-  rank: 6
-  bioguide: I000024
+  rank: 5
+  bioguide: J000293
 - name: Mike Lee
   party: majority
-  rank: 7
+  rank: 6
   bioguide: L000577
-- name: Shelley Moore Capito
+- name: Dan Sullivan
+  party: majority
+  rank: 7
+  bioguide: S001198
+- name: John Thune
   party: majority
   rank: 8
-  bioguide: C001047
+  bioguide: T000250
 - name: Todd Young
   party: majority
   rank: 9
   bioguide: Y000064
-- name: John Thune
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: T000250
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001277
-- name: Amy Klobuchar
+- name: Tammy Baldwin
   party: minority
   rank: 2
+  bioguide: B001230
+- name: Amy Klobuchar
+  party: minority
+  rank: 3
   bioguide: K000367
 - name: Edward J. Markey
   party: minority
-  rank: 3
-  bioguide: M000133
-- name: Tom Udall
-  party: minority
   rank: 4
-  bioguide: U000039
-- name: Tammy Duckworth
+  bioguide: M000133
+- name: Jacky Rosen
   party: minority
   rank: 5
-  bioguide: D000622
-- name: Margaret Wood Hassan
+  bioguide: R000608
+- name: Brian Schatz
   party: minority
   rank: 6
-  bioguide: H001076
-- name: Catherine Cortez Masto
+  bioguide: S001194
+- name: Kyrsten Sinema
   party: minority
   rank: 7
-  bioguide: C001113
+  bioguide: S001191
+- name: Tom Udall
+  party: minority
+  rank: 8
+  bioguide: U000039
 SSCM22:
 - name: Dan Sullivan
   party: majority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -3,57 +3,46 @@ HLIG:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01635'
   bioguide: S001150
 - name: James A. Himes
   party: majority
   rank: 2
-  thomas: '01913'
   bioguide: H001047
 - name: Terri A. Sewell
   party: majority
   rank: 3
-  thomas: '01988'
   bioguide: S001185
 - name: André Carson
   party: majority
   rank: 4
-  thomas: '01889'
   bioguide: C001072
 - name: Jackie Speier
   party: majority
   rank: 5
-  thomas: '01890'
   bioguide: S001175
 - name: Mike Quigley
   party: majority
   rank: 6
-  thomas: '01967'
   bioguide: Q000023
 - name: Eric Swalwell
   party: majority
   rank: 7
-  thomas: '02104'
   bioguide: S001193
 - name: Joaquin Castro
   party: majority
   rank: 8
-  thomas: '02163'
   bioguide: C001091
 - name: Denny Heck
   party: majority
   rank: 9
-  thomas: '02170'
   bioguide: H001064
 - name: Peter Welch
   party: majority
   rank: 10
-  thomas: '01879'
   bioguide: W000800
 - name: Sean Patrick Maloney
   party: majority
   rank: 11
-  thomas: '02150'
   bioguide: M001185
 - name: Val Butler Demings
   party: majority
@@ -67,166 +56,140 @@ HLIG:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01710'
   bioguide: N000181
 - name: K. Michael Conaway
   party: minority
   rank: 2
-  thomas: '01805'
   bioguide: C001062
 - name: Peter T. King
   party: minority
   rank: 3
-  thomas: '00635'
   bioguide: K000210
 - name: Michael R. Turner
   party: minority
   rank: 4
-  thomas: '01741'
   bioguide: T000463
 - name: Brad R. Wenstrup
   party: minority
   rank: 5
-  thomas: '02152'
   bioguide: W000815
 - name: Chris Stewart
   party: minority
   rank: 6
-  thomas: '02168'
   bioguide: S001192
 - name: Eric A. "Rick" Crawford
   party: minority
   rank: 7
-  thomas: '01989'
   bioguide: C001087
 - name: Elise M. Stefanik
   party: minority
   rank: 8
-  thomas: '02263'
   bioguide: S001196
 - name: Will Hurd
   party: minority
   rank: 9
-  thomas: '02269'
   bioguide: H001073
 HSAG:
 - name: K. Michael Conaway
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01805'
   bioguide: C001062
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Glenn Thompson
   party: minority
   rank: 2
-  thomas: '01952'
   bioguide: T000467
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Frank D. Lucas
   party: minority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mike Rogers
   party: minority
   rank: 4
-  thomas: '01704'
   bioguide: R000575
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bob Gibbs
   party: minority
   rank: 5
-  thomas: '02049'
   bioguide: G000563
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Austin Scott
   party: minority
   rank: 6
-  thomas: '02009'
   bioguide: S001189
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Eric A. "Rick" Crawford
   party: minority
   rank: 7
-  thomas: '01989'
   bioguide: C001087
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Scott DesJarlais
   party: minority
   rank: 8
-  thomas: '02062'
   bioguide: D000616
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Vicky Hartzler
   party: minority
   rank: 9
-  thomas: '02032'
   bioguide: H001053
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Doug LaMalfa
   party: minority
   rank: 10
-  thomas: '02100'
   bioguide: L000578
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Rodney Davis
   party: minority
   rank: 11
-  thomas: '02126'
   bioguide: D000619
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ted S. Yoho
   party: minority
   rank: 12
-  thomas: '02115'
   bioguide: Y000065
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Rick W. Allen
   party: minority
   rank: 13
-  thomas: '02239'
   bioguide: A000372
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mike Bost
   party: minority
   rank: 14
-  thomas: '02243'
   bioguide: B001295
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: David Rouzer
   party: minority
   rank: 15
-  thomas: '02256'
   bioguide: R000603
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ralph Lee Abraham
   party: minority
   rank: 16
-  thomas: '02244'
   bioguide: A000374
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Trent Kelly
   party: minority
   rank: 17
-  thomas: '02294'
   bioguide: K000388
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -276,56 +239,48 @@ HSAG:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00910'
   bioguide: P000258
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: David Scott
   party: majority
   rank: 2
-  thomas: '01722'
   bioguide: S001157
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Jim Costa
   party: majority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Marcia L. Fudge
   party: majority
   rank: 4
-  thomas: '01895'
   bioguide: F000455
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: James P. McGovern
   party: majority
   rank: 5
-  thomas: '01504'
   bioguide: M000312
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Filemon Vela
   party: majority
   rank: 6
-  thomas: '02167'
   bioguide: V000132
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Stacey E. Plaskett
   party: majority
   rank: 7
-  thomas: '02274'
   bioguide: P000610
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Alma S. Adams
   party: majority
   rank: 8
-  thomas: '02201'
   bioguide: A000370
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
@@ -392,14 +347,12 @@ HSAG:
 - name: Cheri Bustos
   party: majority
   rank: 19
-  thomas: '02127'
   bioguide: B001286
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Sean Patrick Maloney
   party: majority
   rank: 20
-  thomas: '02150'
   bioguide: M001185
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
@@ -444,7 +397,6 @@ HSAG03:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01895'
   bioguide: F000455
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
@@ -453,7 +405,6 @@ HSAG14:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02274'
   bioguide: P000610
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
@@ -470,7 +421,6 @@ HSAG16:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02167'
   bioguide: V000132
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
@@ -479,7 +429,6 @@ HSAG22:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01722'
   bioguide: S001157
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
@@ -488,7 +437,6 @@ HSAG29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01774'
   bioguide: C001059
   start_date: '2019-01-24'
   source: https://agriculture.house.gov/press/PRArticle.aspx?NewsID=1361
@@ -497,147 +445,126 @@ HSAP:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01487'
   bioguide: G000377
   start_date: '2019-01-03'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
 - name: Harold Rogers
   party: minority
   rank: 2
-  thomas: '00977'
   bioguide: R000395
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Robert B. Aderholt
   party: minority
   rank: 3
-  thomas: '01460'
   bioguide: A000055
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Michael K. Simpson
   party: minority
   rank: 4
-  thomas: '01590'
   bioguide: S001148
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: John R. Carter
   party: minority
   rank: 5
-  thomas: '01752'
   bioguide: C001051
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ken Calvert
   party: minority
   rank: 6
-  thomas: '00165'
   bioguide: C000059
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Tom Cole
   party: minority
   rank: 7
-  thomas: '01742'
   bioguide: C001053
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mario Diaz-Balart
   party: minority
   rank: 8
-  thomas: '01717'
   bioguide: D000600
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Tom Graves
   party: minority
   rank: 9
-  thomas: '01979'
   bioguide: G000560
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Steve Womack
   party: minority
   rank: 10
-  thomas: '01991'
   bioguide: W000809
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Jeff Fortenberry
   party: minority
   rank: 11
-  thomas: '01793'
   bioguide: F000449
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Charles J. "Chuck" Fleischmann
   party: minority
   rank: 12
-  thomas: '02061'
   bioguide: F000459
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Jaime Herrera Beutler
   party: minority
   rank: 13
-  thomas: '02071'
   bioguide: H001056
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: David P. Joyce
   party: minority
   rank: 14
-  thomas: '02154'
   bioguide: J000295
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Andy Harris
   party: minority
   rank: 15
-  thomas: '02026'
   bioguide: H001052
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Martha Roby
   party: minority
   rank: 16
-  thomas: '01986'
   bioguide: R000591
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mark E. Amodei
   party: minority
   rank: 17
-  thomas: '02090'
   bioguide: A000369
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Chris Stewart
   party: minority
   rank: 18
-  thomas: '02168'
   bioguide: S001192
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Steven M. Palazzo
   party: minority
   rank: 19
-  thomas: '02035'
   bioguide: P000601
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Dan Newhouse
   party: minority
   rank: 20
-  thomas: '02275'
   bioguide: N000189
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: John R. Moolenaar
   party: minority
   rank: 21
-  thomas: '02248'
   bioguide: M001194
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -650,7 +577,6 @@ HSAP:
 - name: Will Hurd
   party: minority
   rank: 23
-  thomas: '02269'
   bioguide: H001073
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -658,189 +584,162 @@ HSAP:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00709'
   bioguide: L000480
   start_date: '2019-01-03'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
 - name: Marcy Kaptur
   party: majority
   rank: 2
-  thomas: '00616'
   bioguide: K000009
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Peter J. Visclosky
   party: majority
   rank: 3
-  thomas: '01188'
   bioguide: V000108
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: José E. Serrano
   party: majority
   rank: 4
-  thomas: '01042'
   bioguide: S000248
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Rosa L. DeLauro
   party: majority
   rank: 5
-  thomas: '00281'
   bioguide: D000216
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: David E. Price
   party: majority
   rank: 6
-  thomas: '00930'
   bioguide: P000523
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Lucille Roybal-Allard
   party: majority
   rank: 7
-  thomas: '00997'
   bioguide: R000486
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Sanford D. Bishop, Jr.
   party: majority
   rank: 8
-  thomas: '00091'
   bioguide: B000490
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Barbara Lee
   party: majority
   rank: 9
-  thomas: '01501'
   bioguide: L000551
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Betty McCollum
   party: majority
   rank: 10
-  thomas: '01653'
   bioguide: M001143
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Tim Ryan
   party: majority
   rank: 11
-  thomas: '01756'
   bioguide: R000577
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: C. A. Dutch Ruppersberger
   party: majority
   rank: 12
-  thomas: '01728'
   bioguide: R000576
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Debbie Wasserman Schultz
   party: majority
   rank: 13
-  thomas: '01777'
   bioguide: W000797
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Henry Cuellar
   party: majority
   rank: 14
-  thomas: '01807'
   bioguide: C001063
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Chellie Pingree
   party: majority
   rank: 15
-  thomas: '01927'
   bioguide: P000597
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mike Quigley
   party: majority
   rank: 16
-  thomas: '01967'
   bioguide: Q000023
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Derek Kilmer
   party: majority
   rank: 17
-  thomas: '02169'
   bioguide: K000381
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Matt Cartwright
   party: majority
   rank: 18
-  thomas: '02159'
   bioguide: C001090
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Grace Meng
   party: majority
   rank: 19
-  thomas: '02148'
   bioguide: M001188
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mark Pocan
   party: majority
   rank: 20
-  thomas: '02171'
   bioguide: P000607
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Katherine M. Clark
   party: majority
   rank: 21
-  thomas: '02196'
   bioguide: C001101
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Pete Aguilar
   party: majority
   rank: 22
-  thomas: '02229'
   bioguide: A000371
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Lois Frankel
   party: majority
   rank: 23
-  thomas: '02119'
   bioguide: F000462
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Cheri Bustos
   party: majority
   rank: 24
-  thomas: '02127'
   bioguide: B001286
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Bonnie Watson Coleman
   party: majority
   rank: 25
-  thomas: '02259'
   bioguide: W000822
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Brenda L. Lawrence
   party: majority
   rank: 26
-  thomas: '02252'
   bioguide: L000581
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Norma J. Torres
   party: majority
   rank: 27
-  thomas: '02231'
   bioguide: T000474
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
@@ -867,84 +766,68 @@ HSAP01:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00091'
   bioguide: B000490
 - name: Rosa L. DeLauro
   party: majority
   rank: 2
-  thomas: '00281'
   bioguide: D000216
 - name: Chellie Pingree
   party: majority
   rank: 3
-  thomas: '01927'
   bioguide: P000597
 - name: Mark Pocan
   party: majority
   rank: 4
-  thomas: '02171'
   bioguide: P000607
 - name: Barbara Lee
   party: majority
   rank: 5
-  thomas: '01501'
   bioguide: L000551
 - name: Betty McCollum
   party: majority
   rank: 6
-  thomas: '01653'
   bioguide: M001143
 - name: Henry Cuellar
   party: majority
   rank: 7
-  thomas: '01807'
   bioguide: C001063
 HSAP02:
 - name: Peter J. Visclosky
   party: majority
   rank: 1
   title: Chair
-  thomas: '01188'
   bioguide: V000108
 - name: Betty McCollum
   party: majority
   rank: 2
-  thomas: '01653'
   bioguide: M001143
 - name: Tim Ryan
   party: majority
   rank: 3
-  thomas: '01756'
   bioguide: R000577
 - name: C. A. Dutch Ruppersberger
   party: majority
   rank: 4
-  thomas: '01728'
   bioguide: R000576
 - name: Marcy Kaptur
   party: majority
   rank: 5
-  thomas: '00616'
   bioguide: K000009
 - name: Henry Cuellar
   party: majority
   rank: 6
-  thomas: '01807'
   bioguide: C001063
 - name: Derek Kilmer
   party: majority
   rank: 7
-  thomas: '02169'
   bioguide: K000381
 - name: Pete Aguilar
   party: majority
   rank: 8
-  thomas: '02229'
   bioguide: A000371
 - name: Cheri Bustos
   party: majority
   rank: 9
-  thomas: '02127'
   bioguide: B001286
 - name: Charlie Crist
   party: majority
@@ -959,128 +842,104 @@ HSAP04:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00709'
   bioguide: L000480
 - name: Barbara Lee
   party: majority
   rank: 2
-  thomas: '01501'
   bioguide: L000551
 - name: Grace Meng
   party: majority
   rank: 3
-  thomas: '02148'
   bioguide: M001188
 - name: David E. Price
   party: majority
   rank: 4
-  thomas: '00930'
   bioguide: P000523
 - name: Lois Frankel
   party: majority
   rank: 5
-  thomas: '02119'
   bioguide: F000462
 - name: Norma J. Torres
   party: majority
   rank: 6
-  thomas: '02231'
   bioguide: T000474
 HSAP06:
 - name: Betty McCollum
   party: majority
   rank: 1
   title: Chair
-  thomas: '01653'
   bioguide: M001143
 - name: Chellie Pingree
   party: majority
   rank: 2
-  thomas: '01927'
   bioguide: P000597
 - name: Derek Kilmer
   party: majority
   rank: 3
-  thomas: '02169'
   bioguide: K000381
 - name: José E. Serrano
   party: majority
   rank: 4
-  thomas: '01042'
   bioguide: S000248
 - name: Mike Quigley
   party: majority
   rank: 5
-  thomas: '01967'
   bioguide: Q000023
 - name: Bonnie Watson Coleman
   party: majority
   rank: 6
-  thomas: '02259'
   bioguide: W000822
 - name: Brenda L. Lawrence
   party: majority
   rank: 7
-  thomas: '02252'
   bioguide: L000581
 HSAP07:
 - name: Rosa L. DeLauro
   party: majority
   rank: 1
   title: Chair
-  thomas: '00281'
   bioguide: D000216
 - name: Lucille Roybal-Allard
   party: majority
   rank: 2
-  thomas: '00997'
   bioguide: R000486
 - name: Barbara Lee
   party: majority
   rank: 3
-  thomas: '01501'
   bioguide: L000551
 - name: Mark Pocan
   party: majority
   rank: 4
-  thomas: '02171'
   bioguide: P000607
 - name: Katherine M. Clark
   party: majority
   rank: 5
-  thomas: '02196'
   bioguide: C001101
 - name: Lois Frankel
   party: majority
   rank: 6
-  thomas: '02119'
   bioguide: F000462
 - name: Cheri Bustos
   party: majority
   rank: 7
-  thomas: '02127'
   bioguide: B001286
 - name: Bonnie Watson Coleman
   party: majority
   rank: 8
-  thomas: '02259'
   bioguide: W000822
 HSAP10:
 - name: Marcy Kaptur
   party: majority
   rank: 1
   title: Chair
-  thomas: '00616'
   bioguide: K000009
 - name: Peter J. Visclosky
   party: majority
   rank: 2
-  thomas: '01188'
   bioguide: V000108
 - name: Debbie Wasserman Schultz
   party: majority
   rank: 3
-  thomas: '01777'
   bioguide: W000797
 - name: Ann Kirkpatrick
   party: majority
@@ -1089,66 +948,54 @@ HSAP10:
 - name: Derek Kilmer
   party: majority
   rank: 5
-  thomas: '02169'
   bioguide: K000381
 - name: Mark Pocan
   party: majority
   rank: 6
-  thomas: '02171'
   bioguide: P000607
 - name: Lois Frankel
   party: majority
   rank: 7
-  thomas: '02119'
   bioguide: F000462
 HSAP15:
 - name: Lucille Roybal-Allard
   party: majority
   rank: 1
   title: Chair
-  thomas: '00997'
   bioguide: R000486
 - name: Henry Cuellar
   party: majority
   rank: 2
-  thomas: '01807'
   bioguide: C001063
 - name: C. A. Dutch Ruppersberger
   party: majority
   rank: 3
-  thomas: '01728'
   bioguide: R000576
 - name: David E. Price
   party: majority
   rank: 4
-  thomas: '00930'
   bioguide: P000523
 - name: Debbie Wasserman Schultz
   party: majority
   rank: 5
-  thomas: '01777'
   bioguide: W000797
 - name: Grace Meng
   party: majority
   rank: 6
-  thomas: '02148'
   bioguide: M001188
 - name: Pete Aguilar
   party: majority
   rank: 7
-  thomas: '02229'
   bioguide: A000371
 HSAP18:
 - name: Debbie Wasserman Schultz
   party: majority
   rank: 1
   title: Chair
-  thomas: '01777'
   bioguide: W000797
 - name: Sanford D. Bishop, Jr.
   party: majority
   rank: 2
-  thomas: '00091'
   bioguide: B000490
 - name: Ed Case
   party: majority
@@ -1157,44 +1004,36 @@ HSAP18:
 - name: Tim Ryan
   party: majority
   rank: 4
-  thomas: '01756'
   bioguide: R000577
 - name: Chellie Pingree
   party: majority
   rank: 5
-  thomas: '01927'
   bioguide: P000597
 - name: Matt Cartwright
   party: majority
   rank: 6
-  thomas: '02159'
   bioguide: C001090
 - name: Cheri Bustos
   party: majority
   rank: 7
-  thomas: '02127'
   bioguide: B001286
 HSAP19:
 - name: José E. Serrano
   party: majority
   rank: 1
   title: Chair
-  thomas: '01042'
   bioguide: S000248
 - name: Matt Cartwright
   party: majority
   rank: 2
-  thomas: '02159'
   bioguide: C001090
 - name: Grace Meng
   party: majority
   rank: 3
-  thomas: '02148'
   bioguide: M001188
 - name: Brenda L. Lawrence
   party: majority
   rank: 4
-  thomas: '02252'
   bioguide: L000581
 - name: Charlie Crist
   party: majority
@@ -1207,77 +1046,63 @@ HSAP19:
 - name: Marcy Kaptur
   party: majority
   rank: 7
-  thomas: '00616'
   bioguide: K000009
 HSAP20:
 - name: Mario Diaz-Balart
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01717'
   bioguide: D000600
 - name: David E. Price
   party: majority
   rank: 1
   title: Ranking Member
-  thomas: '00930'
   bioguide: P000523
 - name: Mike Quigley
   party: majority
   rank: 2
-  thomas: '01967'
   bioguide: Q000023
 - name: Katherine M. Clark
   party: majority
   rank: 3
-  thomas: '02196'
   bioguide: C001101
 - name: Bonnie Watson Coleman
   party: majority
   rank: 4
-  thomas: '02259'
   bioguide: W000822
 - name: Brenda L. Lawrence
   party: majority
   rank: 5
-  thomas: '02252'
   bioguide: L000581
 - name: Norma J. Torres
   party: majority
   rank: 6
-  thomas: '02231'
   bioguide: T000474
 - name: Pete Aguilar
   party: majority
   rank: 7
-  thomas: '02229'
   bioguide: A000371
 HSAP23:
 - name: Mike Quigley
   party: majority
   rank: 1
   title: Chair
-  thomas: '01967'
   bioguide: Q000023
 - name: José E. Serrano
   party: majority
   rank: 2
-  thomas: '01042'
   bioguide: S000248
 - name: Matt Cartwright
   party: majority
   rank: 3
-  thomas: '02159'
   bioguide: C001090
 - name: Sanford D. Bishop, Jr.
   party: majority
   rank: 4
-  thomas: '00091'
   bioguide: B000490
 - name: Norma J. Torres
   party: majority
   rank: 5
-  thomas: '02231'
   bioguide: T000474
 - name: Charlie Crist
   party: majority
@@ -1292,17 +1117,14 @@ HSAP24:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01756'
   bioguide: R000577
 - name: C. A. Dutch Ruppersberger
   party: majority
   rank: 2
-  thomas: '01728'
   bioguide: R000576
 - name: Katherine M. Clark
   party: majority
   rank: 3
-  thomas: '02196'
   bioguide: C001101
 - name: Ed Case
   party: majority
@@ -1313,126 +1135,108 @@ HSAS:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01155'
   bioguide: T000238
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Joe Wilson
   party: minority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Rob Bishop
   party: minority
   rank: 3
-  thomas: '01753'
   bioguide: B001250
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Michael R. Turner
   party: minority
   rank: 4
-  thomas: '01741'
   bioguide: T000463
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mike Rogers
   party: minority
   rank: 5
-  thomas: '01704'
   bioguide: R000575
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: K. Michael Conaway
   party: minority
   rank: 6
-  thomas: '01805'
   bioguide: C001062
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Doug Lamborn
   party: minority
   rank: 7
-  thomas: '01834'
   bioguide: L000564
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Robert J. Wittman
   party: minority
   rank: 8
-  thomas: '01886'
   bioguide: W000804
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Vicky Hartzler
   party: minority
   rank: 9
-  thomas: '02032'
   bioguide: H001053
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Austin Scott
   party: minority
   rank: 10
-  thomas: '02009'
   bioguide: S001189
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mo Brooks
   party: minority
   rank: 11
-  thomas: '01987'
   bioguide: B001274
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Paul Cook
   party: minority
   rank: 12
-  thomas: '02103'
   bioguide: C001094
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bradley Byrne
   party: minority
   rank: 13
-  thomas: '02197'
   bioguide: B001289
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Sam Graves
   party: minority
   rank: 14
-  thomas: '01656'
   bioguide: G000546
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Elise M. Stefanik
   party: minority
   rank: 15
-  thomas: '02263'
   bioguide: S001196
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Scott DesJarlais
   party: minority
   rank: 16
-  thomas: '02062'
   bioguide: D000616
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ralph Lee Abraham
   party: minority
   rank: 17
-  thomas: '02244'
   bioguide: A000374
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Trent Kelly
   party: minority
   rank: 18
-  thomas: '02294'
   bioguide: K000388
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -1488,84 +1292,72 @@ HSAS:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01528'
   bioguide: S000510
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Susan A. Davis
   party: majority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: James R. Langevin
   party: majority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Rick Larsen
   party: majority
   rank: 4
-  thomas: '01675'
   bioguide: L000560
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Jim Cooper
   party: majority
   rank: 5
-  thomas: '00231'
   bioguide: C000754
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Joe Courtney
   party: majority
   rank: 6
-  thomas: '01836'
   bioguide: C001069
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: John Garamendi
   party: majority
   rank: 7
-  thomas: '01973'
   bioguide: G000559
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Jackie Speier
   party: majority
   rank: 8
-  thomas: '01890'
   bioguide: S001175
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Tulsi Gabbard
   party: majority
   rank: 9
-  thomas: '02122'
   bioguide: G000571
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Donald Norcross
   party: majority
   rank: 10
-  thomas: '02202'
   bioguide: N000188
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Ruben Gallego
   party: majority
   rank: 11
-  thomas: '02226'
   bioguide: G000574
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Seth Moulton
   party: majority
   rank: 12
-  thomas: '02246'
   bioguide: M001196
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
@@ -1590,14 +1382,12 @@ HSAS:
 - name: William R. Keating
   party: majority
   rank: 16
-  thomas: '02025'
   bioguide: K000375
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Filemon Vela
   party: majority
   rank: 17
-  thomas: '02167'
   bioguide: V000132
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
@@ -1690,7 +1480,6 @@ HSAS02:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02294'
   bioguide: K000388
   start_date: '2019-01-23'
   source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
@@ -1698,21 +1487,18 @@ HSAS02:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01890'
   bioguide: S001175
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Susan A. Davis
   party: majority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Ruben Gallego
   party: majority
   rank: 3
-  thomas: '02226'
   bioguide: G000574
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -1751,7 +1537,6 @@ HSAS03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01834'
   bioguide: L000564
   start_date: '2019-01-23'
   source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
@@ -1759,14 +1544,12 @@ HSAS03:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01973'
   bioguide: G000559
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Tulsi Gabbard
   party: majority
   rank: 2
-  thomas: '02122'
   bioguide: G000571
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -1823,7 +1606,6 @@ HSAS25:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02032'
   bioguide: H001053
   start_date: '2019-01-23'
   source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
@@ -1831,28 +1613,24 @@ HSAS25:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02202'
   bioguide: N000188
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: James R. Langevin
   party: majority
   rank: 2
-  thomas: '01668'
   bioguide: L000559
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Joe Courtney
   party: majority
   rank: 3
-  thomas: '01836'
   bioguide: C001069
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Ruben Gallego
   party: majority
   rank: 4
-  thomas: '02226'
   bioguide: G000574
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -1871,7 +1649,6 @@ HSAS25:
 - name: Filemon Vela
   party: majority
   rank: 7
-  thomas: '02167'
   bioguide: V000132
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -1904,7 +1681,6 @@ HSAS26:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02263'
   bioguide: S001196
   start_date: '2019-01-23'
   source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
@@ -1912,28 +1688,24 @@ HSAS26:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01668'
   bioguide: L000559
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Rick Larsen
   party: majority
   rank: 2
-  thomas: '01675'
   bioguide: L000560
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Jim Cooper
   party: majority
   rank: 3
-  thomas: '00231'
   bioguide: C000754
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Tulsi Gabbard
   party: majority
   rank: 4
-  thomas: '02122'
   bioguide: G000571
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -1952,7 +1724,6 @@ HSAS26:
 - name: William R. Keating
   party: majority
   rank: 7
-  thomas: '02025'
   bioguide: K000375
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -1991,7 +1762,6 @@ HSAS28:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01886'
   bioguide: W000804
   start_date: '2019-01-23'
   source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
@@ -1999,40 +1769,34 @@ HSAS28:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01836'
   bioguide: C001069
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: James R. Langevin
   party: majority
   rank: 2
-  thomas: '01668'
   bioguide: L000559
 - name: Jim Cooper
   party: majority
   rank: 3
-  thomas: '00231'
   bioguide: C000754
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Donald Norcross
   party: majority
   rank: 4
-  thomas: '02202'
   bioguide: N000188
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Seth Moulton
   party: majority
   rank: 5
-  thomas: '02246'
   bioguide: M001196
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Filemon Vela
   party: majority
   rank: 6
-  thomas: '02167'
   bioguide: V000132
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -2071,7 +1835,6 @@ HSAS29:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01741'
   bioguide: T000463
   start_date: '2019-01-23'
   source: https://republicans-armedservices.house.gov/news/press-releases/smith-and-thornberry-announce-subcommittee-chairmen-and-ranking-members
@@ -2079,42 +1842,36 @@ HSAS29:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00231'
   bioguide: C000754
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Susan A. Davis
   party: majority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Rick Larsen
   party: majority
   rank: 3
-  thomas: '01675'
   bioguide: L000560
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: John Garamendi
   party: majority
   rank: 4
-  thomas: '01973'
   bioguide: G000559
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Jackie Speier
   party: majority
   rank: 5
-  thomas: '01890'
   bioguide: S001175
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
 - name: Seth Moulton
   party: majority
   rank: 6
-  thomas: '02246'
   bioguide: M001196
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -2133,7 +1890,6 @@ HSAS29:
 - name: William R. Keating
   party: majority
   rank: 9
-  thomas: '02025'
   bioguide: K000375
   start_date: '2019-01-23'
   source: https://armedservices.house.gov/press-releases?ID=490A6B02-9901-4575-8E4C-5DD946EF5E78
@@ -2148,126 +1904,108 @@ HSBA:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01792'
   bioguide: M001156
   start_date: '2019-01-03'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
 - name: Peter T. King
   party: minority
   rank: 2
-  thomas: '00635'
   bioguide: K000210
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Frank D. Lucas
   party: minority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bill Posey
   party: minority
   rank: 4
-  thomas: '01915'
   bioguide: P000599
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Blaine Luetkemeyer
   party: minority
   rank: 5
-  thomas: '01931'
   bioguide: L000569
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bill Huizenga
   party: minority
   rank: 6
-  thomas: '02028'
   bioguide: H001058
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Sean P. Duffy
   party: minority
   rank: 7
-  thomas: '02072'
   bioguide: D000614
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Steve Stivers
   party: minority
   rank: 8
-  thomas: '02047'
   bioguide: S001187
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ann Wagner
   party: minority
   rank: 9
-  thomas: '02137'
   bioguide: W000812
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Andy Barr
   party: minority
   rank: 10
-  thomas: '02131'
   bioguide: B001282
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Scott R. Tipton
   party: minority
   rank: 11
-  thomas: '01997'
   bioguide: T000470
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Roger Williams
   party: minority
   rank: 12
-  thomas: '02165'
   bioguide: W000816
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: J. French Hill
   party: minority
   rank: 13
-  thomas: '02223'
   bioguide: H001072
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Tom Emmer
   party: minority
   rank: 14
-  thomas: '02253'
   bioguide: E000294
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Lee M. Zeldin
   party: minority
   rank: 15
-  thomas: '02261'
   bioguide: Z000017
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Barry Loudermilk
   party: minority
   rank: 16
-  thomas: '02238'
   bioguide: L000583
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Alexander X. Mooney
   party: minority
   rank: 17
-  thomas: '02277'
   bioguide: M001195
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Warren Davidson
   party: minority
   rank: 18
-  thomas: '02296'
   bioguide: D000626
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -2323,105 +2061,90 @@ HSBA:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01205'
   bioguide: W000187
   start_date: '2019-01-03'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
 - name: Carolyn B. Maloney
   party: majority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Nydia M. Velázquez
   party: majority
   rank: 3
-  thomas: '01184'
   bioguide: V000081
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Brad Sherman
   party: majority
   rank: 4
-  thomas: '01526'
   bioguide: S000344
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Gregory W. Meeks
   party: majority
   rank: 5
-  thomas: '01506'
   bioguide: M001137
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Wm. Lacy Clay
   party: majority
   rank: 6
-  thomas: '01654'
   bioguide: C001049
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: David Scott
   party: majority
   rank: 7
-  thomas: '01722'
   bioguide: S001157
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Al Green
   party: majority
   rank: 8
-  thomas: '01803'
   bioguide: G000553
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Emanuel Cleaver
   party: majority
   rank: 9
-  thomas: '01790'
   bioguide: C001061
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Ed Perlmutter
   party: majority
   rank: 10
-  thomas: '01835'
   bioguide: P000593
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: James A. Himes
   party: majority
   rank: 11
-  thomas: '01913'
   bioguide: H001047
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Bill Foster
   party: majority
   rank: 12
-  thomas: '01888'
   bioguide: F000454
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Joyce Beatty
   party: majority
   rank: 13
-  thomas: '02153'
   bioguide: B001281
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Denny Heck
   party: majority
   rank: 14
-  thomas: '02170'
   bioguide: H001064
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Juan Vargas
   party: majority
   rank: 15
-  thomas: '02112'
   bioguide: V000130
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
@@ -2544,7 +2267,6 @@ HSBA04:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02072'
   bioguide: D000614
   start_date: '2019-01-24'
   source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
@@ -2552,7 +2274,6 @@ HSBA04:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01654'
   bioguide: C001049
   start_date: '2019-01-24'
   source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
@@ -2561,7 +2282,6 @@ HSBA09:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02131'
   bioguide: B001282
   start_date: '2019-01-24'
   source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
@@ -2569,7 +2289,6 @@ HSBA09:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01803'
   bioguide: G000553
   start_date: '2019-01-24'
   source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
@@ -2578,7 +2297,6 @@ HSBA15:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01931'
   bioguide: L000569
   start_date: '2019-01-24'
   source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
@@ -2586,7 +2304,6 @@ HSBA15:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01506'
   bioguide: M001137
   start_date: '2019-01-24'
   source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
@@ -2595,7 +2312,6 @@ HSBA16:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02028'
   bioguide: H001058
   start_date: '2019-01-24'
   source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
@@ -2603,7 +2319,6 @@ HSBA16:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00729'
   bioguide: M000087
   start_date: '2019-01-24'
   source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
@@ -2612,7 +2327,6 @@ HSBA20:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02047'
   bioguide: S001187
   start_date: '2019-01-24'
   source: https://republicans-financialservices.house.gov/news/documentsingle.aspx?DocumentID=404174
@@ -2620,7 +2334,6 @@ HSBA20:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01790'
   bioguide: C001061
   start_date: '2019-01-24'
   source: https://financialservices.house.gov/news/documentsingle.aspx?DocumentID=401732
@@ -2629,7 +2342,6 @@ HSBU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01991'
   bioguide: W000809
   start_date: '2019-01-03'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
@@ -2637,21 +2349,18 @@ HSBU:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01853'
   bioguide: Y000062
   start_date: '2019-01-03'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
 - name: Seth Moulton
   party: majority
   rank: 2
-  thomas: '02246'
   bioguide: M001196
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Hakeem S. Jeffries
   party: majority
   rank: 3
-  thomas: '02149'
   bioguide: J000294
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
@@ -2664,49 +2373,42 @@ HSBU:
 - name: Rosa L. DeLauro
   party: majority
   rank: 5
-  thomas: '00281'
   bioguide: D000216
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Lloyd Doggett
   party: majority
   rank: 6
-  thomas: '00303'
   bioguide: D000399
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: David E. Price
   party: majority
   rank: 7
-  thomas: '00930'
   bioguide: P000523
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Janice D. Schakowsky
   party: majority
   rank: 8
-  thomas: '01588'
   bioguide: S001145
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Brian Higgins
   party: majority
   rank: 9
-  thomas: '01794'
   bioguide: H001038
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Daniel T. Kildee
   party: majority
   rank: 10
-  thomas: '02134'
   bioguide: K000380
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Brendan F. Boyle
   party: majority
   rank: 11
-  thomas: '02267'
   bioguide: B001296
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
@@ -2731,21 +2433,18 @@ HSBU:
 - name: Robert C. "Bobby" Scott
   party: majority
   rank: 15
-  thomas: '01037'
   bioguide: S000185
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Sheila Jackson Lee
   party: majority
   rank: 16
-  thomas: '00588'
   bioguide: J000032
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Barbara Lee
   party: majority
   rank: 17
-  thomas: '01501'
   bioguide: L000551
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
@@ -2766,63 +2465,54 @@ HSED:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01791'
   bioguide: F000450
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: David P. Roe
   party: minority
   rank: 2
-  thomas: '01954'
   bioguide: R000582
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Glenn Thompson
   party: minority
   rank: 3
-  thomas: '01952'
   bioguide: T000467
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Tim Walberg
   party: minority
   rank: 4
-  thomas: '01855'
   bioguide: W000798
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Brett Guthrie
   party: minority
   rank: 5
-  thomas: '01922'
   bioguide: G000558
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bradley Byrne
   party: minority
   rank: 6
-  thomas: '02197'
   bioguide: B001289
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Glenn Grothman
   party: minority
   rank: 7
-  thomas: '02276'
   bioguide: G000576
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Elise M. Stefanik
   party: minority
   rank: 8
-  thomas: '02263'
   bioguide: S001196
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Rick W. Allen
   party: minority
   rank: 9
-  thomas: '02239'
   bioguide: A000372
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -2841,7 +2531,6 @@ HSED:
 - name: Mark Walker
   party: minority
   rank: 12
-  thomas: '02255'
   bioguide: W000819
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -2909,84 +2598,72 @@ HSED:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01037'
   bioguide: S000185
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Susan A. Davis
   party: majority
   rank: 2
-  thomas: '01641'
   bioguide: D000598
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Raúl M. Grijalva
   party: majority
   rank: 3
-  thomas: '01708'
   bioguide: G000551
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Joe Courtney
   party: majority
   rank: 4
-  thomas: '01836'
   bioguide: C001069
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Marcia L. Fudge
   party: majority
   rank: 5
-  thomas: '01895'
   bioguide: F000455
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Gregorio Kilili Camacho Sablan
   party: majority
   rank: 7
-  thomas: '01962'
   bioguide: S001177
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Frederica S. Wilson
   party: majority
   rank: 8
-  thomas: '02004'
   bioguide: W000808
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Suzanne Bonamici
   party: majority
   rank: 9
-  thomas: '02092'
   bioguide: B001278
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mark Takano
   party: majority
   rank: 10
-  thomas: '02110'
   bioguide: T000472
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Alma S. Adams
   party: majority
   rank: 11
-  thomas: '02201'
   bioguide: A000370
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Mark DeSaulnier
   party: majority
   rank: 12
-  thomas: '02227'
   bioguide: D000623
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
 - name: Donald Norcross
   party: majority
   rank: 13
-  thomas: '02202'
   bioguide: N000188
   start_date: '2019-01-15'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
@@ -3103,21 +2780,18 @@ HSED02:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01855'
   bioguide: W000798
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: David P. Roe
   party: minority
   rank: 2
-  thomas: '01954'
   bioguide: R000582
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Rick W. Allen
   party: minority
   rank: 3
-  thomas: '02239'
   bioguide: A000372
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3173,28 +2847,24 @@ HSED02:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02004'
   bioguide: W000808
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Joe Courtney
   party: majority
   rank: 2
-  thomas: '01836'
   bioguide: C001069
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Marcia L. Fudge
   party: majority
   rank: 3
-  thomas: '01895'
   bioguide: F000455
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Donald Norcross
   party: majority
   rank: 4
-  thomas: '02202'
   bioguide: N000188
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3257,7 +2927,6 @@ HSED10:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02197'
   bioguide: B001289
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3270,7 +2939,6 @@ HSED10:
 - name: Mark Walker
   party: minority
   rank: 3
-  thomas: '02255'
   bioguide: W000819
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3290,21 +2958,18 @@ HSED10:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02201'
   bioguide: A000370
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Mark Takano
   party: majority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Mark DeSaulnier
   party: minority
   rank: 3
-  thomas: '02227'
   bioguide: D000623
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3350,21 +3015,18 @@ HSED13:
 - name: Brett Guthrie
   party: minority
   rank: 2
-  thomas: '01922'
   bioguide: G000558
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Glenn Grothman
   party: minority
   rank: 3
-  thomas: '02276'
   bioguide: G000576
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Elise M. Stefanik
   party: minority
   rank: 4
-  thomas: '02263'
   bioguide: S001196
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3377,7 +3039,6 @@ HSED13:
 - name: Mark Walker
   party: minority
   rank: 6
-  thomas: '02255'
   bioguide: W000819
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3421,56 +3082,48 @@ HSED13:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01641'
   bioguide: D000598
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Raúl M. Grijalva
   party: majority
   rank: 2
-  thomas: '01708'
   bioguide: G000551
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Joe Courtney
   party: majority
   rank: 3
-  thomas: '01836'
   bioguide: C001069
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 4
-  thomas: '01962'
   bioguide: S001177
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Suzanne Bonamici
   party: majority
   rank: 5
-  thomas: '02092'
   bioguide: B001278
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Mark Takano
   party: majority
   rank: 6
-  thomas: '02110'
   bioguide: T000472
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Alma S. Adams
   party: majority
   rank: 7
-  thomas: '02201'
   bioguide: A000370
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Donald Norcross
   party: majority
   rank: 8
-  thomas: '02202'
   bioguide: N000188
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3527,21 +3180,18 @@ HSED14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02239'
   bioguide: A000372
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Glenn Thompson
   party: minority
   rank: 2
-  thomas: '01952'
   bioguide: T000467
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Glenn Grothman
   party: minority
   rank: 3
-  thomas: '02276'
   bioguide: G000576
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3561,7 +3211,6 @@ HSED14:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01962'
   bioguide: S001177
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3586,21 +3235,18 @@ HSED14:
 - name: Susan A. Davis
   party: majority
   rank: 5
-  thomas: '01641'
   bioguide: D000598
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Frederica S. Wilson
   party: majority
   rank: 6
-  thomas: '02004'
   bioguide: W000808
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Mark DeSaulnier
   party: majority
   rank: 7
-  thomas: '02227'
   bioguide: D000623
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
@@ -3615,70 +3261,60 @@ HSFA:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01804'
   bioguide: M001157
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Christopher H. Smith
   party: minority
   rank: 2
-  thomas: '01071'
   bioguide: S000522
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Steve Chabot
   party: minority
   rank: 3
-  thomas: '00186'
   bioguide: C000266
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Joe Wilson
   party: minority
   rank: 4
-  thomas: '01688'
   bioguide: W000795
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Scott Perry
   party: minority
   rank: 5
-  thomas: '02157'
   bioguide: P000605
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ted S. Yoho
   party: minority
   rank: 6
-  thomas: '02115'
   bioguide: Y000065
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Adam Kinzinger
   party: minority
   rank: 7
-  thomas: '02014'
   bioguide: K000378
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Lee M. Zeldin
   party: minority
   rank: 8
-  thomas: '02261'
   bioguide: Z000017
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: F. James Sensenbrenner, Jr.
   party: minority
   rank: 9
-  thomas: '01041'
   bioguide: S000244
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Ann Wagner
   party: minority
   rank: 10
-  thomas: '02137'
   bioguide: W000812
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -3752,84 +3388,72 @@ HSFA:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00344'
   bioguide: E000179
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Brad Sherman
   party: majority
   rank: 2
-  thomas: '01526'
   bioguide: S000344
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Gregory W. Meeks
   party: majority
   rank: 3
-  thomas: '01506'
   bioguide: M001137
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Albio Sires
   party: majority
   rank: 4
-  thomas: '01818'
   bioguide: S001165
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Gerald E. Connolly
   party: majority
   rank: 5
-  thomas: '01959'
   bioguide: C001078
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Theodore E. Deutch
   party: majority
   rank: 6
-  thomas: '01976'
   bioguide: D000610
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Karen Bass
   party: majority
   rank: 7
-  thomas: '01996'
   bioguide: B001270
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: William R. Keating
   party: majority
   rank: 8
-  thomas: '02025'
   bioguide: K000375
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: David N. Cicilline
   party: majority
   rank: 9
-  thomas: '02055'
   bioguide: C001084
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Ami Bera
   party: majority
   rank: 10
-  thomas: '02102'
   bioguide: B001287
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Joaquin Castro
   party: majority
   rank: 11
-  thomas: '02163'
   bioguide: C001091
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Dina Titus
   party: majority
   rank: 12
-  thomas: '01940'
   bioguide: T000468
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
@@ -3842,7 +3466,6 @@ HSFA:
 - name: Ted Lieu
   party: majority
   rank: 14
-  thomas: '02230'
   bioguide: L000582
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
@@ -3903,14 +3526,12 @@ HSFA:
 - name: Jim Costa
   party: majority
   rank: 24
-  thomas: '01774'
   bioguide: C001059
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Juan Vargas
   party: majority
   rank: 25
-  thomas: '02112'
   bioguide: V000130
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
@@ -3925,21 +3546,18 @@ HSFA05:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02115'
   bioguide: Y000065
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Scott Perry
   party: minority
   rank: 2
-  thomas: '02157'
   bioguide: P000605
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Ann Wagner
   party: minority
   rank: 3
-  thomas: '02137'
   bioguide: W000812
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
@@ -3959,14 +3577,12 @@ HSFA05:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01526'
   bioguide: S000344
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Dina Titus
   party: majority
   rank: 2
-  thomas: '01940'
   bioguide: T000468
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -3979,14 +3595,12 @@ HSFA05:
 - name: Gerald E. Connolly
   party: majority
   rank: 4
-  thomas: '01959'
   bioguide: C001078
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Ami Bera
   party: majority
   rank: 5
-  thomas: '02102'
   bioguide: B001287
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4013,14 +3627,12 @@ HSFA07:
 - name: Christopher H. Smith
   party: minority
   rank: 2
-  thomas: '01071'
   bioguide: S000522
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Ted S. Yoho
   party: minority
   rank: 3
-  thomas: '02115'
   bioguide: Y000065
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
@@ -4046,21 +3658,18 @@ HSFA07:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01818'
   bioguide: S001165
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Gregory W. Meeks
   party: majority
   rank: 2
-  thomas: '01506'
   bioguide: M001137
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Joaquin Castro
   party: majority
   rank: 3
-  thomas: '02163'
   bioguide: C001091
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4091,7 +3700,6 @@ HSFA07:
 - name: Juan Vargas
   party: majority
   rank: 8
-  thomas: '02112'
   bioguide: V000130
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4100,28 +3708,24 @@ HSFA13:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01688'
   bioguide: W000795
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Steve Chabot
   party: minority
   rank: 2
-  thomas: '00186'
   bioguide: C000266
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Adam Kinzinger
   party: minority
   rank: 3
-  thomas: '02014'
   bioguide: K000378
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Lee M. Zeldin
   party: minority
   rank: 4
-  thomas: '02261'
   bioguide: Z000017
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
@@ -4153,28 +3757,24 @@ HSFA13:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01976'
   bioguide: D000610
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Gerald E. Connolly
   party: majority
   rank: 2
-  thomas: '01959'
   bioguide: C001078
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: David N. Cicilline
   party: majority
   rank: 3
-  thomas: '02055'
   bioguide: C001084
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Ted Lieu
   party: majority
   rank: 4
-  thomas: '02230'
   bioguide: L000582
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4199,21 +3799,18 @@ HSFA13:
 - name: Brad Sherman
   party: majority
   rank: 8
-  thomas: '01526'
   bioguide: S000344
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: William R. Keating
   party: majority
   rank: 9
-  thomas: '02025'
   bioguide: K000375
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Juan Vargas
   party: majority
   rank: 10
-  thomas: '02112'
   bioguide: V000130
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4222,28 +3819,24 @@ HSFA14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02014'
   bioguide: K000378
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Joe Wilson
   party: minority
   rank: 2
-  thomas: '01688'
   bioguide: W000795
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Ann Wagner
   party: minority
   rank: 3
-  thomas: '02137'
   bioguide: W000812
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: F. James Sensenbrenner, Jr.
   party: minority
   rank: 4
-  thomas: '01041'
   bioguide: S000244
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
@@ -4287,7 +3880,6 @@ HSFA14:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02025'
   bioguide: K000375
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4300,35 +3892,30 @@ HSFA14:
 - name: Gregory W. Meeks
   party: majority
   rank: 3
-  thomas: '01506'
   bioguide: M001137
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Albio Sires
   party: majority
   rank: 4
-  thomas: '01818'
   bioguide: S001165
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Theodore E. Deutch
   party: majority
   rank: 5
-  thomas: '01976'
   bioguide: D000610
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: David N. Cicilline
   party: majority
   rank: 6
-  thomas: '02055'
   bioguide: C001084
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
 - name: Dina Titus
   party: majority
   rank: 7
-  thomas: '01940'
   bioguide: T000468
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4347,7 +3934,6 @@ HSFA14:
 - name: Jim Costa
   party: majority
   rank: 10
-  thomas: '01774'
   bioguide: C001059
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4362,14 +3948,12 @@ HSFA16:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01071'
   bioguide: S000522
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 2
-  thomas: '01041'
   bioguide: S000244
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
@@ -4389,7 +3973,6 @@ HSFA16:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01996'
   bioguide: B001270
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4422,14 +4005,12 @@ HSFA18:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02261'
   bioguide: Z000017
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
 - name: Scott Perry
   party: minority
   rank: 2
-  thomas: '02157'
   bioguide: P000605
   start_date: '2019-01-29'
   source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
@@ -4449,7 +4030,6 @@ HSFA18:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02102'
   bioguide: B001287
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4468,7 +4048,6 @@ HSFA18:
 - name: Ted Lieu
   party: majority
   rank: 4
-  thomas: '02230'
   bioguide: L000582
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4481,7 +4060,6 @@ HSFA18:
 - name: David N. Cicilline
   party: majority
   rank: 6
-  thomas: '02055'
   bioguide: C001084
   start_date: '2019-01-29'
   source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
@@ -4490,56 +4068,48 @@ HSGO:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01868'
   bioguide: J000289
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Justin Amash
   party: minority
   rank: 2
-  thomas: '02029'
   bioguide: A000367
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Paul A. Gosar
   party: minority
   rank: 3
-  thomas: '01992'
   bioguide: G000565
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Virginia Foxx
   party: minority
   rank: 4
-  thomas: '01791'
   bioguide: F000450
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Thomas Massie
   party: minority
   rank: 5
-  thomas: '02094'
   bioguide: M001184
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Mark Meadows
   party: minority
   rank: 6
-  thomas: '02142'
   bioguide: M001187
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Jody B. Hice
   party: minority
   rank: 7
-  thomas: '02237'
   bioguide: H001071
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Glenn Grothman
   party: minority
   rank: 8
-  thomas: '02276'
   bioguide: G000576
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
@@ -4607,35 +4177,30 @@ HSGO:
   party: majority
   rank: 1
   title: Chair
-  thomas: '00256'
   bioguide: C000984
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Carolyn B. Maloney
   party: majority
   rank: 2
-  thomas: '00729'
   bioguide: M000087
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: Eleanor Holmes Norton
   party: majority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: Wm. Lacy Clay
   party: majority
   rank: 4
-  thomas: '01654'
   bioguide: C001049
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: Stephen F. Lynch
   party: majority
   rank: 5
-  thomas: '01686'
   bioguide: L000562
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
@@ -4648,7 +4213,6 @@ HSGO:
 - name: Gerald E. Connolly
   party: majority
   rank: 7
-  thomas: '01959'
   bioguide: C001078
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
@@ -4685,14 +4249,12 @@ HSGO:
 - name: John P. Sarbanes
   party: majority
   rank: 13
-  thomas: '01854'
   bioguide: S001168
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: Peter Welch
   party: majority
   rank: 14
-  thomas: '01879'
   bioguide: W000800
   start_date: '2019-01-23'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
@@ -4767,21 +4329,18 @@ HSGO06:
 - name: Justin Amash
   party: minority
   rank: 2
-  thomas: '02029'
   bioguide: A000367
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 - name: Paul A. Gosar
   party: minority
   rank: 3
-  thomas: '01992'
   bioguide: G000565
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 - name: Virginia Foxx
   party: minority
   rank: 4
-  thomas: '01791'
   bioguide: F000450
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
@@ -4863,28 +4422,24 @@ HSGO24:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02142'
   bioguide: M001187
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 - name: Thomas Massie
   party: minority
   rank: 2
-  thomas: '02094'
   bioguide: M001184
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 - name: Jody B. Hice
   party: minority
   rank: 3
-  thomas: '02237'
   bioguide: H001071
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 - name: Glenn Grothman
   party: minority
   rank: 4
-  thomas: '02276'
   bioguide: G000576
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
@@ -4910,21 +4465,18 @@ HSGO24:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01959'
   bioguide: C001078
   start_date: '2019-01-24'
   source: https://oversight.house.gov/news/press-releases/cummings-announces-subcommittee-chairs-and-full-committee-vice-chair
 - name: Eleanor Holmes Norton
   party: majority
   rank: 2
-  thomas: '00868'
   bioguide: N000147
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 - name: John P. Sarbanes
   party: majority
   rank: 3
-  thomas: '01854'
   bioguide: S001168
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
@@ -4937,7 +4489,6 @@ HSGO24:
 - name: Brenda L. Lawrence
   party: majority
   rank: 5
-  thomas: '02252'
   bioguide: L000581
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
@@ -4956,7 +4507,6 @@ HSGO24:
 - name: Stephen F. Lynch
   party: majority
   rank: 8
-  thomas: '01686'
   bioguide: L000562
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
@@ -4966,1803 +4516,1941 @@ HSGO24:
   bioguide: R000606
   start_date: '2019-01-29'
   source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
-HSGO27:
-- name: Jim Jordan
+HSGO28:
+- name: James Comer
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001108
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Paul A. Gosar
+  party: minority
+  rank: 2
+  bioguide: G000565
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Bob Gibbs
+  party: minority
+  rank: 3
+  bioguide: G000563
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Clay Higgins
+  party: minority
+  rank: 4
+  bioguide: H001077
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Kelly Armstrong
+  party: minority
+  rank: 5
+  bioguide: A000377
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Harley Rouda
   party: majority
   rank: 1
   title: Chair
-  thomas: '01868'
-  bioguide: J000289
-- name: Mark Walker
+  bioguide: R000616
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Katie Hill
   party: majority
   rank: 2
-  thomas: '02255'
-  bioguide: W000819
-  title: Vice Chair
-- name: Scott DesJarlais
+  bioguide: H001087
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Rashida Tlaib
+  party: majority
+  rank: 3
+  bioguide: T000481
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Raja Krishnamoorthi
+  party: majority
+  rank: 4
+  bioguide: K000391
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Jackie Speier
   party: majority
   rank: 5
-  thomas: '02062'
-  bioguide: D000616
-- name: Mark Meadows
+  bioguide: S001175
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Jimmy Gomez
   party: majority
   rank: 6
-  thomas: '02142'
-  bioguide: M001187
-- name: Glenn Grothman
+  bioguide: G000585
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Alexandria Ocasio-Cortez
   party: majority
   rank: 7
-  thomas: '02276'
-  bioguide: G000576
-- name: Paul Mitchell
-  party: majority
-  rank: 8
-  bioguide: M001201
-- name: Raja Krishnamoorthi
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: K000391
-- name: Jim Cooper
-  party: minority
-  rank: 2
-  thomas: '00231'
-  bioguide: C000754
-- name: Eleanor Holmes Norton
-  party: minority
-  rank: 3
-  thomas: '00868'
-  bioguide: N000147
-- name: Robin L. Kelly
-  party: minority
-  rank: 4
-  thomas: '02190'
-  bioguide: K000385
-- name: Bonnie Watson Coleman
-  party: minority
-  rank: 5
-  thomas: '02259'
-  bioguide: W000822
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 6
-  thomas: '02274'
-  bioguide: P000610
-HSGO28:
-- name: Greg Gianforte
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: G000584
-- name: Paul A. Gosar
-  party: majority
-  rank: 2
-  thomas: '01992'
-  bioguide: G000565
-  title: Vice Chair
-- name: Gary J. Palmer
-  party: majority
-  rank: 4
-  thomas: '02221'
-  bioguide: P000609
-- name: James Comer
-  party: majority
-  rank: 5
-  bioguide: C001108
-- name: Michael Cloud
-  party: majority
-  rank: 6
-  bioguide: C001115
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02274'
-  bioguide: P000610
-- name: Jamie Raskin
-  party: minority
-  rank: 2
-  bioguide: R000606
-- name: Jimmy Gomez
-  party: minority
-  rank: 3
-  bioguide: G000585
-HSGO29:
-- name: Gary J. Palmer
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02221'
-  bioguide: P000609
-- name: Glenn Grothman
-  party: majority
-  rank: 2
-  thomas: '02276'
-  bioguide: G000576
-  title: Vice Chair
-- name: Virginia Foxx
-  party: majority
-  rank: 4
-  thomas: '01791'
-  bioguide: F000450
-- name: Thomas Massie
-  party: majority
-  rank: 5
-  thomas: '02094'
-  bioguide: M001184
-- name: Mark Walker
-  party: majority
-  rank: 6
-  thomas: '02255'
-  bioguide: W000819
-- name: Jamie Raskin
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: R000606
-- name: Mark DeSaulnier
-  party: minority
-  rank: 2
-  thomas: '02227'
-  bioguide: D000623
-- name: Matt Cartwright
-  party: minority
-  rank: 3
-  thomas: '02159'
-  bioguide: C001090
-- name: Wm. Lacy Clay
-  party: minority
-  rank: 4
-  thomas: '01654'
-  bioguide: C001049
+  bioguide: O000172
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 HSHA:
 - name: Rodney Davis
-  party: majority
-  rank: 2
-  thomas: '02126'
-  bioguide: D000619
-- name: Mark Walker
-  party: majority
-  rank: 4
-  thomas: '02255'
-  bioguide: W000819
-- name: Adrian Smith
-  party: majority
-  rank: 5
-  thomas: '01860'
-  bioguide: S001172
-- name: Barry Loudermilk
-  party: majority
-  rank: 6
-  thomas: '02238'
-  bioguide: L000583
-- name: Zoe Lofgren
-  party: minority
-  rank: 2
-  thomas: '00701'
-  bioguide: L000397
-- name: Jamie Raskin
-  party: minority
-  rank: 3
-  bioguide: R000606
-HSHM:
-- name: Michael T. McCaul
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01804'
-  bioguide: M001157
-- name: Peter T. King
-  party: majority
-  rank: 3
-  thomas: '00635'
-  bioguide: K000210
-- name: Mike Rogers
-  party: majority
-  rank: 4
-  thomas: '01704'
-  bioguide: R000575
-- name: Scott Perry
-  party: majority
-  rank: 6
-  thomas: '02157'
-  bioguide: P000605
-- name: John Katko
-  party: majority
-  rank: 7
-  thomas: '02264'
-  bioguide: K000386
-- name: Will Hurd
-  party: majority
-  rank: 8
-  thomas: '02269'
-  bioguide: H001073
-- name: John Ratcliffe
-  party: majority
-  rank: 10
-  thomas: '02268'
-  bioguide: R000601
-- name: Mike Gallagher
-  party: majority
-  rank: 12
-  bioguide: G000579
-- name: Clay Higgins
-  party: majority
-  rank: 13
-  bioguide: H001077
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 15
-  bioguide: F000466
-- name: Ron Estes
-  party: majority
-  rank: 16
-  bioguide: E000298
-- name: Don Bacon
-  party: majority
-  rank: 17
-  bioguide: B001298
-- name: Debbie Lesko
-  party: majority
-  rank: 18
-  bioguide: L000589
-- name: Bennie G. Thompson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01151'
-  bioguide: T000193
-- name: Sheila Jackson Lee
+  bioguide: D000619
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/32/text
+- name: Zoe Lofgren
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000397
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/31/text
+HSHM:
+- name: Mike Rogers
+  party: minority
+  rank: 1
+  bioguide: R000575
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Michael T. McCaul
   party: minority
   rank: 2
-  thomas: '00588'
-  bioguide: J000032
-- name: James R. Langevin
+  bioguide: M001157
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Peter T. King
   party: minority
   rank: 3
-  thomas: '01668'
-  bioguide: L000559
-- name: Cedric L. Richmond
+  bioguide: K000210
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John Katko
   party: minority
   rank: 4
-  thomas: '02023'
-  bioguide: R000588
-- name: William R. Keating
+  bioguide: K000386
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John Ratcliffe
   party: minority
   rank: 5
-  thomas: '02025'
-  bioguide: K000375
-- name: Donald M. Payne, Jr.
+  bioguide: R000601
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Clay Higgins
   party: minority
   rank: 6
-  thomas: '02097'
-  bioguide: P000604
-- name: Filemon Vela
+  bioguide: H001077
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark Walker
   party: minority
   rank: 7
-  thomas: '02167'
-  bioguide: V000132
-- name: Bonnie Watson Coleman
+  bioguide: W000819
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Debbie Lesko
   party: minority
   rank: 8
-  thomas: '02259'
-  bioguide: W000822
-- name: Kathleen M. Rice
+  bioguide: L000589
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark E. Green
   party: minority
   rank: 9
-  thomas: '02262'
-  bioguide: R000602
-- name: J. Luis Correa
+  bioguide: G000590
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Van Taylor
   party: minority
   rank: 10
-  bioguide: C001110
-- name: Val Butler Demings
+  bioguide: T000479
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John Joyce
   party: minority
   rank: 11
-  bioguide: D000627
-- name: Nanette Diaz Barragán
+  bioguide: J000302
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Dan Crenshaw
   party: minority
   rank: 12
-  bioguide: B001300
-HSHM05:
-- name: Peter T. King
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '00635'
-  bioguide: K000210
-- name: Scott Perry
-  party: majority
-  rank: 3
-  thomas: '02157'
-  bioguide: P000605
-- name: Will Hurd
-  party: majority
-  rank: 4
-  thomas: '02269'
-  bioguide: H001073
-- name: Mike Gallagher
-  party: majority
-  rank: 5
-  bioguide: G000579
-- name: Michael T. McCaul
-  party: majority
-  rank: 6
-  thomas: '01804'
-  bioguide: M001157
-  title: Ex Officio
-- name: Kathleen M. Rice
+  bioguide: C001120
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael Guest
   party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02262'
-  bioguide: R000602
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 2
-  thomas: '00588'
-  bioguide: J000032
-- name: William R. Keating
-  party: minority
-  rank: 3
-  thomas: '02025'
-  bioguide: K000375
+  rank: 13
+  bioguide: G000591
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Bennie G. Thompson
-  party: minority
-  rank: 4
-  thomas: '01151'
-  bioguide: T000193
-  title: Ex Officio
-HSHM07:
-- name: John Katko
   party: majority
   rank: 1
   title: Chair
-  thomas: '02264'
-  bioguide: K000386
-- name: Mike Rogers
-  party: majority
-  rank: 2
-  thomas: '01704'
-  bioguide: R000575
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 3
-  bioguide: F000466
-- name: Ron Estes
-  party: majority
-  rank: 4
-  bioguide: E000298
-- name: Debbie Lesko
-  party: majority
-  rank: 5
-  bioguide: L000589
-- name: Michael T. McCaul
-  party: majority
-  rank: 6
-  thomas: '01804'
-  bioguide: M001157
-  title: Ex Officio
-- name: Bonnie Watson Coleman
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02259'
-  bioguide: W000822
-- name: William R. Keating
-  party: minority
-  rank: 2
-  thomas: '02025'
-  bioguide: K000375
-- name: Donald M. Payne, Jr.
-  party: minority
-  rank: 3
-  thomas: '02097'
-  bioguide: P000604
-- name: Bennie G. Thompson
-  party: minority
-  rank: 4
-  thomas: '01151'
   bioguide: T000193
-  title: Ex Officio
-HSHM08:
-- name: John Ratcliffe
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02268'
-  bioguide: R000601
-- name: John Katko
-  party: majority
-  rank: 2
-  thomas: '02264'
-  bioguide: K000386
-- name: Mike Gallagher
-  party: majority
-  rank: 4
-  bioguide: G000579
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 5
-  bioguide: F000466
-- name: Don Bacon
-  party: majority
-  rank: 6
-  bioguide: B001298
-- name: Michael T. McCaul
-  party: majority
-  rank: 7
-  thomas: '01804'
-  bioguide: M001157
-  title: Ex Officio
-- name: Cedric L. Richmond
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02023'
-  bioguide: R000588
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Sheila Jackson Lee
-  party: minority
+  party: majority
   rank: 2
-  thomas: '00588'
   bioguide: J000032
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: James R. Langevin
-  party: minority
+  party: majority
   rank: 3
-  thomas: '01668'
   bioguide: L000559
-- name: Val Butler Demings
-  party: minority
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Cedric L. Richmond
+  party: majority
   rank: 4
-  bioguide: D000627
-- name: Bennie G. Thompson
-  party: minority
-  rank: 5
-  thomas: '01151'
-  bioguide: T000193
-  title: Ex Officio
-HSHM09:
-- name: Scott Perry
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02157'
-  bioguide: P000605
-- name: John Ratcliffe
-  party: majority
-  rank: 2
-  thomas: '02268'
-  bioguide: R000601
-- name: Clay Higgins
-  party: majority
-  rank: 3
-  bioguide: H001077
-- name: Ron Estes
+  bioguide: R000588
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Donald M. Payne, Jr.
   party: majority
   rank: 5
-  bioguide: E000298
-- name: Michael T. McCaul
-  party: majority
-  rank: 6
-  thomas: '01804'
-  bioguide: M001157
-  title: Ex Officio
-- name: J. Luis Correa
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C001110
+  bioguide: P000604
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: Kathleen M. Rice
-  party: minority
-  rank: 2
-  thomas: '02262'
-  bioguide: R000602
-- name: Nanette Diaz Barragán
-  party: minority
-  rank: 3
-  bioguide: B001300
-- name: Bennie G. Thompson
-  party: minority
-  rank: 4
-  thomas: '01151'
-  bioguide: T000193
-  title: Ex Officio
-HSHM11:
-- name: Mike Rogers
-  party: majority
-  rank: 3
-  thomas: '01704'
-  bioguide: R000575
-- name: Will Hurd
-  party: majority
-  rank: 5
-  thomas: '02269'
-  bioguide: H001073
-- name: Clay Higgins
   party: majority
   rank: 6
-  bioguide: H001077
-- name: Don Bacon
+  bioguide: R000602
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: J. Luis Correa
   party: majority
   rank: 7
-  bioguide: B001298
-- name: Michael T. McCaul
+  bioguide: C001110
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Xochitl Torres Small
   party: majority
   rank: 8
-  thomas: '01804'
-  bioguide: M001157
-  title: Ex Officio
-- name: Filemon Vela
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02167'
-  bioguide: V000132
-- name: Cedric L. Richmond
-  party: minority
-  rank: 2
-  thomas: '02023'
-  bioguide: R000588
-- name: J. Luis Correa
-  party: minority
-  rank: 3
-  bioguide: C001110
-- name: Val Butler Demings
-  party: minority
-  rank: 4
-  bioguide: D000627
-- name: Nanette Diaz Barragán
-  party: minority
-  rank: 5
-  bioguide: B001300
-- name: Bennie G. Thompson
-  party: minority
-  rank: 6
-  thomas: '01151'
-  bioguide: T000193
-  title: Ex Officio
-HSHM12:
-- name: Peter T. King
+  bioguide: T000484
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Max Rose
   party: majority
-  rank: 2
-  thomas: '00635'
-  bioguide: K000210
-- name: Debbie Lesko
+  rank: 9
+  bioguide: R000613
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Lauren Underwood
   party: majority
-  rank: 5
-  bioguide: L000589
-- name: Michael T. McCaul
+  rank: 10
+  bioguide: U000040
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Elissa Slotkin
   party: majority
-  rank: 6
-  thomas: '01804'
-  bioguide: M001157
-  title: Ex Officio
-- name: Donald M. Payne, Jr.
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02097'
-  bioguide: P000604
-- name: James R. Langevin
-  party: minority
-  rank: 2
-  thomas: '01668'
-  bioguide: L000559
+  rank: 11
+  bioguide: S001208
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Emanuel Cleaver
+  party: majority
+  rank: 12
+  bioguide: C001061
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Al Green
+  party: majority
+  rank: 13
+  bioguide: G000553
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Yvette D. Clarke
+  party: majority
+  rank: 14
+  bioguide: C001067
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Dina Titus
+  party: majority
+  rank: 15
+  bioguide: T000468
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: Bonnie Watson Coleman
-  party: minority
-  rank: 3
-  thomas: '02259'
+  party: majority
+  rank: 16
   bioguide: W000822
-- name: Bennie G. Thompson
-  party: minority
-  rank: 4
-  thomas: '01151'
-  bioguide: T000193
-  title: Ex Officio
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Nanette Diaz Barragán
+  party: majority
+  rank: 17
+  bioguide: B001300
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Val Butler Demings
+  party: majority
+  rank: 18
+  bioguide: D000627
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+HSHM05:
+- name: Max Rose
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000613
+  start_date: '2019-01-29'
+  source: https://homeland.house.gov/news/press-releases/chairman-thompson-announces-homeland-security-subcommittee-chairs
+HSHM07:
+- name: J. Luis Correa
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001110
+  start_date: '2019-01-29'
+  source: https://homeland.house.gov/news/press-releases/chairman-thompson-announces-homeland-security-subcommittee-chairs
+HSHM08:
+- name: Cedric L. Richmond
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000588
+  start_date: '2019-01-29'
+  source: https://homeland.house.gov/news/press-releases/chairman-thompson-announces-homeland-security-subcommittee-chairs
+HSHM09:
+- name: Xochitl Torres Small
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: T000484
+  start_date: '2019-01-29'
+  source: https://homeland.house.gov/news/press-releases/chairman-thompson-announces-homeland-security-subcommittee-chairs
+HSHM11:
+- name: Kathleen M. Rice
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000602
+  start_date: '2019-01-29'
+  source: https://homeland.house.gov/news/press-releases/chairman-thompson-announces-homeland-security-subcommittee-chairs
+HSHM12:
+- name: Donald M. Payne, Jr.
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: P000604
+  start_date: '2019-01-29'
+  source: https://homeland.house.gov/news/press-releases/chairman-thompson-announces-homeland-security-subcommittee-chairs
 HSIF:
 - name: Greg Walden
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
-  thomas: '01596'
+  title: Ranking Member
   bioguide: W000791
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
 - name: Fred Upton
-  party: majority
-  rank: 3
-  thomas: '01177'
+  party: minority
+  rank: 2
   bioguide: U000031
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: John Shimkus
-  party: majority
-  rank: 4
-  thomas: '01527'
+  party: minority
+  rank: 3
   bioguide: S000364
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Michael C. Burgess
-  party: majority
-  rank: 5
-  thomas: '01751'
+  party: minority
+  rank: 4
   bioguide: B001248
-- name: Marsha Blackburn
-  party: majority
-  rank: 6
-  thomas: '01748'
-  bioguide: B001243
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Steve Scalise
-  party: majority
-  rank: 7
-  thomas: '01892'
+  party: minority
+  rank: 5
   bioguide: S001176
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Robert E. Latta
-  party: majority
-  rank: 8
-  thomas: '01885'
+  party: minority
+  rank: 6
   bioguide: L000566
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Cathy McMorris Rodgers
-  party: majority
-  rank: 9
-  thomas: '01809'
+  party: minority
+  rank: 7
   bioguide: M001159
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Brett Guthrie
-  party: majority
-  rank: 12
-  thomas: '01922'
-  bioguide: G000558
-- name: Pete Olson
-  party: majority
-  rank: 13
-  thomas: '01955'
-  bioguide: O000168
-- name: David B. McKinley
-  party: majority
-  rank: 14
-  thomas: '02074'
-  bioguide: M001180
-- name: Adam Kinzinger
-  party: majority
-  rank: 15
-  thomas: '02014'
-  bioguide: K000378
-- name: H. Morgan Griffith
-  party: majority
-  rank: 16
-  thomas: '02070'
-  bioguide: G000568
-- name: Gus M. Bilirakis
-  party: majority
-  rank: 17
-  thomas: '01838'
-  bioguide: B001257
-- name: Bill Johnson
-  party: majority
-  rank: 18
-  thomas: '02046'
-  bioguide: J000292
-- name: Billy Long
-  party: majority
-  rank: 19
-  thomas: '02033'
-  bioguide: L000576
-- name: Larry Bucshon
-  party: majority
-  rank: 20
-  thomas: '02018'
-  bioguide: B001275
-- name: Bill Flores
-  party: majority
-  rank: 21
-  thomas: '02065'
-  bioguide: F000461
-- name: Susan W. Brooks
-  party: majority
-  rank: 22
-  thomas: '02129'
-  bioguide: B001284
-- name: Markwayne Mullin
-  party: majority
-  rank: 23
-  thomas: '02156'
-  bioguide: M001190
-- name: Richard Hudson
-  party: majority
-  rank: 24
-  thomas: '02140'
-  bioguide: H001067
-- name: Kevin Cramer
-  party: majority
-  rank: 25
-  thomas: '02144'
-  bioguide: C001096
-- name: Tim Walberg
-  party: majority
-  rank: 26
-  thomas: '01855'
-  bioguide: W000798
-- name: Earl L. "Buddy" Carter
-  party: majority
-  rank: 29
-  thomas: '02236'
-  bioguide: C001103
-- name: Jeff Duncan
-  party: majority
-  rank: 30
-  thomas: '02057'
-  bioguide: D000615
-- name: Frank Pallone, Jr.
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '00887'
-  bioguide: P000034
-- name: Bobby L. Rush
-  party: minority
-  rank: 2
-  thomas: '01003'
-  bioguide: R000515
-- name: Anna G. Eshoo
-  party: minority
-  rank: 3
-  thomas: '00355'
-  bioguide: E000215
-- name: Eliot L. Engel
-  party: minority
-  rank: 4
-  thomas: '00344'
-  bioguide: E000179
-- name: Diana DeGette
-  party: minority
-  rank: 6
-  thomas: '01479'
-  bioguide: D000197
-- name: Michael F. Doyle
-  party: minority
-  rank: 7
-  thomas: '00316'
-  bioguide: D000482
-- name: Janice D. Schakowsky
   party: minority
   rank: 8
-  thomas: '01588'
-  bioguide: S001145
-- name: G. K. Butterfield
+  bioguide: G000558
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Pete Olson
   party: minority
   rank: 9
-  thomas: '01761'
-  bioguide: B001251
-- name: Doris O. Matsui
+  bioguide: O000168
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: David B. McKinley
   party: minority
   rank: 10
-  thomas: '01814'
-  bioguide: M001163
-- name: Kathy Castor
+  bioguide: M001180
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Adam Kinzinger
   party: minority
   rank: 11
-  thomas: '01839'
-  bioguide: C001066
-- name: John P. Sarbanes
+  bioguide: K000378
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: H. Morgan Griffith
   party: minority
   rank: 12
-  thomas: '01854'
-  bioguide: S001168
-- name: Jerry McNerney
+  bioguide: G000568
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Gus M. Bilirakis
   party: minority
   rank: 13
-  thomas: '01832'
-  bioguide: M001166
-- name: Peter Welch
+  bioguide: B001257
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bill Johnson
   party: minority
   rank: 14
-  thomas: '01879'
-  bioguide: W000800
-- name: Ben Ray Luján
+  bioguide: J000292
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Billy Long
   party: minority
   rank: 15
-  thomas: '01939'
-  bioguide: L000570
-- name: Paul Tonko
+  bioguide: L000576
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Larry Bucshon
   party: minority
   rank: 16
-  thomas: '01942'
-  bioguide: T000469
-- name: Yvette D. Clarke
+  bioguide: B001275
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bill Flores
   party: minority
   rank: 17
-  thomas: '01864'
-  bioguide: C001067
-- name: David Loebsack
+  bioguide: F000461
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Susan W. Brooks
   party: minority
   rank: 18
-  thomas: '01846'
-  bioguide: L000565
-- name: Kurt Schrader
+  bioguide: B001284
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Markwayne Mullin
   party: minority
   rank: 19
-  thomas: '01950'
-  bioguide: S001180
-- name: Joseph P. Kennedy III
+  bioguide: M001190
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Richard Hudson
   party: minority
   rank: 20
-  thomas: '02172'
-  bioguide: K000379
-- name: Tony Cárdenas
+  bioguide: H001067
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Tim Walberg
   party: minority
   rank: 21
-  thomas: '02107'
-  bioguide: C001097
-- name: Raul Ruiz
+  bioguide: W000798
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Earl L. "Buddy" Carter
   party: minority
   rank: 22
-  thomas: '02109'
-  bioguide: R000599
-- name: Scott H. Peters
+  bioguide: C001103
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jeff Duncan
   party: minority
   rank: 23
-  thomas: '02113'
-  bioguide: P000608
-- name: Debbie Dingell
-  party: minority
-  rank: 24
-  thomas: '02251'
-  bioguide: D000624
-HSIF02:
-- name: H. Morgan Griffith
-  party: majority
-  rank: 2
-  thomas: '02070'
-  bioguide: G000568
-  title: Vice Chair
-- name: Michael C. Burgess
-  party: majority
-  rank: 4
-  thomas: '01751'
-  bioguide: B001248
-- name: Susan W. Brooks
-  party: majority
-  rank: 5
-  thomas: '02129'
-  bioguide: B001284
-- name: Tim Walberg
-  party: majority
-  rank: 6
-  thomas: '01855'
-  bioguide: W000798
-- name: Earl L. "Buddy" Carter
-  party: majority
-  rank: 9
-  thomas: '02236'
-  bioguide: C001103
-- name: Greg Walden
-  party: majority
-  rank: 11
-  thomas: '01596'
-  bioguide: W000791
-  title: Ex Officio
-- name: Diana DeGette
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01479'
-  bioguide: D000197
-- name: Janice D. Schakowsky
-  party: minority
-  rank: 2
-  thomas: '01588'
-  bioguide: S001145
-- name: Kathy Castor
-  party: minority
-  rank: 3
-  thomas: '01839'
-  bioguide: C001066
-- name: Paul Tonko
-  party: minority
-  rank: 4
-  thomas: '01942'
-  bioguide: T000469
-- name: Yvette D. Clarke
-  party: minority
-  rank: 5
-  thomas: '01864'
-  bioguide: C001067
-- name: Raul Ruiz
-  party: minority
-  rank: 6
-  thomas: '02109'
-  bioguide: R000599
-- name: Scott H. Peters
-  party: minority
-  rank: 7
-  thomas: '02113'
-  bioguide: P000608
-- name: Frank Pallone, Jr.
-  party: minority
-  rank: 8
-  thomas: '00887'
-  bioguide: P000034
-  title: Ex Officio
-HSIF03:
-- name: Fred Upton
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01177'
-  bioguide: U000031
-- name: Pete Olson
-  party: majority
-  rank: 2
-  thomas: '01955'
-  bioguide: O000168
-  title: Vice Chair
-- name: John Shimkus
-  party: majority
-  rank: 4
-  thomas: '01527'
-  bioguide: S000364
-- name: Robert E. Latta
-  party: majority
-  rank: 5
-  thomas: '01885'
-  bioguide: L000566
-- name: David B. McKinley
-  party: majority
-  rank: 7
-  thomas: '02074'
-  bioguide: M001180
-- name: Adam Kinzinger
-  party: majority
-  rank: 8
-  thomas: '02014'
-  bioguide: K000378
-- name: H. Morgan Griffith
-  party: majority
-  rank: 9
-  thomas: '02070'
-  bioguide: G000568
-- name: Bill Johnson
-  party: majority
-  rank: 10
-  thomas: '02046'
-  bioguide: J000292
-- name: Billy Long
-  party: majority
-  rank: 11
-  thomas: '02033'
-  bioguide: L000576
-- name: Larry Bucshon
-  party: majority
-  rank: 12
-  thomas: '02018'
-  bioguide: B001275
-- name: Bill Flores
-  party: majority
-  rank: 13
-  thomas: '02065'
-  bioguide: F000461
-- name: Markwayne Mullin
-  party: majority
-  rank: 14
-  thomas: '02156'
-  bioguide: M001190
-- name: Richard Hudson
-  party: majority
-  rank: 15
-  thomas: '02140'
-  bioguide: H001067
-- name: Kevin Cramer
-  party: majority
-  rank: 16
-  thomas: '02144'
-  bioguide: C001096
-- name: Tim Walberg
-  party: majority
-  rank: 17
-  thomas: '01855'
-  bioguide: W000798
-- name: Jeff Duncan
-  party: majority
-  rank: 18
-  thomas: '02057'
   bioguide: D000615
-- name: Greg Walden
-  party: majority
-  rank: 19
-  thomas: '01596'
-  bioguide: W000791
-  title: Ex Officio
-- name: Bobby L. Rush
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01003'
-  bioguide: R000515
-- name: Jerry McNerney
-  party: minority
-  rank: 2
-  thomas: '01832'
-  bioguide: M001166
-- name: Scott H. Peters
-  party: minority
-  rank: 3
-  thomas: '02113'
-  bioguide: P000608
-- name: Michael F. Doyle
-  party: minority
-  rank: 5
-  thomas: '00316'
-  bioguide: D000482
-- name: Kathy Castor
-  party: minority
-  rank: 6
-  thomas: '01839'
-  bioguide: C001066
-- name: John P. Sarbanes
-  party: minority
-  rank: 7
-  thomas: '01854'
-  bioguide: S001168
-- name: Peter Welch
-  party: minority
-  rank: 8
-  thomas: '01879'
-  bioguide: W000800
-- name: Paul Tonko
-  party: minority
-  rank: 9
-  thomas: '01942'
-  bioguide: T000469
-- name: David Loebsack
-  party: minority
-  rank: 10
-  thomas: '01846'
-  bioguide: L000565
-- name: Kurt Schrader
-  party: minority
-  rank: 11
-  thomas: '01950'
-  bioguide: S001180
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 12
-  thomas: '02172'
-  bioguide: K000379
-- name: G. K. Butterfield
-  party: minority
-  rank: 13
-  thomas: '01761'
-  bioguide: B001251
-- name: Frank Pallone, Jr.
-  party: minority
-  rank: 14
-  thomas: '00887'
-  bioguide: P000034
-  title: Ex Officio
-HSIF14:
-- name: Michael C. Burgess
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01751'
-  bioguide: B001248
-- name: Brett Guthrie
-  party: majority
-  rank: 2
-  thomas: '01922'
-  bioguide: G000558
-  title: Vice Chair
-- name: Fred Upton
-  party: majority
-  rank: 4
-  thomas: '01177'
-  bioguide: U000031
-- name: John Shimkus
-  party: majority
-  rank: 5
-  thomas: '01527'
-  bioguide: S000364
-- name: Marsha Blackburn
-  party: majority
-  rank: 6
-  thomas: '01748'
-  bioguide: B001243
-- name: Robert E. Latta
-  party: majority
-  rank: 7
-  thomas: '01885'
-  bioguide: L000566
-- name: Cathy McMorris Rodgers
-  party: majority
-  rank: 8
-  thomas: '01809'
-  bioguide: M001159
-- name: H. Morgan Griffith
-  party: majority
-  rank: 10
-  thomas: '02070'
-  bioguide: G000568
-- name: Gus M. Bilirakis
-  party: majority
-  rank: 11
-  thomas: '01838'
-  bioguide: B001257
-- name: Billy Long
-  party: majority
-  rank: 12
-  thomas: '02033'
-  bioguide: L000576
-- name: Larry Bucshon
-  party: majority
-  rank: 13
-  thomas: '02018'
-  bioguide: B001275
-- name: Susan W. Brooks
-  party: majority
-  rank: 14
-  thomas: '02129'
-  bioguide: B001284
-- name: Markwayne Mullin
-  party: majority
-  rank: 15
-  thomas: '02156'
-  bioguide: M001190
-- name: Richard Hudson
-  party: majority
-  rank: 16
-  thomas: '02140'
-  bioguide: H001067
-- name: Earl L. "Buddy" Carter
-  party: majority
-  rank: 17
-  thomas: '02236'
-  bioguide: C001103
-- name: Greg Walden
-  party: majority
-  rank: 19
-  thomas: '01596'
-  bioguide: W000791
-  title: Ex Officio
-- name: Eliot L. Engel
-  party: minority
-  rank: 2
-  thomas: '00344'
-  bioguide: E000179
-- name: Janice D. Schakowsky
-  party: minority
-  rank: 3
-  thomas: '01588'
-  bioguide: S001145
-- name: G. K. Butterfield
-  party: minority
-  rank: 4
-  thomas: '01761'
-  bioguide: B001251
-- name: Doris O. Matsui
-  party: minority
-  rank: 5
-  thomas: '01814'
-  bioguide: M001163
-- name: Kathy Castor
-  party: minority
-  rank: 6
-  thomas: '01839'
-  bioguide: C001066
-- name: John P. Sarbanes
-  party: minority
-  rank: 7
-  thomas: '01854'
-  bioguide: S001168
-- name: Ben Ray Luján
-  party: minority
-  rank: 8
-  thomas: '01939'
-  bioguide: L000570
-- name: Kurt Schrader
-  party: minority
-  rank: 9
-  thomas: '01950'
-  bioguide: S001180
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 10
-  thomas: '02172'
-  bioguide: K000379
-- name: Tony Cárdenas
-  party: minority
-  rank: 11
-  thomas: '02107'
-  bioguide: C001097
-- name: Anna G. Eshoo
-  party: minority
-  rank: 12
-  thomas: '00355'
-  bioguide: E000215
-- name: Diana DeGette
-  party: minority
-  rank: 13
-  thomas: '01479'
-  bioguide: D000197
-- name: Frank Pallone, Jr.
-  party: minority
-  rank: 14
-  thomas: '00887'
-  bioguide: P000034
-  title: Ex Officio
-HSIF16:
-- name: Marsha Blackburn
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01748'
-  bioguide: B001243
-- name: John Shimkus
-  party: majority
-  rank: 3
-  thomas: '01527'
-  bioguide: S000364
-- name: Steve Scalise
-  party: majority
-  rank: 4
-  thomas: '01892'
-  bioguide: S001176
-- name: Robert E. Latta
-  party: majority
-  rank: 5
-  thomas: '01885'
-  bioguide: L000566
-- name: Brett Guthrie
-  party: majority
-  rank: 6
-  thomas: '01922'
-  bioguide: G000558
-- name: Pete Olson
-  party: majority
-  rank: 7
-  thomas: '01955'
-  bioguide: O000168
-- name: Adam Kinzinger
-  party: majority
-  rank: 8
-  thomas: '02014'
-  bioguide: K000378
-- name: Gus M. Bilirakis
-  party: majority
-  rank: 9
-  thomas: '01838'
-  bioguide: B001257
-- name: Bill Johnson
-  party: majority
-  rank: 10
-  thomas: '02046'
-  bioguide: J000292
-- name: Billy Long
-  party: majority
-  rank: 11
-  thomas: '02033'
-  bioguide: L000576
-- name: Bill Flores
-  party: majority
-  rank: 12
-  thomas: '02065'
-  bioguide: F000461
-- name: Susan W. Brooks
-  party: majority
-  rank: 13
-  thomas: '02129'
-  bioguide: B001284
-- name: Kevin Cramer
-  party: majority
-  rank: 14
-  thomas: '02144'
-  bioguide: C001096
-- name: Greg Walden
-  party: majority
-  rank: 18
-  thomas: '01596'
-  bioguide: W000791
-  title: Ex Officio
-- name: Michael F. Doyle
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '00316'
-  bioguide: D000482
-- name: Peter Welch
-  party: minority
-  rank: 2
-  thomas: '01879'
-  bioguide: W000800
-- name: Yvette D. Clarke
-  party: minority
-  rank: 3
-  thomas: '01864'
-  bioguide: C001067
-- name: David Loebsack
-  party: minority
-  rank: 4
-  thomas: '01846'
-  bioguide: L000565
-- name: Raul Ruiz
-  party: minority
-  rank: 5
-  thomas: '02109'
-  bioguide: R000599
-- name: Debbie Dingell
-  party: minority
-  rank: 6
-  thomas: '02251'
-  bioguide: D000624
-- name: Bobby L. Rush
-  party: minority
-  rank: 7
-  thomas: '01003'
-  bioguide: R000515
-- name: Anna G. Eshoo
-  party: minority
-  rank: 8
-  thomas: '00355'
-  bioguide: E000215
-- name: Eliot L. Engel
-  party: minority
-  rank: 9
-  thomas: '00344'
-  bioguide: E000179
-- name: G. K. Butterfield
-  party: minority
-  rank: 10
-  thomas: '01761'
-  bioguide: B001251
-- name: Doris O. Matsui
-  party: minority
-  rank: 11
-  thomas: '01814'
-  bioguide: M001163
-- name: Jerry McNerney
-  party: minority
-  rank: 12
-  thomas: '01832'
-  bioguide: M001166
-- name: Frank Pallone, Jr.
-  party: minority
-  rank: 13
-  thomas: '00887'
-  bioguide: P000034
-  title: Ex Officio
-HSIF17:
-- name: Robert E. Latta
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01885'
-  bioguide: L000566
-- name: Adam Kinzinger
-  party: majority
-  rank: 2
-  thomas: '02014'
-  bioguide: K000378
-  title: Vice Chair
-- name: Fred Upton
-  party: majority
-  rank: 3
-  thomas: '01177'
-  bioguide: U000031
-- name: Michael C. Burgess
-  party: majority
-  rank: 4
-  thomas: '01751'
-  bioguide: B001248
-- name: Brett Guthrie
-  party: majority
-  rank: 6
-  thomas: '01922'
-  bioguide: G000558
-- name: David B. McKinley
-  party: majority
-  rank: 7
-  thomas: '02074'
-  bioguide: M001180
-- name: Gus M. Bilirakis
-  party: majority
-  rank: 8
-  thomas: '01838'
-  bioguide: B001257
-- name: Larry Bucshon
-  party: majority
-  rank: 9
-  thomas: '02018'
-  bioguide: B001275
-- name: Markwayne Mullin
-  party: majority
-  rank: 10
-  thomas: '02156'
-  bioguide: M001190
-- name: Jeff Duncan
-  party: majority
-  rank: 13
-  thomas: '02057'
-  bioguide: D000615
-- name: Greg Walden
-  party: majority
-  rank: 14
-  thomas: '01596'
-  bioguide: W000791
-  title: Ex Officio
-- name: Janice D. Schakowsky
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01588'
-  bioguide: S001145
-- name: Ben Ray Luján
-  party: minority
-  rank: 2
-  thomas: '01939'
-  bioguide: L000570
-- name: Yvette D. Clarke
-  party: minority
-  rank: 3
-  thomas: '01864'
-  bioguide: C001067
-- name: Tony Cárdenas
-  party: minority
-  rank: 4
-  thomas: '02107'
-  bioguide: C001097
-- name: Debbie Dingell
-  party: minority
-  rank: 5
-  thomas: '02251'
-  bioguide: D000624
-- name: Doris O. Matsui
-  party: minority
-  rank: 6
-  thomas: '01814'
-  bioguide: M001163
-- name: Peter Welch
-  party: minority
-  rank: 7
-  thomas: '01879'
-  bioguide: W000800
-- name: Joseph P. Kennedy III
-  party: minority
-  rank: 8
-  thomas: '02172'
-  bioguide: K000379
-- name: Frank Pallone, Jr.
-  party: minority
-  rank: 10
-  thomas: '00887'
-  bioguide: P000034
-  title: Ex Officio
-HSIF18:
-- name: John Shimkus
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01527'
-  bioguide: S000364
-- name: David B. McKinley
-  party: majority
-  rank: 2
-  thomas: '02074'
-  bioguide: M001180
-  title: Vice Chair
-- name: Marsha Blackburn
-  party: majority
-  rank: 4
-  thomas: '01748'
-  bioguide: B001243
-- name: Pete Olson
-  party: majority
-  rank: 6
-  thomas: '01955'
-  bioguide: O000168
-- name: Bill Johnson
-  party: majority
-  rank: 7
-  thomas: '02046'
-  bioguide: J000292
-- name: Bill Flores
-  party: majority
-  rank: 8
-  thomas: '02065'
-  bioguide: F000461
-- name: Richard Hudson
-  party: majority
-  rank: 9
-  thomas: '02140'
-  bioguide: H001067
-- name: Kevin Cramer
-  party: majority
-  rank: 10
-  thomas: '02144'
-  bioguide: C001096
-- name: Tim Walberg
-  party: majority
-  rank: 11
-  thomas: '01855'
-  bioguide: W000798
-- name: Earl L. "Buddy" Carter
-  party: majority
-  rank: 12
-  thomas: '02236'
-  bioguide: C001103
-- name: Jeff Duncan
-  party: majority
-  rank: 13
-  thomas: '02057'
-  bioguide: D000615
-- name: Greg Walden
-  party: majority
-  rank: 14
-  thomas: '01596'
-  bioguide: W000791
-  title: Ex Officio
-- name: Paul Tonko
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01942'
-  bioguide: T000469
-- name: Raul Ruiz
-  party: minority
-  rank: 2
-  thomas: '02109'
-  bioguide: R000599
-- name: Scott H. Peters
-  party: minority
-  rank: 3
-  thomas: '02113'
-  bioguide: P000608
-- name: Diana DeGette
-  party: minority
-  rank: 5
-  thomas: '01479'
-  bioguide: D000197
-- name: Jerry McNerney
-  party: minority
-  rank: 6
-  thomas: '01832'
-  bioguide: M001166
-- name: Tony Cárdenas
-  party: minority
-  rank: 7
-  thomas: '02107'
-  bioguide: C001097
-- name: Debbie Dingell
-  party: minority
-  rank: 8
-  thomas: '02251'
-  bioguide: D000624
-- name: Doris O. Matsui
-  party: minority
-  rank: 9
-  thomas: '01814'
-  bioguide: M001163
-- name: Frank Pallone, Jr.
-  party: minority
-  rank: 10
-  thomas: '00887'
-  bioguide: P000034
-  title: Ex Officio
-HSII:
-- name: Rob Bishop
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01753'
-  bioguide: B001250
-- name: Don Young
-  party: majority
-  rank: 2
-  thomas: '01256'
-  bioguide: Y000033
-- name: Louie Gohmert
-  party: majority
-  rank: 3
-  thomas: '01801'
-  bioguide: G000552
-- name: Doug Lamborn
-  party: majority
-  rank: 4
-  thomas: '01834'
-  bioguide: L000564
-- name: Robert J. Wittman
-  party: majority
-  rank: 5
-  thomas: '01886'
-  bioguide: W000804
-- name: Tom McClintock
-  party: majority
-  rank: 6
-  thomas: '01908'
-  bioguide: M001177
-- name: Glenn Thompson
-  party: majority
-  rank: 8
-  thomas: '01952'
-  bioguide: T000467
-- name: Paul A. Gosar
-  party: majority
-  rank: 9
-  thomas: '01992'
-  bioguide: G000565
-- name: Scott R. Tipton
-  party: majority
-  rank: 11
-  thomas: '01997'
-  bioguide: T000470
-- name: Doug LaMalfa
-  party: majority
-  rank: 12
-  thomas: '02100'
-  bioguide: L000578
-- name: Paul Cook
-  party: majority
-  rank: 14
-  thomas: '02103'
-  bioguide: C001094
-- name: Bruce Westerman
-  party: majority
-  rank: 15
-  thomas: '02224'
-  bioguide: W000821
-- name: Garret Graves
-  party: majority
-  rank: 16
-  thomas: '02245'
-  bioguide: G000577
-- name: Jody B. Hice
-  party: majority
-  rank: 17
-  thomas: '02237'
-  bioguide: H001071
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 18
-  thomas: '02222'
-  bioguide: R000600
-- name: Daniel Webster
-  party: majority
-  rank: 19
-  thomas: '02002'
-  bioguide: W000806
-- name: Jack Bergman
-  party: majority
-  rank: 20
-  bioguide: B001301
-- name: Liz Cheney
-  party: majority
-  rank: 21
-  bioguide: C001109
-- name: Mike Johnson
-  party: majority
-  rank: 22
-  bioguide: J000299
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 23
-  bioguide: G000582
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Greg Gianforte
-  party: majority
+  party: minority
   rank: 24
   bioguide: G000584
-- name: John R. Curtis
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Frank Pallone, Jr.
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: P000034
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
+- name: Bobby L. Rush
+  party: majority
+  rank: 2
+  bioguide: R000515
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Anna G. Eshoo
+  party: majority
+  rank: 3
+  bioguide: E000215
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Eliot L. Engel
+  party: majority
+  rank: 4
+  bioguide: E000179
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Diana DeGette
+  party: majority
+  rank: 5
+  bioguide: D000197
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Michael F. Doyle
+  party: majority
+  rank: 6
+  bioguide: D000482
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Janice D. Schakowsky
+  party: majority
+  rank: 7
+  bioguide: S001145
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: G. K. Butterfield
+  party: majority
+  rank: 8
+  bioguide: B001251
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Doris O. Matsui
+  party: majority
+  rank: 9
+  bioguide: M001163
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Kathy Castor
+  party: majority
+  rank: 10
+  bioguide: C001066
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: John P. Sarbanes
+  party: majority
+  rank: 11
+  bioguide: S001168
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jerry McNerney
+  party: majority
+  rank: 12
+  bioguide: M001166
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Peter Welch
+  party: majority
+  rank: 13
+  bioguide: W000800
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ben Ray Luján
+  party: majority
+  rank: 14
+  bioguide: L000570
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Paul Tonko
+  party: majority
+  rank: 15
+  bioguide: T000469
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Yvette D. Clarke
+  party: majority
+  rank: 16
+  bioguide: C001067
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: David Loebsack
+  party: majority
+  rank: 17
+  bioguide: L000565
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Kurt Schrader
+  party: majority
+  rank: 18
+  bioguide: S001180
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Joseph P. Kennedy III
+  party: majority
+  rank: 19
+  bioguide: K000379
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Tony Cárdenas
+  party: majority
+  rank: 20
+  bioguide: C001097
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Raul Ruiz
+  party: majority
+  rank: 21
+  bioguide: R000599
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Scott H. Peters
+  party: majority
+  rank: 22
+  bioguide: P000608
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Debbie Dingell
+  party: majority
+  rank: 23
+  bioguide: D000624
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Marc A. Veasey
+  party: majority
+  rank: 24
+  bioguide: V000131
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ann M. Kuster
   party: majority
   rank: 25
-  bioguide: C001114
-- name: Raúl M. Grijalva
+  bioguide: K000382
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Robin L. Kelly
+  party: majority
+  rank: 26
+  bioguide: K000385
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Nanette Diaz Barragán
+  party: majority
+  rank: 27
+  bioguide: B001300
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: A. Donald McEachin
+  party: majority
+  rank: 28
+  bioguide: M001200
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Lisa Blunt Rochester
+  party: majority
+  rank: 29
+  bioguide: B001303
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Darren Soto
+  party: majority
+  rank: 30
+  bioguide: S001200
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Tom O’Halleran
+  party: majority
+  rank: 31
+  bioguide: O000171
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+HSIF02:
+- name: Brett Guthrie
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01708'
-  bioguide: G000551
-- name: Grace F. Napolitano
+  bioguide: G000558
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Michael C. Burgess
   party: minority
   rank: 2
-  thomas: '01602'
-  bioguide: N000179
-- name: Jim Costa
+  bioguide: B001248
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: David B. McKinley
+  party: minority
+  rank: 3
+  bioguide: M001180
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: H. Morgan Griffith
   party: minority
   rank: 4
-  thomas: '01774'
-  bioguide: C001059
-- name: Gregorio Kilili Camacho Sablan
+  bioguide: G000568
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Susan W. Brooks
   party: minority
   rank: 5
-  thomas: '01962'
-  bioguide: S001177
-- name: Jared Huffman
+  bioguide: B001284
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Markwayne Mullin
+  party: minority
+  rank: 6
+  bioguide: M001190
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Jeff Duncan
   party: minority
   rank: 7
-  thomas: '02101'
-  bioguide: H001068
-- name: Alan S. Lowenthal
+  bioguide: D000615
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Walden
   party: minority
   rank: 8
-  thomas: '02111'
-  bioguide: L000579
-- name: Donald S. Beyer, Jr.
+  bioguide: W000791
+  title: Ex Officio
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Diana DeGette
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000197
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Janice D. Schakowsky
+  party: majority
+  rank: 2
+  bioguide: S001145
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Joseph P. Kennedy III
+  party: majority
+  rank: 3
+  bioguide: K000379
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Raul Ruiz
+  party: majority
+  rank: 4
+  bioguide: R000599
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Ann M. Kuster
+  party: majority
+  rank: 5
+  bioguide: K000382
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Kathy Castor
+  party: majority
+  rank: 6
+  bioguide: C001066
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: John P. Sarbanes
+  party: majority
+  rank: 7
+  bioguide: S001168
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Paul Tonko
+  party: majority
+  rank: 8
+  bioguide: T000469
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Yvette D. Clarke
+  party: majority
+  rank: 9
+  bioguide: C001067
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Scott H. Peters
+  party: majority
+  rank: 10
+  bioguide: P000608
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Frank Pallone, Jr.
+  party: majority
+  rank: 11
+  bioguide: P000034
+  title: Ex Officio
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+HSIF03:
+- name: Fred Upton
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: U000031
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Robert E. Latta
+  party: minority
+  rank: 2
+  bioguide: L000566
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Cathy McMorris Rodgers
+  party: minority
+  rank: 3
+  bioguide: M001159
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Pete Olson
+  party: minority
+  rank: 4
+  bioguide: O000168
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: David B. McKinley
+  party: minority
+  rank: 5
+  bioguide: M001180
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Adam Kinzinger
+  party: minority
+  rank: 6
+  bioguide: K000378
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: H. Morgan Griffith
+  party: minority
+  rank: 7
+  bioguide: G000568
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Bill Johnson
+  party: minority
+  rank: 8
+  bioguide: J000292
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Larry Bucshon
   party: minority
   rank: 9
-  thomas: '02272'
-  bioguide: B001292
-- name: Ruben Gallego
+  bioguide: B001275
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Bill Flores
   party: minority
   rank: 10
-  thomas: '02226'
-  bioguide: G000574
-- name: Nanette Diaz Barragán
+  bioguide: F000461
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Richard Hudson
+  party: minority
+  rank: 11
+  bioguide: H001067
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Tim Walberg
   party: minority
   rank: 12
-  bioguide: B001300
-- name: Darren Soto
+  bioguide: W000798
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Jeff Duncan
   party: minority
   rank: 13
-  bioguide: S001200
-- name: A. Donald McEachin
+  bioguide: D000615
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Walden
   party: minority
   rank: 14
+  bioguide: W000791
+  title: Ex Officio
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Bobby L. Rush
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: R000515
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Scott H. Peters
+  party: majority
+  rank: 2
+  bioguide: P000608
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Michael F. Doyle
+  party: majority
+  rank: 3
+  bioguide: D000482
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: John P. Sarbanes
+  party: majority
+  rank: 4
+  bioguide: S001168
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Jerry McNerney
+  party: majority
+  rank: 5
+  bioguide: M001166
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Paul Tonko
+  party: majority
+  rank: 6
+  bioguide: T000469
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: David Loebsack
+  party: majority
+  rank: 7
+  bioguide: L000565
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: G. K. Butterfield
+  party: majority
+  rank: 8
+  bioguide: B001251
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Peter Welch
+  party: majority
+  rank: 9
+  bioguide: W000800
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Kurt Schrader
+  party: majority
+  rank: 10
+  bioguide: S001180
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Joseph P. Kennedy III
+  party: majority
+  rank: 11
+  bioguide: K000379
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Marc A. Veasey
+  party: majority
+  rank: 12
+  bioguide: V000131
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Ann M. Kuster
+  party: majority
+  rank: 13
+  bioguide: K000382
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Robin L. Kelly
+  party: majority
+  rank: 14
+  bioguide: K000385
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Nanette Diaz Barragán
+  party: majority
+  rank: 15
+  bioguide: B001300
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: A. Donald McEachin
+  party: majority
+  rank: 16
   bioguide: M001200
-- name: Anthony G. Brown
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Tom O’Halleran
+  party: majority
+  rank: 17
+  bioguide: O000171
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Lisa Blunt Rochester
+  party: majority
+  rank: 18
+  bioguide: B001303
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Frank Pallone, Jr.
+  party: majority
+  rank: 19
+  bioguide: P000034
+  title: Ex Officio
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+HSIF14:
+- name: Michael C. Burgess
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001248
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Fred Upton
+  party: minority
+  rank: 2
+  bioguide: U000031
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: John Shimkus
+  party: minority
+  rank: 3
+  bioguide: S000364
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Brett Guthrie
+  party: minority
+  rank: 4
+  bioguide: G000558
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: H. Morgan Griffith
+  party: minority
+  rank: 5
+  bioguide: G000568
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Gus M. Bilirakis
+  party: minority
+  rank: 6
+  bioguide: B001257
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Billy Long
+  party: minority
+  rank: 7
+  bioguide: L000576
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Larry Bucshon
+  party: minority
+  rank: 8
+  bioguide: B001275
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Susan W. Brooks
+  party: minority
+  rank: 9
+  bioguide: B001284
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Markwayne Mullin
+  party: minority
+  rank: 10
+  bioguide: M001190
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Richard Hudson
+  party: minority
+  rank: 11
+  bioguide: H001067
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Earl L. "Buddy" Carter
+  party: minority
+  rank: 12
+  bioguide: C001103
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Gianforte
+  party: minority
+  rank: 13
+  bioguide: G000584
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Walden
+  party: minority
+  rank: 14
+  bioguide: W000791
+  title: Ex Officio
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Anna G. Eshoo
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: E000215
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Eliot L. Engel
+  party: majority
+  rank: 2
+  bioguide: E000179
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: G. K. Butterfield
+  party: majority
+  rank: 3
+  bioguide: B001251
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Doris O. Matsui
+  party: majority
+  rank: 4
+  bioguide: M001163
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Kathy Castor
+  party: majority
+  rank: 5
+  bioguide: C001066
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: John P. Sarbanes
+  party: majority
+  rank: 6
+  bioguide: S001168
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Ben Ray Luján
+  party: majority
+  rank: 7
+  bioguide: L000570
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Kurt Schrader
+  party: majority
+  rank: 8
+  bioguide: S001180
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Joseph P. Kennedy III
+  party: majority
+  rank: 9
+  bioguide: K000379
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Tony Cárdenas
+  party: majority
+  rank: 10
+  bioguide: C001097
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Peter Welch
+  party: majority
+  rank: 11
+  bioguide: W000800
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Raul Ruiz
+  party: majority
+  rank: 12
+  bioguide: R000599
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Debbie Dingell
+  party: majority
+  rank: 13
+  bioguide: D000624
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Ann M. Kuster
+  party: majority
+  rank: 14
+  bioguide: K000382
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Robin L. Kelly
+  party: majority
+  rank: 15
+  bioguide: K000385
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Nanette Diaz Barragán
+  party: majority
+  rank: 16
+  bioguide: B001300
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Lisa Blunt Rochester
+  party: majority
+  rank: 17
+  bioguide: B001303
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Bobby L. Rush
+  party: majority
+  rank: 18
+  bioguide: R000515
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Frank Pallone, Jr.
+  party: majority
+  rank: 19
+  bioguide: P000034
+  title: Ex Officio
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+HSIF16:
+- name: Robert E. Latta
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000566
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: John Shimkus
+  party: minority
+  rank: 2
+  bioguide: S000364
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Steve Scalise
+  party: minority
+  rank: 3
+  bioguide: S001176
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Pete Olson
+  party: minority
+  rank: 4
+  bioguide: O000168
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Adam Kinzinger
+  party: minority
+  rank: 5
+  bioguide: K000378
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Gus M. Bilirakis
+  party: minority
+  rank: 6
+  bioguide: B001257
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Bill Johnson
+  party: minority
+  rank: 7
+  bioguide: J000292
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Billy Long
+  party: minority
+  rank: 8
+  bioguide: L000576
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Bill Flores
+  party: minority
+  rank: 9
+  bioguide: F000461
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Susan W. Brooks
+  party: minority
+  rank: 10
+  bioguide: B001284
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Tim Walberg
+  party: minority
+  rank: 11
+  bioguide: W000798
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Gianforte
+  party: minority
+  rank: 12
+  bioguide: G000584
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Walden
+  party: majority
+  rank: 13
+  bioguide: W000791
+  title: Ex Officio
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Michael F. Doyle
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000482
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Jerry McNerney
+  party: majority
+  rank: 2
+  bioguide: M001166
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Yvette D. Clarke
+  party: majority
+  rank: 3
+  bioguide: C001067
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: David Loebsack
+  party: majority
+  rank: 4
+  bioguide: L000565
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Marc A. Veasey
+  party: majority
+  rank: 5
+  bioguide: V000131
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: A. Donald McEachin
+  party: majority
+  rank: 6
+  bioguide: M001200
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Darren Soto
+  party: majority
+  rank: 7
+  bioguide: S001200
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Tom O’Halleran
+  party: majority
+  rank: 8
+  bioguide: O000171
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Anna G. Eshoo
+  party: majority
+  rank: 9
+  bioguide: E000215
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Diana DeGette
+  party: majority
+  rank: 10
+  bioguide: D000197
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: G. K. Butterfield
+  party: majority
+  rank: 11
+  bioguide: B001251
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Doris O. Matsui
+  party: majority
+  rank: 12
+  bioguide: M001163
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Peter Welch
+  party: majority
+  rank: 13
+  bioguide: W000800
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Ben Ray Luján
+  party: majority
+  rank: 14
+  bioguide: L000570
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Kurt Schrader
+  party: majority
+  rank: 15
+  bioguide: S001180
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Tony Cárdenas
+  party: majority
+  rank: 16
+  bioguide: C001097
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Debbie Dingell
+  party: majority
+  rank: 17
+  bioguide: D000624
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Frank Pallone, Jr.
+  party: majority
+  rank: 18
+  bioguide: P000034
+  title: Ex Officio
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+HSIF17:
+- name: Cathy McMorris Rodgers
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001159
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Fred Upton
+  party: minority
+  rank: 2
+  bioguide: U000031
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Michael C. Burgess
+  party: minority
+  rank: 3
+  bioguide: B001248
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Robert E. Latta
+  party: minority
+  rank: 4
+  bioguide: L000566
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Brett Guthrie
+  party: minority
+  rank: 5
+  bioguide: G000558
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Larry Bucshon
+  party: minority
+  rank: 6
+  bioguide: B001275
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Richard Hudson
+  party: minority
+  rank: 7
+  bioguide: H001067
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Earl L. "Buddy" Carter
+  party: minority
+  rank: 8
+  bioguide: C001103
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Gianforte
+  party: minority
+  rank: 9
+  bioguide: G000584
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Walden
+  party: minority
+  rank: 10
+  bioguide: W000791
+  title: Ex Officio
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Janice D. Schakowsky
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: S001145
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Kathy Castor
+  party: majority
+  rank: 2
+  bioguide: C001066
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Marc A. Veasey
+  party: majority
+  rank: 3
+  bioguide: V000131
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Robin L. Kelly
+  party: majority
+  rank: 4
+  bioguide: K000385
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Tom O’Halleran
+  party: majority
+  rank: 5
+  bioguide: O000171
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Ben Ray Luján
+  party: majority
+  rank: 6
+  bioguide: L000570
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Tony Cárdenas
+  party: majority
+  rank: 7
+  bioguide: C001097
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Lisa Blunt Rochester
+  party: majority
+  rank: 8
+  bioguide: B001303
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Darren Soto
+  party: majority
+  rank: 9
+  bioguide: S001200
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Bobby L. Rush
+  party: majority
+  rank: 10
+  bioguide: R000515
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Doris O. Matsui
+  party: majority
+  rank: 11
+  bioguide: M001163
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Jerry McNerney
+  party: majority
+  rank: 12
+  bioguide: M001166
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Debbie Dingell
+  party: majority
+  rank: 13
+  bioguide: D000624
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Frank Pallone, Jr.
+  party: majority
+  rank: 14
+  bioguide: P000034
+  title: Ex Officio
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+HSIF18:
+- name: John Shimkus
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S000364
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Cathy McMorris Rodgers
+  party: minority
+  rank: 2
+  bioguide: M001159
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: David B. McKinley
+  party: minority
+  rank: 3
+  bioguide: M001180
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Bill Johnson
+  party: minority
+  rank: 4
+  bioguide: J000292
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Billy Long
+  party: minority
+  rank: 5
+  bioguide: L000576
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Bill Flores
+  party: minority
+  rank: 6
+  bioguide: F000461
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Markwayne Mullin
+  party: minority
+  rank: 7
+  bioguide: M001190
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Earl L. "Buddy" Carter
+  party: minority
+  rank: 8
+  bioguide: C001103
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Jeff Duncan
+  party: minority
+  rank: 9
+  bioguide: D000615
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Greg Walden
+  party: minority
+  rank: 10
+  bioguide: W000791
+  title: Ex Officio
+  start_date: '2019-01-18'
+  source: https://republicans-energycommerce.house.gov/news/walden-announces-energy-and-commerce-republican-subcommittee-rosters/
+- name: Paul Tonko
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: T000469
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Yvette D. Clarke
+  party: majority
+  rank: 2
+  bioguide: C001067
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Scott H. Peters
+  party: majority
+  rank: 3
+  bioguide: P000608
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Nanette Diaz Barragán
+  party: majority
+  rank: 4
+  bioguide: B001300
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: A. Donald McEachin
+  party: majority
+  rank: 5
+  bioguide: M001200
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Lisa Blunt Rochester
+  party: majority
+  rank: 6
+  bioguide: B001303
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Darren Soto
+  party: majority
+  rank: 7
+  bioguide: S001200
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Diana DeGette
+  party: majority
+  rank: 8
+  bioguide: D000197
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Janice D. Schakowsky
+  party: majority
+  rank: 9
+  bioguide: S001145
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Doris O. Matsui
+  party: majority
+  rank: 10
+  bioguide: M001163
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Jerry McNerney
+  party: majority
+  rank: 11
+  bioguide: M001166
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Raul Ruiz
+  party: majority
+  rank: 12
+  bioguide: R000599
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Debbie Dingell
+  party: majority
+  rank: 13
+  bioguide: D000624
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+- name: Frank Pallone, Jr.
+  party: majority
+  rank: 14
+  bioguide: P000034
+  title: Ex Officio
+  start_date: '2019-01-15'
+  source: https://energycommerce.house.gov/newsroom/press-releases/pallone-announces-energy-commerce-committee-roster-0
+HSII:
+- name: Rob Bishop
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001250
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Don Young
+  party: minority
+  rank: 2
+  bioguide: Y000033
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Louie Gohmert
+  party: minority
+  rank: 3
+  bioguide: G000552
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Doug Lamborn
+  party: minority
+  rank: 4
+  bioguide: L000564
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Robert J. Wittman
+  party: minority
+  rank: 5
+  bioguide: W000804
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Tom McClintock
+  party: minority
+  rank: 6
+  bioguide: M001177
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Paul A. Gosar
+  party: minority
+  rank: 7
+  bioguide: G000565
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Paul Cook
+  party: minority
+  rank: 8
+  bioguide: C001094
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Bruce Westerman
+  party: minority
+  rank: 9
+  bioguide: W000821
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Garret Graves
+  party: minority
+  rank: 10
+  bioguide: G000577
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Jody B. Hice
+  party: minority
+  rank: 11
+  bioguide: H001071
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Aumua Amata Coleman Radewagen
+  party: minority
+  rank: 12
+  bioguide: R000600
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Daniel Webster
+  party: minority
+  rank: 13
+  bioguide: W000806
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Liz Cheney
+  party: minority
+  rank: 14
+  bioguide: C001109
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Mike Johnson
   party: minority
   rank: 15
-  bioguide: B001304
-- name: Wm. Lacy Clay
+  bioguide: J000299
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Jenniffer González-Colón
   party: minority
   rank: 16
-  thomas: '01654'
-  bioguide: C001049
-- name: Jimmy Gomez
+  bioguide: G000582
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: John R. Curtis
   party: minority
   rank: 17
-  bioguide: G000585
-- name: Nydia M. Velázquez
+  bioguide: C001114
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Kevin Hern
   party: minority
   rank: 18
-  thomas: '01184'
+  bioguide: H001082
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Russ Fulcher
+  party: minority
+  rank: 19
+  bioguide: F000469
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Raúl M. Grijalva
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: G000551
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Grace F. Napolitano
+  party: majority
+  rank: 2
+  bioguide: N000179
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Jim Costa
+  party: majority
+  rank: 3
+  bioguide: C001059
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Gregorio Kilili Camacho Sablan
+  party: majority
+  rank: 4
+  bioguide: S001177
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Jared Huffman
+  party: majority
+  rank: 5
+  bioguide: H001068
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Alan S. Lowenthal
+  party: majority
+  rank: 6
+  bioguide: L000579
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Ruben Gallego
+  party: majority
+  rank: 7
+  bioguide: G000574
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Joe Cunningham
+  party: majority
+  rank: 8
+  bioguide: C001122
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Nydia M. Velázquez
+  party: majority
+  rank: 9
   bioguide: V000081
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Diana DeGette
+  party: majority
+  rank: 10
+  bioguide: D000197
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Wm. Lacy Clay
+  party: majority
+  rank: 11
+  bioguide: C001049
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Debbie Dingell
+  party: majority
+  rank: 12
+  bioguide: D000624
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Anthony G. Brown
+  party: majority
+  rank: 13
+  bioguide: B001304
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: A. Donald McEachin
+  party: majority
+  rank: 14
+  bioguide: M001200
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Darren Soto
+  party: majority
+  rank: 15
+  bioguide: S001200
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Ed Case
+  party: majority
+  rank: 16
+  bioguide: C001055
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Steven Horsford
+  party: majority
+  rank: 17
+  bioguide: H001066
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Michael San Nicolas
+  party: majority
+  rank: 18
+  bioguide: S001204
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 HSII06:
 - name: Paul A. Gosar
   party: majority
   rank: 1
   title: Chair
-  thomas: '01992'
   bioguide: G000565
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
 - name: Doug Lamborn
   party: majority
   rank: 3
-  thomas: '01834'
   bioguide: L000564
 - name: Robert J. Wittman
   party: majority
   rank: 4
-  thomas: '01886'
   bioguide: W000804
 - name: Glenn Thompson
   party: majority
   rank: 6
-  thomas: '01952'
   bioguide: T000467
 - name: Scott R. Tipton
   party: majority
   rank: 7
-  thomas: '01997'
   bioguide: T000470
 - name: Paul Cook
   party: majority
   rank: 8
-  thomas: '02103'
   bioguide: C001094
 - name: Garret Graves
   party: majority
   rank: 9
-  thomas: '02245'
   bioguide: G000577
 - name: Jody B. Hice
   party: majority
   rank: 10
-  thomas: '02237'
   bioguide: H001071
 - name: Jack Bergman
   party: majority
@@ -6779,14 +6467,12 @@ HSII06:
 - name: Rob Bishop
   party: majority
   rank: 14
-  thomas: '01753'
   bioguide: B001250
   title: Ex Officio
 - name: Alan S. Lowenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02111'
   bioguide: L000579
 - name: Anthony G. Brown
   party: minority
@@ -6795,17 +6481,14 @@ HSII06:
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
 - name: Jared Huffman
   party: minority
   rank: 5
-  thomas: '02101'
   bioguide: H001068
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
-  thomas: '02272'
   bioguide: B001292
 - name: Darren Soto
   party: minority
@@ -6818,12 +6501,10 @@ HSII06:
 - name: Nydia M. Velázquez
   party: minority
   rank: 9
-  thomas: '01184'
   bioguide: V000081
 - name: Raúl M. Grijalva
   party: minority
   rank: 11
-  thomas: '01708'
   bioguide: G000551
   title: Ex Officio
 HSII10:
@@ -6831,32 +6512,26 @@ HSII10:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01908'
   bioguide: M001177
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
 - name: Glenn Thompson
   party: majority
   rank: 4
-  thomas: '01952'
   bioguide: T000467
 - name: Scott R. Tipton
   party: majority
   rank: 6
-  thomas: '01997'
   bioguide: T000470
 - name: Bruce Westerman
   party: majority
   rank: 7
-  thomas: '02224'
   bioguide: W000821
 - name: Daniel Webster
   party: majority
   rank: 8
-  thomas: '02002'
   bioguide: W000806
 - name: Jack Bergman
   party: majority
@@ -6877,18 +6552,15 @@ HSII10:
 - name: Rob Bishop
   party: majority
   rank: 13
-  thomas: '01753'
   bioguide: B001250
   title: Ex Officio
 - name: Alan S. Lowenthal
   party: minority
   rank: 3
-  thomas: '02111'
   bioguide: L000579
 - name: Ruben Gallego
   party: minority
   rank: 4
-  thomas: '02226'
   bioguide: G000574
 - name: A. Donald McEachin
   party: minority
@@ -6905,7 +6577,6 @@ HSII10:
 - name: Raúl M. Grijalva
   party: minority
   rank: 10
-  thomas: '01708'
   bioguide: G000551
   title: Ex Officio
 HSII13:
@@ -6913,42 +6584,34 @@ HSII13:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01834'
   bioguide: L000564
 - name: Robert J. Wittman
   party: majority
   rank: 2
-  thomas: '01886'
   bioguide: W000804
 - name: Tom McClintock
   party: majority
   rank: 3
-  thomas: '01908'
   bioguide: M001177
 - name: Paul A. Gosar
   party: majority
   rank: 4
-  thomas: '01992'
   bioguide: G000565
 - name: Doug LaMalfa
   party: majority
   rank: 5
-  thomas: '02100'
   bioguide: L000578
 - name: Garret Graves
   party: majority
   rank: 7
-  thomas: '02245'
   bioguide: G000577
 - name: Jody B. Hice
   party: majority
   rank: 8
-  thomas: '02237'
   bioguide: H001071
 - name: Daniel Webster
   party: majority
   rank: 9
-  thomas: '02002'
   bioguide: W000806
 - name: Mike Johnson
   party: majority
@@ -6961,29 +6624,24 @@ HSII13:
 - name: Rob Bishop
   party: majority
   rank: 12
-  thomas: '01753'
   bioguide: B001250
   title: Ex Officio
 - name: Jared Huffman
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02101'
   bioguide: H001068
 - name: Grace F. Napolitano
   party: minority
   rank: 2
-  thomas: '01602'
   bioguide: N000179
 - name: Jim Costa
   party: minority
   rank: 3
-  thomas: '01774'
   bioguide: C001059
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 4
-  thomas: '02272'
   bioguide: B001292
 - name: Nanette Diaz Barragán
   party: minority
@@ -6992,7 +6650,6 @@ HSII13:
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 7
-  thomas: '01962'
   bioguide: S001177
 - name: Jimmy Gomez
   party: minority
@@ -7001,7 +6658,6 @@ HSII13:
 - name: Raúl M. Grijalva
   party: minority
   rank: 9
-  thomas: '01708'
   bioguide: G000551
   title: Ex Officio
 HSII15:
@@ -7009,17 +6665,14 @@ HSII15:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02224'
   bioguide: W000821
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 4
-  thomas: '02222'
   bioguide: R000600
 - name: Mike Johnson
   party: majority
@@ -7032,7 +6685,6 @@ HSII15:
 - name: Rob Bishop
   party: majority
   rank: 7
-  thomas: '01753'
   bioguide: B001250
   title: Ex Officio
 - name: A. Donald McEachin
@@ -7043,12 +6695,10 @@ HSII15:
 - name: Ruben Gallego
   party: minority
   rank: 2
-  thomas: '02226'
   bioguide: G000574
 - name: Jared Huffman
   party: minority
   rank: 3
-  thomas: '02101'
   bioguide: H001068
 - name: Darren Soto
   party: minority
@@ -7057,12 +6707,10 @@ HSII15:
 - name: Wm. Lacy Clay
   party: minority
   rank: 5
-  thomas: '01654'
   bioguide: C001049
 - name: Raúl M. Grijalva
   party: minority
   rank: 6
-  thomas: '01708'
   bioguide: G000551
   title: Ex Officio
 HSII24:
@@ -7070,22 +6718,18 @@ HSII24:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02100'
   bioguide: L000578
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
 - name: Paul Cook
   party: majority
   rank: 4
-  thomas: '02103'
   bioguide: C001094
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
 - name: Jack Bergman
   party: majority
@@ -7098,19 +6742,16 @@ HSII24:
 - name: Rob Bishop
   party: majority
   rank: 9
-  thomas: '01753'
   bioguide: B001250
   title: Ex Officio
 - name: Ruben Gallego
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02226'
   bioguide: G000574
 - name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 3
-  thomas: '01962'
   bioguide: S001177
 - name: Darren Soto
   party: minority
@@ -7119,64 +6760,52 @@ HSII24:
 - name: Nydia M. Velázquez
   party: minority
   rank: 6
-  thomas: '01184'
   bioguide: V000081
 - name: Raúl M. Grijalva
   party: minority
   rank: 7
-  thomas: '01708'
   bioguide: G000551
   title: Ex Officio
 HSJU:
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 2
-  thomas: '01041'
   bioguide: S000244
 - name: Steve Chabot
   party: majority
   rank: 4
-  thomas: '00186'
   bioguide: C000266
 - name: Steve King
   party: majority
   rank: 6
-  thomas: '01724'
   bioguide: K000362
 - name: Louie Gohmert
   party: majority
   rank: 7
-  thomas: '01801'
   bioguide: G000552
 - name: Jim Jordan
   party: majority
   rank: 8
-  thomas: '01868'
   bioguide: J000289
 - name: Tom Marino
   party: majority
   rank: 10
-  thomas: '02053'
   bioguide: M001179
 - name: Doug Collins
   party: majority
   rank: 13
-  thomas: '02121'
   bioguide: C001093
 - name: Ken Buck
   party: majority
   rank: 14
-  thomas: '02233'
   bioguide: B001297
 - name: John Ratcliffe
   party: majority
   rank: 15
-  thomas: '02268'
   bioguide: R000601
 - name: Martha Roby
   party: majority
   rank: 16
-  thomas: '01986'
   bioguide: R000591
 - name: Matt Gaetz
   party: majority
@@ -7198,62 +6827,50 @@ HSJU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00850'
   bioguide: N000002
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
 - name: Sheila Jackson Lee
   party: minority
   rank: 3
-  thomas: '00588'
   bioguide: J000032
 - name: Steve Cohen
   party: minority
   rank: 4
-  thomas: '01878'
   bioguide: C001068
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 5
-  thomas: '01843'
   bioguide: J000288
 - name: Theodore E. Deutch
   party: minority
   rank: 6
-  thomas: '01976'
   bioguide: D000610
 - name: Karen Bass
   party: minority
   rank: 8
-  thomas: '01996'
   bioguide: B001270
 - name: Cedric L. Richmond
   party: minority
   rank: 9
-  thomas: '02023'
   bioguide: R000588
 - name: Hakeem S. Jeffries
   party: minority
   rank: 10
-  thomas: '02149'
   bioguide: J000294
 - name: David N. Cicilline
   party: minority
   rank: 11
-  thomas: '02055'
   bioguide: C001084
 - name: Eric Swalwell
   party: minority
   rank: 12
-  thomas: '02104'
   bioguide: S001193
 - name: Ted Lieu
   party: minority
   rank: 13
-  thomas: '02230'
   bioguide: L000582
 - name: Jamie Raskin
   party: minority
@@ -7266,7 +6883,6 @@ HSJU:
 - name: Bradley Scott Schneider
   party: minority
   rank: 16
-  thomas: '02124'
   bioguide: S001190
 - name: Val Butler Demings
   party: minority
@@ -7276,23 +6892,19 @@ HSJU01:
 - name: Ken Buck
   party: majority
   rank: 2
-  thomas: '02233'
   bioguide: B001297
   title: Vice Chair
 - name: F. James Sensenbrenner, Jr.
   party: majority
   rank: 3
-  thomas: '01041'
   bioguide: S000244
 - name: Steve King
   party: majority
   rank: 5
-  thomas: '01724'
   bioguide: K000362
 - name: Jim Jordan
   party: majority
   rank: 6
-  thomas: '01868'
   bioguide: J000289
 - name: Mike Johnson
   party: majority
@@ -7306,7 +6918,6 @@ HSJU01:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00701'
   bioguide: L000397
 - name: Pramila Jayapal
   party: minority
@@ -7315,7 +6926,6 @@ HSJU01:
 - name: Sheila Jackson Lee
   party: minority
   rank: 4
-  thomas: '00588'
   bioguide: J000032
 - name: Jamie Raskin
   party: minority
@@ -7325,23 +6935,19 @@ HSJU03:
 - name: Doug Collins
   party: majority
   rank: 2
-  thomas: '02121'
   bioguide: C001093
   title: Vice Chair
 - name: Steve Chabot
   party: majority
   rank: 4
-  thomas: '00186'
   bioguide: C000266
 - name: Jim Jordan
   party: majority
   rank: 5
-  thomas: '01868'
   bioguide: J000289
 - name: Tom Marino
   party: majority
   rank: 7
-  thomas: '02053'
   bioguide: M001179
 - name: Matt Gaetz
   party: majority
@@ -7359,57 +6965,46 @@ HSJU03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01843'
   bioguide: J000288
 - name: Theodore E. Deutch
   party: minority
   rank: 2
-  thomas: '01976'
   bioguide: D000610
 - name: Karen Bass
   party: minority
   rank: 3
-  thomas: '01996'
   bioguide: B001270
 - name: Cedric L. Richmond
   party: minority
   rank: 4
-  thomas: '02023'
   bioguide: R000588
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
-  thomas: '02149'
   bioguide: J000294
 - name: Eric Swalwell
   party: minority
   rank: 6
-  thomas: '02104'
   bioguide: S001193
 - name: Ted Lieu
   party: minority
   rank: 7
-  thomas: '02230'
   bioguide: L000582
 - name: Bradley Scott Schneider
   party: minority
   rank: 8
-  thomas: '02124'
   bioguide: S001190
 - name: Zoe Lofgren
   party: minority
   rank: 9
-  thomas: '00701'
   bioguide: L000397
 - name: Steve Cohen
   party: minority
   rank: 10
-  thomas: '01878'
   bioguide: C001068
 - name: David N. Cicilline
   party: minority
   rank: 11
-  thomas: '02055'
   bioguide: C001084
 - name: Pramila Jayapal
   party: minority
@@ -7420,23 +7015,19 @@ HSJU05:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02053'
   bioguide: M001179
 - name: John Ratcliffe
   party: majority
   rank: 2
-  thomas: '02268'
   bioguide: R000601
   title: Vice Chair
 - name: Doug Collins
   party: majority
   rank: 4
-  thomas: '02121'
   bioguide: C001093
 - name: Ken Buck
   party: majority
   rank: 5
-  thomas: '02233'
   bioguide: B001297
 - name: Matt Gaetz
   party: majority
@@ -7446,22 +7037,18 @@ HSJU05:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02055'
   bioguide: C001084
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 2
-  thomas: '01843'
   bioguide: J000288
 - name: Eric Swalwell
   party: minority
   rank: 3
-  thomas: '02104'
   bioguide: S001193
 - name: Bradley Scott Schneider
   party: minority
   rank: 4
-  thomas: '02124'
   bioguide: S001190
 - name: Val Butler Demings
   party: minority
@@ -7472,28 +7059,23 @@ HSJU08:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01041'
   bioguide: S000244
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
   title: Vice Chair
 - name: Steve Chabot
   party: majority
   rank: 3
-  thomas: '00186'
   bioguide: C000266
 - name: John Ratcliffe
   party: majority
   rank: 6
-  thomas: '02268'
   bioguide: R000601
 - name: Martha Roby
   party: majority
   rank: 7
-  thomas: '01986'
   bioguide: R000591
 - name: Mike Johnson
   party: majority
@@ -7507,7 +7089,6 @@ HSJU08:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00588'
   bioguide: J000032
 - name: Val Butler Demings
   party: minority
@@ -7516,22 +7097,18 @@ HSJU08:
 - name: Karen Bass
   party: minority
   rank: 3
-  thomas: '01996'
   bioguide: B001270
 - name: Cedric L. Richmond
   party: minority
   rank: 4
-  thomas: '02023'
   bioguide: R000588
 - name: Hakeem S. Jeffries
   party: minority
   rank: 5
-  thomas: '02149'
   bioguide: J000294
 - name: Ted Lieu
   party: minority
   rank: 6
-  thomas: '02230'
   bioguide: L000582
 - name: Jamie Raskin
   party: minority
@@ -7542,18 +7119,15 @@ HSJU10:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01724'
   bioguide: K000362
 - name: Louie Gohmert
   party: majority
   rank: 2
-  thomas: '01801'
   bioguide: G000552
 - name: Steve Cohen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01878'
   bioguide: C001068
 - name: Jamie Raskin
   party: minority
@@ -7562,98 +7136,79 @@ HSJU10:
 - name: Theodore E. Deutch
   party: minority
   rank: 3
-  thomas: '01976'
   bioguide: D000610
 HSPW:
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
 - name: Sam Graves
   party: majority
   rank: 5
-  thomas: '01656'
   bioguide: G000546
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 6
-  thomas: '01989'
   bioguide: C001087
 - name: Bob Gibbs
   party: majority
   rank: 8
-  thomas: '02049'
   bioguide: G000563
 - name: Daniel Webster
   party: majority
   rank: 9
-  thomas: '02002'
   bioguide: W000806
 - name: Thomas Massie
   party: majority
   rank: 11
-  thomas: '02094'
   bioguide: M001184
 - name: Mark Meadows
   party: majority
   rank: 12
-  thomas: '02142'
   bioguide: M001187
 - name: Scott Perry
   party: majority
   rank: 13
-  thomas: '02157'
   bioguide: P000605
 - name: Rodney Davis
   party: majority
   rank: 14
-  thomas: '02126'
   bioguide: D000619
 - name: Rob Woodall
   party: majority
   rank: 16
-  thomas: '02008'
   bioguide: W000810
 - name: John Katko
   party: majority
   rank: 18
-  thomas: '02264'
   bioguide: K000386
 - name: Brian Babin
   party: majority
   rank: 19
-  thomas: '02270'
   bioguide: B001291
 - name: Garret Graves
   party: majority
   rank: 20
-  thomas: '02245'
   bioguide: G000577
 - name: David Rouzer
   party: majority
   rank: 22
-  thomas: '02256'
   bioguide: R000603
 - name: Mike Bost
   party: majority
   rank: 23
-  thomas: '02243'
   bioguide: B001295
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 24
-  thomas: '02161'
   bioguide: W000814
 - name: Doug LaMalfa
   party: majority
   rank: 25
-  thomas: '02100'
   bioguide: L000578
 - name: Bruce Westerman
   party: majority
   rank: 26
-  thomas: '02224'
   bioguide: W000821
 - name: Lloyd Smucker
   party: majority
@@ -7679,189 +7234,152 @@ HSPW:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00279'
   bioguide: D000191
 - name: Eleanor Holmes Norton
   party: minority
   rank: 2
-  thomas: '00868'
   bioguide: N000147
 - name: Eddie Bernice Johnson
   party: minority
   rank: 3
-  thomas: '00599'
   bioguide: J000126
 - name: Elijah E. Cummings
   party: minority
   rank: 4
-  thomas: '00256'
   bioguide: C000984
 - name: Rick Larsen
   party: minority
   rank: 5
-  thomas: '01675'
   bioguide: L000560
 - name: Grace F. Napolitano
   party: minority
   rank: 7
-  thomas: '01602'
   bioguide: N000179
 - name: Daniel Lipinski
   party: minority
   rank: 8
-  thomas: '01781'
   bioguide: L000563
 - name: Steve Cohen
   party: minority
   rank: 9
-  thomas: '01878'
   bioguide: C001068
 - name: Albio Sires
   party: minority
   rank: 10
-  thomas: '01818'
   bioguide: S001165
 - name: John Garamendi
   party: minority
   rank: 11
-  thomas: '01973'
   bioguide: G000559
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 12
-  thomas: '01843'
   bioguide: J000288
 - name: André Carson
   party: minority
   rank: 13
-  thomas: '01889'
   bioguide: C001072
 - name: Dina Titus
   party: minority
   rank: 15
-  thomas: '01940'
   bioguide: T000468
 - name: Sean Patrick Maloney
   party: minority
   rank: 16
-  thomas: '02150'
   bioguide: M001185
 - name: Lois Frankel
   party: minority
   rank: 18
-  thomas: '02119'
   bioguide: F000462
 - name: Cheri Bustos
   party: minority
   rank: 19
-  thomas: '02127'
   bioguide: B001286
 - name: Jared Huffman
   party: minority
   rank: 20
-  thomas: '02101'
   bioguide: H001068
 - name: Julia Brownley
   party: minority
   rank: 21
-  thomas: '02106'
   bioguide: B001285
 - name: Frederica S. Wilson
   party: minority
   rank: 22
-  thomas: '02004'
   bioguide: W000808
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 23
-  thomas: '02097'
   bioguide: P000604
 - name: Alan S. Lowenthal
   party: minority
   rank: 24
-  thomas: '02111'
   bioguide: L000579
 - name: Brenda L. Lawrence
   party: minority
   rank: 25
-  thomas: '02252'
   bioguide: L000581
 - name: Mark DeSaulnier
   party: minority
   rank: 26
-  thomas: '02227'
   bioguide: D000623
 - name: Stacey E. Plaskett
   party: minority
   rank: 27
-  thomas: '02274'
   bioguide: P000610
 HSPW02:
 - name: Garret Graves
   party: majority
   rank: 1
   title: Chair
-  thomas: '02245'
   bioguide: G000577
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
-  thomas: '01989'
   bioguide: C001087
 - name: Bob Gibbs
   party: majority
   rank: 3
-  thomas: '02049'
   bioguide: G000563
 - name: Daniel Webster
   party: majority
   rank: 4
-  thomas: '02002'
   bioguide: W000806
 - name: Thomas Massie
   party: majority
   rank: 5
-  thomas: '02094'
   bioguide: M001184
 - name: Rodney Davis
   party: majority
   rank: 6
-  thomas: '02126'
   bioguide: D000619
 - name: Rob Woodall
   party: majority
   rank: 8
-  thomas: '02008'
   bioguide: W000810
 - name: John Katko
   party: majority
   rank: 10
-  thomas: '02264'
   bioguide: K000386
 - name: Brian Babin
   party: majority
   rank: 11
-  thomas: '02270'
   bioguide: B001291
 - name: David Rouzer
   party: majority
   rank: 12
-  thomas: '02256'
   bioguide: R000603
 - name: Mike Bost
   party: majority
   rank: 13
-  thomas: '02243'
   bioguide: B001295
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 14
-  thomas: '02161'
   bioguide: W000814
 - name: Doug LaMalfa
   party: majority
   rank: 15
-  thomas: '02100'
   bioguide: L000578
 - name: A. Drew Ferguson IV
   party: majority
@@ -7875,118 +7393,95 @@ HSPW02:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01602'
   bioguide: N000179
 - name: Lois Frankel
   party: minority
   rank: 2
-  thomas: '02119'
   bioguide: F000462
 - name: Frederica S. Wilson
   party: minority
   rank: 3
-  thomas: '02004'
   bioguide: W000808
 - name: Jared Huffman
   party: minority
   rank: 4
-  thomas: '02101'
   bioguide: H001068
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
-  thomas: '02111'
   bioguide: L000579
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
-  thomas: '00599'
   bioguide: J000126
 - name: John Garamendi
   party: minority
   rank: 7
-  thomas: '01973'
   bioguide: G000559
 - name: Dina Titus
   party: minority
   rank: 8
-  thomas: '01940'
   bioguide: T000468
 - name: Sean Patrick Maloney
   party: minority
   rank: 9
-  thomas: '02150'
   bioguide: M001185
 - name: Cheri Bustos
   party: minority
   rank: 11
-  thomas: '02127'
   bioguide: B001286
 - name: Julia Brownley
   party: minority
   rank: 12
-  thomas: '02106'
   bioguide: B001285
 - name: Brenda L. Lawrence
   party: minority
   rank: 13
-  thomas: '02252'
   bioguide: L000581
 HSPW05:
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
 - name: Sam Graves
   party: majority
   rank: 4
-  thomas: '01656'
   bioguide: G000546
 - name: Bob Gibbs
   party: majority
   rank: 5
-  thomas: '02049'
   bioguide: G000563
 - name: Daniel Webster
   party: majority
   rank: 6
-  thomas: '02002'
   bioguide: W000806
 - name: Thomas Massie
   party: majority
   rank: 8
-  thomas: '02094'
   bioguide: M001184
 - name: Mark Meadows
   party: majority
   rank: 9
-  thomas: '02142'
   bioguide: M001187
 - name: Scott Perry
   party: majority
   rank: 10
-  thomas: '02157'
   bioguide: P000605
 - name: Rodney Davis
   party: majority
   rank: 11
-  thomas: '02126'
   bioguide: D000619
 - name: Rob Woodall
   party: majority
   rank: 13
-  thomas: '02008'
   bioguide: W000810
 - name: Doug LaMalfa
   party: majority
   rank: 16
-  thomas: '02100'
   bioguide: L000578
 - name: Bruce Westerman
   party: majority
   rank: 17
-  thomas: '02224'
   bioguide: W000821
 - name: Lloyd Smucker
   party: majority
@@ -8000,72 +7495,58 @@ HSPW05:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01675'
   bioguide: L000560
 - name: Eddie Bernice Johnson
   party: minority
   rank: 2
-  thomas: '00599'
   bioguide: J000126
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
 - name: André Carson
   party: minority
   rank: 4
-  thomas: '01889'
   bioguide: C001072
 - name: Cheri Bustos
   party: minority
   rank: 5
-  thomas: '02127'
   bioguide: B001286
 - name: Eleanor Holmes Norton
   party: minority
   rank: 6
-  thomas: '00868'
   bioguide: N000147
 - name: Dina Titus
   party: minority
   rank: 7
-  thomas: '01940'
   bioguide: T000468
 - name: Sean Patrick Maloney
   party: minority
   rank: 8
-  thomas: '02150'
   bioguide: M001185
 - name: Julia Brownley
   party: minority
   rank: 9
-  thomas: '02106'
   bioguide: B001285
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 10
-  thomas: '02097'
   bioguide: P000604
 - name: Brenda L. Lawrence
   party: minority
   rank: 11
-  thomas: '02252'
   bioguide: L000581
 - name: Grace F. Napolitano
   party: minority
   rank: 13
-  thomas: '01602'
   bioguide: N000179
 - name: Steve Cohen
   party: minority
   rank: 14
-  thomas: '01878'
   bioguide: C001068
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 15
-  thomas: '01843'
   bioguide: J000288
 HSPW07:
 - name: Brian J. Mast
@@ -8076,135 +7557,109 @@ HSPW07:
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
 - name: Garret Graves
   party: majority
   rank: 4
-  thomas: '02245'
   bioguide: G000577
 - name: David Rouzer
   party: majority
   rank: 5
-  thomas: '02256'
   bioguide: R000603
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 6
-  thomas: '02161'
   bioguide: W000814
 - name: John Garamendi
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01973'
   bioguide: G000559
 - name: Elijah E. Cummings
   party: minority
   rank: 2
-  thomas: '00256'
   bioguide: C000984
 - name: Rick Larsen
   party: minority
   rank: 3
-  thomas: '01675'
   bioguide: L000560
 - name: Jared Huffman
   party: minority
   rank: 4
-  thomas: '02101'
   bioguide: H001068
 - name: Alan S. Lowenthal
   party: minority
   rank: 5
-  thomas: '02111'
   bioguide: L000579
 - name: Stacey E. Plaskett
   party: minority
   rank: 6
-  thomas: '02274'
   bioguide: P000610
 HSPW12:
 - name: Sam Graves
   party: majority
   rank: 1
   title: Chair
-  thomas: '01656'
   bioguide: G000546
 - name: Don Young
   party: majority
   rank: 2
-  thomas: '01256'
   bioguide: Y000033
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 5
-  thomas: '01989'
   bioguide: C001087
 - name: Bob Gibbs
   party: majority
   rank: 7
-  thomas: '02049'
   bioguide: G000563
 - name: Thomas Massie
   party: majority
   rank: 9
-  thomas: '02094'
   bioguide: M001184
 - name: Mark Meadows
   party: majority
   rank: 10
-  thomas: '02142'
   bioguide: M001187
 - name: Scott Perry
   party: majority
   rank: 11
-  thomas: '02157'
   bioguide: P000605
 - name: Rodney Davis
   party: majority
   rank: 12
-  thomas: '02126'
   bioguide: D000619
 - name: Rob Woodall
   party: majority
   rank: 13
-  thomas: '02008'
   bioguide: W000810
 - name: John Katko
   party: majority
   rank: 14
-  thomas: '02264'
   bioguide: K000386
 - name: Brian Babin
   party: majority
   rank: 15
-  thomas: '02270'
   bioguide: B001291
 - name: Garret Graves
   party: majority
   rank: 16
-  thomas: '02245'
   bioguide: G000577
 - name: David Rouzer
   party: majority
   rank: 18
-  thomas: '02256'
   bioguide: R000603
 - name: Mike Bost
   party: majority
   rank: 19
-  thomas: '02243'
   bioguide: B001295
 - name: Doug LaMalfa
   party: majority
   rank: 20
-  thomas: '02100'
   bioguide: L000578
 - name: Bruce Westerman
   party: majority
   rank: 21
-  thomas: '02224'
   bioguide: W000821
 - name: Lloyd Smucker
   party: majority
@@ -8226,103 +7681,83 @@ HSPW12:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00868'
   bioguide: N000147
 - name: Steve Cohen
   party: minority
   rank: 2
-  thomas: '01878'
   bioguide: C001068
 - name: Albio Sires
   party: minority
   rank: 3
-  thomas: '01818'
   bioguide: S001165
 - name: Dina Titus
   party: minority
   rank: 5
-  thomas: '01940'
   bioguide: T000468
 - name: Sean Patrick Maloney
   party: minority
   rank: 6
-  thomas: '02150'
   bioguide: M001185
 - name: Jared Huffman
   party: minority
   rank: 8
-  thomas: '02101'
   bioguide: H001068
 - name: Julia Brownley
   party: minority
   rank: 9
-  thomas: '02106'
   bioguide: B001285
 - name: Alan S. Lowenthal
   party: minority
   rank: 10
-  thomas: '02111'
   bioguide: L000579
 - name: Brenda L. Lawrence
   party: minority
   rank: 11
-  thomas: '02252'
   bioguide: L000581
 - name: Mark DeSaulnier
   party: minority
   rank: 12
-  thomas: '02227'
   bioguide: D000623
 - name: Eddie Bernice Johnson
   party: minority
   rank: 13
-  thomas: '00599'
   bioguide: J000126
 - name: Grace F. Napolitano
   party: minority
   rank: 15
-  thomas: '01602'
   bioguide: N000179
 - name: Daniel Lipinski
   party: minority
   rank: 16
-  thomas: '01781'
   bioguide: L000563
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 17
-  thomas: '01843'
   bioguide: J000288
 - name: Lois Frankel
   party: minority
   rank: 18
-  thomas: '02119'
   bioguide: F000462
 - name: Cheri Bustos
   party: minority
   rank: 19
-  thomas: '02127'
   bioguide: B001286
 - name: Frederica S. Wilson
   party: minority
   rank: 20
-  thomas: '02004'
   bioguide: W000808
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 21
-  thomas: '02097'
   bioguide: P000604
 HSPW13:
 - name: Eric A. "Rick" Crawford
   party: majority
   rank: 2
-  thomas: '01989'
   bioguide: C001087
 - name: Mike Bost
   party: majority
   rank: 4
-  thomas: '02243'
   bioguide: B001295
 - name: A. Drew Ferguson IV
   party: majority
@@ -8340,68 +7775,55 @@ HSPW13:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01940'
   bioguide: T000468
 - name: Henry C. "Hank" Johnson, Jr.
   party: minority
   rank: 2
-  thomas: '01843'
   bioguide: J000288
 - name: Eleanor Holmes Norton
   party: minority
   rank: 3
-  thomas: '00868'
   bioguide: N000147
 - name: Albio Sires
   party: minority
   rank: 4
-  thomas: '01818'
   bioguide: S001165
 - name: Stacey E. Plaskett
   party: minority
   rank: 5
-  thomas: '02274'
   bioguide: P000610
 HSPW14:
 - name: Sam Graves
   party: majority
   rank: 3
-  thomas: '01656'
   bioguide: G000546
 - name: Daniel Webster
   party: majority
   rank: 5
-  thomas: '02002'
   bioguide: W000806
 - name: Mark Meadows
   party: majority
   rank: 6
-  thomas: '02142'
   bioguide: M001187
 - name: Scott Perry
   party: majority
   rank: 7
-  thomas: '02157'
   bioguide: P000605
 - name: John Katko
   party: majority
   rank: 10
-  thomas: '02264'
   bioguide: K000386
 - name: Brian Babin
   party: majority
   rank: 11
-  thomas: '02270'
   bioguide: B001291
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 12
-  thomas: '02161'
   bioguide: W000814
 - name: Bruce Westerman
   party: majority
   rank: 13
-  thomas: '02224'
   bioguide: W000821
 - name: Lloyd Smucker
   party: majority
@@ -8418,74 +7840,60 @@ HSPW14:
 - name: Donald M. Payne, Jr.
   party: minority
   rank: 2
-  thomas: '02097'
   bioguide: P000604
 - name: Elijah E. Cummings
   party: minority
   rank: 3
-  thomas: '00256'
   bioguide: C000984
 - name: Steve Cohen
   party: minority
   rank: 4
-  thomas: '01878'
   bioguide: C001068
 - name: Albio Sires
   party: minority
   rank: 5
-  thomas: '01818'
   bioguide: S001165
 - name: John Garamendi
   party: minority
   rank: 6
-  thomas: '01973'
   bioguide: G000559
 - name: André Carson
   party: minority
   rank: 7
-  thomas: '01889'
   bioguide: C001072
 - name: Cheri Bustos
   party: minority
   rank: 10
-  thomas: '02127'
   bioguide: B001286
 - name: Frederica S. Wilson
   party: minority
   rank: 11
-  thomas: '02004'
   bioguide: W000808
 - name: Mark DeSaulnier
   party: minority
   rank: 12
-  thomas: '02227'
   bioguide: D000623
 - name: Daniel Lipinski
   party: minority
   rank: 13
-  thomas: '01781'
   bioguide: L000563
 - name: Grace F. Napolitano
   party: minority
   rank: 14
-  thomas: '01602'
   bioguide: N000179
 HSRU:
 - name: James P. McGovern
   party: majority
   rank: 1
   title: Chair
-  thomas: '01504'
   bioguide: M000312
 - name: Alcee L. Hastings
   party: majority
   rank: 2
-  thomas: '00511'
   bioguide: H000324
 - name: Norma J. Torres
   party: majority
   rank: 3
-  thomas: '02231'
   bioguide: T000474
 - name: Jamie Raskin
   party: majority
@@ -8506,27 +7914,22 @@ HSRU:
 - name: Doris O. Matsui
   party: majority
   rank: 8
-  thomas: '01814'
   bioguide: M001163
 - name: Ed Perlmutter
   party: majority
   rank: 9
-  thomas: '01835'
   bioguide: P000593
 - name: Tom Cole
   party: minority
   rank: 1
-  thomas: '01742'
   bioguide: C001053
 - name: Rob Woodall
   party: minority
   rank: 2
-  thomas: '02008'
   bioguide: W000810
 - name: Michael C. Burgess
   party: minority
   rank: 3
-  thomas: '01751'
   bioguide: B001248
 - name: Debbie Lesko
   party: minority
@@ -8537,50 +7940,41 @@ HSRU02:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02008'
   bioguide: W000810
 - name: Michael C. Burgess
   party: majority
   rank: 2
-  thomas: '01751'
   bioguide: B001248
 - name: Bradley Byrne
   party: majority
   rank: 3
-  thomas: '02197'
   bioguide: B001289
 - name: Dan Newhouse
   party: majority
   rank: 4
-  thomas: '02275'
   bioguide: N000189
 - name: Ken Buck
   party: majority
   rank: 5
-  thomas: '02233'
   bioguide: B001297
 - name: Alcee L. Hastings
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00511'
   bioguide: H000324
 HSRU04:
 - name: Doug Collins
   party: majority
   rank: 1
   title: Chair
-  thomas: '02121'
   bioguide: C001093
 - name: Bradley Byrne
   party: majority
   rank: 2
-  thomas: '02197'
   bioguide: B001289
 - name: Dan Newhouse
   party: majority
   rank: 3
-  thomas: '02275'
   bioguide: N000189
 - name: Liz Cheney
   party: majority
@@ -8590,39 +7984,32 @@ HSRU04:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01504'
   bioguide: M000312
 - name: Norma J. Torres
   party: minority
   rank: 2
-  thomas: '02231'
   bioguide: T000474
 HSSM:
 - name: Steve Chabot
   party: majority
   rank: 1
   title: Chair
-  thomas: '00186'
   bioguide: C000266
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
-  thomas: '01931'
   bioguide: L000569
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
 - name: Trent Kelly
   party: majority
   rank: 7
-  thomas: '02294'
   bioguide: K000388
 - name: Jenniffer González-Colón
   party: majority
@@ -8652,7 +8039,6 @@ HSSM:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01184'
   bioguide: V000081
 - name: Dwight Evans
   party: minority
@@ -8669,17 +8055,14 @@ HSSM:
 - name: Yvette D. Clarke
   party: minority
   rank: 5
-  thomas: '01864'
   bioguide: C001067
 - name: Judy Chu
   party: minority
   rank: 6
-  thomas: '01970'
   bioguide: C001080
 - name: Alma S. Adams
   party: minority
   rank: 7
-  thomas: '02201'
   bioguide: A000370
 - name: Adriano Espaillat
   party: minority
@@ -8688,13 +8071,11 @@ HSSM:
 - name: Bradley Scott Schneider
   party: minority
   rank: 9
-  thomas: '02124'
   bioguide: S001190
 HSSM23:
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
 - name: Ralph Norman
   party: majority
@@ -8708,7 +8089,6 @@ HSSM23:
 - name: Yvette D. Clarke
   party: minority
   rank: 2
-  thomas: '01864'
   bioguide: C001067
 - name: Dwight Evans
   party: minority
@@ -8723,7 +8103,6 @@ HSSM24:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02294'
   bioguide: K000388
 - name: Roger W. Marshall
   party: majority
@@ -8741,23 +8120,19 @@ HSSM24:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02201'
   bioguide: A000370
 HSSM25:
 - name: Steve King
   party: majority
   rank: 2
-  thomas: '01724'
   bioguide: K000362
 - name: Blaine Luetkemeyer
   party: majority
   rank: 3
-  thomas: '01931'
   bioguide: L000569
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 4
-  thomas: '02222'
   bioguide: R000600
 - name: John R. Curtis
   party: majority
@@ -8771,7 +8146,6 @@ HSSM25:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02124'
   bioguide: S001190
 - name: Al Lawson, Jr.
   party: minority
@@ -8782,12 +8156,10 @@ HSSM26:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02222'
   bioguide: R000600
 - name: Blaine Luetkemeyer
   party: majority
   rank: 2
-  thomas: '01931'
   bioguide: L000569
 - name: Jenniffer González-Colón
   party: majority
@@ -8814,7 +8186,6 @@ HSSM27:
 - name: Trent Kelly
   party: majority
   rank: 3
-  thomas: '02294'
   bioguide: K000388
 - name: Jenniffer González-Colón
   party: majority
@@ -8836,7 +8207,6 @@ HSSM27:
 - name: Judy Chu
   party: minority
   rank: 2
-  thomas: '01970'
   bioguide: C001080
 - name: Stephanie N. Murphy
   party: minority
@@ -8845,35 +8215,29 @@ HSSM27:
 - name: Yvette D. Clarke
   party: minority
   rank: 4
-  thomas: '01864'
   bioguide: C001067
 HSSO:
 - name: Susan W. Brooks
   party: majority
   rank: 1
   title: Chair
-  thomas: '02129'
   bioguide: B001284
 - name: Kenny Marchant
   party: majority
   rank: 2
-  thomas: '01806'
   bioguide: M001158
 - name: John Ratcliffe
   party: majority
   rank: 5
-  thomas: '02268'
   bioguide: R000601
 - name: Theodore E. Deutch
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01976'
   bioguide: D000610
 - name: Yvette D. Clarke
   party: minority
   rank: 2
-  thomas: '01864'
   bioguide: C001067
 - name: Anthony G. Brown
   party: minority
@@ -8882,54 +8246,44 @@ HSSO:
 - name: Steve Cohen
   party: minority
   rank: 5
-  thomas: '01878'
   bioguide: C001068
 HSSY:
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
   title: Vice Chair
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
 - name: Bill Posey
   party: majority
   rank: 6
-  thomas: '01915'
   bioguide: P000599
 - name: Thomas Massie
   party: majority
   rank: 7
-  thomas: '02094'
   bioguide: M001184
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 8
-  thomas: '02161'
   bioguide: W000814
 - name: Brian Babin
   party: majority
   rank: 10
-  thomas: '02270'
   bioguide: B001291
 - name: Ralph Lee Abraham
   party: majority
   rank: 12
-  thomas: '02244'
   bioguide: A000374
 - name: Gary J. Palmer
   party: majority
   rank: 13
-  thomas: '02221'
   bioguide: P000609
 - name: Daniel Webster
   party: majority
   rank: 14
-  thomas: '02002'
   bioguide: W000806
 - name: Andy Biggs
   party: majority
@@ -8967,37 +8321,30 @@ HSSY:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00599'
   bioguide: J000126
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
 - name: Ami Bera
   party: minority
   rank: 5
-  thomas: '02102'
   bioguide: B001287
 - name: Marc A. Veasey
   party: minority
   rank: 7
-  thomas: '02166'
   bioguide: V000131
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 8
-  thomas: '02272'
   bioguide: B001292
 - name: Jacky Rosen
   party: minority
@@ -9010,27 +8357,22 @@ HSSY:
 - name: Jerry McNerney
   party: minority
   rank: 11
-  thomas: '01832'
   bioguide: M001166
 - name: Ed Perlmutter
   party: minority
   rank: 12
-  thomas: '01835'
   bioguide: P000593
 - name: Paul Tonko
   party: minority
   rank: 13
-  thomas: '01942'
   bioguide: T000469
 - name: Bill Foster
   party: minority
   rank: 14
-  thomas: '01888'
   bioguide: F000454
 - name: Mark Takano
   party: minority
   rank: 15
-  thomas: '02110'
   bioguide: T000472
 - name: Charlie Crist
   party: minority
@@ -9040,12 +8382,10 @@ HSSY15:
 - name: Frank D. Lucas
   party: majority
   rank: 2
-  thomas: '00711'
   bioguide: L000491
 - name: Daniel Webster
   party: majority
   rank: 5
-  thomas: '02002'
   bioguide: W000806
 - name: Roger W. Marshall
   party: majority
@@ -9068,7 +8408,6 @@ HSSY15:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01781'
   bioguide: L000563
 - name: Jacky Rosen
   party: minority
@@ -9077,22 +8416,18 @@ HSSY15:
 - name: Suzanne Bonamici
   party: minority
   rank: 4
-  thomas: '02092'
   bioguide: B001278
 - name: Ami Bera
   party: minority
   rank: 5
-  thomas: '02102'
   bioguide: B001287
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 6
-  thomas: '02272'
   bioguide: B001292
 - name: Eddie Bernice Johnson
   party: minority
   rank: 7
-  thomas: '00599'
   bioguide: J000126
   title: Ex Officio
 HSSY16:
@@ -9100,38 +8435,31 @@ HSSY16:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02270'
   bioguide: B001291
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
   title: Vice Chair
 - name: Thomas Massie
   party: majority
   rank: 6
-  thomas: '02094'
   bioguide: M001184
 - name: Bill Posey
   party: majority
   rank: 7
-  thomas: '01915'
   bioguide: P000599
 - name: Ralph Lee Abraham
   party: majority
   rank: 10
-  thomas: '02244'
   bioguide: A000374
 - name: Daniel Webster
   party: majority
   rank: 11
-  thomas: '02002'
   bioguide: W000806
 - name: Andy Biggs
   party: majority
@@ -9149,32 +8477,26 @@ HSSY16:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02102'
   bioguide: B001287
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
 - name: Donald S. Beyer, Jr.
   party: minority
   rank: 3
-  thomas: '02272'
   bioguide: B001292
 - name: Marc A. Veasey
   party: minority
   rank: 4
-  thomas: '02166'
   bioguide: V000131
 - name: Daniel Lipinski
   party: minority
   rank: 5
-  thomas: '01781'
   bioguide: L000563
 - name: Ed Perlmutter
   party: minority
   rank: 6
-  thomas: '01835'
   bioguide: P000593
 - name: Charlie Crist
   party: minority
@@ -9183,7 +8505,6 @@ HSSY16:
 - name: Bill Foster
   party: minority
   rank: 8
-  thomas: '01888'
   bioguide: F000454
 - name: Conor Lamb
   party: minority
@@ -9192,7 +8513,6 @@ HSSY16:
 - name: Eddie Bernice Johnson
   party: minority
   rank: 11
-  thomas: '00599'
   bioguide: J000126
   title: Ex Officio
 HSSY18:
@@ -9204,27 +8524,22 @@ HSSY18:
 - name: Bill Posey
   party: majority
   rank: 3
-  thomas: '01915'
   bioguide: P000599
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
 - name: Randy K. Weber, Sr.
   party: majority
   rank: 5
-  thomas: '02161'
   bioguide: W000814
 - name: Brian Babin
   party: majority
   rank: 6
-  thomas: '02270'
   bioguide: B001291
 - name: Gary J. Palmer
   party: majority
   rank: 7
-  thomas: '02221'
   bioguide: P000609
 - name: Clay Higgins
   party: majority
@@ -9243,7 +8558,6 @@ HSSY18:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02092'
   bioguide: B001278
 - name: Charlie Crist
   party: minority
@@ -9256,7 +8570,6 @@ HSSY18:
 - name: Eddie Bernice Johnson
   party: minority
   rank: 8
-  thomas: '00599'
   bioguide: J000126
   title: Ex Officio
 HSSY20:
@@ -9264,27 +8577,22 @@ HSSY20:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02161'
   bioguide: W000814
 - name: Frank D. Lucas
   party: majority
   rank: 3
-  thomas: '00711'
   bioguide: L000491
 - name: Mo Brooks
   party: majority
   rank: 4
-  thomas: '01987'
   bioguide: B001274
 - name: Gary J. Palmer
   party: majority
   rank: 7
-  thomas: '02221'
   bioguide: P000609
 - name: Daniel Webster
   party: majority
   rank: 8
-  thomas: '02002'
   bioguide: W000806
 - name: Neal P. Dunn
   party: majority
@@ -9302,17 +8610,14 @@ HSSY20:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02166'
   bioguide: V000131
 - name: Zoe Lofgren
   party: minority
   rank: 2
-  thomas: '00701'
   bioguide: L000397
 - name: Daniel Lipinski
   party: minority
   rank: 3
-  thomas: '01781'
   bioguide: L000563
 - name: Jacky Rosen
   party: minority
@@ -9321,27 +8626,22 @@ HSSY20:
 - name: Jerry McNerney
   party: minority
   rank: 5
-  thomas: '01832'
   bioguide: M001166
 - name: Paul Tonko
   party: minority
   rank: 6
-  thomas: '01942'
   bioguide: T000469
 - name: Bill Foster
   party: minority
   rank: 7
-  thomas: '01888'
   bioguide: F000454
 - name: Mark Takano
   party: minority
   rank: 8
-  thomas: '02110'
   bioguide: T000472
 - name: Eddie Bernice Johnson
   party: minority
   rank: 9
-  thomas: '00599'
   bioguide: J000126
   title: Ex Officio
 HSSY21:
@@ -9349,17 +8649,14 @@ HSSY21:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02244'
   bioguide: A000374
 - name: Bill Posey
   party: majority
   rank: 2
-  thomas: '01915'
   bioguide: P000599
 - name: Thomas Massie
   party: majority
   rank: 3
-  thomas: '02094'
   bioguide: M001184
 - name: Roger W. Marshall
   party: majority
@@ -9382,22 +8679,18 @@ HSSY21:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02272'
   bioguide: B001292
 - name: Jerry McNerney
   party: minority
   rank: 2
-  thomas: '01832'
   bioguide: M001166
 - name: Ed Perlmutter
   party: minority
   rank: 3
-  thomas: '01835'
   bioguide: P000593
 - name: Eddie Bernice Johnson
   party: minority
   rank: 6
-  thomas: '00599'
   bioguide: J000126
   title: Ex Officio
 HSVR:
@@ -9405,27 +8698,22 @@ HSVR:
   party: majority
   rank: 1
   title: Chair
-  thomas: '01954'
   bioguide: R000582
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
 - name: Bill Flores
   party: majority
   rank: 4
-  thomas: '02065'
   bioguide: F000461
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 5
-  thomas: '02222'
   bioguide: R000600
 - name: Mike Bost
   party: majority
   rank: 6
-  thomas: '02243'
   bioguide: B001295
 - name: Neal P. Dunn
   party: majority
@@ -9458,22 +8746,18 @@ HSVR:
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
 - name: Julia Brownley
   party: minority
   rank: 3
-  thomas: '02106'
   bioguide: B001285
 - name: Ann M. Kuster
   party: minority
   rank: 4
-  thomas: '02145'
   bioguide: K000382
 - name: Kathleen M. Rice
   party: minority
   rank: 6
-  thomas: '02262'
   bioguide: R000602
 - name: J. Luis Correa
   party: minority
@@ -9486,7 +8770,6 @@ HSVR:
 - name: Scott H. Peters
   party: minority
   rank: 10
-  thomas: '02113'
   bioguide: P000608
 HSVR03:
 - name: Neal P. Dunn
@@ -9497,17 +8780,14 @@ HSVR03:
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
 - name: Bill Flores
   party: majority
   rank: 3
-  thomas: '02065'
   bioguide: F000461
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 4
-  thomas: '02222'
   bioguide: R000600
 - name: Clay Higgins
   party: majority
@@ -9525,17 +8805,14 @@ HSVR03:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02106'
   bioguide: B001285
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
 - name: Ann M. Kuster
   party: minority
   rank: 3
-  thomas: '02145'
   bioguide: K000382
 - name: J. Luis Correa
   party: minority
@@ -9550,7 +8827,6 @@ HSVR08:
 - name: Mike Bost
   party: majority
   rank: 2
-  thomas: '02243'
   bioguide: B001295
 - name: Neal P. Dunn
   party: majority
@@ -9568,17 +8844,14 @@ HSVR08:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02145'
   bioguide: K000382
 - name: Kathleen M. Rice
   party: minority
   rank: 2
-  thomas: '02262'
   bioguide: R000602
 - name: Scott H. Peters
   party: minority
   rank: 3
-  thomas: '02113'
   bioguide: P000608
 - name: Conor Lamb
   party: minority
@@ -9589,12 +8862,10 @@ HSVR09:
   party: majority
   rank: 1
   title: Chair
-  thomas: '02243'
   bioguide: B001295
 - name: Aumua Amata Coleman Radewagen
   party: majority
   rank: 3
-  thomas: '02222'
   bioguide: R000600
 - name: Jack Bergman
   party: majority
@@ -9607,7 +8878,6 @@ HSVR09:
 - name: Julia Brownley
   party: minority
   rank: 2
-  thomas: '02106'
   bioguide: B001285
 - name: Conor Lamb
   party: minority
@@ -9622,12 +8892,10 @@ HSVR10:
 - name: Gus M. Bilirakis
   party: majority
   rank: 2
-  thomas: '01838'
   bioguide: B001257
 - name: Bill Flores
   party: majority
   rank: 3
-  thomas: '02065'
   bioguide: F000461
 - name: Jim Banks
   party: majority
@@ -9640,7 +8908,6 @@ HSVR10:
 - name: Mark Takano
   party: minority
   rank: 2
-  thomas: '02110'
   bioguide: T000472
 - name: J. Luis Correa
   party: minority
@@ -9649,7 +8916,6 @@ HSVR10:
 - name: Kathleen M. Rice
   party: minority
   rank: 4
-  thomas: '02262'
   bioguide: R000602
 HSVR11:
 - name: Jim Banks
@@ -9669,513 +8935,416 @@ HSVR11:
 - name: Scott H. Peters
   party: minority
   rank: 2
-  thomas: '02113'
   bioguide: P000608
 HSWM:
 - name: Kevin Brady
   party: majority
   rank: 1
   title: Chair
-  thomas: '01468'
   bioguide: B000755
 - name: Devin Nunes
   party: majority
   rank: 3
-  thomas: '01710'
   bioguide: N000181
 - name: Vern Buchanan
   party: majority
   rank: 6
-  thomas: '01840'
   bioguide: B001260
 - name: Adrian Smith
   party: majority
   rank: 7
-  thomas: '01860'
   bioguide: S001172
 - name: Kenny Marchant
   party: majority
   rank: 10
-  thomas: '01806'
   bioguide: M001158
 - name: Tom Reed
   party: majority
   rank: 12
-  thomas: '01982'
   bioguide: R000585
 - name: Mike Kelly
   party: majority
   rank: 13
-  thomas: '02051'
   bioguide: K000376
 - name: George Holding
   party: majority
   rank: 16
-  thomas: '02143'
   bioguide: H001065
 - name: Jason Smith
   party: majority
   rank: 17
-  thomas: '02191'
   bioguide: S001195
 - name: Tom Rice
   party: majority
   rank: 18
-  thomas: '02160'
   bioguide: R000597
 - name: David Schweikert
   party: majority
   rank: 19
-  thomas: '01994'
   bioguide: S001183
 - name: Jackie Walorski
   party: majority
   rank: 20
-  thomas: '02128'
   bioguide: W000813
 - name: Darin LaHood
   party: majority
   rank: 23
-  thomas: '02295'
   bioguide: L000585
 - name: Brad R. Wenstrup
   party: majority
   rank: 24
-  thomas: '02152'
   bioguide: W000815
 - name: Richard E. Neal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00854'
   bioguide: N000015
 - name: John Lewis
   party: minority
   rank: 3
-  thomas: '00688'
   bioguide: L000287
 - name: Lloyd Doggett
   party: minority
   rank: 4
-  thomas: '00303'
   bioguide: D000399
 - name: Mike Thompson
   party: minority
   rank: 5
-  thomas: '01593'
   bioguide: T000460
 - name: John B. Larson
   party: minority
   rank: 6
-  thomas: '01583'
   bioguide: L000557
 - name: Earl Blumenauer
   party: minority
   rank: 7
-  thomas: '00099'
   bioguide: B000574
 - name: Ron Kind
   party: minority
   rank: 8
-  thomas: '01498'
   bioguide: K000188
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 9
-  thomas: '01510'
   bioguide: P000096
 - name: Danny K. Davis
   party: minority
   rank: 11
-  thomas: '01477'
   bioguide: D000096
 - name: Linda T. Sánchez
   party: minority
   rank: 12
-  thomas: '01757'
   bioguide: S001156
 - name: Brian Higgins
   party: minority
   rank: 13
-  thomas: '01794'
   bioguide: H001038
 - name: Terri A. Sewell
   party: minority
   rank: 14
-  thomas: '01988'
   bioguide: S001185
 - name: Suzan K. DelBene
   party: minority
   rank: 15
-  thomas: '02096'
   bioguide: D000617
 - name: Judy Chu
   party: minority
   rank: 16
-  thomas: '01970'
   bioguide: C001080
 HSWM01:
 - name: Vern Buchanan
   party: majority
   rank: 3
-  thomas: '01840'
   bioguide: B001260
 - name: Mike Kelly
   party: majority
   rank: 4
-  thomas: '02051'
   bioguide: K000376
 - name: Tom Rice
   party: majority
   rank: 5
-  thomas: '02160'
   bioguide: R000597
 - name: David Schweikert
   party: majority
   rank: 6
-  thomas: '01994'
   bioguide: S001183
 - name: Darin LaHood
   party: majority
   rank: 7
-  thomas: '02295'
   bioguide: L000585
 - name: John B. Larson
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01583'
   bioguide: L000557
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 2
-  thomas: '01510'
   bioguide: P000096
 - name: Linda T. Sánchez
   party: minority
   rank: 4
-  thomas: '01757'
   bioguide: S001156
 HSWM02:
 - name: Devin Nunes
   party: majority
   rank: 3
-  thomas: '01710'
   bioguide: N000181
 - name: Vern Buchanan
   party: majority
   rank: 4
-  thomas: '01840'
   bioguide: B001260
 - name: Adrian Smith
   party: majority
   rank: 5
-  thomas: '01860'
   bioguide: S001172
 - name: Kenny Marchant
   party: majority
   rank: 7
-  thomas: '01806'
   bioguide: M001158
 - name: Tom Reed
   party: majority
   rank: 10
-  thomas: '01982'
   bioguide: R000585
 - name: Mike Kelly
   party: majority
   rank: 11
-  thomas: '02051'
   bioguide: K000376
 - name: Mike Thompson
   party: minority
   rank: 2
-  thomas: '01593'
   bioguide: T000460
 - name: Ron Kind
   party: minority
   rank: 3
-  thomas: '01498'
   bioguide: K000188
 - name: Earl Blumenauer
   party: minority
   rank: 4
-  thomas: '00099'
   bioguide: B000574
 - name: Brian Higgins
   party: minority
   rank: 5
-  thomas: '01794'
   bioguide: H001038
 - name: Terri A. Sewell
   party: minority
   rank: 6
-  thomas: '01988'
   bioguide: S001185
 - name: Judy Chu
   party: minority
   rank: 7
-  thomas: '01970'
   bioguide: C001080
 HSWM03:
 - name: Adrian Smith
   party: majority
   rank: 1
   title: Chair
-  thomas: '01860'
   bioguide: S001172
 - name: Jackie Walorski
   party: majority
   rank: 2
-  thomas: '02128'
   bioguide: W000813
 - name: David Schweikert
   party: majority
   rank: 4
-  thomas: '01994'
   bioguide: S001183
 - name: Darin LaHood
   party: majority
   rank: 5
-  thomas: '02295'
   bioguide: L000585
 - name: Brad R. Wenstrup
   party: majority
   rank: 6
-  thomas: '02152'
   bioguide: W000815
 - name: Danny K. Davis
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01477'
   bioguide: D000096
 - name: Lloyd Doggett
   party: minority
   rank: 2
-  thomas: '00303'
   bioguide: D000399
 - name: Terri A. Sewell
   party: minority
   rank: 3
-  thomas: '01988'
   bioguide: S001185
 - name: Judy Chu
   party: minority
   rank: 4
-  thomas: '01970'
   bioguide: C001080
 HSWM04:
 - name: Devin Nunes
   party: majority
   rank: 2
-  thomas: '01710'
   bioguide: N000181
 - name: Mike Kelly
   party: majority
   rank: 4
-  thomas: '02051'
   bioguide: K000376
 - name: Tom Reed
   party: majority
   rank: 5
-  thomas: '01982'
   bioguide: R000585
 - name: George Holding
   party: majority
   rank: 7
-  thomas: '02143'
   bioguide: H001065
 - name: Tom Rice
   party: majority
   rank: 8
-  thomas: '02160'
   bioguide: R000597
 - name: Kenny Marchant
   party: majority
   rank: 9
-  thomas: '01806'
   bioguide: M001158
 - name: Jason Smith
   party: majority
   rank: 10
-  thomas: '02191'
   bioguide: S001195
 - name: Bill Pascrell, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01510'
   bioguide: P000096
 - name: Ron Kind
   party: minority
   rank: 2
-  thomas: '01498'
   bioguide: K000188
 - name: Lloyd Doggett
   party: minority
   rank: 3
-  thomas: '00303'
   bioguide: D000399
 - name: Danny K. Davis
   party: minority
   rank: 5
-  thomas: '01477'
   bioguide: D000096
 - name: Brian Higgins
   party: minority
   rank: 6
-  thomas: '01794'
   bioguide: H001038
 HSWM05:
 - name: Vern Buchanan
   party: majority
   rank: 1
   title: Chair
-  thomas: '01840'
   bioguide: B001260
 - name: George Holding
   party: majority
   rank: 6
-  thomas: '02143'
   bioguide: H001065
 - name: Jason Smith
   party: majority
   rank: 7
-  thomas: '02191'
   bioguide: S001195
 - name: Tom Rice
   party: majority
   rank: 8
-  thomas: '02160'
   bioguide: R000597
 - name: David Schweikert
   party: majority
   rank: 9
-  thomas: '01994'
   bioguide: S001183
 - name: Lloyd Doggett
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00303'
   bioguide: D000399
 - name: John B. Larson
   party: minority
   rank: 2
-  thomas: '01583'
   bioguide: L000557
 - name: Linda T. Sánchez
   party: minority
   rank: 3
-  thomas: '01757'
   bioguide: S001156
 - name: Mike Thompson
   party: minority
   rank: 4
-  thomas: '01593'
   bioguide: T000460
 - name: Suzan K. DelBene
   party: minority
   rank: 5
-  thomas: '02096'
   bioguide: D000617
 - name: Earl Blumenauer
   party: minority
   rank: 6
-  thomas: '00099'
   bioguide: B000574
 HSWM06:
 - name: Jackie Walorski
   party: majority
   rank: 2
-  thomas: '02128'
   bioguide: W000813
 - name: Darin LaHood
   party: majority
   rank: 5
-  thomas: '02295'
   bioguide: L000585
 - name: Brad R. Wenstrup
   party: majority
   rank: 6
-  thomas: '02152'
   bioguide: W000815
 - name: Kenny Marchant
   party: majority
   rank: 7
-  thomas: '01806'
   bioguide: M001158
 - name: John Lewis
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00688'
   bioguide: L000287
 - name: Suzan K. DelBene
   party: minority
   rank: 3
-  thomas: '02096'
   bioguide: D000617
 - name: Earl Blumenauer
   party: minority
   rank: 4
-  thomas: '00099'
   bioguide: B000574
 JCSE:
 - name: Roger F. Wicker
   party: majority
   rank: 1
   title: Cochairman
-  thomas: '01226'
   bioguide: W000437
   chamber: senate
 - name: John Boozman
   party: majority
   rank: 2
-  thomas: '01687'
   bioguide: B001236
   chamber: senate
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
   chamber: senate
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
   chamber: senate
 - name: Cory Gardner
   party: majority
   rank: 5
-  thomas: '01998'
   bioguide: G000562
   chamber: senate
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
-  thomas: '00174'
   bioguide: C000141
   chamber: senate
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
-  thomas: '01823'
   bioguide: W000802
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
   chamber: senate
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
   chamber: senate
 - name: Christopher H. Smith
@@ -10183,86 +9352,72 @@ JCSE:
   rank: 1
   title: Co-Chairman
   bioguide: S000522
-  thomas: '01071'
   chamber: house
 - name: Robert Aderholt
   party: majority
   rank: 3
   bioguide: A000055
-  thomas: '01460'
   chamber: house
 - name: Michael C. Burgess
   party: majority
   rank: 4
   bioguide: B001248
-  thomas: '01751'
   chamber: house
 - name: Alcee L. Hastings
   party: minority
   rank: 1
   bioguide: H000324
-  thomas: '00511'
   chamber: house
 - name: Steve Cohen
   party: minority
   rank: 3
   bioguide: C001068
-  thomas: '01878'
   chamber: house
 JSEC:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Vice Chairman
-  thomas: '02080'
   bioguide: L000577
   chamber: senate
 - name: Tom Cotton
   party: majority
   rank: 2
-  thomas: '02098'
   bioguide: C001095
   chamber: senate
 - name: Ben Sasse
   party: majority
   rank: 3
-  thomas: '02289'
   bioguide: S001197
   chamber: senate
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
   chamber: senate
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
   chamber: senate
 - name: Bill Cassidy
   party: majority
   rank: 6
-  thomas: '01925'
   bioguide: C001075
   chamber: senate
 - name: Martin Heinrich
   party: minority
   rank: 1
-  thomas: '01937'
   bioguide: H001046
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
   chamber: senate
 - name: Gary C. Peters
   party: minority
   rank: 3
-  thomas: '01929'
   bioguide: P000595
   chamber: senate
 - name: Margaret Wood Hassan
@@ -10274,263 +9429,218 @@ JSEC:
   party: majority
   rank: 1
   bioguide: B000755
-  thomas: '01468'
   title: Chairman
   chamber: house
 - name: Sean P. Duffy
   party: majority
   rank: 3
   bioguide: D000614
-  thomas: '02072'
   chamber: house
 - name: Justin Amash
   party: majority
   rank: 4
   bioguide: A000367
-  thomas: '02029'
   chamber: house
 - name: Carolyn B. Maloney
   party: minority
   rank: 1
   bioguide: M000087
-  thomas: '00729'
   chamber: house
 - name: Elijah E. Cummings
   party: minority
   rank: 3
   bioguide: C000984
-  thomas: '00256'
   chamber: house
 JSLC:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Vice Chairman
-  thomas: '01464'
   bioguide: B000575
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
   chamber: senate
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 1
-  thomas: '01826'
   bioguide: K000367
   chamber: senate
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
   chamber: senate
 - name: Tom Cole
   party: majority
   rank: 3
   bioguide: C001053
-  thomas: '01742'
   chamber: house
 - name: Zoe Lofgren
   party: minority
   rank: 2
   bioguide: L000397
-  thomas: '00701'
   chamber: house
 JSPR:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
   chamber: senate
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
   chamber: senate
 - name: Roger F. Wicker
   party: majority
   rank: 3
-  thomas: '01226'
   bioguide: W000437
   chamber: senate
 - name: Amy Klobuchar
   party: minority
   rank: 1
-  thomas: '01826'
   bioguide: K000367
   chamber: senate
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
   chamber: senate
 - name: Juan Vargas
   party: minority
   rank: 2
   bioguide: V000130
-  thomas: '02112'
   chamber: house
 JSTX:
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
   chamber: senate
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
   chamber: senate
 - name: Ron Wyden
   party: minority
   rank: 1
-  thomas: '01247'
   bioguide: W000779
   chamber: senate
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
   chamber: senate
 - name: Kevin Brady
   party: majority
   rank: 3
   bioguide: B000755
-  thomas: '01468'
   chamber: house
 SCNC:
 - name: Chuck Grassley
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00457'
   bioguide: G000386
 - name: John Cornyn
   party: majority
   rank: 2
-  thomas: '01692'
   bioguide: C001056
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
 - name: Dianne Feinstein
   party: minority
   rank: 1
-  thomas: '01332'
   bioguide: F000062
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
-  thomas: '01823'
   bioguide: W000802
 SLET:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01984'
   bioguide: C001088
 - name: Brian Schatz
   party: minority
   rank: 2
-  thomas: '02173'
   bioguide: S001194
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
 SLIA:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02079'
   bioguide: H001061
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
 - name: James Lankford
   party: majority
   rank: 4
-  thomas: '02050'
   bioguide: L000575
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
 - name: Mike Crapo
   party: majority
   rank: 6
-  thomas: '00250'
   bioguide: C000880
 - name: Jerry Moran
   party: majority
   rank: 7
-  thomas: '01507'
   bioguide: M000934
 - name: Tom Udall
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01567'
   bioguide: U000039
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
 - name: Catherine Cortez Masto
   party: minority
@@ -10545,85 +9655,69 @@ SLIN:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00153'
   bioguide: B001135
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
 - name: Roy Blunt
   party: majority
   rank: 5
-  thomas: '01464'
   bioguide: B000575
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
 - name: Tom Cotton
   party: majority
   rank: 7
-  thomas: '02098'
   bioguide: C001095
 - name: John Cornyn
   party: majority
   rank: 8
-  thomas: '01692'
   bioguide: C001056
 - name: Mitch McConnell
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01395'
   bioguide: M000355
 - name: James M. Inhofe
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Vice Chairman
-  thomas: '01897'
   bioguide: W000805
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
 - name: Ron Wyden
   party: minority
   rank: 3
-  thomas: '01247'
   bioguide: W000779
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
 - name: Joe Manchin, III
   party: minority
   rank: 6
-  thomas: '01983'
   bioguide: M001183
 - name: Kamala D. Harris
   party: minority
@@ -10633,66 +9727,54 @@ SLIN:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '01036'
   bioguide: S000148
 - name: Jack Reed
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SPAG:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01541'
   bioguide: C001035
 - name: Tim Scott
   party: majority
   rank: 4
-  thomas: '02056'
   bioguide: S001184
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
 - name: Richard Burr
   party: majority
   rank: 7
-  thomas: '00153'
   bioguide: B001135
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
 - name: Deb Fischer
   party: majority
   rank: 9
-  thomas: '02179'
   bioguide: F000463
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 3
-  thomas: '01866'
   bioguide: G000555
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
 - name: Elizabeth Warren
   party: minority
   rank: 6
-  thomas: '02182'
   bioguide: W000817
 - name: Catherine Cortez Masto
   party: minority
@@ -10707,52 +9789,42 @@ SSAF:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00968'
   bioguide: R000307
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
 - name: Joni Ernst
   party: majority
   rank: 5
-  thomas: '02283'
   bioguide: E000295
 - name: Chuck Grassley
   party: majority
   rank: 6
-  thomas: '00457'
   bioguide: G000386
 - name: John Thune
   party: majority
   rank: 7
-  thomas: '01534'
   bioguide: T000250
 - name: Steve Daines
   party: majority
   rank: 8
-  thomas: '02138'
   bioguide: D000618
 - name: David Perdue
   party: majority
   rank: 9
-  thomas: '02286'
   bioguide: P000612
 - name: Deb Fischer
   party: majority
   rank: 10
-  thomas: '02179'
   bioguide: F000463
 - name: Cindy Hyde-Smith
   party: majority
@@ -10762,37 +9834,30 @@ SSAF:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01531'
   bioguide: S000770
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Sherrod Brown
   party: minority
   rank: 3
-  thomas: '00136'
   bioguide: B000944
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
 - name: Michael F. Bennet
   party: minority
   rank: 5
-  thomas: '01965'
   bioguide: B001267
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
-  thomas: '01866'
   bioguide: G000555
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 7
-  thomas: '01828'
   bioguide: C001070
 - name: Tina Smith
   party: minority
@@ -10801,39 +9866,32 @@ SSAF:
 - name: Richard J. Durbin
   party: minority
   rank: 9
-  thomas: '00326'
   bioguide: D000563
 SSAF13:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
 - name: John Hoeven
   party: majority
   rank: 2
-  thomas: '02079'
   bioguide: H001061
 - name: Chuck Grassley
   party: majority
   rank: 3
-  thomas: '00457'
   bioguide: G000386
 - name: John Thune
   party: majority
   rank: 4
-  thomas: '01534'
   bioguide: T000250
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
 - name: David Perdue
   party: majority
   rank: 6
-  thomas: '02286'
   bioguide: P000612
 - name: Cindy Hyde-Smith
   party: majority
@@ -10843,22 +9901,18 @@ SSAF13:
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
 - name: Sherrod Brown
   party: minority
   rank: 2
-  thomas: '00136'
   bioguide: B000944
 - name: Michael F. Bennet
   party: minority
   rank: 3
-  thomas: '01965'
   bioguide: B001267
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  thomas: '01866'
   bioguide: G000555
 - name: Tina Smith
   party: minority
@@ -10868,34 +9922,28 @@ SSAF13:
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
 SSAF14:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02138'
   bioguide: D000618
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
 - name: David Perdue
   party: majority
   rank: 5
-  thomas: '02286'
   bioguide: P000612
 - name: Cindy Hyde-Smith
   party: majority
@@ -10905,66 +9953,54 @@ SSAF14:
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01965'
   bioguide: B001267
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
-  thomas: '01828'
   bioguide: C001070
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
 SSAF15:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02283'
   bioguide: E000295
 - name: John Boozman
   party: majority
   rank: 2
-  thomas: '01687'
   bioguide: B001236
 - name: John Hoeven
   party: majority
   rank: 3
-  thomas: '02079'
   bioguide: H001061
 - name: John Thune
   party: majority
   rank: 4
-  thomas: '01534'
   bioguide: T000250
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
 - name: Deb Fischer
   party: majority
   rank: 6
-  thomas: '02179'
   bioguide: F000463
 - name: Cindy Hyde-Smith
   party: majority
@@ -10974,7 +10010,6 @@ SSAF15:
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
 - name: Tina Smith
   party: minority
@@ -10984,82 +10019,67 @@ SSAF15:
 - name: Sherrod Brown
   party: minority
   rank: 2
-  thomas: '00136'
   bioguide: B000944
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
 - name: Michael F. Bennet
   party: minority
   rank: 4
-  thomas: '01965'
   bioguide: B001267
 - name: Debbie Stabenow
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
 SSAF16:
 - name: David Perdue
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02286'
   bioguide: P000612
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
 - name: Joni Ernst
   party: majority
   rank: 5
-  thomas: '02283'
   bioguide: E000295
 - name: Deb Fischer
   party: majority
   rank: 6
-  thomas: '02179'
   bioguide: F000463
 - name: Pat Roberts
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Sherrod Brown
   party: minority
   rank: 3
-  thomas: '00136'
   bioguide: B000944
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 4
-  thomas: '01866'
   bioguide: G000555
 - name: Tina Smith
   party: minority
@@ -11069,139 +10089,113 @@ SSAF16:
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
 SSAF17:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02179'
   bioguide: F000463
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
 - name: Pat Roberts
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00968'
   bioguide: R000307
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01866'
   bioguide: G000555
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 5
-  thomas: '01828'
   bioguide: C001070
 - name: Debbie Stabenow
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '01531'
   bioguide: S000770
 SSAP:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01049'
   bioguide: S000320
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
 - name: Lisa Murkowski
   party: majority
   rank: 5
-  thomas: '01694'
   bioguide: M001153
 - name: Lindsey Graham
   party: majority
   rank: 6
-  thomas: '00452'
   bioguide: G000359
 - name: Roy Blunt
   party: majority
   rank: 7
-  thomas: '01464'
   bioguide: B000575
 - name: Jerry Moran
   party: majority
   rank: 8
-  thomas: '01507'
   bioguide: M000934
 - name: John Hoeven
   party: majority
   rank: 9
-  thomas: '02079'
   bioguide: H001061
 - name: John Boozman
   party: majority
   rank: 10
-  thomas: '01687'
   bioguide: B001236
 - name: Shelley Moore Capito
   party: majority
   rank: 11
-  thomas: '01676'
   bioguide: C001047
 - name: James Lankford
   party: majority
   rank: 12
-  thomas: '02050'
   bioguide: L000575
 - name: Steve Daines
   party: majority
   rank: 13
-  thomas: '02138'
   bioguide: D000618
 - name: John Kennedy
   party: majority
@@ -11210,7 +10204,6 @@ SSAP:
 - name: Marco Rubio
   party: majority
   rank: 15
-  thomas: '02084'
   bioguide: R000595
 - name: Cindy Hyde-Smith
   party: majority
@@ -11220,109 +10213,88 @@ SSAP:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01383'
   bioguide: L000174
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
 - name: Jack Reed
   party: minority
   rank: 5
-  thomas: '00949'
   bioguide: R000122
 - name: Jon Tester
   party: minority
   rank: 6
-  thomas: '01829'
   bioguide: T000464
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
 - name: Jeanne Shaheen
   party: minority
   rank: 8
-  thomas: '01901'
   bioguide: S001181
 - name: Jeff Merkley
   party: minority
   rank: 9
-  thomas: '01900'
   bioguide: M001176
 - name: Christopher A. Coons
   party: minority
   rank: 10
-  thomas: '01984'
   bioguide: C001088
 - name: Brian Schatz
   party: minority
   rank: 11
-  thomas: '02173'
   bioguide: S001194
 - name: Tammy Baldwin
   party: minority
   rank: 12
-  thomas: '01558'
   bioguide: B001230
 - name: Christopher Murphy
   party: minority
   rank: 13
-  thomas: '01837'
   bioguide: M001169
 - name: Joe Manchin, III
   party: minority
   rank: 14
-  thomas: '01983'
   bioguide: M001183
 - name: Chris Van Hollen
   party: minority
   rank: 15
-  thomas: '01729'
   bioguide: V000128
 SSAP01:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02079'
   bioguide: H001061
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Susan M. Collins
   party: majority
   rank: 3
-  thomas: '01541'
   bioguide: C001035
 - name: Roy Blunt
   party: majority
   rank: 4
-  thomas: '01464'
   bioguide: B000575
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
 - name: Marco Rubio
   party: majority
   rank: 6
-  thomas: '02084'
   bioguide: R000595
 - name: Cindy Hyde-Smith
   party: majority
@@ -11332,143 +10304,116 @@ SSAP01:
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01049'
   bioguide: S000320
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01900'
   bioguide: M001176
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
 - name: Tom Udall
   party: minority
   rank: 4
-  thomas: '01567'
   bioguide: U000039
 - name: Patrick J. Leahy
   party: minority
   rank: 5
-  thomas: '01383'
   bioguide: L000174
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
 SSAP02:
 - name: Richard C. Shelby
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01049'
   bioguide: S000320
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
 - name: Lisa Murkowski
   party: majority
   rank: 5
-  thomas: '01694'
   bioguide: M001153
 - name: Lindsey Graham
   party: majority
   rank: 6
-  thomas: '00452'
   bioguide: G000359
 - name: Roy Blunt
   party: majority
   rank: 7
-  thomas: '01464'
   bioguide: B000575
 - name: Steve Daines
   party: majority
   rank: 8
-  thomas: '02138'
   bioguide: D000618
 - name: Jerry Moran
   party: majority
   rank: 9
-  thomas: '01507'
   bioguide: M000934
 - name: John Hoeven
   party: majority
   rank: 10
-  thomas: '02079'
   bioguide: H001061
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00326'
   bioguide: D000563
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
 - name: Patty Murray
   party: minority
   rank: 4
-  thomas: '01409'
   bioguide: M001111
 - name: Jack Reed
   party: minority
   rank: 5
-  thomas: '00949'
   bioguide: R000122
 - name: Jon Tester
   party: minority
   rank: 6
-  thomas: '01829'
   bioguide: T000464
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
 - name: Brian Schatz
   party: minority
   rank: 8
-  thomas: '02173'
   bioguide: S001194
 - name: Tammy Baldwin
   party: minority
   rank: 9
-  thomas: '01558'
   bioguide: B001230
 SSAP08:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02138'
   bioguide: D000618
 - name: Cindy Hyde-Smith
   party: majority
@@ -11477,56 +10422,46 @@ SSAP08:
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
 - name: Chris Van Hollen
   party: minority
   rank: 2
-  thomas: '01729'
   bioguide: V000128
 - name: Patrick J. Leahy
   party: minority
   rank: 3
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
 SSAP14:
 - name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01676'
   bioguide: C001047
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
 - name: John Hoeven
   party: majority
   rank: 5
-  thomas: '02079'
   bioguide: H001061
 - name: James Lankford
   party: majority
   rank: 6
-  thomas: '02050'
   bioguide: L000575
 - name: John Kennedy
   party: majority
@@ -11536,74 +10471,60 @@ SSAP14:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01829'
   bioguide: T000464
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
 - name: Patty Murray
   party: minority
   rank: 4
-  thomas: '01409'
   bioguide: M001111
 - name: Tammy Baldwin
   party: minority
   rank: 5
-  thomas: '01558'
   bioguide: B001230
 - name: Joe Manchin, III
   party: minority
   rank: 6
-  thomas: '01983'
   bioguide: M001183
 SSAP16:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01507'
   bioguide: M000934
 - name: Lamar Alexander
   party: majority
   rank: 2
-  thomas: '01695'
   bioguide: A000360
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
 - name: John Boozman
   party: majority
   rank: 6
-  thomas: '01687'
   bioguide: B001236
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
 - name: James Lankford
   party: majority
   rank: 8
-  thomas: '02050'
   bioguide: L000575
 - name: John Kennedy
   party: majority
@@ -11613,85 +10534,69 @@ SSAP16:
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01049'
   bioguide: S000320
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
   bioguide: S001181
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Dianne Feinstein
   party: minority
   rank: 3
-  thomas: '01332'
   bioguide: F000062
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
 - name: Joe Manchin, III
   party: minority
   rank: 7
-  thomas: '01983'
   bioguide: M001183
 - name: Chris Van Hollen
   party: minority
   rank: 8
-  thomas: '01729'
   bioguide: V000128
 SSAP17:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01694'
   bioguide: M001153
 - name: Lamar Alexander
   party: majority
   rank: 2
-  thomas: '01695'
   bioguide: A000360
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
 - name: Mitch McConnell
   party: majority
   rank: 4
-  thomas: '01395'
   bioguide: M000355
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
 - name: Marco Rubio
   party: majority
   rank: 7
-  thomas: '02084'
   bioguide: R000595
 - name: Cindy Hyde-Smith
   party: majority
@@ -11701,80 +10606,65 @@ SSAP17:
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01049'
   bioguide: S000320
 - name: Tom Udall
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01567'
   bioguide: U000039
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
 - name: Jon Tester
   party: minority
   rank: 5
-  thomas: '01829'
   bioguide: T000464
 - name: Jeff Merkley
   party: minority
   rank: 6
-  thomas: '01900'
   bioguide: M001176
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
 SSAP18:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
 - name: James Lankford
   party: majority
   rank: 7
-  thomas: '02050'
   bioguide: L000575
 - name: John Kennedy
   party: majority
@@ -11783,7 +10673,6 @@ SSAP18:
 - name: Marco Rubio
   party: majority
   rank: 9
-  thomas: '02084'
   bioguide: R000595
 - name: Cindy Hyde-Smith
   party: majority
@@ -11793,180 +10682,146 @@ SSAP18:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01409'
   bioguide: M001111
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
 - name: Jack Reed
   party: minority
   rank: 3
-  thomas: '00949'
   bioguide: R000122
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
 - name: Tammy Baldwin
   party: minority
   rank: 7
-  thomas: '01558'
   bioguide: B001230
 - name: Christopher Murphy
   party: minority
   rank: 8
-  thomas: '01837'
   bioguide: M001169
 - name: Joe Manchin, III
   party: minority
   rank: 9
-  thomas: '01983'
   bioguide: M001183
 - name: Patrick J. Leahy
   party: minority
   rank: 10
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
 SSAP19:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Lisa Murkowski
   party: majority
   rank: 3
-  thomas: '01694'
   bioguide: M001153
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
 - name: Susan M. Collins
   party: majority
   rank: 5
-  thomas: '01541'
   bioguide: C001035
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
 - name: Jerry Moran
   party: majority
   rank: 7
-  thomas: '01507'
   bioguide: M000934
 - name: Marco Rubio
   party: majority
   rank: 8
-  thomas: '02084'
   bioguide: R000595
 - name: Richard C. Shelby
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01049'
   bioguide: S000320
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02173'
   bioguide: S001194
 - name: Jon Tester
   party: minority
   rank: 2
-  thomas: '01829'
   bioguide: T000464
 - name: Patty Murray
   party: minority
   rank: 3
-  thomas: '01409'
   bioguide: M001111
 - name: Jack Reed
   party: minority
   rank: 4
-  thomas: '00949'
   bioguide: R000122
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
 - name: Christopher Murphy
   party: minority
   rank: 7
-  thomas: '01837'
   bioguide: M001169
 - name: Patrick J. Leahy
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
 SSAP20:
 - name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00452'
   bioguide: G000359
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
 - name: James Lankford
   party: majority
   rank: 5
-  thomas: '02050'
   bioguide: L000575
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
 - name: Marco Rubio
   party: majority
   rank: 7
-  thomas: '02084'
   bioguide: R000595
 - name: Cindy Hyde-Smith
   party: majority
@@ -11976,80 +10831,65 @@ SSAP20:
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01049'
   bioguide: S000320
 - name: Patrick J. Leahy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01383'
   bioguide: L000174
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
 - name: Christopher Murphy
   party: minority
   rank: 6
-  thomas: '01837'
   bioguide: M001169
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
 SSAP22:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01695'
   bioguide: A000360
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Richard C. Shelby
   party: majority
   rank: 3
-  thomas: '01049'
   bioguide: S000320
 - name: Susan M. Collins
   party: majority
   rank: 4
-  thomas: '01541'
   bioguide: C001035
 - name: Lisa Murkowski
   party: majority
   rank: 5
-  thomas: '01694'
   bioguide: M001153
 - name: Lindsey Graham
   party: majority
   rank: 6
-  thomas: '00452'
   bioguide: G000359
 - name: John Hoeven
   party: majority
   rank: 7
-  thomas: '02079'
   bioguide: H001061
 - name: John Kennedy
   party: majority
@@ -12058,76 +10898,62 @@ SSAP22:
 - name: James Lankford
   party: majority
   rank: 9
-  thomas: '02050'
   bioguide: L000575
 - name: Dianne Feinstein
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01332'
   bioguide: F000062
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
 - name: Jeanne Shaheen
   party: minority
   rank: 6
-  thomas: '01901'
   bioguide: S001181
 - name: Jeff Merkley
   party: minority
   rank: 7
-  thomas: '01900'
   bioguide: M001176
 - name: Christopher A. Coons
   party: minority
   rank: 8
-  thomas: '01984'
   bioguide: C001088
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
 SSAP23:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02050'
   bioguide: L000575
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
 - name: Steve Daines
   party: majority
   rank: 4
-  thomas: '02138'
   bioguide: D000618
 - name: John Kennedy
   party: majority
@@ -12137,256 +10963,207 @@ SSAP23:
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '01049'
   bioguide: S000320
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01984'
   bioguide: C001088
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
 - name: Joe Manchin, III
   party: minority
   rank: 3
-  thomas: '01983'
   bioguide: M001183
 - name: Chris Van Hollen
   party: minority
   rank: 4
-  thomas: '01729'
   bioguide: V000128
 - name: Patrick J. Leahy
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
 SSAP24:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01541'
   bioguide: C001035
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
 - name: Roy Blunt
   party: majority
   rank: 4
-  thomas: '01464'
   bioguide: B000575
 - name: John Boozman
   party: majority
   rank: 5
-  thomas: '01687'
   bioguide: B001236
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
 - name: Lindsey Graham
   party: majority
   rank: 8
-  thomas: '00452'
   bioguide: G000359
 - name: John Hoeven
   party: majority
   rank: 9
-  thomas: '02079'
   bioguide: H001061
 - name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00949'
   bioguide: R000122
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
 - name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '00326'
   bioguide: D000563
 - name: Dianne Feinstein
   party: minority
   rank: 4
-  thomas: '01332'
   bioguide: F000062
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
 - name: Christopher Murphy
   party: minority
   rank: 7
-  thomas: '01837'
   bioguide: M001169
 - name: Joe Manchin, III
   party: minority
   rank: 8
-  thomas: '01983'
   bioguide: M001183
 - name: Patrick J. Leahy
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01383'
   bioguide: L000174
 SSAS:
 - name: James M. Inhofe
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00583'
   bioguide: I000024
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 3
-  thomas: '02179'
   bioguide: F000463
 - name: Tom Cotton
   party: majority
   rank: 4
-  thomas: '02098'
   bioguide: C001095
 - name: Mike Rounds
   party: majority
   rank: 5
-  thomas: '02288'
   bioguide: R000605
 - name: Joni Ernst
   party: majority
   rank: 6
-  thomas: '02283'
   bioguide: E000295
 - name: Thom Tillis
   party: majority
   rank: 7
-  thomas: '02291'
   bioguide: T000476
 - name: Dan Sullivan
   party: majority
   rank: 8
-  thomas: '02290'
   bioguide: S001198
 - name: David Perdue
   party: majority
   rank: 9
-  thomas: '02286'
   bioguide: P000612
 - name: Ted Cruz
   party: majority
   rank: 10
-  thomas: '02175'
   bioguide: C001098
 - name: Lindsey Graham
   party: majority
   rank: 11
-  thomas: '00452'
   bioguide: G000359
 - name: Ben Sasse
   party: majority
   rank: 12
-  thomas: '02289'
   bioguide: S001197
 - name: Tim Scott
   party: majority
   rank: 13
-  thomas: '02056'
   bioguide: S001184
 - name: Jack Reed
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00949'
   bioguide: R000122
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 3
-  thomas: '01866'
   bioguide: G000555
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '01844'
   bioguide: H001042
 - name: Tim Kaine
   party: minority
   rank: 6
-  thomas: '02176'
   bioguide: K000384
 - name: Angus S. King, Jr.
   party: minority
   rank: 7
-  thomas: '02185'
   bioguide: K000383
 - name: Martin Heinrich
   party: minority
   rank: 8
-  thomas: '01937'
   bioguide: H001046
 - name: Elizabeth Warren
   party: minority
   rank: 9
-  thomas: '02182'
   bioguide: W000817
 - name: Gary C. Peters
   party: minority
   rank: 10
-  thomas: '01929'
   bioguide: P000595
 - name: Joe Manchin, III
   party: minority
   rank: 11
-  thomas: '01983'
   bioguide: M001183
 - name: Tammy Duckworth
   party: minority
   rank: 12
-  thomas: '02123'
   bioguide: D000622
 - name: Doug Jones
   party: minority
@@ -12397,435 +11174,355 @@ SSAS13:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01226'
   bioguide: W000437
 - name: Tom Cotton
   party: majority
   rank: 2
-  thomas: '02098'
   bioguide: C001095
 - name: Mike Rounds
   party: majority
   rank: 3
-  thomas: '02288'
   bioguide: R000605
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
 - name: Tim Scott
   party: majority
   rank: 5
-  thomas: '02056'
   bioguide: S001184
 - name: James M. Inhofe
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Mazie K. Hirono
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01844'
   bioguide: H001042
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
 - name: Jack Reed
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SSAS14:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02098'
   bioguide: C001095
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
 - name: Thom Tillis
   party: majority
   rank: 3
-  thomas: '02291'
   bioguide: T000476
 - name: Dan Sullivan
   party: majority
   rank: 4
-  thomas: '02290'
   bioguide: S001198
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
 - name: James M. Inhofe
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02185'
   bioguide: K000383
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
 - name: Elizabeth Warren
   party: minority
   rank: 5
-  thomas: '02182'
   bioguide: W000817
 - name: Gary C. Peters
   party: minority
   rank: 6
-  thomas: '01929'
   bioguide: P000595
 - name: Jack Reed
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SSAS15:
 - name: Dan Sullivan
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02290'
   bioguide: S001198
 - name: Mike Rounds
   party: majority
   rank: 2
-  thomas: '02288'
   bioguide: R000605
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
 - name: David Perdue
   party: majority
   rank: 4
-  thomas: '02286'
   bioguide: P000612
 - name: James M. Inhofe
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02176'
   bioguide: K000384
 - name: Jeanne Shaheen
   party: minority
   rank: 2
-  thomas: '01901'
   bioguide: S001181
 - name: Mazie K. Hirono
   party: minority
   rank: 3
-  thomas: '01844'
   bioguide: H001042
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SSAS16:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02179'
   bioguide: F000463
 - name: Tom Cotton
   party: majority
   rank: 2
-  thomas: '02098'
   bioguide: C001095
 - name: Dan Sullivan
   party: majority
   rank: 3
-  thomas: '02290'
   bioguide: S001198
 - name: Ted Cruz
   party: majority
   rank: 4
-  thomas: '02175'
   bioguide: C001098
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
 - name: James M. Inhofe
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Martin Heinrich
   party: minority
   rank: 2
-  thomas: '01937'
   bioguide: H001046
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SSAS17:
 - name: Thom Tillis
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02291'
   bioguide: T000476
 - name: Joni Ernst
   party: majority
   rank: 2
-  thomas: '02283'
   bioguide: E000295
 - name: Lindsey Graham
   party: majority
   rank: 3
-  thomas: '00452'
   bioguide: G000359
 - name: Ben Sasse
   party: majority
   rank: 4
-  thomas: '02289'
   bioguide: S001197
 - name: James M. Inhofe
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01866'
   bioguide: G000555
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
 - name: Jack Reed
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SSAS20:
 - name: Joni Ernst
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02283'
   bioguide: E000295
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 3
-  thomas: '02179'
   bioguide: F000463
 - name: David Perdue
   party: majority
   rank: 4
-  thomas: '02286'
   bioguide: P000612
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
 - name: Tim Scott
   party: majority
   rank: 6
-  thomas: '02056'
   bioguide: S001184
 - name: James M. Inhofe
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Martin Heinrich
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01937'
   bioguide: H001046
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SSAS21:
 - name: Mike Rounds
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02288'
   bioguide: R000605
 - name: Deb Fischer
   party: majority
   rank: 2
-  thomas: '02179'
   bioguide: F000463
 - name: David Perdue
   party: majority
   rank: 3
-  thomas: '02286'
   bioguide: P000612
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
 - name: Ben Sasse
   party: majority
   rank: 5
-  thomas: '02289'
   bioguide: S001197
 - name: James M. Inhofe
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00583'
   bioguide: I000024
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 3
-  thomas: '01866'
   bioguide: G000555
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
 - name: Jack Reed
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00949'
   bioguide: R000122
 SSBK:
 - name: Mike Crapo
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00250'
   bioguide: C000880
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
 - name: Tim Scott
   party: majority
   rank: 6
-  thomas: '02056'
   bioguide: S001184
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
 - name: Tom Cotton
   party: majority
   rank: 8
-  thomas: '02098'
   bioguide: C001095
 - name: Mike Rounds
   party: majority
   rank: 9
-  thomas: '02288'
   bioguide: R000605
 - name: David Perdue
   party: majority
   rank: 10
-  thomas: '02286'
   bioguide: P000612
 - name: Thom Tillis
   party: majority
   rank: 11
-  thomas: '02291'
   bioguide: T000476
 - name: John Kennedy
   party: majority
@@ -12834,48 +11531,39 @@ SSBK:
 - name: Jerry Moran
   party: majority
   rank: 13
-  thomas: '01507'
   bioguide: M000934
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00136'
   bioguide: B000944
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
 - name: Robert Menendez
   party: minority
   rank: 3
-  thomas: '00791'
   bioguide: M000639
 - name: Jon Tester
   party: minority
   rank: 4
-  thomas: '01829'
   bioguide: T000464
 - name: Mark R. Warner
   party: minority
   rank: 5
-  thomas: '01897'
   bioguide: W000805
 - name: Elizabeth Warren
   party: minority
   rank: 6
-  thomas: '02182'
   bioguide: W000817
 - name: Brian Schatz
   party: minority
   rank: 9
-  thomas: '02173'
   bioguide: S001194
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
 - name: Catherine Cortez Masto
   party: minority
@@ -12889,74 +11577,60 @@ SSBK04:
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
 - name: Tim Scott
   party: majority
   rank: 5
-  thomas: '02056'
   bioguide: S001184
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
 - name: Mike Rounds
   party: majority
   rank: 7
-  thomas: '02288'
   bioguide: R000605
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
 - name: Jerry Moran
   party: majority
   rank: 9
-  thomas: '01507'
   bioguide: M000934
 - name: Mike Crapo
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01897'
   bioguide: W000805
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
 - name: Robert Menendez
   party: minority
   rank: 3
-  thomas: '00791'
   bioguide: M000639
 - name: Jon Tester
   party: minority
   rank: 4
-  thomas: '01829'
   bioguide: T000464
 - name: Elizabeth Warren
   party: minority
   rank: 5
-  thomas: '02182'
   bioguide: W000817
 - name: Chris Van Hollen
   party: minority
   rank: 6
-  thomas: '01729'
   bioguide: V000128
 - name: Catherine Cortez Masto
   party: minority
@@ -12970,83 +11644,68 @@ SSBK04:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
 SSBK05:
 - name: Ben Sasse
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02289'
   bioguide: S001197
 - name: Tom Cotton
   party: majority
   rank: 3
-  thomas: '02098'
   bioguide: C001095
 - name: Mike Rounds
   party: majority
   rank: 4
-  thomas: '02288'
   bioguide: R000605
 - name: David Perdue
   party: majority
   rank: 5
-  thomas: '02286'
   bioguide: P000612
 - name: Mike Crapo
   party: majority
   rank: 6
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
 - name: Mark R. Warner
   party: minority
   rank: 2
-  thomas: '01897'
   bioguide: W000805
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
 - name: Sherrod Brown
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
 SSBK08:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02085'
   bioguide: T000461
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
 - name: Tim Scott
   party: majority
   rank: 5
-  thomas: '02056'
   bioguide: S001184
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
 - name: Tom Cotton
   party: majority
   rank: 7
-  thomas: '02098'
   bioguide: C001095
 - name: David Perdue
   party: majority
   rank: 8
-  thomas: '02286'
   bioguide: P000612
 - name: John Kennedy
   party: majority
@@ -13056,38 +11715,31 @@ SSBK08:
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
 - name: Elizabeth Warren
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02182'
   bioguide: W000817
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
 - name: Jon Tester
   party: minority
   rank: 3
-  thomas: '01829'
   bioguide: T000464
 - name: Mark R. Warner
   party: minority
   rank: 4
-  thomas: '01897'
   bioguide: W000805
 - name: Brian Schatz
   party: minority
   rank: 6
-  thomas: '02173'
   bioguide: S001194
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
 - name: Catherine Cortez Masto
   party: minority
@@ -13097,29 +11749,24 @@ SSBK08:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
 SSBK09:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02056'
   bioguide: S001184
 - name: Richard C. Shelby
   party: majority
   rank: 2
-  thomas: '01049'
   bioguide: S000320
 - name: Mike Rounds
   party: majority
   rank: 4
-  thomas: '02288'
   bioguide: R000605
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
 - name: John Kennedy
   party: majority
@@ -13128,34 +11775,28 @@ SSBK09:
 - name: Jerry Moran
   party: majority
   rank: 7
-  thomas: '01507'
   bioguide: M000934
 - name: Mike Crapo
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00791'
   bioguide: M000639
 - name: Jack Reed
   party: minority
   rank: 2
-  thomas: '00949'
   bioguide: R000122
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
 - name: Chris Van Hollen
   party: minority
   rank: 5
-  thomas: '01729'
   bioguide: V000128
 - name: Doug Jones
   party: minority
@@ -13165,29 +11806,24 @@ SSBK09:
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
 SSBK12:
 - name: Tom Cotton
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02098'
   bioguide: C001095
 - name: Patrick J. Toomey
   party: majority
   rank: 2
-  thomas: '02085'
   bioguide: T000461
 - name: David Perdue
   party: majority
   rank: 3
-  thomas: '02286'
   bioguide: P000612
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
 - name: John Kennedy
   party: majority
@@ -13196,23 +11832,19 @@ SSBK12:
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
 - name: Mike Crapo
   party: majority
   rank: 7
   title: Ex Officio
-  thomas: '00250'
   bioguide: C000880
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
 - name: Elizabeth Warren
   party: minority
   rank: 3
-  thomas: '02182'
   bioguide: W000817
 - name: Doug Jones
   party: minority
@@ -13222,49 +11854,40 @@ SSBK12:
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00136'
   bioguide: B000944
 SSBU:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01542'
   bioguide: E000285
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
 - name: Patrick J. Toomey
   party: majority
   rank: 5
-  thomas: '02085'
   bioguide: T000461
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
 - name: David Perdue
   party: majority
   rank: 8
-  thomas: '02286'
   bioguide: P000612
 - name: Cory Gardner
   party: majority
   rank: 9
-  thomas: '01998'
   bioguide: G000562
 - name: John Kennedy
   party: majority
@@ -13273,63 +11896,51 @@ SSBU:
 - name: John Boozman
   party: majority
   rank: 11
-  thomas: '01687'
   bioguide: B001236
 - name: Tom Cotton
   party: majority
   rank: 12
-  thomas: '02098'
   bioguide: C001095
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01010'
   bioguide: S000033
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
 - name: Ron Wyden
   party: minority
   rank: 3
-  thomas: '01247'
   bioguide: W000779
 - name: Debbie Stabenow
   party: minority
   rank: 4
-  thomas: '01531'
   bioguide: S000770
 - name: Sheldon Whitehouse
   party: minority
   rank: 5
-  thomas: '01823'
   bioguide: W000802
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
 - name: Jeff Merkley
   party: minority
   rank: 7
-  thomas: '01900'
   bioguide: M001176
 - name: Tim Kaine
   party: minority
   rank: 8
-  thomas: '02176'
   bioguide: K000384
 - name: Angus S. King, Jr.
   party: minority
   rank: 9
-  thomas: '02185'
   bioguide: K000383
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
 - name: Kamala D. Harris
   party: minority
@@ -13340,112 +11951,90 @@ SSCM:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01534'
   bioguide: T000250
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
 - name: Ted Cruz
   party: majority
   rank: 4
-  thomas: '02175'
   bioguide: C001098
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
 - name: Dan Sullivan
   party: majority
   rank: 7
-  thomas: '02290'
   bioguide: S001198
 - name: James M. Inhofe
   party: majority
   rank: 9
-  thomas: '00583'
   bioguide: I000024
 - name: Mike Lee
   party: majority
   rank: 10
-  thomas: '02080'
   bioguide: L000577
 - name: Ron Johnson
   party: majority
   rank: 11
-  thomas: '02086'
   bioguide: J000293
 - name: Shelley Moore Capito
   party: majority
   rank: 12
-  thomas: '01676'
   bioguide: C001047
 - name: Cory Gardner
   party: majority
   rank: 13
-  thomas: '01998'
   bioguide: G000562
 - name: Todd Young
   party: majority
   rank: 14
-  thomas: '02019'
   bioguide: Y000064
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
 - name: Brian Schatz
   party: minority
   rank: 5
-  thomas: '02173'
   bioguide: S001194
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
 - name: Tom Udall
   party: minority
   rank: 7
-  thomas: '01567'
   bioguide: U000039
 - name: Gary C. Peters
   party: minority
   rank: 8
-  thomas: '01929'
   bioguide: P000595
 - name: Tammy Baldwin
   party: minority
   rank: 9
-  thomas: '01558'
   bioguide: B001230
 - name: Tammy Duckworth
   party: minority
   rank: 10
-  thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
@@ -13458,116 +12047,94 @@ SSCM:
 - name: Jon Tester
   party: minority
   rank: 13
-  thomas: '01829'
   bioguide: T000464
 SSCM01:
 - name: Roy Blunt
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
 - name: Dan Sullivan
   party: majority
   rank: 6
-  thomas: '02290'
   bioguide: S001198
 - name: James M. Inhofe
   party: majority
   rank: 8
-  thomas: '00583'
   bioguide: I000024
 - name: Mike Lee
   party: majority
   rank: 9
-  thomas: '02080'
   bioguide: L000577
 - name: Shelley Moore Capito
   party: majority
   rank: 10
-  thomas: '01676'
   bioguide: C001047
 - name: Cory Gardner
   party: majority
   rank: 11
-  thomas: '01998'
   bioguide: G000562
 - name: Todd Young
   party: majority
   rank: 12
-  thomas: '02019'
   bioguide: Y000064
 - name: John Thune
   party: majority
   rank: 13
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
 - name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00172'
   bioguide: C000127
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
 - name: Tom Udall
   party: minority
   rank: 6
-  thomas: '01567'
   bioguide: U000039
 - name: Gary C. Peters
   party: minority
   rank: 7
-  thomas: '01929'
   bioguide: P000595
 - name: Tammy Baldwin
   party: minority
   rank: 8
-  thomas: '01558'
   bioguide: B001230
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
@@ -13576,81 +12143,66 @@ SSCM01:
 - name: Jon Tester
   party: minority
   rank: 11
-  thomas: '01829'
   bioguide: T000464
 SSCM20:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01507'
   bioguide: M000934
 - name: Roy Blunt
   party: majority
   rank: 2
-  thomas: '01464'
   bioguide: B000575
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
 - name: James M. Inhofe
   party: majority
   rank: 6
-  thomas: '00583'
   bioguide: I000024
 - name: Mike Lee
   party: majority
   rank: 7
-  thomas: '02080'
   bioguide: L000577
 - name: Shelley Moore Capito
   party: majority
   rank: 8
-  thomas: '01676'
   bioguide: C001047
 - name: Todd Young
   party: majority
   rank: 9
-  thomas: '02019'
   bioguide: Y000064
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02076'
   bioguide: B001277
 - name: Amy Klobuchar
   party: minority
   rank: 2
-  thomas: '01826'
   bioguide: K000367
 - name: Edward J. Markey
   party: minority
   rank: 3
-  thomas: '00735'
   bioguide: M000133
 - name: Tom Udall
   party: minority
   rank: 4
-  thomas: '01567'
   bioguide: U000039
 - name: Tammy Duckworth
   party: minority
   rank: 5
-  thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
@@ -13665,148 +12217,120 @@ SSCM22:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02290'
   bioguide: S001198
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 3
-  thomas: '02179'
   bioguide: F000463
 - name: James M. Inhofe
   party: majority
   rank: 4
-  thomas: '00583'
   bioguide: I000024
 - name: Mike Lee
   party: majority
   rank: 5
-  thomas: '02080'
   bioguide: L000577
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
 - name: Todd Young
   party: majority
   rank: 8
-  thomas: '02019'
   bioguide: Y000064
 - name: John Thune
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
 - name: Tammy Baldwin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01558'
   bioguide: B001230
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
 - name: Brian Schatz
   party: minority
   rank: 4
-  thomas: '02173'
   bioguide: S001194
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
 - name: Gary C. Peters
   party: minority
   rank: 6
-  thomas: '01929'
   bioguide: P000595
 SSCM24:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02175'
   bioguide: C001098
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
 - name: Dan Sullivan
   party: majority
   rank: 3
-  thomas: '02290'
   bioguide: S001198
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
 - name: Ron Johnson
   party: majority
   rank: 5
-  thomas: '02086'
   bioguide: J000293
 - name: Shelley Moore Capito
   party: majority
   rank: 6
-  thomas: '01676'
   bioguide: C001047
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
 - name: John Thune
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00735'
   bioguide: M000133
 - name: Brian Schatz
   party: minority
   rank: 2
-  thomas: '02173'
   bioguide: S001194
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
 - name: Tammy Baldwin
   party: minority
   rank: 5
-  thomas: '01558'
   bioguide: B001230
 - name: Margaret Wood Hassan
   party: minority
@@ -13817,84 +12341,68 @@ SSCM25:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02179'
   bioguide: F000463
 - name: Roger F. Wicker
   party: majority
   rank: 2
-  thomas: '01226'
   bioguide: W000437
 - name: Roy Blunt
   party: majority
   rank: 3
-  thomas: '01464'
   bioguide: B000575
 - name: James M. Inhofe
   party: majority
   rank: 5
-  thomas: '00583'
   bioguide: I000024
 - name: Ron Johnson
   party: majority
   rank: 6
-  thomas: '02086'
   bioguide: J000293
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
 - name: Cory Gardner
   party: majority
   rank: 8
-  thomas: '01998'
   bioguide: G000562
 - name: Todd Young
   party: majority
   rank: 9
-  thomas: '02019'
   bioguide: Y000064
 - name: John Thune
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
 - name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01929'
   bioguide: P000595
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
 - name: Tammy Baldwin
   party: minority
   rank: 6
-  thomas: '01558'
   bioguide: B001230
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
@@ -13905,114 +12413,92 @@ SSCM26:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01226'
   bioguide: W000437
 - name: Roy Blunt
   party: majority
   rank: 2
-  thomas: '01464'
   bioguide: B000575
 - name: Ted Cruz
   party: majority
   rank: 3
-  thomas: '02175'
   bioguide: C001098
 - name: Deb Fischer
   party: majority
   rank: 4
-  thomas: '02179'
   bioguide: F000463
 - name: Jerry Moran
   party: majority
   rank: 5
-  thomas: '01507'
   bioguide: M000934
 - name: Dan Sullivan
   party: majority
   rank: 6
-  thomas: '02290'
   bioguide: S001198
 - name: James M. Inhofe
   party: majority
   rank: 8
-  thomas: '00583'
   bioguide: I000024
 - name: Mike Lee
   party: majority
   rank: 9
-  thomas: '02080'
   bioguide: L000577
 - name: Ron Johnson
   party: majority
   rank: 10
-  thomas: '02086'
   bioguide: J000293
 - name: Shelley Moore Capito
   party: majority
   rank: 11
-  thomas: '01676'
   bioguide: C001047
 - name: Cory Gardner
   party: majority
   rank: 12
-  thomas: '01998'
   bioguide: G000562
 - name: Todd Young
   party: majority
   rank: 13
-  thomas: '02019'
   bioguide: Y000064
 - name: John Thune
   party: majority
   rank: 14
   title: Ex Officio
-  thomas: '01534'
   bioguide: T000250
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02173'
   bioguide: S001194
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
 - name: Amy Klobuchar
   party: minority
   rank: 3
-  thomas: '01826'
   bioguide: K000367
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
 - name: Tom Udall
   party: minority
   rank: 6
-  thomas: '01567'
   bioguide: U000039
 - name: Gary C. Peters
   party: minority
   rank: 7
-  thomas: '01929'
   bioguide: P000595
 - name: Tammy Baldwin
   party: minority
   rank: 8
-  thomas: '01558'
   bioguide: B001230
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
 - name: Margaret Wood Hassan
   party: minority
@@ -14025,110 +12511,89 @@ SSCM26:
 - name: Jon Tester
   party: minority
   rank: 12
-  thomas: '01829'
   bioguide: T000464
 SSEG:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01694'
   bioguide: M001153
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
 - name: Steve Daines
   party: majority
   rank: 6
-  thomas: '02138'
   bioguide: D000618
 - name: Cory Gardner
   party: majority
   rank: 7
-  thomas: '01998'
   bioguide: G000562
 - name: Lamar Alexander
   party: majority
   rank: 8
-  thomas: '01695'
   bioguide: A000360
 - name: John Hoeven
   party: majority
   rank: 9
-  thomas: '02079'
   bioguide: H001061
 - name: Bill Cassidy
   party: majority
   rank: 10
-  thomas: '01925'
   bioguide: C001075
 - name: Rob Portman
   party: majority
   rank: 11
-  thomas: '00924'
   bioguide: P000449
 - name: Shelley Moore Capito
   party: majority
   rank: 12
-  thomas: '01676'
   bioguide: C001047
 - name: Maria Cantwell
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00172'
   bioguide: C000127
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
 - name: Debbie Stabenow
   party: minority
   rank: 4
-  thomas: '01531'
   bioguide: S000770
 - name: Joe Manchin, III
   party: minority
   rank: 5
-  thomas: '01983'
   bioguide: M001183
 - name: Martin Heinrich
   party: minority
   rank: 6
-  thomas: '01937'
   bioguide: H001046
 - name: Mazie K. Hirono
   party: minority
   rank: 7
-  thomas: '01844'
   bioguide: H001042
 - name: Angus S. King, Jr.
   party: minority
   rank: 8
-  thomas: '02185'
   bioguide: K000383
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
 - name: Catherine Cortez Masto
   party: minority
@@ -14143,79 +12608,64 @@ SSEG01:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01998'
   bioguide: G000562
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
 - name: Steve Daines
   party: majority
   rank: 4
-  thomas: '02138'
   bioguide: D000618
 - name: Lamar Alexander
   party: majority
   rank: 5
-  thomas: '01695'
   bioguide: A000360
 - name: John Hoeven
   party: majority
   rank: 6
-  thomas: '02079'
   bioguide: H001061
 - name: Bill Cassidy
   party: majority
   rank: 7
-  thomas: '01925'
   bioguide: C001075
 - name: Rob Portman
   party: majority
   rank: 8
-  thomas: '00924'
   bioguide: P000449
 - name: Shelley Moore Capito
   party: majority
   rank: 9
-  thomas: '01676'
   bioguide: C001047
 - name: Lisa Murkowski
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
 - name: Joe Manchin, III
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01983'
   bioguide: M001183
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
-  thomas: '02185'
   bioguide: K000383
 - name: Tammy Duckworth
   party: minority
   rank: 6
-  thomas: '02123'
   bioguide: D000622
 - name: Tina Smith
   party: minority
@@ -14225,86 +12675,70 @@ SSEG01:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
 SSEG03:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02080'
   bioguide: L000577
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
 - name: Steve Daines
   party: majority
   rank: 5
-  thomas: '02138'
   bioguide: D000618
 - name: Cory Gardner
   party: majority
   rank: 6
-  thomas: '01998'
   bioguide: G000562
 - name: Lamar Alexander
   party: majority
   rank: 7
-  thomas: '01695'
   bioguide: A000360
 - name: John Hoeven
   party: majority
   rank: 8
-  thomas: '02079'
   bioguide: H001061
 - name: Bill Cassidy
   party: majority
   rank: 9
-  thomas: '01925'
   bioguide: C001075
 - name: Shelley Moore Capito
   party: majority
   rank: 10
-  thomas: '01676'
   bioguide: C001047
 - name: Lisa Murkowski
   party: majority
   rank: 11
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
 - name: Joe Manchin, III
   party: minority
   rank: 3
-  thomas: '01983'
   bioguide: M001183
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
 - name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '01844'
   bioguide: H001042
 - name: Catherine Cortez Masto
   party: minority
@@ -14318,124 +12752,101 @@ SSEG03:
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
 SSEG04:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02138'
   bioguide: D000618
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
 - name: Mike Lee
   party: majority
   rank: 3
-  thomas: '02080'
   bioguide: L000577
 - name: Cory Gardner
   party: majority
   rank: 4
-  thomas: '01998'
   bioguide: G000562
 - name: Lamar Alexander
   party: majority
   rank: 5
-  thomas: '01695'
   bioguide: A000360
 - name: John Hoeven
   party: majority
   rank: 6
-  thomas: '02079'
   bioguide: H001061
 - name: Rob Portman
   party: majority
   rank: 7
-  thomas: '00924'
   bioguide: P000449
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02185'
   bioguide: K000383
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
 - name: Debbie Stabenow
   party: minority
   rank: 3
-  thomas: '01531'
   bioguide: S000770
 - name: Martin Heinrich
   party: minority
   rank: 4
-  thomas: '01937'
   bioguide: H001046
 - name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '01844'
   bioguide: H001042
 - name: Tammy Duckworth
   party: minority
   rank: 6
-  thomas: '02123'
   bioguide: D000622
 - name: Maria Cantwell
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
 SSEG07:
 - name: John Barrasso
   party: majority
   rank: 2
-  thomas: '01881'
   bioguide: B001261
 - name: James E. Risch
   party: majority
   rank: 3
-  thomas: '01896'
   bioguide: R000584
 - name: Mike Lee
   party: majority
   rank: 4
-  thomas: '02080'
   bioguide: L000577
 - name: Bill Cassidy
   party: majority
   rank: 5
-  thomas: '01925'
   bioguide: C001075
 - name: Rob Portman
   party: majority
   rank: 6
-  thomas: '00924'
   bioguide: P000449
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01694'
   bioguide: M001153
 - name: Catherine Cortez Masto
   party: minority
@@ -14445,1456 +12856,1181 @@ SSEG07:
 - name: Ron Wyden
   party: minority
   rank: 2
-  thomas: '01247'
   bioguide: W000779
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
 - name: Joe Manchin, III
   party: minority
   rank: 4
-  thomas: '01983'
   bioguide: M001183
 - name: Tammy Duckworth
   party: minority
   rank: 5
-  thomas: '02123'
   bioguide: D000622
 - name: Maria Cantwell
   party: minority
   rank: 6
   title: Ex Officio
-  thomas: '00172'
   bioguide: C000127
 SSEV:
 - name: John Barrasso
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01881'
   bioguide: B001261
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
 - name: Shelley Moore Capito
   party: majority
   rank: 3
-  thomas: '01676'
   bioguide: C001047
 - name: John Boozman
   party: majority
   rank: 4
-  thomas: '01687'
   bioguide: B001236
 - name: Roger F. Wicker
   party: majority
   rank: 5
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 6
-  thomas: '02179'
   bioguide: F000463
 - name: Jerry Moran
   party: majority
   rank: 7
-  thomas: '01507'
   bioguide: M000934
 - name: Mike Rounds
   party: majority
   rank: 8
-  thomas: '02288'
   bioguide: R000605
 - name: Joni Ernst
   party: majority
   rank: 9
-  thomas: '02283'
   bioguide: E000295
 - name: Dan Sullivan
   party: majority
   rank: 10
-  thomas: '02290'
   bioguide: S001198
 - name: Richard C. Shelby
   party: majority
   rank: 11
-  thomas: '01049'
   bioguide: S000320
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00179'
   bioguide: C000174
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
-  thomas: '01823'
   bioguide: W000802
 - name: Jeff Merkley
   party: minority
   rank: 5
-  thomas: '01900'
   bioguide: M001176
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
-  thomas: '01866'
   bioguide: G000555
 - name: Cory A. Booker
   party: minority
   rank: 7
-  thomas: '02194'
   bioguide: B001288
 - name: Edward J. Markey
   party: minority
   rank: 8
-  thomas: '00735'
   bioguide: M000133
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
 - name: Chris Van Hollen
   party: minority
   rank: 10
-  thomas: '01729'
   bioguide: V000128
 SSEV08:
 - name: James M. Inhofe
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00583'
   bioguide: I000024
 - name: Shelley Moore Capito
   party: majority
   rank: 2
-  thomas: '01676'
   bioguide: C001047
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
 - name: Roger F. Wicker
   party: majority
   rank: 4
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
 - name: Joni Ernst
   party: majority
   rank: 7
-  thomas: '02283'
   bioguide: E000295
 - name: Dan Sullivan
   party: majority
   rank: 8
-  thomas: '02290'
   bioguide: S001198
 - name: Richard C. Shelby
   party: majority
   rank: 9
-  thomas: '01049'
   bioguide: S000320
 - name: John Barrasso
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00174'
   bioguide: C000141
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
 - name: Cory A. Booker
   party: minority
   rank: 8
-  thomas: '02194'
   bioguide: B001288
 - name: Thomas R. Carper
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
 SSEV09:
 - name: Mike Rounds
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02288'
   bioguide: R000605
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
 - name: Joni Ernst
   party: majority
   rank: 3
-  thomas: '02283'
   bioguide: E000295
 - name: Dan Sullivan
   party: majority
   rank: 4
-  thomas: '02290'
   bioguide: S001198
 - name: John Barrasso
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
 - name: Cory A. Booker
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02194'
   bioguide: B001288
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
 - name: Chris Van Hollen
   party: minority
   rank: 3
-  thomas: '01729'
   bioguide: V000128
 - name: Thomas R. Carper
   party: minority
   rank: 4
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
 SSEV10:
 - name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01676'
   bioguide: C001047
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
 - name: Roger F. Wicker
   party: majority
   rank: 4
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
 - name: Jerry Moran
   party: majority
   rank: 6
-  thomas: '01507'
   bioguide: M000934
 - name: Joni Ernst
   party: majority
   rank: 7
-  thomas: '02283'
   bioguide: E000295
 - name: Richard C. Shelby
   party: majority
   rank: 8
-  thomas: '01049'
   bioguide: S000320
 - name: John Barrasso
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
 - name: Sheldon Whitehouse
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01823'
   bioguide: W000802
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
 - name: Tammy Duckworth
   party: minority
   rank: 7
-  thomas: '02123'
   bioguide: D000622
 - name: Thomas R. Carper
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
 SSEV15:
 - name: John Boozman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01687'
   bioguide: B001236
 - name: James M. Inhofe
   party: majority
   rank: 2
-  thomas: '00583'
   bioguide: I000024
 - name: Shelley Moore Capito
   party: majority
   rank: 3
-  thomas: '01676'
   bioguide: C001047
 - name: Roger F. Wicker
   party: majority
   rank: 4
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 5
-  thomas: '02179'
   bioguide: F000463
 - name: Mike Rounds
   party: majority
   rank: 6
-  thomas: '02288'
   bioguide: R000605
 - name: Dan Sullivan
   party: majority
   rank: 7
-  thomas: '02290'
   bioguide: S001198
 - name: Richard C. Shelby
   party: majority
   rank: 8
-  thomas: '01049'
   bioguide: S000320
 - name: John Barrasso
   party: majority
   rank: 9
   title: Ex Officio
-  thomas: '01881'
   bioguide: B001261
 - name: Tammy Duckworth
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02123'
   bioguide: D000622
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
   title: Ranking Member
-  thomas: '01823'
   bioguide: W000802
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 5
-  thomas: '01866'
   bioguide: G000555
 - name: Edward J. Markey
   party: minority
   rank: 6
-  thomas: '00735'
   bioguide: M000133
 - name: Chris Van Hollen
   party: minority
   rank: 7
-  thomas: '01729'
   bioguide: V000128
 - name: Thomas R. Carper
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '00179'
   bioguide: C000174
 SSFI:
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
 - name: Pat Roberts
   party: majority
   rank: 4
-  thomas: '00968'
   bioguide: R000307
 - name: Michael B. Enzi
   party: majority
   rank: 5
-  thomas: '01542'
   bioguide: E000285
 - name: John Cornyn
   party: majority
   rank: 6
-  thomas: '01692'
   bioguide: C001056
 - name: John Thune
   party: majority
   rank: 7
-  thomas: '01534'
   bioguide: T000250
 - name: Richard Burr
   party: majority
   rank: 8
-  thomas: '00153'
   bioguide: B001135
 - name: Johnny Isakson
   party: majority
   rank: 9
-  thomas: '01608'
   bioguide: I000055
 - name: Rob Portman
   party: majority
   rank: 10
-  thomas: '00924'
   bioguide: P000449
 - name: Patrick J. Toomey
   party: majority
   rank: 11
-  thomas: '02085'
   bioguide: T000461
 - name: Tim Scott
   party: majority
   rank: 13
-  thomas: '02056'
   bioguide: S001184
 - name: Bill Cassidy
   party: majority
   rank: 14
-  thomas: '01925'
   bioguide: C001075
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
 - name: Maria Cantwell
   party: minority
   rank: 3
-  thomas: '00172'
   bioguide: C000127
 - name: Robert Menendez
   party: minority
   rank: 5
-  thomas: '00791'
   bioguide: M000639
 - name: Thomas R. Carper
   party: minority
   rank: 6
-  thomas: '00179'
   bioguide: C000174
 - name: Benjamin L. Cardin
   party: minority
   rank: 7
-  thomas: '00174'
   bioguide: C000141
 - name: Sherrod Brown
   party: minority
   rank: 8
-  thomas: '00136'
   bioguide: B000944
 - name: Michael F. Bennet
   party: minority
   rank: 9
-  thomas: '01965'
   bioguide: B001267
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 10
-  thomas: '01828'
   bioguide: C001070
 - name: Mark R. Warner
   party: minority
   rank: 11
-  thomas: '01897'
   bioguide: W000805
 - name: Sheldon Whitehouse
   party: minority
   rank: 13
-  thomas: '01823'
   bioguide: W000802
 SSFI02:
 - name: Bill Cassidy
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01925'
   bioguide: C001075
 - name: Rob Portman
   party: majority
   rank: 2
-  thomas: '00924'
   bioguide: P000449
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
 - name: Patrick J. Toomey
   party: majority
   rank: 4
-  thomas: '02085'
   bioguide: T000461
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00136'
   bioguide: B000944
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
-  thomas: '01828'
   bioguide: C001070
 - name: Ron Wyden
   party: minority
   rank: 3
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
 SSFI10:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02085'
   bioguide: T000461
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
 - name: Richard Burr
   party: majority
   rank: 6
-  thomas: '00153'
   bioguide: B001135
 - name: Johnny Isakson
   party: majority
   rank: 7
-  thomas: '01608'
   bioguide: I000055
 - name: Rob Portman
   party: majority
   rank: 8
-  thomas: '00924'
   bioguide: P000449
 - name: Bill Cassidy
   party: majority
   rank: 10
-  thomas: '01925'
   bioguide: C001075
 - name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01531'
   bioguide: S000770
 - name: Robert Menendez
   party: minority
   rank: 2
-  thomas: '00791'
   bioguide: M000639
 - name: Maria Cantwell
   party: minority
   rank: 3
-  thomas: '00172'
   bioguide: C000127
 - name: Thomas R. Carper
   party: minority
   rank: 4
-  thomas: '00179'
   bioguide: C000174
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
-  thomas: '00174'
   bioguide: C000141
 - name: Sherrod Brown
   party: minority
   rank: 6
-  thomas: '00136'
   bioguide: B000944
 - name: Mark R. Warner
   party: minority
   rank: 7
-  thomas: '01897'
   bioguide: W000805
 - name: Ron Wyden
   party: minority
   rank: 8
-  thomas: '01247'
   bioguide: W000779
 - name: Sheldon Whitehouse
   party: minority
   rank: 9
-  thomas: '01823'
   bioguide: W000802
 SSFI11:
 - name: Rob Portman
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00924'
   bioguide: P000449
 - name: Mike Crapo
   party: majority
   rank: 2
-  thomas: '00250'
   bioguide: C000880
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
 - name: John Cornyn
   party: majority
   rank: 5
-  thomas: '01692'
   bioguide: C001056
 - name: John Thune
   party: majority
   rank: 6
-  thomas: '01534'
   bioguide: T000250
 - name: Richard Burr
   party: majority
   rank: 7
-  thomas: '00153'
   bioguide: B001135
 - name: Johnny Isakson
   party: majority
   rank: 8
-  thomas: '01608'
   bioguide: I000055
 - name: Patrick J. Toomey
   party: majority
   rank: 9
-  thomas: '02085'
   bioguide: T000461
 - name: Tim Scott
   party: majority
   rank: 10
-  thomas: '02056'
   bioguide: S001184
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01897'
   bioguide: W000805
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
 - name: Benjamin L. Cardin
   party: minority
   rank: 3
-  thomas: '00174'
   bioguide: C000141
 - name: Robert Menendez
   party: minority
   rank: 5
-  thomas: '00791'
   bioguide: M000639
 - name: Michael F. Bennet
   party: minority
   rank: 6
-  thomas: '01965'
   bioguide: B001267
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 7
-  thomas: '01828'
   bioguide: C001070
 - name: Maria Cantwell
   party: minority
   rank: 8
-  thomas: '00172'
   bioguide: C000127
 - name: Sheldon Whitehouse
   party: minority
   rank: 9
-  thomas: '01823'
   bioguide: W000802
 - name: Ron Wyden
   party: minority
   rank: 10
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
 SSFI12:
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
 - name: Michael B. Enzi
   party: majority
   rank: 4
-  thomas: '01542'
   bioguide: E000285
 - name: John Cornyn
   party: majority
   rank: 5
-  thomas: '01692'
   bioguide: C001056
 - name: Richard Burr
   party: majority
   rank: 6
-  thomas: '00153'
   bioguide: B001135
 - name: Tim Scott
   party: majority
   rank: 7
-  thomas: '02056'
   bioguide: S001184
 - name: Bill Cassidy
   party: majority
   rank: 8
-  thomas: '01925'
   bioguide: C001075
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01965'
   bioguide: B001267
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
 - name: Robert Menendez
   party: minority
   rank: 4
-  thomas: '00791'
   bioguide: M000639
 - name: Thomas R. Carper
   party: minority
   rank: 5
-  thomas: '00179'
   bioguide: C000174
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
 - name: Sheldon Whitehouse
   party: minority
   rank: 7
-  thomas: '01823'
   bioguide: W000802
 - name: Ron Wyden
   party: minority
   rank: 8
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
 SSFI13:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01692'
   bioguide: C001056
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: Pat Roberts
   party: majority
   rank: 3
-  thomas: '00968'
   bioguide: R000307
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
 - name: John Thune
   party: majority
   rank: 5
-  thomas: '01534'
   bioguide: T000250
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
 - name: Debbie Stabenow
   party: minority
   rank: 2
-  thomas: '01531'
   bioguide: S000770
 - name: Ron Wyden
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '01247'
   bioguide: W000779
 - name: Benjamin L. Cardin
   party: minority
   rank: 6
-  thomas: '00174'
   bioguide: C000141
 SSFI14:
 - name: Tim Scott
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02056'
   bioguide: S001184
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01247'
   bioguide: W000779
 SSFR:
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
 - name: Ron Johnson
   party: majority
   rank: 4
-  thomas: '02086'
   bioguide: J000293
 - name: Cory Gardner
   party: majority
   rank: 6
-  thomas: '01998'
   bioguide: G000562
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
 - name: John Barrasso
   party: majority
   rank: 8
-  thomas: '01881'
   bioguide: B001261
 - name: Johnny Isakson
   party: majority
   rank: 9
-  thomas: '01608'
   bioguide: I000055
 - name: Rob Portman
   party: majority
   rank: 10
-  thomas: '00924'
   bioguide: P000449
 - name: Rand Paul
   party: majority
   rank: 11
-  thomas: '02082'
   bioguide: P000603
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00791'
   bioguide: M000639
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
 - name: Christopher Murphy
   party: minority
   rank: 6
-  thomas: '01837'
   bioguide: M001169
 - name: Tim Kaine
   party: minority
   rank: 7
-  thomas: '02176'
   bioguide: K000384
 - name: Edward J. Markey
   party: minority
   rank: 8
-  thomas: '00735'
   bioguide: M000133
 - name: Jeff Merkley
   party: minority
   rank: 9
-  thomas: '01900'
   bioguide: M001176
 - name: Cory A. Booker
   party: minority
   rank: 10
-  thomas: '02194'
   bioguide: B001288
 SSFR01:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02086'
   bioguide: J000293
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
 - name: John Barrasso
   party: majority
   rank: 3
-  thomas: '01881'
   bioguide: B001261
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
 - name: Christopher Murphy
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01837'
   bioguide: M001169
 - name: Edward J. Markey
   party: minority
   rank: 2
-  thomas: '00735'
   bioguide: M000133
 - name: Benjamin L. Cardin
   party: minority
   rank: 3
-  thomas: '00174'
   bioguide: C000141
 - name: Jeanne Shaheen
   party: minority
   rank: 4
-  thomas: '01901'
   bioguide: S001181
 - name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00791'
   bioguide: M000639
 SSFR02:
 - name: Cory Gardner
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01998'
   bioguide: G000562
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
 - name: John Barrasso
   party: majority
   rank: 4
-  thomas: '01881'
   bioguide: B001261
 - name: Johnny Isakson
   party: majority
   rank: 5
-  thomas: '01608'
   bioguide: I000055
 - name: Edward J. Markey
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00735'
   bioguide: M000133
 - name: Jeff Merkley
   party: minority
   rank: 2
-  thomas: '01900'
   bioguide: M001176
 - name: Christopher Murphy
   party: minority
   rank: 3
-  thomas: '01837'
   bioguide: M001169
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
 - name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00791'
   bioguide: M000639
 SSFR06:
 - name: Marco Rubio
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02084'
   bioguide: R000595
 - name: Ron Johnson
   party: majority
   rank: 2
-  thomas: '02086'
   bioguide: J000293
 - name: Cory Gardner
   party: majority
   rank: 4
-  thomas: '01998'
   bioguide: G000562
 - name: Johnny Isakson
   party: majority
   rank: 5
-  thomas: '01608'
   bioguide: I000055
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00174'
   bioguide: C000141
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
 - name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00791'
   bioguide: M000639
 SSFR07:
 - name: James E. Risch
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01896'
   bioguide: R000584
 - name: Marco Rubio
   party: majority
   rank: 2
-  thomas: '02084'
   bioguide: R000595
 - name: Ron Johnson
   party: majority
   rank: 3
-  thomas: '02086'
   bioguide: J000293
 - name: Todd Young
   party: majority
   rank: 4
-  thomas: '02019'
   bioguide: Y000064
 - name: Rob Portman
   party: majority
   rank: 5
-  thomas: '00924'
   bioguide: P000449
 - name: Tim Kaine
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02176'
   bioguide: K000384
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
-  thomas: '00174'
   bioguide: C000141
 - name: Christopher Murphy
   party: minority
   rank: 3
-  thomas: '01837'
   bioguide: M001169
 - name: Cory A. Booker
   party: minority
   rank: 4
-  thomas: '02194'
   bioguide: B001288
 - name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00791'
   bioguide: M000639
 SSFR09:
 - name: Todd Young
   party: majority
   rank: 2
-  thomas: '02019'
   bioguide: Y000064
 - name: John Barrasso
   party: majority
   rank: 3
-  thomas: '01881'
   bioguide: B001261
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
 - name: Cory A. Booker
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02194'
   bioguide: B001288
 - name: Christopher A. Coons
   party: minority
   rank: 2
-  thomas: '01984'
   bioguide: C001088
 - name: Tom Udall
   party: minority
   rank: 3
-  thomas: '01567'
   bioguide: U000039
 - name: Jeff Merkley
   party: minority
   rank: 4
-  thomas: '01900'
   bioguide: M001176
 - name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00791'
   bioguide: M000639
 SSFR14:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
 - name: James E. Risch
   party: majority
   rank: 2
-  thomas: '01896'
   bioguide: R000584
 - name: Marco Rubio
   party: majority
   rank: 3
-  thomas: '02084'
   bioguide: R000595
 - name: Rob Portman
   party: majority
   rank: 4
-  thomas: '00924'
   bioguide: P000449
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
 - name: Jeanne Shaheen
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01901'
   bioguide: S001181
 - name: Christopher A. Coons
   party: minority
   rank: 2
-  thomas: '01984'
   bioguide: C001088
 - name: Cory A. Booker
   party: minority
   rank: 3
-  thomas: '02194'
   bioguide: B001288
 - name: Tom Udall
   party: minority
   rank: 4
-  thomas: '01567'
   bioguide: U000039
 - name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00791'
   bioguide: M000639
 SSFR15:
 - name: Todd Young
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02019'
   bioguide: Y000064
 - name: Cory Gardner
   party: majority
   rank: 3
-  thomas: '01998'
   bioguide: G000562
 - name: John Barrasso
   party: majority
   rank: 4
-  thomas: '01881'
   bioguide: B001261
 - name: Rob Portman
   party: majority
   rank: 5
-  thomas: '00924'
   bioguide: P000449
 - name: Jeff Merkley
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01900'
   bioguide: M001176
 - name: Tom Udall
   party: minority
   rank: 2
-  thomas: '01567'
   bioguide: U000039
 - name: Christopher A. Coons
   party: minority
   rank: 3
-  thomas: '01984'
   bioguide: C001088
 - name: Edward J. Markey
   party: minority
   rank: 4
-  thomas: '00735'
   bioguide: M000133
 - name: Robert Menendez
   party: minority
   rank: 5
   title: Ex Officio
-  thomas: '00791'
   bioguide: M000639
 SSGA:
 - name: Ron Johnson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02086'
   bioguide: J000293
 - name: Rob Portman
   party: majority
   rank: 2
-  thomas: '00924'
   bioguide: P000449
 - name: Rand Paul
   party: majority
   rank: 3
-  thomas: '02082'
   bioguide: P000603
 - name: James Lankford
   party: majority
   rank: 4
-  thomas: '02050'
   bioguide: L000575
 - name: Michael B. Enzi
   party: majority
   rank: 5
-  thomas: '01542'
   bioguide: E000285
 - name: John Hoeven
   party: majority
   rank: 6
-  thomas: '02079'
   bioguide: H001061
 - name: Steve Daines
   party: majority
   rank: 7
-  thomas: '02138'
   bioguide: D000618
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
 - name: Gary C. Peters
   party: minority
   rank: 4
-  thomas: '01929'
   bioguide: P000595
 - name: Margaret Wood Hassan
   party: minority
@@ -15913,39 +14049,32 @@ SSGA01:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00924'
   bioguide: P000449
 - name: James Lankford
   party: majority
   rank: 2
-  thomas: '02050'
   bioguide: L000575
 - name: Rand Paul
   party: majority
   rank: 3
-  thomas: '02082'
   bioguide: P000603
 - name: Steve Daines
   party: majority
   rank: 4
-  thomas: '02138'
   bioguide: D000618
 - name: Ron Johnson
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00179'
   bioguide: C000174
 - name: Gary C. Peters
   party: minority
   rank: 3
-  thomas: '01929'
   bioguide: P000595
 - name: Margaret Wood Hassan
   party: minority
@@ -15956,34 +14085,28 @@ SSGA18:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02082'
   bioguide: P000603
 - name: James Lankford
   party: majority
   rank: 2
-  thomas: '02050'
   bioguide: L000575
 - name: Michael B. Enzi
   party: majority
   rank: 3
-  thomas: '01542'
   bioguide: E000285
 - name: John Hoeven
   party: majority
   rank: 4
-  thomas: '02079'
   bioguide: H001061
 - name: Ron Johnson
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
 - name: Gary C. Peters
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01929'
   bioguide: P000595
 - name: Kamala D. Harris
   party: minority
@@ -15998,33 +14121,27 @@ SSGA19:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02050'
   bioguide: L000575
 - name: Rob Portman
   party: majority
   rank: 2
-  thomas: '00924'
   bioguide: P000449
 - name: Michael B. Enzi
   party: majority
   rank: 3
-  thomas: '01542'
   bioguide: E000285
 - name: Steve Daines
   party: majority
   rank: 4
-  thomas: '02138'
   bioguide: D000618
 - name: Ron Johnson
   party: majority
   rank: 5
   title: Ex Officio
-  thomas: '02086'
   bioguide: J000293
 - name: Thomas R. Carper
   party: minority
   rank: 2
-  thomas: '00179'
   bioguide: C000174
 - name: Margaret Wood Hassan
   party: minority
@@ -16039,98 +14156,79 @@ SSHR:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01695'
   bioguide: A000360
 - name: Michael B. Enzi
   party: majority
   rank: 2
-  thomas: '01542'
   bioguide: E000285
 - name: Richard Burr
   party: majority
   rank: 3
-  thomas: '00153'
   bioguide: B001135
 - name: Johnny Isakson
   party: majority
   rank: 4
-  thomas: '01608'
   bioguide: I000055
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
 - name: Susan M. Collins
   party: majority
   rank: 6
-  thomas: '01541'
   bioguide: C001035
 - name: Bill Cassidy
   party: majority
   rank: 7
-  thomas: '01925'
   bioguide: C001075
 - name: Todd Young
   party: majority
   rank: 8
-  thomas: '02019'
   bioguide: Y000064
 - name: Pat Roberts
   party: majority
   rank: 10
-  thomas: '00968'
   bioguide: R000307
 - name: Lisa Murkowski
   party: majority
   rank: 11
-  thomas: '01694'
   bioguide: M001153
 - name: Tim Scott
   party: majority
   rank: 12
-  thomas: '02056'
   bioguide: S001184
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01409'
   bioguide: M001111
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 3
-  thomas: '01828'
   bioguide: C001070
 - name: Michael F. Bennet
   party: minority
   rank: 4
-  thomas: '01965'
   bioguide: B001267
 - name: Tammy Baldwin
   party: minority
   rank: 5
-  thomas: '01558'
   bioguide: B001230
 - name: Christopher Murphy
   party: minority
   rank: 6
-  thomas: '01837'
   bioguide: M001169
 - name: Elizabeth Warren
   party: minority
   rank: 7
-  thomas: '02182'
   bioguide: W000817
 - name: Tim Kaine
   party: minority
   rank: 8
-  thomas: '02176'
   bioguide: K000384
 - name: Margaret Wood Hassan
   party: minority
@@ -16149,59 +14247,48 @@ SSHR09:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02082'
   bioguide: P000603
 - name: Lisa Murkowski
   party: majority
   rank: 2
-  thomas: '01694'
   bioguide: M001153
 - name: Richard Burr
   party: majority
   rank: 3
-  thomas: '00153'
   bioguide: B001135
 - name: Bill Cassidy
   party: majority
   rank: 4
-  thomas: '01925'
   bioguide: C001075
 - name: Todd Young
   party: majority
   rank: 5
-  thomas: '02019'
   bioguide: Y000064
 - name: Pat Roberts
   party: majority
   rank: 7
-  thomas: '00968'
   bioguide: R000307
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01828'
   bioguide: C001070
 - name: Bernard Sanders
   party: minority
   rank: 2
-  thomas: '01010'
   bioguide: S000033
 - name: Michael F. Bennet
   party: minority
   rank: 3
-  thomas: '01965'
   bioguide: B001267
 - name: Tim Kaine
   party: minority
   rank: 4
-  thomas: '02176'
   bioguide: K000384
 - name: Margaret Wood Hassan
   party: minority
@@ -16215,71 +14302,58 @@ SSHR09:
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
 SSHR11:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
 - name: Pat Roberts
   party: majority
   rank: 2
-  thomas: '00968'
   bioguide: R000307
 - name: Tim Scott
   party: majority
   rank: 3
-  thomas: '02056'
   bioguide: S001184
 - name: Richard Burr
   party: majority
   rank: 4
-  thomas: '00153'
   bioguide: B001135
 - name: Rand Paul
   party: majority
   rank: 5
-  thomas: '02082'
   bioguide: P000603
 - name: Bill Cassidy
   party: majority
   rank: 6
-  thomas: '01925'
   bioguide: C001075
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
 - name: Tammy Baldwin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01558'
   bioguide: B001230
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
-  thomas: '01828'
   bioguide: C001070
 - name: Christopher Murphy
   party: minority
   rank: 3
-  thomas: '01837'
   bioguide: M001169
 - name: Elizabeth Warren
   party: minority
   rank: 4
-  thomas: '02182'
   bioguide: W000817
 - name: Tina Smith
   party: minority
@@ -16293,86 +14367,70 @@ SSHR11:
   party: minority
   rank: 7
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
 SSHR12:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01542'
   bioguide: E000285
 - name: Richard Burr
   party: majority
   rank: 2
-  thomas: '00153'
   bioguide: B001135
 - name: Susan M. Collins
   party: majority
   rank: 3
-  thomas: '01541'
   bioguide: C001035
 - name: Bill Cassidy
   party: majority
   rank: 4
-  thomas: '01925'
   bioguide: C001075
 - name: Todd Young
   party: majority
   rank: 5
-  thomas: '02019'
   bioguide: Y000064
 - name: Pat Roberts
   party: majority
   rank: 7
-  thomas: '00968'
   bioguide: R000307
 - name: Tim Scott
   party: majority
   rank: 8
-  thomas: '02056'
   bioguide: S001184
 - name: Lisa Murkowski
   party: majority
   rank: 9
-  thomas: '01694'
   bioguide: M001153
 - name: Lamar Alexander
   party: majority
   rank: 10
   title: Ex Officio
-  thomas: '01695'
   bioguide: A000360
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01010'
   bioguide: S000033
 - name: Michael F. Bennet
   party: minority
   rank: 2
-  thomas: '01965'
   bioguide: B001267
 - name: Tammy Baldwin
   party: minority
   rank: 3
-  thomas: '01558'
   bioguide: B001230
 - name: Christopher Murphy
   party: minority
   rank: 4
-  thomas: '01837'
   bioguide: M001169
 - name: Elizabeth Warren
   party: minority
   rank: 5
-  thomas: '02182'
   bioguide: W000817
 - name: Tim Kaine
   party: minority
   rank: 6
-  thomas: '02176'
   bioguide: K000384
 - name: Margaret Wood Hassan
   party: minority
@@ -16386,49 +14444,40 @@ SSHR12:
   party: minority
   rank: 9
   title: Ex Officio
-  thomas: '01409'
   bioguide: M001111
 SSJU:
 - name: Chuck Grassley
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00457'
   bioguide: G000386
 - name: Lindsey Graham
   party: majority
   rank: 3
-  thomas: '00452'
   bioguide: G000359
 - name: John Cornyn
   party: majority
   rank: 4
-  thomas: '01692'
   bioguide: C001056
 - name: Mike Lee
   party: majority
   rank: 5
-  thomas: '02080'
   bioguide: L000577
 - name: Ted Cruz
   party: majority
   rank: 6
-  thomas: '02175'
   bioguide: C001098
 - name: Ben Sasse
   party: majority
   rank: 7
-  thomas: '02289'
   bioguide: S001197
 - name: Mike Crapo
   party: majority
   rank: 9
-  thomas: '00250'
   bioguide: C000880
 - name: Thom Tillis
   party: majority
   rank: 10
-  thomas: '02291'
   bioguide: T000476
 - name: John Kennedy
   party: majority
@@ -16438,47 +14487,38 @@ SSJU:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01332'
   bioguide: F000062
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '00326'
   bioguide: D000563
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
-  thomas: '01823'
   bioguide: W000802
 - name: Amy Klobuchar
   party: minority
   rank: 5
-  thomas: '01826'
   bioguide: K000367
 - name: Christopher A. Coons
   party: minority
   rank: 6
-  thomas: '01984'
   bioguide: C001088
 - name: Richard Blumenthal
   party: minority
   rank: 7
-  thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
   rank: 8
-  thomas: '01844'
   bioguide: H001042
 - name: Cory A. Booker
   party: minority
   rank: 9
-  thomas: '02194'
   bioguide: B001288
 - name: Kamala D. Harris
   party: minority
@@ -16489,55 +14529,45 @@ SSJU01:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02080'
   bioguide: L000577
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: Lindsey Graham
   party: majority
   rank: 4
-  thomas: '00452'
   bioguide: G000359
 - name: Thom Tillis
   party: majority
   rank: 5
-  thomas: '02291'
   bioguide: T000476
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01826'
   bioguide: K000367
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Richard Blumenthal
   party: minority
   rank: 3
-  thomas: '02076'
   bioguide: B001277
 - name: Cory A. Booker
   party: minority
   rank: 4
-  thomas: '02194'
   bioguide: B001288
 SSJU04:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01692'
   bioguide: C001056
 - name: Thom Tillis
   party: majority
   rank: 2
-  thomas: '02291'
   bioguide: T000476
 - name: John Kennedy
   party: majority
@@ -16546,85 +14576,69 @@ SSJU04:
 - name: Chuck Grassley
   party: majority
   rank: 4
-  thomas: '00457'
   bioguide: G000386
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
 - name: Mike Crapo
   party: majority
   rank: 7
-  thomas: '00250'
   bioguide: C000880
 - name: Mike Lee
   party: majority
   rank: 8
-  thomas: '02080'
   bioguide: L000577
 - name: Richard J. Durbin
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00326'
   bioguide: D000563
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
 - name: Patrick J. Leahy
   party: minority
   rank: 3
-  thomas: '01383'
   bioguide: L000174
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
 - name: Richard Blumenthal
   party: minority
   rank: 5
-  thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
   rank: 6
-  thomas: '01844'
   bioguide: H001042
 - name: Cory A. Booker
   party: minority
   rank: 7
-  thomas: '02194'
   bioguide: B001288
 SSJU21:
 - name: Ted Cruz
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02175'
   bioguide: C001098
 - name: John Cornyn
   party: majority
   rank: 2
-  thomas: '01692'
   bioguide: C001056
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
 - name: Ben Sasse
   party: majority
   rank: 4
-  thomas: '02289'
   bioguide: S001197
 - name: Lindsey Graham
   party: majority
   rank: 5
-  thomas: '00452'
   bioguide: G000359
 - name: John Kennedy
   party: majority
@@ -16634,22 +14648,18 @@ SSJU21:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01844'
   bioguide: H001042
 - name: Richard J. Durbin
   party: minority
   rank: 2
-  thomas: '00326'
   bioguide: D000563
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
 - name: Christopher A. Coons
   party: minority
   rank: 4
-  thomas: '01984'
   bioguide: C001088
 - name: Kamala D. Harris
   party: minority
@@ -16660,27 +14670,22 @@ SSJU22:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '00452'
   bioguide: G000359
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: John Cornyn
   party: majority
   rank: 4
-  thomas: '01692'
   bioguide: C001056
 - name: Ted Cruz
   party: majority
   rank: 5
-  thomas: '02175'
   bioguide: C001098
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
 - name: John Kennedy
   party: majority
@@ -16690,53 +14695,43 @@ SSJU22:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01823'
   bioguide: W000802
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
 - name: Richard J. Durbin
   party: minority
   rank: 3
-  thomas: '00326'
   bioguide: D000563
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
 SSJU23:
 - name: Mike Lee
   party: majority
   rank: 3
-  thomas: '02080'
   bioguide: L000577
 - name: Thom Tillis
   party: majority
   rank: 4
-  thomas: '02291'
   bioguide: T000476
 - name: Mike Crapo
   party: majority
   rank: 5
-  thomas: '00250'
   bioguide: C000880
 - name: Ben Sasse
   party: majority
   rank: 6
-  thomas: '02289'
   bioguide: S001197
 - name: John Kennedy
   party: majority
@@ -16746,27 +14741,22 @@ SSJU23:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01984'
   bioguide: C001088
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
 - name: Richard Blumenthal
   party: minority
   rank: 4
-  thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
   rank: 5
-  thomas: '01844'
   bioguide: H001042
 - name: Kamala D. Harris
   party: minority
@@ -16777,17 +14767,14 @@ SSJU25:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '02289'
   bioguide: S001197
 - name: Chuck Grassley
   party: majority
   rank: 2
-  thomas: '00457'
   bioguide: G000386
 - name: Mike Crapo
   party: majority
   rank: 3
-  thomas: '00250'
   bioguide: C000880
 - name: John Kennedy
   party: majority
@@ -16796,43 +14783,35 @@ SSJU25:
 - name: Mike Lee
   party: majority
   rank: 6
-  thomas: '02080'
   bioguide: L000577
 - name: Thom Tillis
   party: majority
   rank: 8
-  thomas: '02291'
   bioguide: T000476
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02076'
   bioguide: B001277
 - name: Patrick J. Leahy
   party: minority
   rank: 2
-  thomas: '01383'
   bioguide: L000174
 - name: Sheldon Whitehouse
   party: minority
   rank: 3
-  thomas: '01823'
   bioguide: W000802
 - name: Amy Klobuchar
   party: minority
   rank: 4
-  thomas: '01826'
   bioguide: K000367
 - name: Christopher A. Coons
   party: minority
   rank: 5
-  thomas: '01984'
   bioguide: C001088
 - name: Mazie K. Hirono
   party: minority
   rank: 6
-  thomas: '01844'
   bioguide: H001042
 - name: Kamala D. Harris
   party: minority
@@ -16843,47 +14822,38 @@ SSRA:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01464'
   bioguide: B000575
 - name: Mitch McConnell
   party: majority
   rank: 2
-  thomas: '01395'
   bioguide: M000355
 - name: Lamar Alexander
   party: majority
   rank: 3
-  thomas: '01695'
   bioguide: A000360
 - name: Pat Roberts
   party: majority
   rank: 4
-  thomas: '00968'
   bioguide: R000307
 - name: Richard C. Shelby
   party: majority
   rank: 5
-  thomas: '01049'
   bioguide: S000320
 - name: Ted Cruz
   party: majority
   rank: 6
-  thomas: '02175'
   bioguide: C001098
 - name: Shelley Moore Capito
   party: majority
   rank: 7
-  thomas: '01676'
   bioguide: C001047
 - name: Roger F. Wicker
   party: majority
   rank: 8
-  thomas: '01226'
   bioguide: W000437
 - name: Deb Fischer
   party: majority
   rank: 9
-  thomas: '02179'
   bioguide: F000463
 - name: Cindy Hyde-Smith
   party: majority
@@ -16893,42 +14863,34 @@ SSRA:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01826'
   bioguide: K000367
 - name: Dianne Feinstein
   party: minority
   rank: 2
-  thomas: '01332'
   bioguide: F000062
 - name: Charles E. Schumer
   party: minority
   rank: 3
-  thomas: '01036'
   bioguide: S000148
 - name: Richard J. Durbin
   party: minority
   rank: 4
-  thomas: '00326'
   bioguide: D000563
 - name: Tom Udall
   party: minority
   rank: 5
-  thomas: '01567'
   bioguide: U000039
 - name: Mark R. Warner
   party: minority
   rank: 6
-  thomas: '01897'
   bioguide: W000805
 - name: Patrick J. Leahy
   party: minority
   rank: 7
-  thomas: '01383'
   bioguide: L000174
 - name: Angus S. King, Jr.
   party: minority
   rank: 8
-  thomas: '02185'
   bioguide: K000383
 - name: Catherine Cortez Masto
   party: minority
@@ -16939,47 +14901,38 @@ SSSB:
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01896'
   bioguide: R000584
 - name: Marco Rubio
   party: majority
   rank: 2
-  thomas: '02084'
   bioguide: R000595
 - name: Rand Paul
   party: majority
   rank: 3
-  thomas: '02082'
   bioguide: P000603
 - name: Tim Scott
   party: majority
   rank: 4
-  thomas: '02056'
   bioguide: S001184
 - name: Joni Ernst
   party: majority
   rank: 5
-  thomas: '02283'
   bioguide: E000295
 - name: James M. Inhofe
   party: majority
   rank: 6
-  thomas: '00583'
   bioguide: I000024
 - name: Todd Young
   party: majority
   rank: 7
-  thomas: '02019'
   bioguide: Y000064
 - name: Michael B. Enzi
   party: majority
   rank: 8
-  thomas: '01542'
   bioguide: E000285
 - name: Mike Rounds
   party: majority
   rank: 9
-  thomas: '02288'
   bioguide: R000605
 - name: John Kennedy
   party: majority
@@ -16989,113 +14942,91 @@ SSSB:
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00174'
   bioguide: C000141
 - name: Maria Cantwell
   party: minority
   rank: 2
-  thomas: '00172'
   bioguide: C000127
 - name: Jeanne Shaheen
   party: minority
   rank: 3
-  thomas: '01901'
   bioguide: S001181
 - name: Edward J. Markey
   party: minority
   rank: 5
-  thomas: '00735'
   bioguide: M000133
 - name: Cory A. Booker
   party: minority
   rank: 6
-  thomas: '02194'
   bioguide: B001288
 - name: Christopher A. Coons
   party: minority
   rank: 7
-  thomas: '01984'
   bioguide: C001088
 - name: Mazie K. Hirono
   party: minority
   rank: 8
-  thomas: '01844'
   bioguide: H001042
 - name: Tammy Duckworth
   party: minority
   rank: 9
-  thomas: '02123'
   bioguide: D000622
 SSVA:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
-  thomas: '01608'
   bioguide: I000055
 - name: Jerry Moran
   party: majority
   rank: 2
-  thomas: '01507'
   bioguide: M000934
 - name: John Boozman
   party: majority
   rank: 3
-  thomas: '01687'
   bioguide: B001236
 - name: Bill Cassidy
   party: majority
   rank: 5
-  thomas: '01925'
   bioguide: C001075
 - name: Mike Rounds
   party: majority
   rank: 6
-  thomas: '02288'
   bioguide: R000605
 - name: Thom Tillis
   party: majority
   rank: 7
-  thomas: '02291'
   bioguide: T000476
 - name: Dan Sullivan
   party: majority
   rank: 8
-  thomas: '02290'
   bioguide: S001198
 - name: Jon Tester
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01829'
   bioguide: T000464
 - name: Patty Murray
   party: minority
   rank: 2
-  thomas: '01409'
   bioguide: M001111
 - name: Bernard Sanders
   party: minority
   rank: 3
-  thomas: '01010'
   bioguide: S000033
 - name: Sherrod Brown
   party: minority
   rank: 4
-  thomas: '00136'
   bioguide: B000944
 - name: Richard Blumenthal
   party: minority
   rank: 5
-  thomas: '02076'
   bioguide: B001277
 - name: Mazie K. Hirono
   party: minority
   rank: 6
-  thomas: '01844'
   bioguide: H001042
 - name: Joe Manchin, III
   party: minority
   rank: 7
-  thomas: '01983'
   bioguide: M001183

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -10218,51 +10218,71 @@ JSEC:
   title: Vice Chairman
   bioguide: L000577
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tom Cotton
   party: majority
   rank: 2
   bioguide: C001095
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ben Sasse
   party: majority
   rank: 3
   bioguide: S001197
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rob Portman
   party: majority
   rank: 4
   bioguide: P000449
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ted Cruz
   party: majority
   rank: 5
   bioguide: C001098
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Bill Cassidy
   party: majority
   rank: 6
   bioguide: C001075
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Martin Heinrich
   party: minority
   rank: 1
   bioguide: H001046
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Amy Klobuchar
   party: minority
   rank: 2
   bioguide: K000367
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Gary C. Peters
   party: minority
   rank: 3
   bioguide: P000595
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Margaret Wood Hassan
   party: minority
   rank: 4
   bioguide: H001076
   chamber: senate
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 JSLC:
 - name: Roy Blunt
   party: majority
@@ -10339,255 +10359,370 @@ JSTX:
   bioguide: S000770
   chamber: senate
 SCNC:
-- name: Chuck Grassley
+- name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
-  bioguide: G000386
-- name: John Cornyn
+  bioguide: C001056
+- name: Chuck Grassley
   party: majority
   rank: 2
-  bioguide: C001056
+  bioguide: G000386
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
+- name: David Perdue
+  party: majority
+  rank: 4
+  bioguide: P000612
 - name: Dianne Feinstein
   party: minority
   rank: 1
+  title: Vice Chairman
   bioguide: F000062
 - name: Sheldon Whitehouse
   party: minority
   rank: 2
   bioguide: W000802
+- name: Jacky Rosen
+  party: minority
+  rank: 3
+  bioguide: R000608
 SLET:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000055
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Pat Roberts
   party: majority
   rank: 2
   bioguide: R000307
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Christopher A. Coons
   party: minority
   rank: 1
   title: Vice Chairman
   bioguide: C001088
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Brian Schatz
   party: minority
   rank: 2
   bioguide: S001194
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SLIA:
 - name: John Hoeven
   party: majority
   rank: 1
   title: Chairman
   bioguide: H001061
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Lisa Murkowski
   party: majority
   rank: 3
   bioguide: M001153
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James Lankford
   party: majority
   rank: 4
   bioguide: L000575
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Steve Daines
   party: majority
   rank: 5
   bioguide: D000618
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Martha McSally
   party: majority
   rank: 6
   bioguide: M001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Jerry Moran
   party: majority
   rank: 7
   bioguide: M000934
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tom Udall
   party: minority
   rank: 1
   title: Vice Chairman
   bioguide: U000039
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jon Tester
   party: minority
   rank: 3
   bioguide: T000464
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Brian Schatz
   party: minority
   rank: 4
   bioguide: S001194
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Catherine Cortez Masto
   party: minority
   rank: 6
   bioguide: C001113
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tina Smith
   party: minority
   rank: 7
   bioguide: S001203
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SLIN:
 - name: Richard Burr
   party: majority
   rank: 1
   title: Chairman
   bioguide: B001135
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Marco Rubio
   party: majority
   rank: 3
   bioguide: R000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Susan M. Collins
   party: majority
   rank: 4
   bioguide: C001035
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Roy Blunt
   party: majority
   rank: 5
   bioguide: B000575
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tom Cotton
   party: majority
   rank: 6
   bioguide: C001095
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Cornyn
   party: majority
   rank: 7
   bioguide: C001056
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ben Sasse
   party: majority
   rank: 8
   bioguide: S001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mitch McConnell
   party: majority
   rank: 9
   title: Ex Officio
   bioguide: M000355
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James M. Inhofe
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: I000024
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mark R. Warner
   party: minority
   rank: 1
   title: Vice Chairman
   bioguide: W000805
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Dianne Feinstein
   party: minority
   rank: 2
   bioguide: F000062
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Ron Wyden
   party: minority
   rank: 3
   bioguide: W000779
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Martin Heinrich
   party: minority
   rank: 4
   bioguide: H001046
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Angus S. King, Jr.
   party: minority
   rank: 5
   bioguide: K000383
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kamala D. Harris
   party: minority
   rank: 6
   bioguide: H001075
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Michael F. Bennet
   party: minority
   rank: 7
   bioguide: B001267
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Charles E. Schumer
   party: minority
   rank: 8
   title: Ex Officio
   bioguide: S000148
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jack Reed
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: R000122
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SPAG:
 - name: Susan M. Collins
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001035
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tim Scott
   party: majority
   rank: 2
   bioguide: S001184
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Richard Burr
   party: majority
   rank: 3
   bioguide: B001135
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Martha McSally
   party: majority
   rank: 4
   bioguide: M001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Marco Rubio
   party: majority
   rank: 5
   bioguide: R000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Josh Hawley
   party: majority
   rank: 6
   bioguide: H001089
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Braun
   party: majority
   rank: 7
   bioguide: B001310
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rick Scott
   party: majority
   rank: 8
   bioguide: S001217
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001070
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 2
   bioguide: G000555
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard Blumenthal
   party: minority
   rank: 3
   bioguide: B001277
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Elizabeth Warren
   party: minority
   rank: 4
   bioguide: W000817
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Doug Jones
   party: minority
   rank: 5
   bioguide: J000300
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kyrsten Sinema
   party: minority
   rank: 6
   bioguide: S001191
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jacky Rosen
   party: minority
   rank: 7
   bioguide: R000608
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSAF:
 - name: Pat Roberts
   party: majority
@@ -14062,1100 +14197,1407 @@ SSEG01:
   rank: 1
   title: Chairman
   bioguide: C001075
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Mike Lee
   party: majority
   rank: 3
   bioguide: L000577
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Steve Daines
   party: majority
   rank: 4
   bioguide: D000618
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Cory Gardner
   party: majority
   rank: 5
   bioguide: G000562
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Cindy Hyde-Smith
   party: majority
   rank: 6
   bioguide: H001079
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Martha McSally
   party: majority
   rank: 7
   bioguide: M001197
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Lamar Alexander
   party: majority
   rank: 8
   bioguide: A000360
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: John Hoeven
   party: majority
   rank: 9
   bioguide: H001061
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Lisa Murkowski
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: M001153
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Martin Heinrich
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: H001046
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Ron Wyden
   party: minority
   rank: 2
   bioguide: W000779
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Maria Cantwell
   party: minority
   rank: 3
   bioguide: C000127
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Bernard Sanders
   party: minority
   rank: 4
   bioguide: S000033
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Debbie Stabenow
   party: minority
   rank: 5
   bioguide: S000770
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Mazie K. Hirono
   party: minority
   rank: 6
   bioguide: H001042
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Angus S. King, Jr.
   party: minority
   rank: 7
   bioguide: K000383
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Catherine Cortez Masto
   party: minority
   rank: 8
   bioguide: C001113
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Joe Manchin, III
   party: minority
   rank: 9
   bioguide: M001183
   title: Ex Officio
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 SSEG03:
 - name: Mike Lee
   party: majority
   rank: 1
   title: Chairman
   bioguide: L000577
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Steve Daines
   party: majority
   rank: 5
   bioguide: D000618
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Bill Cassidy
   party: majority
   rank: 6
   bioguide: C001075
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Cory Gardner
   party: majority
   rank: 7
   bioguide: G000562
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Cindy Hyde-Smith
   party: majority
   rank: 8
   bioguide: H001079
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Martha McSally
   party: majority
   rank: 9
   bioguide: M001197
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: John Hoeven
   party: majority
   rank: 10
   bioguide: H001061
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Lisa Murkowski
   party: majority
   rank: 11
   title: Ex Officio
   bioguide: M001153
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000779
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Debbie Stabenow
   party: minority
   rank: 3
   bioguide: S000770
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Martin Heinrich
   party: minority
   rank: 4
   bioguide: H001046
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Mazie K. Hirono
   party: minority
   rank: 5
   bioguide: H001042
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Angus S. King, Jr.
   party: minority
   rank: 6
   bioguide: K000383
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Catherine Cortez Masto
   party: minority
   rank: 7
   bioguide: C001113
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Joe Manchin, III
   party: minority
   rank: 8
   bioguide: M001183
   title: Ex Officio
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 SSEG04:
 - name: Steve Daines
   party: majority
   rank: 1
   title: Chairman
   bioguide: D000618
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Mike Lee
   party: majority
   rank: 3
   bioguide: L000577
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Cory Gardner
   party: majority
   rank: 4
   bioguide: G000562
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Cindy Hyde-Smith
   party: majority
   rank: 5
   bioguide: H001079
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Lamar Alexander
   party: majority
   rank: 6
   bioguide: A000360
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: John Hoeven
   party: majority
   rank: 7
   bioguide: H001061
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Lisa Murkowski
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: M001153
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Angus S. King, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000383
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Bernard Sanders
   party: minority
   rank: 2
   bioguide: S000033
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Debbie Stabenow
   party: minority
   rank: 3
   bioguide: S000770
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Martin Heinrich
   party: minority
   rank: 4
   bioguide: H001046
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Mazie K. Hirono
   party: minority
   rank: 5
   bioguide: H001042
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Joe Manchin, III
   party: minority
   rank: 6
   bioguide: M001183
   title: Ex Officio
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 SSEG07:
+- name: Martha McSally
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: M001197
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
-- name: Mike Lee
-  party: majority
-  rank: 4
-  bioguide: L000577
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Bill Cassidy
   party: majority
-  rank: 5
+  rank: 4
   bioguide: C001075
-- name: Rob Portman
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
+- name: Cory Gardner
+  party: majority
+  rank: 5
+  bioguide: G000562
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
+- name: Lamar Alexander
   party: majority
   rank: 6
-  bioguide: P000449
-- name: Shelley Moore Capito
-  party: majority
-  rank: 7
-  bioguide: C001047
+  bioguide: A000360
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Lisa Murkowski
   party: majority
-  rank: 8
+  rank: 7
   title: Ex Officio
   bioguide: M001153
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Catherine Cortez Masto
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001113
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Ron Wyden
   party: minority
   rank: 2
   bioguide: W000779
-- name: Bernard Sanders
-  party: minority
-  rank: 3
-  bioguide: S000033
-- name: Joe Manchin, III
-  party: minority
-  rank: 4
-  bioguide: M001183
-- name: Tammy Duckworth
-  party: minority
-  rank: 5
-  bioguide: D000622
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 - name: Maria Cantwell
   party: minority
-  rank: 6
-  title: Ex Officio
+  rank: 3
   bioguide: C000127
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
+- name: Bernard Sanders
+  party: minority
+  rank: 4
+  bioguide: S000033
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
+- name: Joe Manchin, III
+  party: minority
+  rank: 5
+  bioguide: M001183
+  title: Ex Officio
+  start_date: '2019-02-05'
+  source: https://www.energy.senate.gov/public/index.cfm/republican-news?ID=C1777A5C-73BB-4A08-A9B3-6ABDFCFA40C3
 SSEV:
 - name: John Barrasso
   party: majority
   rank: 1
   title: Chairman
   bioguide: B001261
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James M. Inhofe
   party: majority
   rank: 2
   bioguide: I000024
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Shelley Moore Capito
   party: majority
   rank: 3
   bioguide: C001047
-- name: John Boozman
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Kevin Cramer
   party: majority
   rank: 4
-  bioguide: B001236
-- name: Roger F. Wicker
+  bioguide: C001096
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mike Braun
   party: majority
   rank: 5
-  bioguide: W000437
-- name: Deb Fischer
-  party: majority
-  rank: 6
-  bioguide: F000463
-- name: Jerry Moran
-  party: majority
-  rank: 7
-  bioguide: M000934
+  bioguide: B001310
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Rounds
   party: majority
-  rank: 8
+  rank: 6
   bioguide: R000605
-- name: Joni Ernst
-  party: majority
-  rank: 9
-  bioguide: E000295
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Dan Sullivan
   party: majority
-  rank: 10
+  rank: 7
   bioguide: S001198
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: John Boozman
+  party: majority
+  rank: 8
+  bioguide: B001236
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Roger F. Wicker
+  party: majority
+  rank: 9
+  bioguide: W000437
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Richard C. Shelby
   party: majority
-  rank: 11
+  rank: 10
   bioguide: S000320
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Joni Ernst
+  party: majority
+  rank: 11
+  bioguide: E000295
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000174
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
   bioguide: C000141
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Bernard Sanders
   party: minority
   rank: 3
   bioguide: S000033
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
   bioguide: W000802
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeff Merkley
   party: minority
   rank: 5
   bioguide: M001176
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kirsten E. Gillibrand
   party: minority
   rank: 6
   bioguide: G000555
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Cory A. Booker
   party: minority
   rank: 7
   bioguide: B001288
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Edward J. Markey
   party: minority
   rank: 8
   bioguide: M000133
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tammy Duckworth
   party: minority
   rank: 9
   bioguide: D000622
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Chris Van Hollen
   party: minority
   rank: 10
   bioguide: V000128
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSEV08:
-- name: James M. Inhofe
+- name: Shelley Moore Capito
   party: majority
   rank: 1
   title: Chairman
-  bioguide: I000024
-- name: Shelley Moore Capito
-  party: majority
-  rank: 2
   bioguide: C001047
-- name: John Boozman
-  party: majority
-  rank: 3
-  bioguide: B001236
-- name: Roger F. Wicker
-  party: majority
-  rank: 4
-  bioguide: W000437
-- name: Deb Fischer
-  party: majority
-  rank: 5
-  bioguide: F000463
-- name: Jerry Moran
-  party: majority
-  rank: 6
-  bioguide: M000934
-- name: Joni Ernst
-  party: majority
-  rank: 7
-  bioguide: E000295
-- name: Dan Sullivan
-  party: majority
-  rank: 8
-  bioguide: S001198
-- name: Richard C. Shelby
-  party: majority
-  rank: 9
-  bioguide: S000320
-- name: John Barrasso
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: B001261
-- name: Benjamin L. Cardin
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: C000141
-- name: Bernard Sanders
-  party: minority
-  rank: 2
-  bioguide: S000033
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  bioguide: W000802
-- name: Jeff Merkley
-  party: minority
-  rank: 4
-  bioguide: M001176
-- name: Kirsten E. Gillibrand
-  party: minority
-  rank: 5
-  bioguide: G000555
-- name: Edward J. Markey
-  party: minority
-  rank: 6
-  bioguide: M000133
-- name: Tammy Duckworth
-  party: minority
-  rank: 7
-  bioguide: D000622
-- name: Cory A. Booker
-  party: minority
-  rank: 8
-  bioguide: B001288
-- name: Thomas R. Carper
-  party: minority
-  rank: 9
-  title: Ex Officio
-  bioguide: C000174
+  start_date: '2019-01-28'
+  source: https://www.epw.senate.gov/public/index.cfm/press-releases-republican?ID=86C37177-F7DE-43C3-A215-5112B659E21F
 SSEV09:
 - name: Mike Rounds
   party: majority
   rank: 1
   title: Chairman
   bioguide: R000605
-- name: Jerry Moran
-  party: majority
-  rank: 2
-  bioguide: M000934
-- name: Joni Ernst
-  party: majority
-  rank: 3
-  bioguide: E000295
-- name: Dan Sullivan
-  party: majority
-  rank: 4
-  bioguide: S001198
-- name: John Barrasso
-  party: majority
-  rank: 5
-  title: Ex Officio
-  bioguide: B001261
-- name: Cory A. Booker
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001288
-- name: Bernard Sanders
-  party: minority
-  rank: 2
-  bioguide: S000033
-- name: Chris Van Hollen
-  party: minority
-  rank: 3
-  bioguide: V000128
-- name: Thomas R. Carper
-  party: minority
-  rank: 4
-  title: Ex Officio
-  bioguide: C000174
+  start_date: '2019-01-28'
+  source: https://www.epw.senate.gov/public/index.cfm/press-releases-republican?ID=86C37177-F7DE-43C3-A215-5112B659E21F
 SSEV10:
-- name: Shelley Moore Capito
+- name: Mike Braun
   party: majority
   rank: 1
   title: Chairman
-  bioguide: C001047
-- name: James M. Inhofe
-  party: majority
-  rank: 2
-  bioguide: I000024
-- name: John Boozman
-  party: majority
-  rank: 3
-  bioguide: B001236
-- name: Roger F. Wicker
-  party: majority
-  rank: 4
-  bioguide: W000437
-- name: Deb Fischer
-  party: majority
-  rank: 5
-  bioguide: F000463
-- name: Jerry Moran
-  party: majority
-  rank: 6
-  bioguide: M000934
-- name: Joni Ernst
-  party: majority
-  rank: 7
-  bioguide: E000295
-- name: Richard C. Shelby
-  party: majority
-  rank: 8
-  bioguide: S000320
-- name: John Barrasso
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: B001261
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: W000802
-- name: Benjamin L. Cardin
-  party: minority
-  rank: 2
-  bioguide: C000141
-- name: Bernard Sanders
-  party: minority
-  rank: 3
-  bioguide: S000033
-- name: Jeff Merkley
-  party: minority
-  rank: 4
-  bioguide: M001176
-- name: Kirsten E. Gillibrand
-  party: minority
-  rank: 5
-  bioguide: G000555
-- name: Edward J. Markey
-  party: minority
-  rank: 6
-  bioguide: M000133
-- name: Tammy Duckworth
-  party: minority
-  rank: 7
-  bioguide: D000622
-- name: Thomas R. Carper
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: C000174
+  bioguide: B001310
+  start_date: '2019-01-28'
+  source: https://www.epw.senate.gov/public/index.cfm/press-releases-republican?ID=86C37177-F7DE-43C3-A215-5112B659E21F
 SSEV15:
-- name: John Boozman
+- name: Kevin Cramer
   party: majority
   rank: 1
   title: Chairman
-  bioguide: B001236
-- name: James M. Inhofe
-  party: majority
-  rank: 2
-  bioguide: I000024
-- name: Shelley Moore Capito
-  party: majority
-  rank: 3
-  bioguide: C001047
-- name: Roger F. Wicker
-  party: majority
-  rank: 4
-  bioguide: W000437
-- name: Deb Fischer
-  party: majority
-  rank: 5
-  bioguide: F000463
-- name: Mike Rounds
-  party: majority
-  rank: 6
-  bioguide: R000605
-- name: Dan Sullivan
-  party: majority
-  rank: 7
-  bioguide: S001198
-- name: Richard C. Shelby
-  party: majority
-  rank: 8
-  bioguide: S000320
-- name: John Barrasso
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: B001261
-- name: Tammy Duckworth
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: D000622
-- name: Benjamin L. Cardin
-  party: minority
-  rank: 2
-  bioguide: C000141
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 3
-  title: Ranking Member
-  bioguide: W000802
-- name: Jeff Merkley
-  party: minority
-  rank: 4
-  bioguide: M001176
-- name: Kirsten E. Gillibrand
-  party: minority
-  rank: 5
-  bioguide: G000555
-- name: Edward J. Markey
-  party: minority
-  rank: 6
-  bioguide: M000133
-- name: Chris Van Hollen
-  party: minority
-  rank: 7
-  bioguide: V000128
-- name: Thomas R. Carper
-  party: minority
-  rank: 8
-  title: Ex Officio
-  bioguide: C000174
+  bioguide: C001096
+  start_date: '2019-01-28'
+  source: https://www.epw.senate.gov/public/index.cfm/press-releases-republican?ID=86C37177-F7DE-43C3-A215-5112B659E21F
 SSFI:
 - name: Chuck Grassley
   party: majority
-  rank: 2
+  rank: 1
+  title: Chairman
   bioguide: G000386
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Crapo
   party: majority
-  rank: 3
+  rank: 2
   bioguide: C000880
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Pat Roberts
   party: majority
-  rank: 4
+  rank: 3
   bioguide: R000307
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Michael B. Enzi
   party: majority
-  rank: 5
+  rank: 4
   bioguide: E000285
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Cornyn
   party: majority
-  rank: 6
+  rank: 5
   bioguide: C001056
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Thune
   party: majority
-  rank: 7
+  rank: 6
   bioguide: T000250
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Richard Burr
   party: majority
-  rank: 8
+  rank: 7
   bioguide: B001135
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Johnny Isakson
   party: majority
-  rank: 9
+  rank: 8
   bioguide: I000055
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rob Portman
   party: majority
-  rank: 10
+  rank: 9
   bioguide: P000449
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Patrick J. Toomey
   party: majority
-  rank: 11
+  rank: 10
   bioguide: T000461
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tim Scott
   party: majority
-  rank: 13
+  rank: 11
   bioguide: S001184
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Bill Cassidy
   party: majority
-  rank: 14
+  rank: 12
   bioguide: C001075
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: James Lankford
+  party: majority
+  rank: 13
+  bioguide: L000575
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Steve Daines
+  party: majority
+  rank: 14
+  bioguide: D000618
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Todd Young
+  party: majority
+  rank: 15
+  bioguide: Y000064
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ron Wyden
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: W000779
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Debbie Stabenow
   party: minority
   rank: 2
   bioguide: S000770
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Maria Cantwell
   party: minority
   rank: 3
   bioguide: C000127
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Robert Menendez
   party: minority
-  rank: 5
+  rank: 4
   bioguide: M000639
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Thomas R. Carper
   party: minority
-  rank: 6
+  rank: 5
   bioguide: C000174
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Benjamin L. Cardin
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C000141
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Sherrod Brown
   party: minority
-  rank: 8
+  rank: 7
   bioguide: B000944
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Michael F. Bennet
   party: minority
-  rank: 9
+  rank: 8
   bioguide: B001267
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Robert P. Casey, Jr.
   party: minority
-  rank: 10
+  rank: 9
   bioguide: C001070
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mark R. Warner
   party: minority
-  rank: 11
+  rank: 10
   bioguide: W000805
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Sheldon Whitehouse
   party: minority
-  rank: 13
+  rank: 11
   bioguide: W000802
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Margaret Wood Hassan
+  party: minority
+  rank: 12
+  bioguide: H001076
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Catherine Cortez Masto
+  party: minority
+  rank: 13
+  bioguide: C001113
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSFI02:
-- name: Bill Cassidy
+- name: Rob Portman
   party: majority
   rank: 1
   title: Chairman
-  bioguide: C001075
-- name: Rob Portman
+  bioguide: P000449
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Chuck Grassley
   party: majority
   rank: 2
-  bioguide: P000449
-- name: Mike Crapo
+  bioguide: G000386
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Bill Cassidy
   party: majority
   rank: 3
-  bioguide: C000880
-- name: Patrick J. Toomey
+  bioguide: C001075
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: James Lankford
   party: majority
   rank: 4
-  bioguide: T000461
+  bioguide: L000575
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Todd Young
+  party: majority
+  rank: 5
+  bioguide: Y000064
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Sherrod Brown
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B000944
-- name: Robert P. Casey, Jr.
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Michael F. Bennet
   party: minority
   rank: 2
-  bioguide: C001070
-- name: Ron Wyden
+  bioguide: B001267
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Robert P. Casey, Jr.
   party: minority
   rank: 3
+  bioguide: C001070
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Catherine Cortez Masto
+  party: minority
+  rank: 4
+  bioguide: C001113
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Ron Wyden
+  party: minority
+  rank: 5
   title: Ex Officio
   bioguide: W000779
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 SSFI10:
 - name: Patrick J. Toomey
   party: majority
   rank: 1
   title: Chairman
   bioguide: T000461
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Pat Roberts
   party: majority
   rank: 3
   bioguide: R000307
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Michael B. Enzi
   party: majority
   rank: 4
   bioguide: E000285
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: John Thune
   party: majority
   rank: 5
   bioguide: T000250
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Richard Burr
   party: majority
   rank: 6
   bioguide: B001135
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Johnny Isakson
   party: majority
   rank: 7
   bioguide: I000055
-- name: Rob Portman
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Tim Scott
   party: majority
   rank: 8
-  bioguide: P000449
+  bioguide: S001184
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Bill Cassidy
   party: majority
-  rank: 10
+  rank: 9
   bioguide: C001075
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: James Lankford
+  party: majority
+  rank: 10
+  bioguide: L000575
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Steve Daines
+  party: majority
+  rank: 11
+  bioguide: D000618
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Todd Young
+  party: majority
+  rank: 12
+  bioguide: Y000064
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Debbie Stabenow
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000770
-- name: Robert Menendez
-  party: minority
-  rank: 2
-  bioguide: M000639
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Maria Cantwell
   party: minority
-  rank: 3
+  rank: 2
   bioguide: C000127
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Robert Menendez
+  party: minority
+  rank: 3
+  bioguide: M000639
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Thomas R. Carper
   party: minority
   rank: 4
   bioguide: C000174
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Benjamin L. Cardin
   party: minority
   rank: 5
   bioguide: C000141
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Sherrod Brown
   party: minority
   rank: 6
   bioguide: B000944
-- name: Mark R. Warner
-  party: minority
-  rank: 7
-  bioguide: W000805
-- name: Ron Wyden
-  party: minority
-  rank: 8
-  bioguide: W000779
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 9
-  bioguide: W000802
-SSFI11:
-- name: Rob Portman
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: P000449
-- name: Mike Crapo
-  party: majority
-  rank: 2
-  bioguide: C000880
-- name: Pat Roberts
-  party: majority
-  rank: 3
-  bioguide: R000307
-- name: Michael B. Enzi
-  party: majority
-  rank: 4
-  bioguide: E000285
-- name: John Cornyn
-  party: majority
-  rank: 5
-  bioguide: C001056
-- name: John Thune
-  party: majority
-  rank: 6
-  bioguide: T000250
-- name: Richard Burr
-  party: majority
-  rank: 7
-  bioguide: B001135
-- name: Johnny Isakson
-  party: majority
-  rank: 8
-  bioguide: I000055
-- name: Patrick J. Toomey
-  party: majority
-  rank: 9
-  bioguide: T000461
-- name: Tim Scott
-  party: majority
-  rank: 10
-  bioguide: S001184
-- name: Mark R. Warner
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: W000805
-- name: Thomas R. Carper
-  party: minority
-  rank: 2
-  bioguide: C000174
-- name: Benjamin L. Cardin
-  party: minority
-  rank: 3
-  bioguide: C000141
-- name: Robert Menendez
-  party: minority
-  rank: 5
-  bioguide: M000639
-- name: Michael F. Bennet
-  party: minority
-  rank: 6
-  bioguide: B001267
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 7
   bioguide: C001070
-- name: Maria Cantwell
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Mark R. Warner
   party: minority
   rank: 8
-  bioguide: C000127
+  bioguide: W000805
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Sheldon Whitehouse
   party: minority
   rank: 9
   bioguide: W000802
-- name: Ron Wyden
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Margaret Wood Hassan
   party: minority
   rank: 10
+  bioguide: H001076
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Catherine Cortez Masto
+  party: minority
+  rank: 11
+  bioguide: C001113
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+SSFI11:
+- name: John Thune
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: T000250
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Mike Crapo
+  party: majority
+  rank: 2
+  bioguide: C000880
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Michael B. Enzi
+  party: majority
+  rank: 3
+  bioguide: E000285
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: John Cornyn
+  party: majority
+  rank: 4
+  bioguide: C001056
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Richard Burr
+  party: majority
+  rank: 5
+  bioguide: B001135
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Johnny Isakson
+  party: majority
+  rank: 6
+  bioguide: I000055
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Rob Portman
+  party: majority
+  rank: 7
+  bioguide: P000449
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Patrick J. Toomey
+  party: majority
+  rank: 8
+  bioguide: T000461
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Mark R. Warner
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000805
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Robert Menendez
+  party: minority
+  rank: 2
+  bioguide: M000639
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Thomas R. Carper
+  party: minority
+  rank: 3
+  bioguide: C000174
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Benjamin L. Cardin
+  party: minority
+  rank: 4
+  bioguide: C000141
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Michael F. Bennet
+  party: minority
+  rank: 5
+  bioguide: B001267
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 6
+  bioguide: W000802
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Ron Wyden
+  party: minority
+  rank: 7
   title: Ex Officio
   bioguide: W000779
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 SSFI12:
+- name: Tim Scott
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: S001184
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Chuck Grassley
   party: majority
   rank: 2
   bioguide: G000386
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Mike Crapo
   party: majority
   rank: 3
   bioguide: C000880
-- name: Michael B. Enzi
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Pat Roberts
   party: majority
   rank: 4
-  bioguide: E000285
-- name: John Cornyn
+  bioguide: R000307
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Michael B. Enzi
   party: majority
   rank: 5
-  bioguide: C001056
-- name: Richard Burr
+  bioguide: E000285
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: John Cornyn
   party: majority
   rank: 6
-  bioguide: B001135
-- name: Tim Scott
+  bioguide: C001056
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Richard Burr
   party: majority
   rank: 7
-  bioguide: S001184
-- name: Bill Cassidy
+  bioguide: B001135
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Steve Daines
   party: majority
   rank: 8
-  bioguide: C001075
+  bioguide: D000618
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Michael F. Bennet
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001267
-- name: Maria Cantwell
-  party: minority
-  rank: 2
-  bioguide: C000127
-- name: Robert Menendez
-  party: minority
-  rank: 4
-  bioguide: M000639
-- name: Thomas R. Carper
-  party: minority
-  rank: 5
-  bioguide: C000174
-- name: Mark R. Warner
-  party: minority
-  rank: 6
-  bioguide: W000805
-- name: Sheldon Whitehouse
-  party: minority
-  rank: 7
-  bioguide: W000802
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Ron Wyden
   party: minority
-  rank: 8
-  title: Ex Officio
+  rank: 2
   bioguide: W000779
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Maria Cantwell
+  party: minority
+  rank: 3
+  bioguide: C000127
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Thomas R. Carper
+  party: minority
+  rank: 4
+  bioguide: C000174
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Sheldon Whitehouse
+  party: minority
+  rank: 5
+  bioguide: W000802
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Margaret Wood Hassan
+  party: minority
+  rank: 6
+  bioguide: H001076
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 SSFI13:
 - name: John Cornyn
   party: majority
   rank: 1
   title: Chairman
   bioguide: C001056
-- name: Chuck Grassley
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Mike Crapo
   party: majority
   rank: 2
-  bioguide: G000386
+  bioguide: C000880
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Pat Roberts
   party: majority
   rank: 3
   bioguide: R000307
-- name: Johnny Isakson
-  party: majority
-  rank: 4
-  bioguide: I000055
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: John Thune
   party: majority
-  rank: 5
+  rank: 4
   bioguide: T000250
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Johnny Isakson
+  party: majority
+  rank: 5
+  bioguide: I000055
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Rob Portman
+  party: majority
+  rank: 6
+  bioguide: P000449
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Patrick J. Toomey
+  party: majority
+  rank: 7
+  bioguide: T000461
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Tim Scott
+  party: majority
+  rank: 8
+  bioguide: S001184
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Bill Cassidy
+  party: majority
+  rank: 9
+  bioguide: C001075
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Steve Daines
+  party: majority
+  rank: 10
+  bioguide: D000618
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Todd Young
+  party: majority
+  rank: 11
+  bioguide: Y000064
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001070
-- name: Debbie Stabenow
-  party: minority
-  rank: 2
-  bioguide: S000770
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Ron Wyden
   party: minority
-  rank: 5
-  title: Ex Officio
+  rank: 2
   bioguide: W000779
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Debbie Stabenow
+  party: minority
+  rank: 3
+  bioguide: S000770
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Maria Cantwell
+  party: minority
+  rank: 4
+  bioguide: C000127
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Robert Menendez
+  party: minority
+  rank: 5
+  bioguide: M000639
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 - name: Benjamin L. Cardin
   party: minority
   rank: 6
   bioguide: C000141
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Sherrod Brown
+  party: minority
+  rank: 7
+  bioguide: B000944
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Mark R. Warner
+  party: minority
+  rank: 8
+  bioguide: W000805
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Catherine Cortez Masto
+  party: minority
+  rank: 9
+  bioguide: C001113
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 SSFI14:
-- name: Tim Scott
+- name: Bill Cassidy
   party: majority
   rank: 1
   title: Chairman
+  bioguide: C001075
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Tim Scott
+  party: majority
+  rank: 2
   bioguide: S001184
-- name: Ron Wyden
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: James Lankford
+  party: majority
+  rank: 3
+  bioguide: L000575
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Margaret Wood Hassan
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: H001076
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
+- name: Ron Wyden
+  party: minority
+  rank: 2
   bioguide: W000779
+  start_date: '2019-01-31'
+  source: https://www.finance.senate.gov/chairmans-news/grassley-wyden-announce-expected-finance-committee-subcommittee-membership
 SSFR:
 - name: James E. Risch
   party: majority
-  rank: 2
+  rank: 1
+  title: Chairman
   bioguide: R000584
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Marco Rubio
   party: majority
-  rank: 3
+  rank: 2
   bioguide: R000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ron Johnson
   party: majority
-  rank: 4
+  rank: 3
   bioguide: J000293
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Cory Gardner
   party: majority
-  rank: 6
+  rank: 4
   bioguide: G000562
-- name: Todd Young
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mitt Romney
+  party: majority
+  rank: 5
+  bioguide: R000615
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Lindsey Graham
+  party: majority
+  rank: 6
+  bioguide: G000359
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Johnny Isakson
   party: majority
   rank: 7
-  bioguide: Y000064
+  bioguide: I000055
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Barrasso
   party: majority
   rank: 8
   bioguide: B001261
-- name: Johnny Isakson
-  party: majority
-  rank: 9
-  bioguide: I000055
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rob Portman
   party: majority
-  rank: 10
+  rank: 9
   bioguide: P000449
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rand Paul
   party: majority
-  rank: 11
+  rank: 10
   bioguide: P000603
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Todd Young
+  party: majority
+  rank: 11
+  bioguide: Y000064
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Ted Cruz
+  party: majority
+  rank: 12
+  bioguide: C001098
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Robert Menendez
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M000639
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Benjamin L. Cardin
   party: minority
   rank: 2
   bioguide: C000141
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Christopher A. Coons
   party: minority
   rank: 4
   bioguide: C001088
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Christopher Murphy
   party: minority
   rank: 6
   bioguide: M001169
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tim Kaine
   party: minority
   rank: 7
   bioguide: K000384
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Edward J. Markey
   party: minority
   rank: 8
   bioguide: M000133
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeff Merkley
   party: minority
   rank: 9
   bioguide: M001176
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Cory A. Booker
   party: minority
   rank: 10
   bioguide: B001288
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSFR01:
 - name: Ron Johnson
   party: majority
@@ -15457,530 +15899,807 @@ SSGA:
   rank: 1
   title: Chairman
   bioguide: J000293
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rob Portman
   party: majority
   rank: 2
   bioguide: P000449
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rand Paul
   party: majority
   rank: 3
   bioguide: P000603
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James Lankford
   party: majority
   rank: 4
   bioguide: L000575
-- name: Michael B. Enzi
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mitt Romney
   party: majority
   rank: 5
-  bioguide: E000285
-- name: John Hoeven
+  bioguide: R000615
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Rick Scott
   party: majority
   rank: 6
-  bioguide: H001061
-- name: Steve Daines
+  bioguide: S001217
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Michael B. Enzi
   party: majority
   rank: 7
-  bioguide: D000618
+  bioguide: E000285
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Josh Hawley
+  party: majority
+  rank: 8
+  bioguide: H001089
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Gary C. Peters
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: P000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Thomas R. Carper
   party: minority
   rank: 2
   bioguide: C000174
-- name: Gary C. Peters
-  party: minority
-  rank: 4
-  bioguide: P000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Margaret Wood Hassan
   party: minority
-  rank: 5
+  rank: 3
   bioguide: H001076
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kamala D. Harris
   party: minority
-  rank: 6
+  rank: 4
   bioguide: H001075
-- name: Doug Jones
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Kyrsten Sinema
   party: minority
-  rank: 7
-  bioguide: J000300
+  rank: 5
+  bioguide: S001191
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Jacky Rosen
+  party: minority
+  rank: 6
+  bioguide: R000608
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSGA01:
 - name: Rob Portman
   party: majority
   rank: 1
   title: Chairman
   bioguide: P000449
-- name: James Lankford
-  party: majority
-  rank: 2
-  bioguide: L000575
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Rand Paul
   party: majority
-  rank: 3
+  rank: 2
   bioguide: P000603
-- name: Steve Daines
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: James Lankford
+  party: majority
+  rank: 3
+  bioguide: L000575
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Mitt Romney
   party: majority
   rank: 4
-  bioguide: D000618
-- name: Ron Johnson
+  bioguide: R000615
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Josh Hawley
   party: majority
   rank: 5
+  bioguide: H001089
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Ron Johnson
+  party: majority
+  rank: 6
   title: Ex Officio
   bioguide: J000293
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Thomas R. Carper
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000174
-- name: Gary C. Peters
-  party: minority
-  rank: 3
-  bioguide: P000595
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Margaret Wood Hassan
   party: minority
-  rank: 4
+  rank: 2
   bioguide: H001076
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Kamala D. Harris
+  party: minority
+  rank: 3
+  bioguide: H001075
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Jacky Rosen
+  party: minority
+  rank: 4
+  bioguide: R000608
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Gary C. Peters
+  party: minority
+  rank: 5
+  title: Ex Officio
+  bioguide: P000595
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 SSGA18:
 - name: Rand Paul
   party: majority
   rank: 1
   title: Chairman
   bioguide: P000603
-- name: James Lankford
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Rick Scott
   party: majority
   rank: 2
-  bioguide: L000575
+  bioguide: S001217
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Michael B. Enzi
   party: majority
   rank: 3
   bioguide: E000285
-- name: John Hoeven
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Josh Hawley
   party: majority
   rank: 4
-  bioguide: H001061
+  bioguide: H001089
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Ron Johnson
   party: majority
   rank: 5
   title: Ex Officio
   bioguide: J000293
-- name: Gary C. Peters
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Margaret Wood Hassan
   party: minority
   rank: 1
+  bioguide: H001076
   title: Ranking Member
-  bioguide: P000595
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Kamala D. Harris
   party: minority
   rank: 2
   bioguide: H001075
-- name: Doug Jones
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Kyrsten Sinema
   party: minority
   rank: 3
-  bioguide: J000300
+  bioguide: S001191
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Gary C. Peters
+  party: minority
+  rank: 4
+  title: Ex Officio
+  bioguide: P000595
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 SSGA19:
 - name: James Lankford
   party: majority
   rank: 1
   title: Chairman
   bioguide: L000575
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Rob Portman
   party: majority
   rank: 2
   bioguide: P000449
-- name: Michael B. Enzi
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Mitt Romney
   party: majority
   rank: 3
-  bioguide: E000285
-- name: Steve Daines
+  bioguide: R000615
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Rick Scott
   party: majority
   rank: 4
-  bioguide: D000618
-- name: Ron Johnson
+  bioguide: S001217
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Michael B. Enzi
   party: majority
   rank: 5
+  bioguide: E000285
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Ron Johnson
+  party: majority
+  rank: 6
   title: Ex Officio
   bioguide: J000293
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Kyrsten Sinema
+  party: minority
+  rank: 1
+  title: Ex Officio
+  bioguide: S001191
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 - name: Thomas R. Carper
   party: minority
   rank: 2
   bioguide: C000174
-- name: Margaret Wood Hassan
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Jacky Rosen
   party: minority
   rank: 3
-  bioguide: H001076
-- name: Kamala D. Harris
+  bioguide: R000608
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
+- name: Gary C. Peters
   party: minority
   rank: 4
-  bioguide: H001075
+  title: Ex Officio
+  bioguide: P000595
+  start_date: '2019-01-31'
+  source: https://www.hsgac.senate.gov/media/majority-media/johnson-peters-announce-homeland-security-and-governmental-affairs-subcommittee-membership
 SSHR:
 - name: Lamar Alexander
   party: majority
   rank: 1
   title: Chairman
   bioguide: A000360
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Michael B. Enzi
   party: majority
   rank: 2
   bioguide: E000285
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Richard Burr
   party: majority
   rank: 3
   bioguide: B001135
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Johnny Isakson
   party: majority
   rank: 4
   bioguide: I000055
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rand Paul
   party: majority
   rank: 5
   bioguide: P000603
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Susan M. Collins
   party: majority
   rank: 6
   bioguide: C001035
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Bill Cassidy
   party: majority
   rank: 7
   bioguide: C001075
-- name: Todd Young
-  party: majority
-  rank: 8
-  bioguide: Y000064
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Pat Roberts
   party: majority
-  rank: 10
+  rank: 8
   bioguide: R000307
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Lisa Murkowski
   party: majority
-  rank: 11
+  rank: 9
   bioguide: M001153
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tim Scott
   party: majority
-  rank: 12
+  rank: 10
   bioguide: S001184
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mitt Romney
+  party: majority
+  rank: 11
+  bioguide: R000615
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mike Braun
+  party: majority
+  rank: 12
+  bioguide: B001310
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Patty Murray
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: M001111
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Bernard Sanders
   party: minority
   rank: 2
   bioguide: S000033
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 3
   bioguide: C001070
-- name: Michael F. Bennet
-  party: minority
-  rank: 4
-  bioguide: B001267
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tammy Baldwin
   party: minority
-  rank: 5
+  rank: 4
   bioguide: B001230
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Christopher Murphy
   party: minority
-  rank: 6
+  rank: 5
   bioguide: M001169
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Elizabeth Warren
   party: minority
-  rank: 7
+  rank: 6
   bioguide: W000817
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tim Kaine
   party: minority
-  rank: 8
+  rank: 7
   bioguide: K000384
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Margaret Wood Hassan
   party: minority
-  rank: 9
+  rank: 8
   bioguide: H001076
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tina Smith
   party: minority
-  rank: 10
+  rank: 9
   bioguide: S001203
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Doug Jones
   party: minority
-  rank: 11
+  rank: 10
   bioguide: J000300
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Jacky Rosen
+  party: minority
+  rank: 11
+  bioguide: R000608
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSHR09:
 - name: Rand Paul
   party: majority
   rank: 1
   title: Chairman
   bioguide: P000603
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Lisa Murkowski
   party: majority
   rank: 2
   bioguide: M001153
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Richard Burr
   party: majority
   rank: 3
   bioguide: B001135
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Bill Cassidy
   party: majority
   rank: 4
   bioguide: C001075
-- name: Todd Young
-  party: majority
-  rank: 5
-  bioguide: Y000064
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 5
   bioguide: R000307
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
+- name: Tim Scott
+  party: majority
+  rank: 6
+  bioguide: S001184
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
+- name: Mitt Romney
+  party: majority
+  rank: 7
+  bioguide: R000615
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: A000360
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C001070
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Bernard Sanders
   party: minority
   rank: 2
   bioguide: S000033
-- name: Michael F. Bennet
-  party: minority
-  rank: 3
-  bioguide: B001267
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Tim Kaine
   party: minority
-  rank: 4
+  rank: 3
   bioguide: K000384
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Margaret Wood Hassan
   party: minority
-  rank: 5
+  rank: 4
   bioguide: H001076
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Tina Smith
   party: minority
-  rank: 6
+  rank: 5
   bioguide: S001203
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 - name: Patty Murray
   party: minority
-  rank: 7
+  rank: 6
   title: Ex Officio
   bioguide: M001111
+  source: https://www.help.senate.gov/about/subcommittees/children-and-families
 SSHR11:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000055
-- name: Pat Roberts
-  party: majority
-  rank: 2
-  bioguide: R000307
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Tim Scott
   party: majority
-  rank: 3
+  rank: 2
   bioguide: S001184
-- name: Richard Burr
-  party: majority
-  rank: 4
-  bioguide: B001135
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Rand Paul
   party: majority
-  rank: 5
+  rank: 3
   bioguide: P000603
-- name: Bill Cassidy
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
+- name: Mitt Romney
+  party: majority
+  rank: 4
+  bioguide: R000615
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
+- name: Mike Braun
+  party: majority
+  rank: 5
+  bioguide: B001310
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
+- name: Richard Burr
   party: majority
   rank: 6
-  bioguide: C001075
-- name: Todd Young
+  bioguide: B001135
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
+- name: Bill Cassidy
   party: majority
   rank: 7
-  bioguide: Y000064
+  bioguide: C001075
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Lamar Alexander
   party: majority
   rank: 8
   title: Ex Officio
   bioguide: A000360
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Tammy Baldwin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001230
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Robert P. Casey, Jr.
   party: minority
   rank: 2
   bioguide: C001070
-- name: Christopher Murphy
-  party: minority
-  rank: 3
-  bioguide: M001169
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Elizabeth Warren
   party: minority
-  rank: 4
+  rank: 3
   bioguide: W000817
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Tina Smith
   party: minority
-  rank: 5
+  rank: 4
   bioguide: S001203
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Doug Jones
   party: minority
-  rank: 6
+  rank: 5
   bioguide: J000300
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
+- name: Jacky Rosen
+  party: minority
+  rank: 6
+  bioguide: R000608
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 - name: Patty Murray
   party: minority
   rank: 7
   title: Ex Officio
   bioguide: M001111
+  source: https://www.help.senate.gov/about/subcommittees/employment-and-workplace-safety
 SSHR12:
 - name: Michael B. Enzi
   party: majority
   rank: 1
   title: Chairman
   bioguide: E000285
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Richard Burr
   party: majority
   rank: 2
   bioguide: B001135
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Susan M. Collins
   party: majority
   rank: 3
   bioguide: C001035
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Bill Cassidy
   party: majority
   rank: 4
   bioguide: C001075
-- name: Todd Young
-  party: majority
-  rank: 5
-  bioguide: Y000064
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Pat Roberts
   party: majority
-  rank: 7
+  rank: 5
   bioguide: R000307
-- name: Tim Scott
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
+- name: Mitt Romney
   party: majority
-  rank: 8
-  bioguide: S001184
+  rank: 6
+  bioguide: R000615
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
+- name: Mike Braun
+  party: majority
+  rank: 7
+  bioguide: B001310
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Lisa Murkowski
   party: majority
-  rank: 9
+  rank: 8
   bioguide: M001153
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
+- name: Tim Scott
+  party: majority
+  rank: 9
+  bioguide: S001184
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Lamar Alexander
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: A000360
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Bernard Sanders
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S000033
-- name: Michael F. Bennet
-  party: minority
-  rank: 2
-  bioguide: B001267
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Tammy Baldwin
   party: minority
-  rank: 3
+  rank: 2
   bioguide: B001230
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Christopher Murphy
   party: minority
-  rank: 4
+  rank: 3
   bioguide: M001169
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Elizabeth Warren
   party: minority
-  rank: 5
+  rank: 4
   bioguide: W000817
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Tim Kaine
   party: minority
-  rank: 6
+  rank: 5
   bioguide: K000384
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Margaret Wood Hassan
   party: minority
-  rank: 7
+  rank: 6
   bioguide: H001076
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Doug Jones
   party: minority
-  rank: 8
+  rank: 7
   bioguide: J000300
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
+- name: Jacky Rosen
+  party: minority
+  rank: 8
+  bioguide: R000608
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 - name: Patty Murray
   party: minority
   rank: 9
   title: Ex Officio
   bioguide: M001111
+  source: https://www.help.senate.gov/about/subcommittees/primary-health-and-retirement-security
 SSJU:
-- name: Chuck Grassley
+- name: Lindsey Graham
   party: majority
   rank: 1
   title: Chairman
-  bioguide: G000386
-- name: Lindsey Graham
-  party: majority
-  rank: 3
   bioguide: G000359
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Chuck Grassley
+  party: majority
+  rank: 2
+  bioguide: G000386
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Cornyn
   party: majority
-  rank: 4
+  rank: 3
   bioguide: C001056
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Lee
   party: majority
-  rank: 5
+  rank: 4
   bioguide: L000577
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ted Cruz
   party: majority
-  rank: 6
+  rank: 5
   bioguide: C001098
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ben Sasse
   party: majority
-  rank: 7
+  rank: 6
   bioguide: S001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Josh Hawley
+  party: majority
+  rank: 7
+  bioguide: H001089
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Thom Tillis
+  party: majority
+  rank: 8
+  bioguide: T000476
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Crapo
   party: majority
   rank: 9
   bioguide: C000880
-- name: Thom Tillis
-  party: majority
-  rank: 10
-  bioguide: T000476
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Kennedy
   party: majority
-  rank: 11
+  rank: 10
   bioguide: K000393
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Marsha Blackburn
+  party: majority
+  rank: 11
+  bioguide: B001243
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Dianne Feinstein
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: F000062
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Patrick J. Leahy
   party: minority
   rank: 2
   bioguide: L000174
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard J. Durbin
   party: minority
   rank: 3
   bioguide: D000563
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Sheldon Whitehouse
   party: minority
   rank: 4
   bioguide: W000802
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Amy Klobuchar
   party: minority
   rank: 5
   bioguide: K000367
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Christopher A. Coons
   party: minority
   rank: 6
   bioguide: C001088
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard Blumenthal
   party: minority
   rank: 7
   bioguide: B001277
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mazie K. Hirono
   party: minority
   rank: 8
   bioguide: H001042
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Cory A. Booker
   party: minority
   rank: 9
   bioguide: B001288
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Kamala D. Harris
   party: minority
   rank: 10
   bioguide: H001075
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSJU01:
 - name: Mike Lee
   party: majority
@@ -16280,210 +16999,330 @@ SSRA:
   rank: 1
   title: Chairman
   bioguide: B000575
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mitch McConnell
   party: majority
   rank: 2
   bioguide: M000355
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Lamar Alexander
   party: majority
   rank: 3
   bioguide: A000360
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Pat Roberts
   party: majority
   rank: 4
   bioguide: R000307
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Richard C. Shelby
   party: majority
   rank: 5
   bioguide: S000320
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Ted Cruz
   party: majority
   rank: 6
   bioguide: C001098
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Shelley Moore Capito
   party: majority
   rank: 7
   bioguide: C001047
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Roger F. Wicker
   party: majority
   rank: 8
   bioguide: W000437
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Deb Fischer
   party: majority
   rank: 9
   bioguide: F000463
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Cindy Hyde-Smith
   party: majority
   rank: 10
   bioguide: H001079
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Amy Klobuchar
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: K000367
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Dianne Feinstein
   party: minority
   rank: 2
   bioguide: F000062
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Charles E. Schumer
   party: minority
   rank: 3
   bioguide: S000148
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard J. Durbin
   party: minority
   rank: 4
   bioguide: D000563
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tom Udall
   party: minority
   rank: 5
   bioguide: U000039
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mark R. Warner
   party: minority
   rank: 6
   bioguide: W000805
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Patrick J. Leahy
   party: minority
   rank: 7
   bioguide: L000174
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Angus S. King, Jr.
   party: minority
   rank: 8
   bioguide: K000383
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Catherine Cortez Masto
   party: minority
   rank: 9
   bioguide: C001113
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSSB:
-- name: James E. Risch
+- name: Marco Rubio
   party: majority
   rank: 1
   title: Chairman
-  bioguide: R000584
-- name: Marco Rubio
+  bioguide: R000595
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: James E. Risch
   party: majority
   rank: 2
-  bioguide: R000595
+  bioguide: R000584
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Rand Paul
   party: majority
   rank: 3
   bioguide: P000603
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Tim Scott
   party: majority
   rank: 4
   bioguide: S001184
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Joni Ernst
   party: majority
   rank: 5
   bioguide: E000295
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James M. Inhofe
   party: majority
   rank: 6
   bioguide: I000024
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Todd Young
   party: majority
   rank: 7
   bioguide: Y000064
-- name: Michael B. Enzi
-  party: majority
-  rank: 8
-  bioguide: E000285
-- name: Mike Rounds
-  party: majority
-  rank: 9
-  bioguide: R000605
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Kennedy
   party: majority
-  rank: 10
+  rank: 8
   bioguide: K000393
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Mitt Romney
+  party: majority
+  rank: 9
+  bioguide: R000615
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Josh Hawley
+  party: majority
+  rank: 10
+  bioguide: H001089
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Benjamin L. Cardin
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: C000141
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Maria Cantwell
   party: minority
   rank: 2
   bioguide: C000127
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Jeanne Shaheen
   party: minority
   rank: 3
   bioguide: S001181
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Edward J. Markey
   party: minority
-  rank: 5
+  rank: 4
   bioguide: M000133
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Cory A. Booker
   party: minority
-  rank: 6
+  rank: 5
   bioguide: B001288
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Christopher A. Coons
   party: minority
-  rank: 7
+  rank: 6
   bioguide: C001088
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mazie K. Hirono
   party: minority
-  rank: 8
+  rank: 7
   bioguide: H001042
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Tammy Duckworth
   party: minority
-  rank: 9
+  rank: 8
   bioguide: D000622
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Jacky Rosen
+  party: minority
+  rank: 9
+  bioguide: R000608
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSVA:
 - name: Johnny Isakson
   party: majority
   rank: 1
   title: Chairman
   bioguide: I000055
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Jerry Moran
   party: majority
   rank: 2
   bioguide: M000934
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Boozman
   party: majority
   rank: 3
   bioguide: B001236
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Bill Cassidy
   party: majority
-  rank: 5
+  rank: 4
   bioguide: C001075
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Rounds
   party: majority
-  rank: 6
+  rank: 5
   bioguide: R000605
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Thom Tillis
   party: majority
-  rank: 7
+  rank: 6
   bioguide: T000476
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Dan Sullivan
   party: majority
-  rank: 8
+  rank: 7
   bioguide: S001198
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Kevin Cramer
+  party: majority
+  rank: 8
+  bioguide: C001096
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Jon Tester
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: T000464
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Patty Murray
   party: minority
   rank: 2
   bioguide: M001111
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Bernard Sanders
   party: minority
   rank: 3
   bioguide: S000033
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Sherrod Brown
   party: minority
   rank: 4
   bioguide: B000944
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Richard Blumenthal
   party: minority
   rank: 5
   bioguide: B001277
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mazie K. Hirono
   party: minority
   rank: 6
   bioguide: H001042
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Joe Manchin, III
   party: minority
   rank: 7
   bioguide: M001183
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Kyrsten Sinema
+  party: minority
+  rank: 8
+  bioguide: S001191
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -3932,7 +3932,6 @@ HSED10:
   party: majority
   rank: 6
   bioguide: M001208
-  start_date: '2019-01-15'
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Ilhan Omar

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -5598,26 +5598,26 @@ HSHA01:
   rank: 1
   title: Chair
   bioguide: F000455
-  start: '2019-02-07'
+  start_date: '2019-02-07'
   source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
 - name: G. K. Butterfield
   party: majority
   rank: 2
   bioguide: B001251
-  start: '2019-02-07'
+  start_date: '2019-02-07'
   source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
 - name: Pete Aguilar
   party: majority
   rank: 3
   bioguide: A000371
-  start: '2019-02-07'
+  start_date: '2019-02-07'
   source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
 - name: Rodney Davis
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000619
-  start: '2019-02-07'
+  start_date: '2019-02-07'
   source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
 HSHM:
 - name: Mike Rogers

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -5234,6 +5234,18 @@ HSHA:
   bioguide: D000619
   start_date: '2019-01-09'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/32/text
+- name: Mark Walker
+  party: minority
+  rank: 2
+  bioguide: W000819
+  start_date: '2019-02-06'
+  source: https://republicans-cha.house.gov/press-release/cha-announces-republican-members-116th-congress
+- name: Barry Loudermilk
+  party: minority
+  rank: 3
+  bioguide: L000583
+  start_date: '2019-02-06'
+  source: https://republicans-cha.house.gov/press-release/cha-announces-republican-members-116th-congress
 - name: Zoe Lofgren
   party: majority
   rank: 1
@@ -5244,6 +5256,7 @@ HSHA:
 - name: Jamie Raskin
   party: majority
   rank: 2
+  title: Vice Chair
   bioguide: R000606
   start_date: '2019-01-29'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
@@ -5271,6 +5284,33 @@ HSHA:
   bioguide: A000371
   start_date: '2019-01-29'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/85/text
+HSHA01:
+- name: Marcia L. Fudge
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: F000455
+  start: '2019-02-07'
+  source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
+- name: G. K. Butterfield
+  party: majority
+  rank: 2
+  bioguide: B001251
+  start: '2019-02-07'
+  source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
+- name: Pete Aguilar
+  party: majority
+  rank: 3
+  bioguide: A000371
+  start: '2019-02-07'
+  source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
+- name: Rodney Davis
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000619
+  start: '2019-02-07'
+  source: https://docs.house.gov/meetings/HA/HA00/20190207/108886/HMTG-116-HA00-20190207-SD002.pdf
 HSHM:
 - name: Mike Rogers
   party: minority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -2539,53 +2539,6 @@ HSBA:
   bioguide: P000616
   start_date: '2019-01-17'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
-HSBA01:
-- name: Scott R. Tipton
-  party: minority
-  rank: 5
-  thomas: '01997'
-  bioguide: T000470
-- name: Ed Perlmutter
-  party: majority
-  rank: 1
-  title: Ranking Member
-  thomas: '01835'
-  bioguide: P000593
-- name: Carolyn B. Maloney
-  party: majority
-  rank: 2
-  thomas: '00729'
-  bioguide: M000087
-- name: James A. Himes
-  party: majority
-  rank: 3
-  thomas: '01913'
-  bioguide: H001047
-- name: Bill Foster
-  party: majority
-  rank: 4
-  thomas: '01888'
-  bioguide: F000454
-- name: Juan Vargas
-  party: majority
-  rank: 8
-  thomas: '02112'
-  bioguide: V000130
-- name: Josh Gottheimer
-  party: majority
-  rank: 9
-  bioguide: G000583
-- name: Stephen F. Lynch
-  party: majority
-  rank: 11
-  thomas: '01686'
-  bioguide: L000562
-- name: Maxine Waters
-  party: majority
-  rank: 12
-  thomas: '01205'
-  bioguide: W000187
-  title: Ex Officio
 HSBA04:
 - name: Sean P. Duffy
   party: minority
@@ -2688,6 +2641,126 @@ HSBU:
   bioguide: Y000062
   start_date: '2019-01-03'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
+- name: Seth Moulton
+  party: majority
+  rank: 2
+  thomas: '02246'
+  bioguide: M001196
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Hakeem S. Jeffries
+  party: majority
+  rank: 3
+  thomas: '02149'
+  bioguide: J000294
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Ro Khanna
+  party: majority
+  rank: 4
+  bioguide: K000389
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Rosa L. DeLauro
+  party: majority
+  rank: 5
+  thomas: '00281'
+  bioguide: D000216
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Lloyd Doggett
+  party: majority
+  rank: 6
+  thomas: '00303'
+  bioguide: D000399
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: David E. Price
+  party: majority
+  rank: 7
+  thomas: '00930'
+  bioguide: P000523
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Janice D. Schakowsky
+  party: majority
+  rank: 8
+  thomas: '01588'
+  bioguide: S001145
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Brian Higgins
+  party: majority
+  rank: 9
+  thomas: '01794'
+  bioguide: H001038
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Daniel T. Kildee
+  party: majority
+  rank: 10
+  thomas: '02134'
+  bioguide: K000380
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Brendan F. Boyle
+  party: majority
+  rank: 11
+  thomas: '02267'
+  bioguide: B001296
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Jimmy Panetta
+  party: majority
+  rank: 12
+  bioguide: P000613
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Joseph D. Morelle
+  party: majority
+  rank: 13
+  bioguide: M001206
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name:
+  party: majority
+  rank: 14
+  bioguide: H001066
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Robert C. "Bobby" Scott
+  party: majority
+  rank: 15
+  thomas: '01037'
+  bioguide: S000185
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Sheila Jackson Lee
+  party: majority
+  rank: 16
+  thomas: '00588'
+  bioguide: J000032
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Barbara Lee
+  party: majority
+  rank: 17
+  thomas: '01501'
+  bioguide: L000551
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Pramila Jayapal
+  party: majority
+  rank: 18
+  bioguide: J000298
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Ilhan Omar
+  party: majority
+  rank: 19
+  bioguide: O000173
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 HSED:
 - name: Virginia Foxx
   party: minority
@@ -3267,1001 +3340,1632 @@ HSED10:
   start_date: '2019-01-29'
   source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 HSED13:
-- name: Brett Guthrie
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01922'
-  bioguide: G000558
-- name: Glenn Thompson
-  party: majority
-  rank: 2
-  thomas: '01952'
-  bioguide: T000467
-- name: Bradley Byrne
-  party: majority
-  rank: 5
-  thomas: '02197'
-  bioguide: B001289
-- name: Glenn Grothman
-  party: majority
-  rank: 6
-  thomas: '02276'
-  bioguide: G000576
-- name: Elise M. Stefanik
-  party: majority
-  rank: 7
-  thomas: '02263'
-  bioguide: S001196
-- name: Rick W. Allen
-  party: majority
-  rank: 8
-  thomas: '02239'
-  bioguide: A000372
 - name: Lloyd Smucker
-  party: majority
-  rank: 11
-  bioguide: S001199
-- name: Ron Estes
-  party: majority
-  rank: 12
-  bioguide: E000298
-- name: Jim Banks
-  party: majority
-  rank: 13
-  bioguide: B001299
-- name: Susan A. Davis
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '01641'
-  bioguide: D000598
-- name: Joe Courtney
+  bioguide: S001199
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Brett Guthrie
   party: minority
   rank: 2
-  thomas: '01836'
-  bioguide: C001069
-- name: Alma S. Adams
+  thomas: '01922'
+  bioguide: G000558
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Glenn Grothman
   party: minority
   rank: 3
-  thomas: '02201'
-  bioguide: A000370
-- name: Mark DeSaulnier
+  thomas: '02276'
+  bioguide: G000576
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Elise M. Stefanik
   party: minority
   rank: 4
-  thomas: '02227'
-  bioguide: D000623
-- name: Raja Krishnamoorthi
+  thomas: '02263'
+  bioguide: S001196
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Jim Banks
   party: minority
   rank: 5
-  bioguide: K000391
-- name: Gregorio Kilili Camacho Sablan
+  bioguide: B001299
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Mark Walker
+  party: minority
+  rank: 6
+  thomas: '02255'
+  bioguide: W000819
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: James Comer
   party: minority
   rank: 7
-  thomas: '01962'
-  bioguide: S001177
-- name: Mark Takano
+  bioguide: C001108
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Ben Cline
   party: minority
   rank: 8
-  thomas: '02110'
-  bioguide: T000472
-- name: Lisa Blunt Rochester
+  bioguide: C001118
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Russ Fulcher
   party: minority
   rank: 9
-  bioguide: B001303
-- name: Adriano Espaillat
+  bioguide: F000469
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Steven C. Watkins
   party: minority
   rank: 10
-  bioguide: E000297
-HSED14:
-- name: David P. Roe
-  party: majority
-  rank: 2
-  thomas: '01954'
-  bioguide: R000582
-- name: Glenn Thompson
-  party: majority
-  rank: 3
-  thomas: '01952'
-  bioguide: T000467
-- name: Raúl M. Grijalva
+  bioguide: W000824
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Daniel Meuser
   party: minority
+  rank: 11
+  bioguide: M001204
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: William Timmons
+  party: minority
+  rank: 12
+  bioguide: T000480
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Susan A. Davis
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01641'
+  bioguide: D000598
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Raúl M. Grijalva
+  party: majority
   rank: 2
   thomas: '01708'
   bioguide: G000551
-- name: Marcia L. Fudge
-  party: minority
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Joe Courtney
+  party: majority
   rank: 3
-  thomas: '01895'
-  bioguide: F000455
-- name: Suzanne Bonamici
+  thomas: '01836'
+  bioguide: C001069
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Gregorio Kilili Camacho Sablan
   party: minority
   rank: 4
+  thomas: '01962'
+  bioguide: S001177
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Suzanne Bonamici
+  party: majority
+  rank: 5
   thomas: '02092'
   bioguide: B001278
-- name: Susan A. Davis
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Mark Takano
+  party: majority
+  rank: 6
+  thomas: '02110'
+  bioguide: T000472
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Alma S. Adams
+  party: majority
+  rank: 7
+  thomas: '02201'
+  bioguide: A000370
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Donald Norcross
+  party: majority
+  rank: 8
+  thomas: '02202'
+  bioguide: N000188
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Pramila Jayapal
+  party: majority
+  rank: 9
+  bioguide: J000298
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Josh Harder
+  party: majority
+  rank: 10
+  bioguide: H001090
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Andy Levin
+  party: majority
+  rank: 11
+  bioguide: L000592
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Ilhan Omar
+  party: majority
+  rank: 12
+  bioguide: O000173
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: David J. Trone
+  party: majority
+  rank: 13
+  bioguide: T000483
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Susie Lee
+  party: majority
+  rank: 14
+  bioguide: L000590
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Joaquin Castro
+  party: majority
+  rank: 15
+  bioguide: C001091
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Lori Trahan
+  party: majority
+  rank: 16
+  bioguide: T000482
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+HSED14:
+- name: Rick W. Allen
   party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '02239'
+  bioguide: A000372
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Glenn Thompson
+  party: minority
+  rank: 2
+  thomas: '01952'
+  bioguide: T000467
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Glenn Grothman
+  party: minority
+  rank: 3
+  thomas: '02276'
+  bioguide: G000576
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Van Taylor
+  party: minority
+  rank: 4
+  bioguide: T000479
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: William Timmons
+  party: minority
+  rank: 5
+  bioguide: T000480
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Gregorio Kilili Camacho Sablan
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01962'
+  bioguide: S001177
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Kim Schrier
+  party: majority
+  rank: 2
+  bioguide: S001216
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Jahana Hayes
+  party: majority
+  rank: 3
+  bioguide: H001081
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Donna E. Shalala
+  party: majority
+  rank: 4
+  bioguide: S001206
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Susan A. Davis
+  party: majority
   rank: 5
   thomas: '01641'
   bioguide: D000598
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
 - name: Frederica S. Wilson
-  party: minority
+  party: majority
   rank: 6
   thomas: '02004'
   bioguide: W000808
-HSFA:
-- name: Christopher H. Smith
-  party: majority
-  rank: 2
-  thomas: '01071'
-  bioguide: S000522
-- name: Steve Chabot
-  party: majority
-  rank: 5
-  thomas: '00186'
-  bioguide: C000266
-- name: Joe Wilson
-  party: majority
-  rank: 6
-  thomas: '01688'
-  bioguide: W000795
-- name: Michael T. McCaul
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Mark DeSaulnier
   party: majority
   rank: 7
-  thomas: '01804'
-  bioguide: M001157
-- name: Tom Marino
+  thomas: '02227'
+  bioguide: D000623
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+- name: Joseph D. Morelle
   party: majority
-  rank: 10
-  thomas: '02053'
-  bioguide: M001179
-- name: Mo Brooks
-  party: majority
-  rank: 11
-  thomas: '01987'
-  bioguide: B001274
-- name: Paul Cook
-  party: majority
-  rank: 12
-  thomas: '02103'
-  bioguide: C001094
-- name: Scott Perry
-  party: majority
-  rank: 13
-  thomas: '02157'
-  bioguide: P000605
-- name: Mark Meadows
-  party: majority
-  rank: 14
-  thomas: '02142'
-  bioguide: M001187
-- name: Ted S. Yoho
-  party: majority
-  rank: 15
-  thomas: '02115'
-  bioguide: Y000065
-- name: Adam Kinzinger
-  party: majority
-  rank: 16
-  thomas: '02014'
-  bioguide: K000378
-- name: Lee M. Zeldin
-  party: majority
-  rank: 17
-  thomas: '02261'
-  bioguide: Z000017
-- name: F. James Sensenbrenner, Jr.
-  party: majority
-  rank: 19
-  thomas: '01041'
-  bioguide: S000244
-- name: Ann Wagner
-  party: majority
-  rank: 20
-  thomas: '02137'
-  bioguide: W000812
-- name: Brian J. Mast
-  party: majority
-  rank: 21
-  bioguide: M001199
-- name: Francis Rooney
-  party: majority
-  rank: 22
-  bioguide: R000607
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 23
-  bioguide: F000466
-- name: John R. Curtis
-  party: majority
-  rank: 25
-  bioguide: C001114
-- name: Eliot L. Engel
+  rank: 8
+  bioguide: M001206
+  start_date: '2019-01-29'
+  source: https://edlabor.house.gov/imo/media/doc/2019-01-29%20Committee%20Roster.pdf
+HSFA:
+- name: Michael T. McCaul
   party: minority
   rank: 1
   title: Ranking Member
+  thomas: '01804'
+  bioguide: M001157
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Christopher H. Smith
+  party: minority
+  rank: 2
+  thomas: '01071'
+  bioguide: S000522
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Steve Chabot
+  party: minority
+  rank: 3
+  thomas: '00186'
+  bioguide: C000266
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Joe Wilson
+  party: minority
+  rank: 4
+  thomas: '01688'
+  bioguide: W000795
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Scott Perry
+  party: minority
+  rank: 5
+  thomas: '02157'
+  bioguide: P000605
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ted S. Yoho
+  party: minority
+  rank: 6
+  thomas: '02115'
+  bioguide: Y000065
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Adam Kinzinger
+  party: minority
+  rank: 7
+  thomas: '02014'
+  bioguide: K000378
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Lee M. Zeldin
+  party: minority
+  rank: 8
+  thomas: '02261'
+  bioguide: Z000017
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: F. James Sensenbrenner, Jr.
+  party: minority
+  rank: 9
+  thomas: '01041'
+  bioguide: S000244
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ann Wagner
+  party: minority
+  rank: 10
+  thomas: '02137'
+  bioguide: W000812
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Brian J. Mast
+  party: minority
+  rank: 11
+  bioguide: M001199
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Francis Rooney
+  party: minority
+  rank: 12
+  bioguide: R000607
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Brian K. Fitzpatrick
+  party: minority
+  rank: 13
+  bioguide: F000466
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John R. Curtis
+  party: minority
+  rank: 14
+  bioguide: C001114
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ken Buck
+  party: minority
+  rank: 15
+  bioguide: B001297
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ron Wright
+  party: minority
+  rank: 16
+  bioguide: W000827
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Guy Reschenthaler
+  party: minority
+  rank: 17
+  bioguide: R000610
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Tim Burchett
+  party: minority
+  rank: 18
+  bioguide: B001309
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Greg Pence
+  party: minority
+  rank: 19
+  bioguide: P000615
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Steven C. Watkins
+  party: minority
+  rank: 20
+  bioguide: W000824
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael Guest
+  party: minority
+  rank: 21
+  bioguide: G000591
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Eliot L. Engel
+  party: majority
+  rank: 1
+  title: Chair
   thomas: '00344'
   bioguide: E000179
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Brad Sherman
-  party: minority
+  party: majority
   rank: 2
   thomas: '01526'
   bioguide: S000344
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Gregory W. Meeks
-  party: minority
+  party: majority
   rank: 3
   thomas: '01506'
   bioguide: M001137
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Albio Sires
-  party: minority
+  party: majority
   rank: 4
   thomas: '01818'
   bioguide: S001165
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Gerald E. Connolly
-  party: minority
+  party: majority
   rank: 5
   thomas: '01959'
   bioguide: C001078
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Theodore E. Deutch
-  party: minority
+  party: majority
   rank: 6
   thomas: '01976'
   bioguide: D000610
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Karen Bass
-  party: minority
+  party: majority
   rank: 7
   thomas: '01996'
   bioguide: B001270
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: William R. Keating
-  party: minority
+  party: majority
   rank: 8
   thomas: '02025'
   bioguide: K000375
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: David N. Cicilline
-  party: minority
+  party: majority
   rank: 9
   thomas: '02055'
   bioguide: C001084
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 - name: Ami Bera
-  party: minority
+  party: majority
   rank: 10
   thomas: '02102'
   bioguide: B001287
-- name: Lois Frankel
-  party: minority
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Joaquin Castro
+  party: majority
   rank: 11
-  thomas: '02119'
-  bioguide: F000462
-- name: Tulsi Gabbard
-  party: minority
+  thomas: '02163'
+  bioguide: C001091
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Dina Titus
+  party: majority
   rank: 12
-  thomas: '02122'
-  bioguide: G000571
-- name: Joaquin Castro
-  party: minority
+  thomas: '01940'
+  bioguide: T000468
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Adriano Espaillat
+  party: majority
   rank: 13
-  thomas: '02163'
-  bioguide: C001091
-- name: Robin L. Kelly
-  party: minority
+  bioguide: E000297
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Ted Lieu
+  party: majority
   rank: 14
-  thomas: '02190'
-  bioguide: K000385
-- name: Brendan F. Boyle
-  party: minority
+  thomas: '02230'
+  bioguide: L000582
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Susan Wild
+  party: majority
   rank: 15
-  thomas: '02267'
-  bioguide: B001296
-- name: Dina Titus
-  party: minority
+  bioguide: W000826
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Dean Phillips
+  party: majority
   rank: 16
-  thomas: '01940'
-  bioguide: T000468
-- name: Norma J. Torres
-  party: minority
-  rank: 17
-  thomas: '02231'
-  bioguide: T000474
-- name: Bradley Scott Schneider
-  party: minority
-  rank: 18
-  thomas: '02124'
-  bioguide: S001190
-- name: Thomas R. Suozzi
-  party: minority
-  rank: 19
-  bioguide: S001201
-- name: Adriano Espaillat
-  party: minority
-  rank: 20
-  bioguide: E000297
-- name: Ted Lieu
-  party: minority
-  rank: 21
-  thomas: '02230'
-  bioguide: L000582
-HSFA05:
-- name: Ted S. Yoho
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02115'
-  bioguide: Y000065
-- name: Steve Chabot
-  party: majority
-  rank: 3
-  thomas: '00186'
-  bioguide: C000266
-- name: Tom Marino
-  party: majority
-  rank: 4
-  thomas: '02053'
-  bioguide: M001179
-- name: Mo Brooks
-  party: majority
-  rank: 5
-  thomas: '01987'
-  bioguide: B001274
-- name: Scott Perry
-  party: majority
-  rank: 6
-  thomas: '02157'
-  bioguide: P000605
-- name: Adam Kinzinger
-  party: majority
-  rank: 7
-  thomas: '02014'
-  bioguide: K000378
-- name: Ann Wagner
-  party: majority
-  rank: 8
-  thomas: '02137'
-  bioguide: W000812
-- name: Brad Sherman
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01526'
-  bioguide: S000344
-- name: Ami Bera
-  party: minority
-  rank: 2
-  thomas: '02102'
-  bioguide: B001287
-- name: Dina Titus
-  party: minority
-  rank: 3
-  thomas: '01940'
-  bioguide: T000468
-- name: Gerald E. Connolly
-  party: minority
-  rank: 4
-  thomas: '01959'
-  bioguide: C001078
-- name: Theodore E. Deutch
-  party: minority
-  rank: 5
-  thomas: '01976'
-  bioguide: D000610
-- name: Tulsi Gabbard
-  party: minority
-  rank: 6
-  thomas: '02122'
-  bioguide: G000571
-HSFA07:
-- name: Paul Cook
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '02103'
-  bioguide: C001094
-- name: Christopher H. Smith
-  party: majority
-  rank: 2
-  thomas: '01071'
-  bioguide: S000522
-- name: Michael T. McCaul
-  party: majority
-  rank: 4
-  thomas: '01804'
-  bioguide: M001157
-- name: Mo Brooks
-  party: majority
-  rank: 5
-  thomas: '01987'
-  bioguide: B001274
-- name: Ted S. Yoho
-  party: majority
-  rank: 6
-  thomas: '02115'
-  bioguide: Y000065
-- name: Francis Rooney
-  party: majority
-  rank: 7
-  bioguide: R000607
-- name: Albio Sires
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01818'
-  bioguide: S001165
-- name: Joaquin Castro
-  party: minority
-  rank: 2
-  thomas: '02163'
-  bioguide: C001091
-- name: Robin L. Kelly
-  party: minority
-  rank: 3
-  thomas: '02190'
-  bioguide: K000385
-- name: Norma J. Torres
-  party: minority
-  rank: 4
-  thomas: '02231'
-  bioguide: T000474
-- name: Adriano Espaillat
-  party: minority
-  rank: 5
-  bioguide: E000297
-- name: Gregory W. Meeks
-  party: minority
-  rank: 6
-  thomas: '01506'
-  bioguide: M001137
-HSFA13:
-- name: Steve Chabot
-  party: majority
-  rank: 2
-  thomas: '00186'
-  bioguide: C000266
-- name: Mark Meadows
-  party: majority
-  rank: 4
-  thomas: '02142'
-  bioguide: M001187
-- name: Adam Kinzinger
-  party: majority
-  rank: 5
-  thomas: '02014'
-  bioguide: K000378
-- name: Lee M. Zeldin
-  party: majority
-  rank: 6
-  thomas: '02261'
-  bioguide: Z000017
-- name: Ann Wagner
-  party: majority
-  rank: 8
-  thomas: '02137'
-  bioguide: W000812
-- name: Brian J. Mast
-  party: majority
-  rank: 9
-  bioguide: M001199
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 10
-  bioguide: F000466
-- name: John R. Curtis
-  party: majority
-  rank: 11
-  bioguide: C001114
-- name: Theodore E. Deutch
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01976'
-  bioguide: D000610
-- name: Gerald E. Connolly
-  party: minority
-  rank: 2
-  thomas: '01959'
-  bioguide: C001078
-- name: David N. Cicilline
-  party: minority
-  rank: 3
-  thomas: '02055'
-  bioguide: C001084
-- name: Lois Frankel
-  party: minority
-  rank: 4
-  thomas: '02119'
-  bioguide: F000462
-- name: Brendan F. Boyle
-  party: minority
-  rank: 5
-  thomas: '02267'
-  bioguide: B001296
-- name: Tulsi Gabbard
-  party: minority
-  rank: 6
-  thomas: '02122'
-  bioguide: G000571
-- name: Bradley Scott Schneider
-  party: minority
-  rank: 7
-  thomas: '02124'
-  bioguide: S001190
-- name: Thomas R. Suozzi
-  party: minority
-  rank: 8
-  bioguide: S001201
-- name: Ted Lieu
-  party: minority
-  rank: 9
-  thomas: '02230'
-  bioguide: L000582
-HSFA14:
-- name: Joe Wilson
-  party: majority
-  rank: 2
-  thomas: '01688'
-  bioguide: W000795
-- name: Tom Marino
-  party: majority
-  rank: 4
-  thomas: '02053'
-  bioguide: M001179
-- name: F. James Sensenbrenner, Jr.
-  party: majority
-  rank: 5
-  thomas: '01041'
-  bioguide: S000244
-- name: Francis Rooney
-  party: majority
-  rank: 6
-  bioguide: R000607
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 7
-  bioguide: F000466
-- name: John R. Curtis
-  party: majority
-  rank: 8
-  bioguide: C001114
-- name: Gregory W. Meeks
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01506'
-  bioguide: M001137
-- name: Brad Sherman
-  party: minority
-  rank: 2
-  thomas: '01526'
-  bioguide: S000344
-- name: Albio Sires
-  party: minority
-  rank: 3
-  thomas: '01818'
-  bioguide: S001165
-- name: William R. Keating
-  party: minority
-  rank: 4
-  thomas: '02025'
-  bioguide: K000375
-- name: David N. Cicilline
-  party: minority
-  rank: 5
-  thomas: '02055'
-  bioguide: C001084
-- name: Robin L. Kelly
-  party: minority
-  rank: 6
-  thomas: '02190'
-  bioguide: K000385
-HSFA16:
-- name: Christopher H. Smith
-  party: majority
-  rank: 1
-  title: Chair
-  thomas: '01071'
-  bioguide: S000522
-- name: Mark Meadows
-  party: majority
-  rank: 2
-  thomas: '02142'
-  bioguide: M001187
-- name: F. James Sensenbrenner, Jr.
-  party: majority
-  rank: 4
-  thomas: '01041'
-  bioguide: S000244
-- name: Karen Bass
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01996'
-  bioguide: B001270
-- name: Ami Bera
-  party: minority
-  rank: 2
-  thomas: '02102'
-  bioguide: B001287
-- name: Joaquin Castro
-  party: minority
-  rank: 3
-  thomas: '02163'
-  bioguide: C001091
-- name: Thomas R. Suozzi
-  party: minority
-  rank: 4
-  bioguide: S001201
-HSFA18:
-- name: Joe Wilson
-  party: majority
-  rank: 2
-  thomas: '01688'
-  bioguide: W000795
-- name: Paul Cook
-  party: majority
-  rank: 4
-  thomas: '02103'
-  bioguide: C001094
-- name: Scott Perry
-  party: majority
-  rank: 5
-  thomas: '02157'
-  bioguide: P000605
-- name: Lee M. Zeldin
-  party: majority
-  rank: 6
-  thomas: '02261'
-  bioguide: Z000017
-- name: Brian J. Mast
-  party: majority
-  rank: 7
-  bioguide: M001199
-- name: William R. Keating
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '02025'
-  bioguide: K000375
-- name: Lois Frankel
-  party: minority
-  rank: 2
-  thomas: '02119'
-  bioguide: F000462
-- name: Brendan F. Boyle
-  party: minority
-  rank: 3
-  thomas: '02267'
-  bioguide: B001296
-- name: Dina Titus
-  party: minority
-  rank: 4
-  thomas: '01940'
-  bioguide: T000468
-- name: Norma J. Torres
-  party: minority
-  rank: 5
-  thomas: '02231'
-  bioguide: T000474
-- name: Bradley Scott Schneider
-  party: minority
-  rank: 6
-  thomas: '02124'
-  bioguide: S001190
-HSGO:
-- name: Jim Jordan
-  party: majority
-  rank: 4
-  thomas: '01868'
-  bioguide: J000289
-- name: Justin Amash
-  party: majority
-  rank: 6
-  thomas: '02029'
-  bioguide: A000367
-- name: Paul A. Gosar
-  party: majority
-  rank: 7
-  thomas: '01992'
-  bioguide: G000565
-- name: Scott DesJarlais
-  party: majority
-  rank: 8
-  thomas: '02062'
-  bioguide: D000616
-- name: Virginia Foxx
-  party: majority
-  rank: 9
-  thomas: '01791'
-  bioguide: F000450
-- name: Thomas Massie
-  party: majority
-  rank: 10
-  thomas: '02094'
-  bioguide: M001184
-- name: Mark Meadows
-  party: majority
-  rank: 11
-  thomas: '02142'
-  bioguide: M001187
-- name: Mark Walker
-  party: majority
-  rank: 13
-  thomas: '02255'
-  bioguide: W000819
-- name: Jody B. Hice
-  party: majority
-  rank: 15
-  thomas: '02237'
-  bioguide: H001071
-- name: Glenn Grothman
+  bioguide: P000616
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Ilhan Omar
   party: majority
   rank: 17
-  thomas: '02276'
-  bioguide: G000576
-- name: Will Hurd
+  bioguide: O000173
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Colin Allred
   party: majority
   rank: 18
-  thomas: '02269'
-  bioguide: H001073
-- name: Gary J. Palmer
+  bioguide: A000376
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Andy Levin
   party: majority
   rank: 19
-  thomas: '02221'
-  bioguide: P000609
-- name: James Comer
+  bioguide: L000592
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Abigail Spanberger
   party: majority
   rank: 20
-  bioguide: C001108
-- name: Paul Mitchell
+  bioguide: S001209
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Chrissy Houlahan
   party: majority
   rank: 21
-  bioguide: M001201
-- name: Greg Gianforte
+  bioguide: H001085
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Tom Malinowski
   party: majority
   rank: 22
-  bioguide: G000584
-- name: Michael Cloud
+  bioguide: M001203
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: David J. Trone
   party: majority
   rank: 23
-  bioguide: C001115
-- name: Elijah E. Cummings
+  bioguide: T000483
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jim Costa
+  party: majority
+  rank: 24
+  thomas: '01774'
+  bioguide: C001059
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Juan Vargas
+  party: majority
+  rank: 25
+  thomas: '02112'
+  bioguide: V000130
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Vicente Gonzalez
+  party: majority
+  rank: 26
+  bioguide: G000581
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+HSFA05:
+- name: Ted S. Yoho
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '00256'
-  bioguide: C000984
-- name: Carolyn B. Maloney
+  thomas: '02115'
+  bioguide: Y000065
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Scott Perry
   party: minority
   rank: 2
-  thomas: '00729'
-  bioguide: M000087
-- name: Eleanor Holmes Norton
+  thomas: '02157'
+  bioguide: P000605
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ann Wagner
   party: minority
   rank: 3
-  thomas: '00868'
-  bioguide: N000147
-- name: Wm. Lacy Clay
+  thomas: '02137'
+  bioguide: W000812
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Brian J. Mast
   party: minority
   rank: 4
-  thomas: '01654'
-  bioguide: C001049
-- name: Stephen F. Lynch
+  bioguide: M001199
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: John R. Curtis
   party: minority
   rank: 5
-  thomas: '01686'
-  bioguide: L000562
-- name: Jim Cooper
-  party: minority
-  rank: 6
-  thomas: '00231'
-  bioguide: C000754
-- name: Gerald E. Connolly
-  party: minority
-  rank: 7
-  thomas: '01959'
-  bioguide: C001078
-- name: Robin L. Kelly
-  party: minority
-  rank: 8
-  thomas: '02190'
-  bioguide: K000385
-- name: Brenda L. Lawrence
-  party: minority
-  rank: 9
-  thomas: '02252'
-  bioguide: L000581
-- name: Bonnie Watson Coleman
-  party: minority
-  rank: 10
-  thomas: '02259'
-  bioguide: W000822
-- name: Raja Krishnamoorthi
-  party: minority
-  rank: 11
-  bioguide: K000391
-- name: Jamie Raskin
-  party: minority
-  rank: 12
-  bioguide: R000606
-- name: Jimmy Gomez
-  party: minority
-  rank: 13
-  bioguide: G000585
-- name: Peter Welch
-  party: minority
-  rank: 14
-  thomas: '01879'
-  bioguide: W000800
-- name: Matt Cartwright
-  party: minority
-  rank: 15
-  thomas: '02159'
-  bioguide: C001090
-- name: Mark DeSaulnier
-  party: minority
-  rank: 16
-  thomas: '02227'
-  bioguide: D000623
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 17
-  thomas: '02274'
-  bioguide: P000610
-- name: John P. Sarbanes
-  party: minority
-  rank: 18
-  thomas: '01854'
-  bioguide: S001168
-HSGO06:
-- name: Justin Amash
-  party: majority
-  rank: 3
-  thomas: '02029'
-  bioguide: A000367
-- name: Paul A. Gosar
-  party: majority
-  rank: 4
-  thomas: '01992'
-  bioguide: G000565
-- name: Virginia Foxx
-  party: majority
-  rank: 5
-  thomas: '01791'
-  bioguide: F000450
-- name: Jody B. Hice
-  party: majority
-  rank: 6
-  thomas: '02237'
-  bioguide: H001071
-- name: James Comer
-  party: majority
-  rank: 7
-  bioguide: C001108
-- name: Stephen F. Lynch
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01686'
-  bioguide: L000562
-- name: Peter Welch
-  party: minority
-  rank: 2
-  thomas: '01879'
-  bioguide: W000800
-- name: Mark DeSaulnier
-  party: minority
-  rank: 3
-  thomas: '02227'
-  bioguide: D000623
-- name: Jimmy Gomez
-  party: minority
-  rank: 4
-  bioguide: G000585
-- name: John P. Sarbanes
-  party: minority
-  rank: 5
-  thomas: '01854'
-  bioguide: S001168
-HSGO24:
-- name: Mark Meadows
+  bioguide: C001114
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Brad Sherman
   party: majority
   rank: 1
   title: Chair
-  thomas: '02142'
-  bioguide: M001187
-- name: Jody B. Hice
+  thomas: '01526'
+  bioguide: S000344
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Dina Titus
   party: majority
   rank: 2
-  thomas: '02237'
-  bioguide: H001071
-  title: Vice Chair
-- name: Jim Jordan
+  thomas: '01940'
+  bioguide: T000468
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Chrissy Houlahan
   party: majority
   rank: 3
+  bioguide: H001085
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Gerald E. Connolly
+  party: majority
+  rank: 4
+  thomas: '01959'
+  bioguide: C001078
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Ami Bera
+  party: majority
+  rank: 5
+  thomas: '02102'
+  bioguide: B001287
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Andy Levin
+  party: majority
+  rank: 6
+  bioguide: L000592
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Abigail Spanberger
+  party: majority
+  rank: 7
+  bioguide: S001209
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+HSFA07:
+- name: Francis Rooney
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000607
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Christopher H. Smith
+  party: minority
+  rank: 2
+  thomas: '01071'
+  bioguide: S000522
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ted S. Yoho
+  party: minority
+  rank: 3
+  thomas: '02115'
+  bioguide: Y000065
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: John R. Curtis
+  party: minority
+  rank: 4
+  bioguide: C001114
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ken Buck
+  party: minority
+  rank: 5
+  bioguide: B001297
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Michael Guest
+  party: minority
+  rank: 6
+  bioguide: G000591
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Albio Sires
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01818'
+  bioguide: S001165
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Gregory W. Meeks
+  party: majority
+  rank: 2
+  thomas: '01506'
+  bioguide: M001137
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Joaquin Castro
+  party: majority
+  rank: 3
+  thomas: '02163'
+  bioguide: C001091
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Adriano Espaillat
+  party: majority
+  rank: 4
+  bioguide: E000297
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Dean Phillips
+  party: majority
+  rank: 5
+  bioguide: P000616
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Andy Levin
+  party: majority
+  rank: 6
+  bioguide: L000592
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Vicente Gonzalez
+  party: majority
+  rank: 7
+  bioguide: G000581
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Juan Vargas
+  party: majority
+  rank: 8
+  thomas: '02112'
+  bioguide: V000130
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+HSFA13:
+- name: Joe Wilson
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01688'
+  bioguide: W000795
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Steve Chabot
+  party: minority
+  rank: 2
+  thomas: '00186'
+  bioguide: C000266
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Adam Kinzinger
+  party: minority
+  rank: 3
+  thomas: '02014'
+  bioguide: K000378
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Lee M. Zeldin
+  party: minority
+  rank: 4
+  thomas: '02261'
+  bioguide: Z000017
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Brian J. Mast
+  party: minority
+  rank: 5
+  bioguide: M001199
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Brian K. Fitzpatrick
+  party: minority
+  rank: 6
+  bioguide: F000466
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Guy Reschenthaler
+  party: minority
+  rank: 7
+  bioguide: R000610
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Steven C. Watkins
+  party: minority
+  rank: 8
+  bioguide: W000824
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Theodore E. Deutch
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01976'
+  bioguide: D000610
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Gerald E. Connolly
+  party: majority
+  rank: 2
+  thomas: '01959'
+  bioguide: C001078
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: David N. Cicilline
+  party: majority
+  rank: 3
+  thomas: '02055'
+  bioguide: C001084
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Ted Lieu
+  party: majority
+  rank: 4
+  thomas: '02230'
+  bioguide: L000582
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Colin Allred
+  party: majority
+  rank: 5
+  bioguide: A000376
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Tom Malinowski
+  party: majority
+  rank: 6
+  bioguide: M001203
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: David J. Trone
+  party: majority
+  rank: 7
+  bioguide: T000483
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Brad Sherman
+  party: majority
+  rank: 8
+  thomas: '01526'
+  bioguide: S000344
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: William R. Keating
+  party: majority
+  rank: 9
+  thomas: '02025'
+  bioguide: K000375
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Juan Vargas
+  party: majority
+  rank: 10
+  thomas: '02112'
+  bioguide: V000130
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+HSFA14:
+- name: Adam Kinzinger
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '02014'
+  bioguide: K000378
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Joe Wilson
+  party: minority
+  rank: 2
+  thomas: '01688'
+  bioguide: W000795
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ann Wagner
+  party: minority
+  rank: 3
+  thomas: '02137'
+  bioguide: W000812
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: F. James Sensenbrenner, Jr.
+  party: minority
+  rank: 4
+  thomas: '01041'
+  bioguide: S000244
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Francis Rooney
+  party: minority
+  rank: 5
+  bioguide: R000607
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Brian K. Fitzpatrick
+  party: minority
+  rank: 6
+  bioguide: F000466
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Greg Pence
+  party: minority
+  rank: 7
+  bioguide: P000615
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ron Wright
+  party: minority
+  rank: 8
+  bioguide: W000827
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Michael Guest
+  party: minority
+  rank: 9
+  bioguide: G000591
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Tim Burchett
+  party: minority
+  rank: 10
+  bioguide: B001309
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: William R. Keating
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '02025'
+  bioguide: K000375
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Abigail Spanberger
+  party: majority
+  rank: 2
+  bioguide: S001209
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Gregory W. Meeks
+  party: majority
+  rank: 3
+  thomas: '01506'
+  bioguide: M001137
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Albio Sires
+  party: majority
+  rank: 4
+  thomas: '01818'
+  bioguide: S001165
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Theodore E. Deutch
+  party: majority
+  rank: 5
+  thomas: '01976'
+  bioguide: D000610
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: David N. Cicilline
+  party: majority
+  rank: 6
+  thomas: '02055'
+  bioguide: C001084
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Dina Titus
+  party: majority
+  rank: 7
+  thomas: '01940'
+  bioguide: T000468
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Susan Wild
+  party: majority
+  rank: 8
+  bioguide: W000826
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: David J. Trone
+  party: majority
+  rank: 9
+  bioguide: T000483
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Jim Costa
+  party: majority
+  rank: 10
+  thomas: '01774'
+  bioguide: C001059
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Vicente Gonzalez
+  party: majority
+  rank: 11
+  bioguide: G000581
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+HSFA16:
+- name: Christopher H. Smith
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '01071'
+  bioguide: S000522
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: F. James Sensenbrenner, Jr.
+  party: majority
+  rank: 2
+  thomas: '01041'
+  bioguide: S000244
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ron Wright
+  party: minority
+  rank: 3
+  bioguide: W000827
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Tim Burchett
+  party: minority
+  rank: 4
+  bioguide: B001309
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Karen Bass
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01996'
+  bioguide: B001270
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Susan Wild
+  party: majority
+  rank: 2
+  bioguide: W000826
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Dean Phillips
+  party: majority
+  rank: 3
+  bioguide: P000616
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Ilhan Omar
+  party: majority
+  rank: 4
+  bioguide: O000173
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Chrissy Houlahan
+  party: majority
+  rank: 5
+  bioguide: H001085
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+HSFA18:
+- name: Lee M. Zeldin
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '02261'
+  bioguide: Z000017
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Scott Perry
+  party: minority
+  rank: 2
+  thomas: '02157'
+  bioguide: P000605
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ken Buck
+  party: minority
+  rank: 3
+  bioguide: B001297
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Guy Reschenthaler
+  party: minority
+  rank: 4
+  bioguide: R000610
+  start_date: '2019-01-29'
+  source: https://republicans-foreignaffairs.house.gov/press-release/mccaul-announces-republican-subcommittee-leadership-and-membership-rosters-at-116th-committee-organizational-meeting/
+- name: Ami Bera
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '02102'
+  bioguide: B001287
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Ilhan Omar
+  party: majority
+  rank: 2
+  bioguide: O000173
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Adriano Espaillat
+  party: majority
+  rank: 3
+  bioguide: E000297
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Ted Lieu
+  party: majority
+  rank: 4
+  thomas: '02230'
+  bioguide: L000582
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: Tom Malinowski
+  party: majority
+  rank: 5
+  bioguide: M001203
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+- name: David N. Cicilline
+  party: majority
+  rank: 6
+  thomas: '02055'
+  bioguide: C001084
+  start_date: '2019-01-29'
+  source: https://foreignaffairs.house.gov/press-releases?ID=1F0FB8B1-CCA6-4B3A-B360-22907C33D03B
+HSGO:
+- name: Jim Jordan
+  party: minority
+  rank: 1
+  title: Ranking Member
   thomas: '01868'
   bioguide: J000289
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Justin Amash
+  party: minority
+  rank: 2
+  thomas: '02029'
+  bioguide: A000367
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Paul A. Gosar
+  party: minority
+  rank: 3
+  thomas: '01992'
+  bioguide: G000565
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Virginia Foxx
+  party: minority
+  rank: 4
+  thomas: '01791'
+  bioguide: F000450
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
 - name: Thomas Massie
-  party: majority
+  party: minority
   rank: 5
   thomas: '02094'
   bioguide: M001184
-- name: Gerald E. Connolly
-  party: minority
-  rank: 1
-  title: Ranking Member
-  thomas: '01959'
-  bioguide: C001078
-- name: Carolyn B. Maloney
-  party: minority
-  rank: 2
-  thomas: '00729'
-  bioguide: M000087
-- name: Eleanor Holmes Norton
-  party: minority
-  rank: 3
-  thomas: '00868'
-  bioguide: N000147
-- name: Wm. Lacy Clay
-  party: minority
-  rank: 4
-  thomas: '01654'
-  bioguide: C001049
-- name: Brenda L. Lawrence
-  party: minority
-  rank: 5
-  thomas: '02252'
-  bioguide: L000581
-- name: Bonnie Watson Coleman
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark Meadows
   party: minority
   rank: 6
-  thomas: '02259'
-  bioguide: W000822
-HSGO25:
-- name: Will Hurd
+  thomas: '02142'
+  bioguide: M001187
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jody B. Hice
+  party: minority
+  rank: 7
+  thomas: '02237'
+  bioguide: H001071
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Glenn Grothman
+  party: minority
+  rank: 8
+  thomas: '02276'
+  bioguide: G000576
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: James Comer
+  party: minority
+  rank: 9
+  bioguide: C001108
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael Cloud
+  party: minority
+  rank: 10
+  bioguide: C001115
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bob Gibbs
+  party: minority
+  rank: 11
+  bioguide: G000563
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Clay Higgins
+  party: minority
+  rank: 12
+  bioguide: H001077
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ralph Norman
+  party: minority
+  rank: 13
+  bioguide: N000190
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Chip Roy
+  party: minority
+  rank: 14
+  bioguide: R000614
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Carol D. Miller
+  party: minority
+  rank: 15
+  bioguide: M001205
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark E. Green
+  party: minority
+  rank: 16
+  bioguide: G000590
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Kelly Armstrong
+  party: minority
+  rank: 17
+  bioguide: A000377
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: W. Gregory Steube
+  party: minority
+  rank: 18
+  bioguide: S001214
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Elijah E. Cummings
   party: majority
   rank: 1
   title: Chair
-  thomas: '02269'
-  bioguide: H001073
-- name: Paul Mitchell
+  thomas: '00256'
+  bioguide: C000984
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Carolyn B. Maloney
   party: majority
   rank: 2
-  bioguide: M001201
-  title: Vice Chair
-- name: Justin Amash
+  thomas: '00729'
+  bioguide: M000087
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Eleanor Holmes Norton
+  party: majority
+  rank: 3
+  thomas: '00868'
+  bioguide: N000147
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Wm. Lacy Clay
   party: majority
   rank: 4
-  thomas: '02029'
-  bioguide: A000367
-- name: Greg Gianforte
+  thomas: '01654'
+  bioguide: C001049
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Stephen F. Lynch
+  party: majority
+  rank: 5
+  thomas: '01686'
+  bioguide: L000562
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Jim Cooper
   party: majority
   rank: 6
-  bioguide: G000584
-- name: Michael Cloud
+  bioguide: C000754
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Gerald E. Connolly
   party: majority
   rank: 7
-  bioguide: C001115
+  thomas: '01959'
+  bioguide: C001078
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Raja Krishnamoorthi
+  party: majority
+  rank: 8
+  bioguide: K000391
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Jamie Raskin
+  party: majority
+  rank: 9
+  bioguide: R000606
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Harley Rouda
+  party: majority
+  rank: 10
+  bioguide: R000616
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Katie Hill
+  party: majority
+  rank: 11
+  bioguide: H001087
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Debbie Wasserman Schultz
+  party: majority
+  rank: 12
+  bioguide: W000797
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: John P. Sarbanes
+  party: majority
+  rank: 13
+  thomas: '01854'
+  bioguide: S001168
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Peter Welch
+  party: majority
+  rank: 14
+  thomas: '01879'
+  bioguide: W000800
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Jackie Speier
+  party: majority
+  rank: 15
+  bioguide: S001175
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 - name: Robin L. Kelly
+  party: majority
+  rank: 16
+  bioguide: K000385
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Mark DeSaulnier
+  party: majority
+  rank: 17
+  bioguide: D000623
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Brenda L. Lawrence
+  party: majority
+  rank: 18
+  bioguide: L000581
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Stacey E. Plaskett
+  party: majority
+  rank: 19
+  bioguide: P000610
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Ro Khanna
+  party: majority
+  rank: 20
+  bioguide: K000389
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Jimmy Gomez
+  party: majority
+  rank: 21
+  bioguide: G000585
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Alexandria Ocasio-Cortez
+  party: majority
+  rank: 22
+  bioguide: O000172
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Ayanna Pressley
+  party: majority
+  rank: 23
+  bioguide: P000617
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Rashida Tlaib
+  party: majority
+  rank: 24
+  bioguide: T000481
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+HSGO06:
+- name: Jody B. Hice
   party: minority
   rank: 1
   title: Ranking Member
-  thomas: '02190'
-  bioguide: K000385
-- name: Jamie Raskin
+  bioguide: H001071
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Justin Amash
   party: minority
   rank: 2
-  bioguide: R000606
-- name: Stephen F. Lynch
+  thomas: '02029'
+  bioguide: A000367
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Paul A. Gosar
   party: minority
   rank: 3
-  thomas: '01686'
-  bioguide: L000562
-- name: Gerald E. Connolly
+  thomas: '01992'
+  bioguide: G000565
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Virginia Foxx
   party: minority
   rank: 4
-  thomas: '01959'
-  bioguide: C001078
-- name: Raja Krishnamoorthi
+  thomas: '01791'
+  bioguide: F000450
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Mark Meadows
   party: minority
   rank: 5
-  bioguide: K000391
+  bioguide: M001187
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Michael Cloud
+  party: minority
+  rank: 6
+  bioguide: C001115
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Mark E. Green
+  party: minority
+  rank: 7
+  bioguide: G000590
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Stephen F. Lynch
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000562
+  start_date: '2019-01-24'
+  source: https://oversight.house.gov/news/press-releases/cummings-announces-subcommittee-chairs-and-full-committee-vice-chair
+- name: Jim Cooper
+  party: majority
+  rank: 2
+  bioguide: C000754
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Peter Welch
+  party: majority
+  rank: 3
+  bioguide: W000800
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Harley Rouda
+  party: majority
+  rank: 4
+  bioguide: R000616
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Debbie Wasserman Schultz
+  party: majority
+  rank: 5
+  bioguide: W000797
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Robin L. Kelly
+  party: majority
+  rank: 6
+  bioguide: K000385
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Mark DeSaulnier
+  party: majority
+  rank: 7
+  bioguide: D000623
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Stacey E. Plaskett
+  party: majority
+  rank: 8
+  bioguide: P000610
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Brenda L. Lawrence
+  party: majority
+  rank: 9
+  bioguide: L000581
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+HSGO24:
+- name: Mark Meadows
+  party: minority
+  rank: 1
+  title: Ranking Member
+  thomas: '02142'
+  bioguide: M001187
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Thomas Massie
+  party: minority
+  rank: 2
+  thomas: '02094'
+  bioguide: M001184
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Jody B. Hice
+  party: minority
+  rank: 3
+  thomas: '02237'
+  bioguide: H001071
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Glenn Grothman
+  party: minority
+  rank: 4
+  thomas: '02276'
+  bioguide: G000576
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: James Comer
+  party: minority
+  rank: 5
+  bioguide: C001108
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Ralph Norman
+  party: minority
+  rank: 6
+  bioguide: N000190
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: W. Gregory Steube
+  party: minority
+  rank: 7
+  bioguide: S001214
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Gerald E. Connolly
+  party: majority
+  rank: 1
+  title: Chair
+  thomas: '01959'
+  bioguide: C001078
+  start_date: '2019-01-24'
+  source: https://oversight.house.gov/news/press-releases/cummings-announces-subcommittee-chairs-and-full-committee-vice-chair
+- name: Eleanor Holmes Norton
+  party: majority
+  rank: 2
+  thomas: '00868'
+  bioguide: N000147
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: John P. Sarbanes
+  party: majority
+  rank: 3
+  thomas: '01854'
+  bioguide: S001168
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Jackie Speier
+  party: majority
+  rank: 4
+  bioguide: S001175
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Brenda L. Lawrence
+  party: majority
+  rank: 5
+  thomas: '02252'
+  bioguide: L000581
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Stacey E. Plaskett
+  party: majority
+  rank: 6
+  bioguide: P000610
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Ro Khanna
+  party: majority
+  rank: 7
+  bioguide: K000389
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Stephen F. Lynch
+  party: majority
+  rank: 8
+  thomas: '01686'
+  bioguide: L000562
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
+- name: Jamie Raskin
+  party: majority
+  rank: 9
+  bioguide: R000606
+  start_date: '2019-01-29'
+  source: https://oversight.house.gov/sites/democrats.oversight.house.gov/files/116th%20COR%20Sub.Cmt_.%20Assignments.pdf
 HSGO27:
 - name: Jim Jordan
   party: majority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -13438,598 +13438,705 @@ SSCM01:
   rank: 1
   title: Chairman
   bioguide: C001098
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Marsha Blackburn
   party: majority
   rank: 2
   bioguide: B001243
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Roy Blunt
   party: majority
   rank: 3
   bioguide: B000575
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Shelley Moore Capito
   party: majority
   rank: 4
   bioguide: C001047
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Cory Gardner
   party: majority
   rank: 5
   bioguide: G000562
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Mike Lee
   party: majority
   rank: 6
   bioguide: L000577
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jerry Moran
   party: majority
   rank: 7
   bioguide: M000934
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: John Thune
   party: majority
   rank: 8
   bioguide: T000250
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Tammy Duckworth
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000622
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Amy Klobuchar
   party: minority
   rank: 2
   bioguide: K000367
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Gary C. Peters
   party: minority
   rank: 3
   bioguide: P000595
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jacky Rosen
   party: minority
   rank: 4
   bioguide: R000608
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Brian Schatz
   party: minority
   rank: 5
   bioguide: S001194
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jon Tester
   party: minority
   rank: 6
   bioguide: T000464
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Tom Udall
   party: minority
   rank: 7
   bioguide: U000039
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 SSCM20:
 - name: Jerry Moran
   party: majority
   rank: 1
   title: Chairman
   bioguide: M000934
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Marsha Blackburn
   party: majority
   rank: 2
   bioguide: B001243
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Shelley Moore Capito
   party: majority
   rank: 3
   bioguide: C001047
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Deb Fischer
   party: majority
   rank: 4
   bioguide: F000463
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Ron Johnson
   party: majority
   rank: 5
   bioguide: J000293
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Mike Lee
   party: majority
   rank: 6
   bioguide: L000577
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Dan Sullivan
   party: majority
   rank: 7
   bioguide: S001198
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: John Thune
   party: majority
   rank: 8
   bioguide: T000250
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Todd Young
   party: majority
   rank: 9
   bioguide: Y000064
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Richard Blumenthal
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: B001277
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Tammy Baldwin
   party: minority
   rank: 2
   bioguide: B001230
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Amy Klobuchar
   party: minority
   rank: 3
   bioguide: K000367
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Edward J. Markey
   party: minority
   rank: 4
   bioguide: M000133
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jacky Rosen
   party: minority
   rank: 5
   bioguide: R000608
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Brian Schatz
   party: minority
   rank: 6
   bioguide: S001194
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Kyrsten Sinema
   party: minority
   rank: 7
   bioguide: S001191
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Tom Udall
   party: minority
   rank: 8
   bioguide: U000039
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 SSCM22:
-- name: Dan Sullivan
+- name: Cory Gardner
   party: majority
   rank: 1
   title: Chairman
-  bioguide: S001198
-- name: Roger F. Wicker
-  party: majority
-  rank: 2
-  bioguide: W000437
-- name: Deb Fischer
-  party: majority
-  rank: 3
-  bioguide: F000463
-- name: James M. Inhofe
-  party: majority
-  rank: 4
-  bioguide: I000024
-- name: Mike Lee
-  party: majority
-  rank: 5
-  bioguide: L000577
-- name: Ron Johnson
-  party: majority
-  rank: 6
-  bioguide: J000293
-- name: Cory Gardner
-  party: majority
-  rank: 7
   bioguide: G000562
-- name: Todd Young
-  party: majority
-  rank: 8
-  bioguide: Y000064
-- name: John Thune
-  party: majority
-  rank: 9
-  title: Ex Officio
-  bioguide: T000250
-- name: Tammy Baldwin
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001230
-- name: Maria Cantwell
-  party: minority
-  rank: 2
-  bioguide: C000127
-- name: Richard Blumenthal
-  party: minority
-  rank: 3
-  bioguide: B001277
-- name: Brian Schatz
-  party: minority
-  rank: 4
-  bioguide: S001194
-- name: Edward J. Markey
-  party: minority
-  rank: 5
-  bioguide: M000133
-- name: Gary C. Peters
-  party: minority
-  rank: 6
-  bioguide: P000595
-SSCM24:
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Ted Cruz
   party: majority
-  rank: 1
-  title: Chairman
-  bioguide: C001098
-- name: Jerry Moran
-  party: majority
   rank: 2
-  bioguide: M000934
-- name: Dan Sullivan
-  party: majority
-  rank: 3
-  bioguide: S001198
-- name: Mike Lee
-  party: majority
-  rank: 4
-  bioguide: L000577
+  bioguide: C001098
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Ron Johnson
   party: majority
-  rank: 5
+  rank: 3
   bioguide: J000293
-- name: Shelley Moore Capito
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Rick Scott
   party: majority
-  rank: 6
-  bioguide: C001047
-- name: Cory Gardner
+  rank: 4
+  bioguide: S001217
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Dan Sullivan
   party: majority
-  rank: 7
-  bioguide: G000562
-- name: John Thune
-  party: majority
-  rank: 8
-  title: Ex Officio
-  bioguide: T000250
-- name: Edward J. Markey
+  rank: 5
+  bioguide: S001198
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tammy Baldwin
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: M000133
-- name: Brian Schatz
+  bioguide: B001230
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Richard Blumenthal
   party: minority
   rank: 2
-  bioguide: S001194
-- name: Tom Udall
-  party: minority
-  rank: 3
-  bioguide: U000039
+  bioguide: B001277
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Gary C. Peters
   party: minority
-  rank: 4
+  rank: 3
   bioguide: P000595
-- name: Tammy Baldwin
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Brian Schatz
   party: minority
-  rank: 5
-  bioguide: B001230
-- name: Margaret Wood Hassan
-  party: minority
-  rank: 6
-  bioguide: H001076
+  rank: 4
+  bioguide: S001194
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 SSCM25:
 - name: Deb Fischer
   party: majority
   rank: 1
   title: Chairman
   bioguide: F000463
-- name: Roger F. Wicker
-  party: majority
-  rank: 2
-  bioguide: W000437
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Roy Blunt
   party: majority
-  rank: 3
+  rank: 2
   bioguide: B000575
-- name: James M. Inhofe
-  party: majority
-  rank: 5
-  bioguide: I000024
-- name: Ron Johnson
-  party: majority
-  rank: 6
-  bioguide: J000293
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Shelley Moore Capito
   party: majority
-  rank: 7
+  rank: 3
   bioguide: C001047
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Cory Gardner
   party: majority
-  rank: 8
+  rank: 4
   bioguide: G000562
-- name: Todd Young
-  party: majority
-  rank: 9
-  bioguide: Y000064
-- name: John Thune
-  party: majority
-  rank: 10
-  title: Ex Officio
-  bioguide: T000250
-- name: Gary C. Peters
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: P000595
-- name: Maria Cantwell
-  party: minority
-  rank: 2
-  bioguide: C000127
-- name: Amy Klobuchar
-  party: minority
-  rank: 3
-  bioguide: K000367
-- name: Richard Blumenthal
-  party: minority
-  rank: 4
-  bioguide: B001277
-- name: Tom Udall
-  party: minority
-  rank: 5
-  bioguide: U000039
-- name: Tammy Baldwin
-  party: minority
-  rank: 6
-  bioguide: B001230
-- name: Tammy Duckworth
-  party: minority
-  rank: 7
-  bioguide: D000622
-- name: Margaret Wood Hassan
-  party: minority
-  rank: 8
-  bioguide: H001076
-SSCM26:
-- name: Roger F. Wicker
-  party: majority
-  rank: 1
-  title: Chairman
-  bioguide: W000437
-- name: Roy Blunt
-  party: majority
-  rank: 2
-  bioguide: B000575
-- name: Ted Cruz
-  party: majority
-  rank: 3
-  bioguide: C001098
-- name: Deb Fischer
-  party: majority
-  rank: 4
-  bioguide: F000463
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jerry Moran
   party: majority
   rank: 5
   bioguide: M000934
-- name: Dan Sullivan
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Rick Scott
   party: majority
   rank: 6
-  bioguide: S001198
-- name: James M. Inhofe
+  bioguide: S001217
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: John Thune
+  party: majority
+  rank: 7
+  bioguide: T000250
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Todd Young
   party: majority
   rank: 8
-  bioguide: I000024
+  bioguide: Y000064
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tammy Duckworth
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000622
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tammy Baldwin
+  party: minority
+  rank: 2
+  bioguide: B001230
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Richard Blumenthal
+  party: minority
+  rank: 3
+  bioguide: B001277
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Amy Klobuchar
+  party: minority
+  rank: 4
+  bioguide: K000367
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Edward J. Markey
+  party: minority
+  rank: 5
+  bioguide: M000133
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Gary C. Peters
+  party: minority
+  rank: 6
+  bioguide: P000595
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Kyrsten Sinema
+  party: minority
+  rank: 7
+  bioguide: S001191
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tom Udall
+  party: minority
+  rank: 8
+  bioguide: U000039
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+SSCM26:
+- name: John Thune
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: T000250
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Marsha Blackburn
+  party: majority
+  rank: 2
+  bioguide: B001243
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Roy Blunt
+  party: majority
+  rank: 3
+  bioguide: B000575
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Shelley Moore Capito
+  party: majority
+  rank: 4
+  bioguide: C001047
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Ted Cruz
+  party: majority
+  rank: 5
+  bioguide: C001098
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Deb Fischer
+  party: majority
+  rank: 6
+  bioguide: F000463
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Cory Gardner
+  party: majority
+  rank: 7
+  bioguide: G000562
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Ron Johnson
+  party: majority
+  rank: 8
+  bioguide: J000293
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Mike Lee
   party: majority
   rank: 9
   bioguide: L000577
-- name: Ron Johnson
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Jerry Moran
   party: majority
   rank: 10
-  bioguide: J000293
-- name: Shelley Moore Capito
+  bioguide: M000934
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Rick Scott
   party: majority
   rank: 11
-  bioguide: C001047
-- name: Cory Gardner
+  bioguide: S001217
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Dan Sullivan
   party: majority
   rank: 12
-  bioguide: G000562
+  bioguide: S001198
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Todd Young
   party: majority
   rank: 13
   bioguide: Y000064
-- name: John Thune
-  party: majority
-  rank: 14
-  title: Ex Officio
-  bioguide: T000250
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Brian Schatz
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: S001194
-- name: Maria Cantwell
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tammy Baldwin
   party: minority
   rank: 2
-  bioguide: C000127
-- name: Amy Klobuchar
-  party: minority
-  rank: 3
-  bioguide: K000367
+  bioguide: B001230
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Richard Blumenthal
   party: minority
-  rank: 4
+  rank: 3
   bioguide: B001277
-- name: Edward J. Markey
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tammy Duckworth
+  party: minority
+  rank: 4
+  bioguide: D000622
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Amy Klobuchar
   party: minority
   rank: 5
-  bioguide: M000133
-- name: Tom Udall
+  bioguide: K000367
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Edward J. Markey
   party: minority
   rank: 6
-  bioguide: U000039
+  bioguide: M000133
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Gary C. Peters
   party: minority
   rank: 7
   bioguide: P000595
-- name: Tammy Baldwin
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Jacky Rosen
   party: minority
   rank: 8
-  bioguide: B001230
-- name: Tammy Duckworth
+  bioguide: R000608
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Kyrsten Sinema
   party: minority
   rank: 9
-  bioguide: D000622
-- name: Margaret Wood Hassan
-  party: minority
-  rank: 10
-  bioguide: H001076
-- name: Catherine Cortez Masto
-  party: minority
-  rank: 11
-  bioguide: C001113
+  bioguide: S001191
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jon Tester
   party: minority
-  rank: 12
+  rank: 10
   bioguide: T000464
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tom Udall
+  party: minority
+  rank: 11
+  bioguide: U000039
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 SSEG:
 - name: Lisa Murkowski
   party: majority
   rank: 1
   title: Chairman
   bioguide: M001153
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: John Barrasso
   party: majority
   rank: 2
   bioguide: B001261
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: James E. Risch
   party: majority
   rank: 3
   bioguide: R000584
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Mike Lee
   party: majority
   rank: 4
   bioguide: L000577
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Steve Daines
   party: majority
-  rank: 6
+  rank: 5
   bioguide: D000618
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Bill Cassidy
+  party: majority
+  rank: 6
+  bioguide: C001075
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
 - name: Cory Gardner
   party: majority
   rank: 7
   bioguide: G000562
-- name: Lamar Alexander
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Cindy Hyde-Smith
   party: majority
   rank: 8
-  bioguide: A000360
-- name: John Hoeven
+  bioguide: H001079
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Martha McSally
   party: majority
   rank: 9
-  bioguide: H001061
-- name: Bill Cassidy
+  bioguide: M001197
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Lamar Alexander
   party: majority
   rank: 10
-  bioguide: C001075
-- name: Rob Portman
+  bioguide: A000360
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: John Hoeven
   party: majority
   rank: 11
-  bioguide: P000449
-- name: Shelley Moore Capito
-  party: majority
-  rank: 12
-  bioguide: C001047
-- name: Maria Cantwell
+  bioguide: H001061
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/12/text
+- name: Joe Manchin, III
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: C000127
+  bioguide: M001183
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Ron Wyden
   party: minority
   rank: 2
   bioguide: W000779
-- name: Bernard Sanders
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Maria Cantwell
   party: minority
   rank: 3
-  bioguide: S000033
-- name: Debbie Stabenow
+  bioguide: C000127
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Bernard Sanders
   party: minority
   rank: 4
-  bioguide: S000770
-- name: Joe Manchin, III
+  bioguide: S000033
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
+- name: Debbie Stabenow
   party: minority
   rank: 5
-  bioguide: M001183
+  bioguide: S000770
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Martin Heinrich
   party: minority
   rank: 6
   bioguide: H001046
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Mazie K. Hirono
   party: minority
   rank: 7
   bioguide: H001042
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Angus S. King, Jr.
   party: minority
   rank: 8
   bioguide: K000383
-- name: Tammy Duckworth
-  party: minority
-  rank: 9
-  bioguide: D000622
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 - name: Catherine Cortez Masto
   party: minority
-  rank: 10
+  rank: 9
   bioguide: C001113
-- name: Tina Smith
-  party: minority
-  rank: 11
-  bioguide: S001203
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/senate-resolution/13/text
 SSEG01:
-- name: Cory Gardner
+- name: Bill Cassidy
   party: majority
   rank: 1
   title: Chairman
-  bioguide: G000562
+  bioguide: C001075
 - name: James E. Risch
   party: majority
   rank: 2
   bioguide: R000584
+- name: Mike Lee
+  party: majority
+  rank: 3
+  bioguide: L000577
 - name: Steve Daines
   party: majority
   rank: 4
   bioguide: D000618
-- name: Lamar Alexander
+- name: Cory Gardner
   party: majority
   rank: 5
+  bioguide: G000562
+- name: Cindy Hyde-Smith
+  party: majority
+  rank: 6
+  bioguide: H001079
+- name: Martha McSally
+  party: majority
+  rank: 7
+  bioguide: M001197
+- name: Lamar Alexander
+  party: majority
+  rank: 8
   bioguide: A000360
 - name: John Hoeven
   party: majority
-  rank: 6
-  bioguide: H001061
-- name: Bill Cassidy
-  party: majority
-  rank: 7
-  bioguide: C001075
-- name: Rob Portman
-  party: majority
-  rank: 8
-  bioguide: P000449
-- name: Shelley Moore Capito
-  party: majority
   rank: 9
-  bioguide: C001047
+  bioguide: H001061
 - name: Lisa Murkowski
   party: majority
   rank: 10
   title: Ex Officio
   bioguide: M001153
-- name: Joe Manchin, III
+- name: Martin Heinrich
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: M001183
+  bioguide: H001046
 - name: Ron Wyden
   party: minority
   rank: 2
   bioguide: W000779
-- name: Bernard Sanders
-  party: minority
-  rank: 3
-  bioguide: S000033
-- name: Martin Heinrich
-  party: minority
-  rank: 4
-  bioguide: H001046
-- name: Angus S. King, Jr.
-  party: minority
-  rank: 5
-  bioguide: K000383
-- name: Tammy Duckworth
-  party: minority
-  rank: 6
-  bioguide: D000622
-- name: Tina Smith
-  party: minority
-  rank: 7
-  bioguide: S001203
 - name: Maria Cantwell
   party: minority
-  rank: 8
-  title: Ex Officio
+  rank: 3
   bioguide: C000127
+- name: Bernard Sanders
+  party: minority
+  rank: 4
+  bioguide: S000033
+- name: Debbie Stabenow
+  party: minority
+  rank: 5
+  bioguide: S000770
+- name: Mazie K. Hirono
+  party: minority
+  rank: 6
+  bioguide: H001042
+- name: Angus S. King, Jr.
+  party: minority
+  rank: 7
+  bioguide: K000383
+- name: Catherine Cortez Masto
+  party: minority
+  rank: 8
+  bioguide: C001113
+- name: Joe Manchin, III
+  party: minority
+  rank: 9
+  bioguide: M001183
+  title: Ex Officio
 SSEG03:
 - name: Mike Lee
   party: majority
@@ -14048,26 +14155,26 @@ SSEG03:
   party: majority
   rank: 5
   bioguide: D000618
-- name: Cory Gardner
-  party: majority
-  rank: 6
-  bioguide: G000562
-- name: Lamar Alexander
-  party: majority
-  rank: 7
-  bioguide: A000360
-- name: John Hoeven
-  party: majority
-  rank: 8
-  bioguide: H001061
 - name: Bill Cassidy
   party: majority
-  rank: 9
+  rank: 6
   bioguide: C001075
-- name: Shelley Moore Capito
+- name: Cory Gardner
+  party: majority
+  rank: 7
+  bioguide: G000562
+- name: Cindy Hyde-Smith
+  party: majority
+  rank: 8
+  bioguide: H001079
+- name: Martha McSally
+  party: majority
+  rank: 9
+  bioguide: M001197
+- name: John Hoeven
   party: majority
   rank: 10
-  bioguide: C001047
+  bioguide: H001061
 - name: Lisa Murkowski
   party: majority
   rank: 11
@@ -14078,14 +14185,14 @@ SSEG03:
   rank: 1
   title: Ranking Member
   bioguide: W000779
-- name: Debbie Stabenow
+- name: Maria Cantwell
   party: minority
   rank: 2
-  bioguide: S000770
-- name: Joe Manchin, III
+  bioguide: C000127
+- name: Debbie Stabenow
   party: minority
   rank: 3
-  bioguide: M001183
+  bioguide: S000770
 - name: Martin Heinrich
   party: minority
   rank: 4
@@ -14094,19 +14201,19 @@ SSEG03:
   party: minority
   rank: 5
   bioguide: H001042
-- name: Catherine Cortez Masto
+- name: Angus S. King, Jr.
   party: minority
   rank: 6
-  bioguide: C001113
-- name: Tina Smith
+  bioguide: K000383
+- name: Catherine Cortez Masto
   party: minority
   rank: 7
-  bioguide: S001203
-- name: Maria Cantwell
+  bioguide: C001113
+- name: Joe Manchin, III
   party: minority
   rank: 8
+  bioguide: M001183
   title: Ex Officio
-  bioguide: C000127
 SSEG04:
 - name: Steve Daines
   party: majority
@@ -14125,18 +14232,18 @@ SSEG04:
   party: majority
   rank: 4
   bioguide: G000562
-- name: Lamar Alexander
+- name: Cindy Hyde-Smith
   party: majority
   rank: 5
+  bioguide: H001079
+- name: Lamar Alexander
+  party: majority
+  rank: 6
   bioguide: A000360
 - name: John Hoeven
   party: majority
-  rank: 6
-  bioguide: H001061
-- name: Rob Portman
-  party: majority
   rank: 7
-  bioguide: P000449
+  bioguide: H001061
 - name: Lisa Murkowski
   party: majority
   rank: 8
@@ -14163,15 +14270,11 @@ SSEG04:
   party: minority
   rank: 5
   bioguide: H001042
-- name: Tammy Duckworth
+- name: Joe Manchin, III
   party: minority
   rank: 6
-  bioguide: D000622
-- name: Maria Cantwell
-  party: minority
-  rank: 7
+  bioguide: M001183
   title: Ex Officio
-  bioguide: C000127
 SSEG07:
 - name: John Barrasso
   party: majority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -6348,743 +6348,1215 @@ HSII:
   bioguide: G000574
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
-- name: Joe Cunningham
+- name: T.J. Cox
   party: majority
   rank: 8
+  bioguide: C001124
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Joe Neguse
+  party: majority
+  rank: 9
+  bioguide: N000191
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Mike Levin
+  party: majority
+  rank: 10
+  bioguide: L000593
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Deb Haaland
+  party: majority
+  rank: 11
+  bioguide: H001080
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+  title: Vice-Chair
+- name: Jefferson Van Drew
+  party: majority
+  rank: 12
+  bioguide: V000133
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Joe Cunningham
+  party: majority
+  rank: 13
   bioguide: C001122
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Nydia M. Velázquez
   party: majority
-  rank: 9
+  rank: 14
   bioguide: V000081
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Diana DeGette
   party: majority
-  rank: 10
+  rank: 15
   bioguide: D000197
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Wm. Lacy Clay
   party: majority
-  rank: 11
+  rank: 16
   bioguide: C001049
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Debbie Dingell
   party: majority
-  rank: 12
+  rank: 17
   bioguide: D000624
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Anthony G. Brown
   party: majority
-  rank: 13
+  rank: 18
   bioguide: B001304
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: A. Donald McEachin
   party: majority
-  rank: 14
+  rank: 19
   bioguide: M001200
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Darren Soto
   party: majority
-  rank: 15
+  rank: 20
   bioguide: S001200
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Ed Case
   party: majority
-  rank: 16
+  rank: 21
   bioguide: C001055
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Steven Horsford
   party: majority
-  rank: 17
+  rank: 22
   bioguide: H001066
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Michael San Nicolas
   party: majority
-  rank: 18
+  rank: 23
   bioguide: S001204
   start_date: '2019-01-24'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 HSII06:
 - name: Paul A. Gosar
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000565
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Doug Lamborn
+  party: minority
+  rank: 2
+  bioguide: L000564
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Bruce Westerman
+  party: minority
+  rank: 3
+  bioguide: W000821
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Garret Graves
+  party: minority
+  rank: 4
+  bioguide: G000577
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Liz Cheney
+  party: minority
+  rank: 5
+  bioguide: C001109
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Kevin Hern
+  party: minority
+  rank: 6
+  bioguide: H001082
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Alan S. Lowenthal
   party: majority
   rank: 1
   title: Chair
-  bioguide: G000565
-- name: Louie Gohmert
+  bioguide: L000579
+  start_date: '2019-01-29'
+  source: https://naturalresources.house.gov/media/press-releases/chair-ral-m-grijalva-announces-natural-resources-committee-democratic-leadership-team
+- name: Mike Levin
   party: majority
+  rank: 2
+  bioguide: L000593
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Joe Cunningham
+  party: majority
+  rank: 3
+  bioguide: C001122
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: A. Donald McEachin
+  party: majority
+  rank: 4
+  bioguide: M001200
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Diana DeGette
+  party: majority
+  rank: 5
+  bioguide: D000197
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Anthony G. Brown
+  party: majority
+  rank: 6
+  bioguide: B001304
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Jared Huffman
+  party: majority
+  rank: 7
+  bioguide: H001068
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Raúl M. Grijalva
+  party: majority
+  rank: 8
+  bioguide: G000551
+  title: Ex Officio
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+HSII10:
+- name: Don Young
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: Y000033
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Louie Gohmert
+  party: minority
   rank: 2
   bioguide: G000552
-- name: Doug Lamborn
-  party: majority
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Tom McClintock
+  party: minority
   rank: 3
-  bioguide: L000564
-- name: Robert J. Wittman
-  party: majority
-  rank: 4
-  bioguide: W000804
-- name: Glenn Thompson
-  party: majority
-  rank: 6
-  bioguide: T000467
-- name: Scott R. Tipton
-  party: majority
-  rank: 7
-  bioguide: T000470
+  bioguide: M001177
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
 - name: Paul Cook
-  party: majority
-  rank: 8
+  party: minority
+  rank: 4
   bioguide: C001094
-- name: Garret Graves
-  party: majority
-  rank: 9
-  bioguide: G000577
-- name: Jody B. Hice
-  party: majority
-  rank: 10
-  bioguide: H001071
-- name: Jack Bergman
-  party: majority
-  rank: 11
-  bioguide: B001301
-- name: Liz Cheney
-  party: majority
-  rank: 12
-  bioguide: C001109
-- name: John R. Curtis
-  party: majority
-  rank: 13
-  bioguide: C001114
-- name: Rob Bishop
-  party: majority
-  rank: 14
-  bioguide: B001250
-  title: Ex Officio
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000579
-- name: Anthony G. Brown
-  party: minority
-  rank: 2
-  bioguide: B001304
-- name: Jim Costa
-  party: minority
-  rank: 3
-  bioguide: C001059
-- name: Jared Huffman
-  party: minority
-  rank: 5
-  bioguide: H001068
-- name: Donald S. Beyer, Jr.
-  party: minority
-  rank: 6
-  bioguide: B001292
-- name: Darren Soto
-  party: minority
-  rank: 7
-  bioguide: S001200
-- name: Nanette Diaz Barragán
-  party: minority
-  rank: 8
-  bioguide: B001300
-- name: Nydia M. Velázquez
-  party: minority
-  rank: 9
-  bioguide: V000081
-- name: Raúl M. Grijalva
-  party: minority
-  rank: 11
-  bioguide: G000551
-  title: Ex Officio
-HSII10:
-- name: Tom McClintock
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: M001177
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-- name: Glenn Thompson
-  party: majority
-  rank: 4
-  bioguide: T000467
-- name: Scott R. Tipton
-  party: majority
-  rank: 6
-  bioguide: T000470
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
 - name: Bruce Westerman
-  party: majority
-  rank: 7
-  bioguide: W000821
-- name: Daniel Webster
-  party: majority
-  rank: 8
-  bioguide: W000806
-- name: Jack Bergman
-  party: majority
-  rank: 9
-  bioguide: B001301
-- name: Liz Cheney
-  party: majority
-  rank: 10
-  bioguide: C001109
-- name: Greg Gianforte
-  party: majority
-  rank: 11
-  bioguide: G000584
-- name: John R. Curtis
-  party: majority
-  rank: 12
-  bioguide: C001114
-- name: Rob Bishop
-  party: majority
-  rank: 13
-  bioguide: B001250
-  title: Ex Officio
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 3
-  bioguide: L000579
-- name: Ruben Gallego
-  party: minority
-  rank: 4
-  bioguide: G000574
-- name: A. Donald McEachin
   party: minority
   rank: 5
-  bioguide: M001200
-- name: Anthony G. Brown
+  bioguide: W000821
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Jody B. Hice
   party: minority
   rank: 6
-  bioguide: B001304
-- name: Jimmy Gomez
+  bioguide: H001071
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Daniel Webster
   party: minority
   rank: 7
-  bioguide: G000585
-- name: Raúl M. Grijalva
+  bioguide: W000806
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: John R. Curtis
   party: minority
+  rank: 8
+  bioguide: C001114
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Russ Fulcher
+  party: minority
+  rank: 9
+  bioguide: F000469
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Rob Bishop
+  party: minority
+  rank: 10
+  title: Ex Officio
+  bioguide: B001250
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Deb Haaland
+  party: majority
+  rank: 1
+  bioguide: H001080
+  start_date: '2019-01-29'
+  source: https://naturalresources.house.gov/media/press-releases/chair-ral-m-grijalva-announces-natural-resources-committee-democratic-leadership-team
+- name: Joe Neguse
+  party: majority
+  rank: 2
+  bioguide: N000191
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Diana DeGette
+  party: majority
+  rank: 3
+  bioguide: D000197
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Debbie Dingell
+  party: majority
+  rank: 4
+  bioguide: D000624
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Steven Horsford
+  party: majority
+  rank: 5
+  bioguide: H001066
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Jared Huffman
+  party: majority
+  rank: 6
+  bioguide: H001068
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Ruben Gallego
+  party: majority
+  rank: 7
+  bioguide: G000574
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Alan S. Lowenthal
+  party: majority
+  rank: 8
+  bioguide: L000579
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Ed Case
+  party: majority
+  rank: 9
+  bioguide: C001055
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Raúl M. Grijalva
+  party: majority
   rank: 10
   bioguide: G000551
   title: Ex Officio
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
 HSII13:
-- name: Doug Lamborn
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: L000564
-- name: Robert J. Wittman
-  party: majority
-  rank: 2
-  bioguide: W000804
 - name: Tom McClintock
-  party: majority
-  rank: 3
-  bioguide: M001177
-- name: Paul A. Gosar
-  party: majority
-  rank: 4
-  bioguide: G000565
-- name: Doug LaMalfa
-  party: majority
-  rank: 5
-  bioguide: L000578
-- name: Garret Graves
-  party: majority
-  rank: 7
-  bioguide: G000577
-- name: Jody B. Hice
-  party: majority
-  rank: 8
-  bioguide: H001071
-- name: Daniel Webster
-  party: majority
-  rank: 9
-  bioguide: W000806
-- name: Mike Johnson
-  party: majority
-  rank: 10
-  bioguide: J000299
-- name: Greg Gianforte
-  party: majority
-  rank: 11
-  bioguide: G000584
-- name: Rob Bishop
-  party: majority
-  rank: 12
-  bioguide: B001250
-  title: Ex Officio
-- name: Jared Huffman
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: H001068
-- name: Grace F. Napolitano
+  bioguide: M001177
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Doug Lamborn
   party: minority
+  rank: 2
+  bioguide: L000564
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Robert J. Wittman
+  party: minority
+  rank: 3
+  bioguide: W000804
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Garret Graves
+  party: minority
+  rank: 4
+  bioguide: G000577
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Jody B. Hice
+  party: minority
+  rank: 5
+  bioguide: H001071
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Aumua Amata Coleman Radewagen
+  party: minority
+  rank: 6
+  bioguide: R000600
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Daniel Webster
+  party: minority
+  rank: 7
+  bioguide: W000806
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Mike Johnson
+  party: minority
+  rank: 8
+  bioguide: J000299
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Jenniffer González-Colón
+  party: minority
+  rank: 9
+  bioguide: G000582
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Russ Fulcher
+  party: minority
+  rank: 10
+  bioguide: F000469
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Rob Bishop
+  party: minority
+  rank: 11
+  bioguide: B001250
+  title: Ex Officio
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Jared Huffman
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: H001068
+  start_date: '2019-01-29'
+  source: https://naturalresources.house.gov/media/press-releases/chair-ral-m-grijalva-announces-natural-resources-committee-democratic-leadership-team
+- name: Grace F. Napolitano
+  party: majority
   rank: 2
   bioguide: N000179
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
 - name: Jim Costa
-  party: minority
+  party: majority
   rank: 3
   bioguide: C001059
-- name: Donald S. Beyer, Jr.
-  party: minority
-  rank: 4
-  bioguide: B001292
-- name: Nanette Diaz Barragán
-  party: minority
-  rank: 5
-  bioguide: B001300
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
 - name: Gregorio Kilili Camacho Sablan
-  party: minority
-  rank: 7
+  party: majority
+  rank: 4
   bioguide: S001177
-- name: Jimmy Gomez
-  party: minority
-  rank: 8
-  bioguide: G000585
-- name: Raúl M. Grijalva
-  party: minority
-  rank: 9
-  bioguide: G000551
-  title: Ex Officio
-HSII15:
-- name: Bruce Westerman
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: W000821
-- name: Louie Gohmert
-  party: majority
-  rank: 2
-  bioguide: G000552
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 4
-  bioguide: R000600
-- name: Mike Johnson
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Jefferson Van Drew
   party: majority
   rank: 5
-  bioguide: J000299
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 6
-  bioguide: G000582
-- name: Rob Bishop
-  party: majority
-  rank: 7
-  bioguide: B001250
-  title: Ex Officio
-- name: A. Donald McEachin
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M001200
-- name: Ruben Gallego
-  party: minority
-  rank: 2
-  bioguide: G000574
-- name: Jared Huffman
-  party: minority
-  rank: 3
-  bioguide: H001068
-- name: Darren Soto
-  party: minority
-  rank: 4
-  bioguide: S001200
-- name: Wm. Lacy Clay
-  party: minority
-  rank: 5
-  bioguide: C001049
-- name: Raúl M. Grijalva
-  party: minority
-  rank: 6
-  bioguide: G000551
-  title: Ex Officio
-HSII24:
-- name: Doug LaMalfa
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: L000578
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-- name: Paul Cook
-  party: majority
-  rank: 4
-  bioguide: C001094
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 5
-  bioguide: R000600
-- name: Jack Bergman
-  party: majority
-  rank: 6
-  bioguide: B001301
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 7
-  bioguide: G000582
-- name: Rob Bishop
-  party: majority
-  rank: 9
-  bioguide: B001250
-  title: Ex Officio
-- name: Ruben Gallego
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: G000574
-- name: Gregorio Kilili Camacho Sablan
-  party: minority
-  rank: 3
-  bioguide: S001177
-- name: Darren Soto
-  party: minority
-  rank: 4
-  bioguide: S001200
+  bioguide: V000133
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
 - name: Nydia M. Velázquez
-  party: minority
+  party: majority
   rank: 6
   bioguide: V000081
-- name: Raúl M. Grijalva
-  party: minority
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Anthony G. Brown
+  party: majority
   rank: 7
+  bioguide: B001304
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Ed Case
+  party: majority
+  rank: 8
+  bioguide: C001055
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Alan S. Lowenthal
+  party: majority
+  rank: 9
+  bioguide: L000579
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: T.J. Cox
+  party: majority
+  rank: 10
+  bioguide: C001124
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Joe Neguse
+  party: majority
+  rank: 11
+  bioguide: N000191
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Mike Levin
+  party: majority
+  rank: 12
+  bioguide: L000593
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Joe Cunningham
+  party: majority
+  rank: 13
+  bioguide: C001122
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Raúl M. Grijalva
+  party: majority
+  rank: 14
   bioguide: G000551
   title: Ex Officio
-HSJU:
-- name: F. James Sensenbrenner, Jr.
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+HSII15:
+- name: Louie Gohmert
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000552
+  start_date: '2019-01-30'
+  source: https://republicans-naturalresources.house.gov/newsroom/documentsingle.aspx?DocumentID=405998
+- name: Paul A. Gosar
+  party: minority
+  rank: 3
+  bioguide: G000565
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Mike Johnson
+  party: minority
+  rank: 3
+  bioguide: J000299
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Jenniffer González-Colón
+  party: minority
+  rank: 4
+  bioguide: G000582
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Rob Bishop
+  party: minority
+  rank: 5
+  bioguide: B001250
+  title: Ex Officio
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: T.J. Cox
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001124
+  start_date: '2019-01-29'
+  source: https://naturalresources.house.gov/media/press-releases/chair-ral-m-grijalva-announces-natural-resources-committee-democratic-leadership-team
+- name: Debbie Dingell
   party: majority
   rank: 2
-  bioguide: S000244
-- name: Steve Chabot
+  bioguide: D000624
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: A. Donald McEachin
+  party: majority
+  rank: 3
+  bioguide: M001200
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Michael San Nicolas
   party: majority
   rank: 4
+  bioguide: S001204
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Raúl M. Grijalva
+  party: majority
+  rank: 5
+  bioguide: G000551
+  title: Ex Officio
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+HSII24:
+- name: Paul Cook
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001094
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Don Young
+  party: minority
+  rank: 2
+  bioguide: Y000033
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Robert J. Wittman
+  party: minority
+  rank: 3
+  bioguide: W000804
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Aumua Amata Coleman Radewagen
+  party: minority
+  rank: 4
+  bioguide: R000600
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: John R. Curtis
+  party: minority
+  rank: 5
+  bioguide: C001114
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Kevin Hern
+  party: minority
+  rank: 6
+  bioguide: H001082
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Rob Bishop
+  party: minority
+  rank: 7
+  bioguide: B001250
+  title: Ex Officio
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Ruben Gallego
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: G000574
+  start_date: '2019-01-29'
+  source: https://naturalresources.house.gov/media/press-releases/chair-ral-m-grijalva-announces-natural-resources-committee-democratic-leadership-team
+- name: Darren Soto
+  party: majority
+  rank: 2
+  bioguide: S001200
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Deb Haaland
+  party: majority
+  rank: 3
+  bioguide: H001080
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Ed Case
+  party: majority
+  rank: 4
+  bioguide: C001055
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+- name: Raúl M. Grijalva
+  party: majority
+  rank: 5
+  bioguide: G000551
+  title: Ex Officio
+  start_date: '2019-01-30'
+  source: https://naturalresources.house.gov/imo/media/doc/NRC%20Full%20and%20Sub%20Mbrs_116th%20Congress%20woimage_01.30.20191.docx
+HSJU:
+- name: Doug Collins
+  party: minority
+  rank: 1
+  bioguide: C001093
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: F. James Sensenbrenner, Jr.
+  party: minority
+  rank: 2
+  bioguide: S000244
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Steve Chabot
+  party: minority
+  rank: 3
   bioguide: C000266
-- name: Steve King
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Louie Gohmert
+  party: minority
+  rank: 4
+  bioguide: G000552
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jim Jordan
+  party: minority
+  rank: 5
+  bioguide: J000289
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ken Buck
+  party: minority
+  rank: 6
+  bioguide: B001297
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John Ratcliffe
+  party: minority
+  rank: 7
+  bioguide: R000601
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Martha Roby
+  party: minority
+  rank: 8
+  bioguide: R000591
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Matt Gaetz
+  party: minority
+  rank: 9
+  bioguide: G000578
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mike Johnson
+  party: minority
+  rank: 10
+  bioguide: J000299
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Andy Biggs
+  party: minority
+  rank: 11
+  bioguide: B001302
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Tom McClintock
+  party: minority
+  rank: 12
+  bioguide: M001177
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Debbie Lesko
+  party: minority
+  rank: 13
+  bioguide: L000589
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Guy Reschenthaler
+  party: minority
+  rank: 14
+  bioguide: R000610
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ben Cline
+  party: minority
+  rank: 15
+  bioguide: C001118
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Kelly Armstrong
+  party: minority
+  rank: 16
+  bioguide: A000377
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: W. Gregory Steube
+  party: minority
+  rank: 17
+  bioguide: S001214
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jerrold Nadler
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: N000002
+  start_date: "2019-01-04"
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Zoe Lofgren
+  party: majority
+  rank: 2
+  bioguide: L000397
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Sheila Jackson Lee
+  party: majority
+  rank: 3
+  bioguide: J000032
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Steve Cohen
+  party: majority
+  rank: 4
+  bioguide: C001068
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Henry C. "Hank" Johnson, Jr.
+  party: majority
+  rank: 5
+  bioguide: J000288
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Theodore E. Deutch
   party: majority
   rank: 6
-  bioguide: K000362
-- name: Louie Gohmert
-  party: majority
-  rank: 7
-  bioguide: G000552
-- name: Jim Jordan
+  bioguide: D000610
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Karen Bass
   party: majority
   rank: 8
-  bioguide: J000289
-- name: Tom Marino
+  bioguide: B001270
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Cedric L. Richmond
+  party: majority
+  rank: 9
+  bioguide: R000588
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Hakeem S. Jeffries
   party: majority
   rank: 10
-  bioguide: M001179
-- name: Doug Collins
+  bioguide: J000294
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: David N. Cicilline
+  party: majority
+  rank: 11
+  bioguide: C001084
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Eric Swalwell
+  party: majority
+  rank: 12
+  bioguide: S001193
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Ted Lieu
   party: majority
   rank: 13
-  bioguide: C001093
-- name: Ken Buck
+  bioguide: L000582
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Jamie Raskin
   party: majority
   rank: 14
-  bioguide: B001297
-- name: John Ratcliffe
+  bioguide: R000606
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Pramila Jayapal
   party: majority
   rank: 15
-  bioguide: R000601
-- name: Martha Roby
+  bioguide: J000298
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Val Butler Demings
   party: majority
   rank: 16
-  bioguide: R000591
-- name: Matt Gaetz
+  bioguide: D000627
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: J. Luis Correa
   party: majority
   rank: 17
-  bioguide: G000578
-- name: Mike Johnson
+  bioguide: C001110
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Mary Gay Scanlon
   party: majority
   rank: 18
-  bioguide: J000299
-- name: Andy Biggs
+  bioguide: S001205
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Sylvia R. Garcia
   party: majority
   rank: 19
-  bioguide: B001302
-- name: John H. Rutherford
+  bioguide: G000587
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Joe Neguse
   party: majority
   rank: 20
-  bioguide: R000609
-- name: Jerrold Nadler
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: N000002
-- name: Zoe Lofgren
-  party: minority
-  rank: 2
-  bioguide: L000397
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 3
-  bioguide: J000032
-- name: Steve Cohen
-  party: minority
-  rank: 4
-  bioguide: C001068
-- name: Henry C. "Hank" Johnson, Jr.
-  party: minority
-  rank: 5
-  bioguide: J000288
-- name: Theodore E. Deutch
-  party: minority
-  rank: 6
-  bioguide: D000610
-- name: Karen Bass
-  party: minority
-  rank: 8
-  bioguide: B001270
-- name: Cedric L. Richmond
-  party: minority
-  rank: 9
-  bioguide: R000588
-- name: Hakeem S. Jeffries
-  party: minority
-  rank: 10
-  bioguide: J000294
-- name: David N. Cicilline
-  party: minority
-  rank: 11
-  bioguide: C001084
-- name: Eric Swalwell
-  party: minority
-  rank: 12
-  bioguide: S001193
-- name: Ted Lieu
-  party: minority
-  rank: 13
-  bioguide: L000582
-- name: Jamie Raskin
-  party: minority
-  rank: 14
-  bioguide: R000606
-- name: Pramila Jayapal
-  party: minority
-  rank: 15
-  bioguide: J000298
-- name: Bradley Scott Schneider
-  party: minority
-  rank: 16
-  bioguide: S001190
-- name: Val Butler Demings
-  party: minority
-  rank: 17
-  bioguide: D000627
+  bioguide: N000191
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Lucy McBath
+  party: majority
+  rank: 21
+  bioguide: M001208
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Greg Stanton
+  party: majority
+  rank: 22
+  bioguide: S001211
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Madeleine Dean
+  party: majority
+  rank: 23
+  bioguide: D000631
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Debbie Mucarsel-Powell
+  party: majority
+  rank: 24
+  bioguide: M001207
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
+- name: Veronica Escobar
+  party: majority
+  rank: 25
+  bioguide: E000299
+  start_date: '2019-01-16'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/46/text
 HSJU01:
 - name: Ken Buck
+  party: minority
+  rank: 1
+  bioguide: B001297
+  title: Ranking Member
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Andy Biggs
+  party: minority
+  rank: 2
+  bioguide: B001302
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Tom McClintock
+  party: minority
+  rank: 3
+  bioguide: M001177
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Debbie Lesko
+  party: minority
+  rank: 4
+  bioguide: L000589
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Kelly Armstrong
+  party: minority
+  rank: 5
+  bioguide: A000377
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: W. Gregory Steube
+  party: minority
+  rank: 6
+  bioguide: S001214
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Zoe Lofgren
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000397
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Pramila Jayapal
   party: majority
   rank: 2
-  bioguide: B001297
+  bioguide: J000298
   title: Vice Chair
-- name: F. James Sensenbrenner, Jr.
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: J. Luis Correa
   party: majority
   rank: 3
-  bioguide: S000244
-- name: Steve King
+  bioguide: C001110
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Sylvia R. Garcia
+  party: majority
+  rank: 4
+  bioguide: G000587
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Joe Neguse
   party: majority
   rank: 5
-  bioguide: K000362
-- name: Jim Jordan
+  bioguide: N000191
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Debbie Mucarsel-Powell
   party: majority
   rank: 6
-  bioguide: J000289
-- name: Mike Johnson
+  bioguide: M001207
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Veronica Escobar
   party: majority
   rank: 7
-  bioguide: J000299
-- name: Andy Biggs
+  bioguide: E000299
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Sheila Jackson Lee
   party: majority
   rank: 8
-  bioguide: B001302
-- name: Zoe Lofgren
+  bioguide: J000032
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Mary Gay Scanlon
+  party: majority
+  rank: 9
+  bioguide: S001205
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+HSJU03:
+- name: Martha Roby
   party: minority
   rank: 1
+  bioguide: R000591
   title: Ranking Member
-  bioguide: L000397
-- name: Pramila Jayapal
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Steve Chabot
+  party: minority
+  rank: 2
+  bioguide: C000266
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Jim Jordan
   party: minority
   rank: 3
-  bioguide: J000298
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 4
-  bioguide: J000032
-- name: Jamie Raskin
-  party: minority
-  rank: 5
-  bioguide: R000606
-HSJU03:
-- name: Doug Collins
-  party: majority
-  rank: 2
-  bioguide: C001093
-  title: Vice Chair
-- name: Steve Chabot
-  party: majority
-  rank: 4
-  bioguide: C000266
-- name: Jim Jordan
-  party: majority
-  rank: 5
   bioguide: J000289
-- name: Tom Marino
-  party: majority
-  rank: 7
-  bioguide: M001179
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: John Ratcliffe
+  party: minority
+  rank: 4
+  bioguide: R000601
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Matt Gaetz
-  party: majority
-  rank: 10
+  party: minority
+  rank: 5
   bioguide: G000578
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Mike Johnson
+  party: minority
+  rank: 6
+  bioguide: J000299
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Andy Biggs
-  party: majority
-  rank: 11
+  party: minority
+  rank: 7
   bioguide: B001302
-- name: John H. Rutherford
-  party: majority
-  rank: 12
-  bioguide: R000609
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Guy Reschenthaler
+  party: minority
+  rank: 8
+  bioguide: R000610
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Ben Cline
+  party: minority
+  rank: 9
+  bioguide: C001118
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Henry C. "Hank" Johnson, Jr.
-  party: minority
+  party: majority
   rank: 1
-  title: Ranking Member
+  title: Chair
   bioguide: J000288
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Theodore E. Deutch
-  party: minority
+  party: majority
   rank: 2
   bioguide: D000610
-- name: Karen Bass
-  party: minority
-  rank: 3
-  bioguide: B001270
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Cedric L. Richmond
-  party: minority
-  rank: 4
+  party: majority
+  rank: 3
   bioguide: R000588
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Hakeem S. Jeffries
-  party: minority
-  rank: 5
-  bioguide: J000294
-- name: Eric Swalwell
-  party: minority
-  rank: 6
-  bioguide: S001193
-- name: Ted Lieu
-  party: minority
-  rank: 7
-  bioguide: L000582
-- name: Bradley Scott Schneider
-  party: minority
-  rank: 8
-  bioguide: S001190
-- name: Zoe Lofgren
-  party: minority
-  rank: 9
-  bioguide: L000397
-- name: Steve Cohen
-  party: minority
-  rank: 10
-  bioguide: C001068
-- name: David N. Cicilline
-  party: minority
-  rank: 11
-  bioguide: C001084
-- name: Pramila Jayapal
-  party: minority
-  rank: 12
-  bioguide: J000298
-HSJU05:
-- name: Tom Marino
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: M001179
-- name: John Ratcliffe
-  party: majority
-  rank: 2
-  bioguide: R000601
-  title: Vice Chair
-- name: Doug Collins
   party: majority
   rank: 4
-  bioguide: C001093
-- name: Ken Buck
+  bioguide: J000294
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Ted Lieu
   party: majority
   rank: 5
-  bioguide: B001297
-- name: Matt Gaetz
+  bioguide: L000582
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Greg Stanton
   party: majority
   rank: 6
-  bioguide: G000578
-- name: David N. Cicilline
+  bioguide: S001211
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Zoe Lofgren
+  party: majority
+  rank: 7
+  bioguide: L000397
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Steve Cohen
+  party: majority
+  rank: 8
+  bioguide: C001068
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Karen Bass
+  party: majority
+  rank: 9
+  bioguide: B001270
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Eric Swalwell
+  party: majority
+  rank: 10
+  bioguide: S001193
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: J. Luis Correa
+  party: majority
+  rank: 11
+  bioguide: C001110
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+HSJU05:
+- name: F. James Sensenbrenner, Jr.
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: C001084
-- name: Henry C. "Hank" Johnson, Jr.
+  bioguide: S000244
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Matt Gaetz
   party: minority
   rank: 2
-  bioguide: J000288
-- name: Eric Swalwell
+  bioguide: G000578
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Ken Buck
   party: minority
   rank: 3
-  bioguide: S001193
-- name: Bradley Scott Schneider
+  bioguide: B001297
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Kelly Armstrong
   party: minority
   rank: 4
-  bioguide: S001190
-- name: Val Butler Demings
+  bioguide: A000377
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: W. Gregory Steube
   party: minority
   rank: 5
-  bioguide: D000627
-HSJU08:
-- name: F. James Sensenbrenner, Jr.
+  bioguide: S001214
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: David N. Cicilline
   party: majority
   rank: 1
   title: Chair
-  bioguide: S000244
-- name: Louie Gohmert
+  bioguide: C001084
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Henry C. "Hank" Johnson, Jr.
   party: majority
   rank: 2
-  bioguide: G000552
-  title: Vice Chair
-- name: Steve Chabot
+  bioguide: J000288
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Jamie Raskin
   party: majority
   rank: 3
-  bioguide: C000266
-- name: John Ratcliffe
+  bioguide: R000606
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Pramila Jayapal
+  party: majority
+  rank: 4
+  bioguide: J000298
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Val Butler Demings
+  party: majority
+  rank: 5
+  bioguide: D000627
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Mary Gay Scanlon
   party: majority
   rank: 6
-  bioguide: R000601
-- name: Martha Roby
+  bioguide: S001205
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Joe Neguse
   party: majority
   rank: 7
-  bioguide: R000591
-- name: Mike Johnson
+  bioguide: N000191
+  title: Vice Chair
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Lucy McBath
   party: majority
   rank: 8
-  bioguide: J000299
-- name: John H. Rutherford
-  party: majority
+  bioguide: M001208
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+HSJU08:
+- name: John Ratcliffe
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000601
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: F. James Sensenbrenner, Jr.
+  party: minority
+  rank: 2
+  bioguide: S000244
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Steve Chabot
+  party: minority
+  rank: 3
+  bioguide: C000266
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Louie Gohmert
+  party: minority
+  rank: 4
+  bioguide: G000552
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Tom McClintock
+  party: minority
+  rank: 5
+  bioguide: M001177
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Debbie Lesko
+  party: minority
+  rank: 6
+  bioguide: L000589
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Guy Reschenthaler
+  party: minority
+  rank: 7
+  bioguide: R000610
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Ben Cline
+  party: minority
+  rank: 8
+  bioguide: C001118
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: W. Gregory Steube
+  party: minority
   rank: 9
-  bioguide: R000609
+  bioguide: S001214
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Sheila Jackson Lee
   party: minority
   rank: 1

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -7557,2144 +7557,2385 @@ HSJU08:
   bioguide: S001214
   start_date: '2019-01-28'
   source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
-- name: Sheila Jackson Lee
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: J000032
-- name: Val Butler Demings
-  party: minority
-  rank: 2
-  bioguide: D000627
 - name: Karen Bass
-  party: minority
-  rank: 3
-  bioguide: B001270
-- name: Cedric L. Richmond
-  party: minority
-  rank: 4
-  bioguide: R000588
-- name: Hakeem S. Jeffries
-  party: minority
-  rank: 5
-  bioguide: J000294
-- name: Ted Lieu
-  party: minority
-  rank: 6
-  bioguide: L000582
-- name: Jamie Raskin
-  party: minority
-  rank: 7
-  bioguide: R000606
-HSJU10:
-- name: Steve King
   party: majority
   rank: 1
   title: Chair
-  bioguide: K000362
-- name: Louie Gohmert
+  bioguide: B001270
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Sheila Jackson Lee
   party: majority
+  rank: 2
+  bioguide: J000032
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Val Butler Demings
+  party: majority
+  rank: 3
+  title: Vice Chair
+  bioguide: D000627
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Lucy McBath
+  party: majority
+  rank: 4
+  bioguide: M001208
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Theodore E. Deutch
+  party: majority
+  rank: 5
+  bioguide: D000610
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Cedric L. Richmond
+  party: majority
+  rank: 6
+  bioguide: R000588
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Hakeem S. Jeffries
+  party: majority
+  rank: 7
+  bioguide: J000294
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: David N. Cicilline
+  party: majority
+  rank: 8
+  bioguide: C001084
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Ted Lieu
+  party: majority
+  rank: 9
+  bioguide: L000582
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Madeleine Dean
+  party: majority
+  rank: 10
+  bioguide: D000631
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Debbie Mucarsel-Powell
+  party: majority
+  rank: 11
+  bioguide: M001207
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Steve Cohen
+  party: majority
+  rank: 12
+  bioguide: C001068
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+HSJU10:
+- name: Mike Johnson
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: J000299
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Louie Gohmert
+  party: minority
   rank: 2
   bioguide: G000552
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Jim Jordan
+  party: minority
+  rank: 3
+  bioguide: J000289
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Guy Reschenthaler
+  party: minority
+  rank: 4
+  bioguide: R000610
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Ben Cline
+  party: minority
+  rank: 5
+  bioguide: C001118
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Kelly Armstrong
+  party: minority
+  rank: 6
+  bioguide: A000377
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
 - name: Steve Cohen
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001068
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Jamie Raskin
+  party: majority
+  rank: 2
+  title: Vice Chair
+  bioguide: R000606
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Eric Swalwell
+  party: majority
+  rank: 3
+  bioguide: S001193
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Mary Gay Scanlon
+  party: majority
+  rank: 4
+  bioguide: S001205
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Madeleine Dean
+  party: majority
+  rank: 5
+  bioguide: D000631
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Sylvia R. Garcia
+  party: majority
+  rank: 6
+  bioguide: G000587
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Veronica Escobar
+  party: majority
+  rank: 7
+  bioguide: E000299
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+- name: Sheila Jackson Lee
+  party: majority
+  rank: 8
+  bioguide: J000032
+  start_date: '2019-01-28'
+  source: https://judiciary.house.gov/news/press-releases/chairman-nadler-ranking-member-collins-hold-first-judiciary-committee-meeting-0
+HSPW:
+- name: Sam Graves
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: C001068
-- name: Jamie Raskin
-  party: minority
-  rank: 2
-  bioguide: R000606
-- name: Theodore E. Deutch
-  party: minority
-  rank: 3
-  bioguide: D000610
-HSPW:
+  bioguide: G000546
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Don Young
-  party: majority
+  party: minority
   rank: 2
   bioguide: Y000033
-- name: Sam Graves
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Eric A. "Rick" Crawford
+  party: minority
+  rank: 3
+  bioguide: C001087
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bob Gibbs
+  party: minority
+  rank: 4
+  bioguide: G000563
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Daniel Webster
+  party: minority
+  rank: 5
+  bioguide: W000806
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Thomas Massie
+  party: minority
+  rank: 6
+  bioguide: M001184
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark Meadows
+  party: minority
+  rank: 7
+  bioguide: M001187
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Scott Perry
+  party: minority
+  rank: 8
+  bioguide: P000605
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Rodney Davis
+  party: minority
+  rank: 9
+  bioguide: D000619
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Rob Woodall
+  party: minority
+  rank: 10
+  bioguide: W000810
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: John Katko
+  party: minority
+  rank: 11
+  bioguide: K000386
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Brian Babin
+  party: minority
+  rank: 12
+  bioguide: B001291
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Garret Graves
+  party: minority
+  rank: 13
+  bioguide: G000577
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: David Rouzer
+  party: minority
+  rank: 14
+  bioguide: R000603
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mike Bost
+  party: minority
+  rank: 15
+  bioguide: B001295
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Randy K. Weber, Sr.
+  party: minority
+  rank: 16
+  bioguide: W000814
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Doug LaMalfa
+  party: minority
+  rank: 17
+  bioguide: L000578
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bruce Westerman
+  party: minority
+  rank: 18
+  bioguide: W000821
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Lloyd Smucker
+  party: minority
+  rank: 19
+  bioguide: S001199
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Paul Mitchell
+  party: minority
+  rank: 20
+  bioguide: M001201
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Brian J. Mast
+  party: minority
+  rank: 21
+  bioguide: M001199
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mike Gallagher
+  party: minority
+  rank: 22
+  bioguide: G000579
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Gary J. Palmer
+  party: minority
+  rank: 23
+  bioguide: P000609
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Brian K. Fitzpatrick
+  party: minority
+  rank: 24
+  bioguide: F000466
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jenniffer González-Colón
+  party: minority
+  rank: 25
+  bioguide: G000582
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Troy Balderson
+  party: minority
+  rank: 26
+  bioguide: B001306
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ross Spano
+  party: minority
+  rank: 27
+  bioguide: S001210
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Pete Stauber
+  party: minority
+  rank: 28
+  bioguide: S001212
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Carol D. Miller
+  party: minority
+  rank: 29
+  bioguide: M001205
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Greg Pence
+  party: minority
+  rank: 30
+  bioguide: P000615
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Peter A. DeFazio
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000191
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Eleanor Holmes Norton
+  party: majority
+  rank: 2
+  bioguide: N000147
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Eddie Bernice Johnson
+  party: majority
+  rank: 3
+  bioguide: J000126
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Elijah E. Cummings
+  party: majority
+  rank: 4
+  bioguide: C000984
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Rick Larsen
   party: majority
   rank: 5
-  bioguide: G000546
-- name: Eric A. "Rick" Crawford
+  bioguide: L000560
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Grace F. Napolitano
   party: majority
   rank: 6
-  bioguide: C001087
-- name: Bob Gibbs
+  bioguide: N000179
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Daniel Lipinski
+  party: majority
+  rank: 7
+  bioguide: L000563
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Steve Cohen
   party: majority
   rank: 8
-  bioguide: G000563
-- name: Daniel Webster
+  bioguide: C001068
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Albio Sires
   party: majority
   rank: 9
-  bioguide: W000806
-- name: Thomas Massie
+  bioguide: S001165
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: John Garamendi
+  party: majority
+  rank: 10
+  bioguide: G000559
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Henry C. "Hank" Johnson, Jr.
   party: majority
   rank: 11
-  bioguide: M001184
-- name: Mark Meadows
+  bioguide: J000288
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: André Carson
   party: majority
   rank: 12
-  bioguide: M001187
-- name: Scott Perry
+  bioguide: C001072
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Dina Titus
   party: majority
   rank: 13
-  bioguide: P000605
-- name: Rodney Davis
+  bioguide: T000468
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Sean Patrick Maloney
   party: majority
   rank: 14
-  bioguide: D000619
-- name: Rob Woodall
+  bioguide: M001185
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jared Huffman
+  party: majority
+  rank: 15
+  bioguide: H001068
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Julia Brownley
   party: majority
   rank: 16
-  bioguide: W000810
-- name: John Katko
+  bioguide: B001285
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Frederica S. Wilson
+  party: majority
+  rank: 17
+  bioguide: W000808
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Donald M. Payne, Jr.
   party: majority
   rank: 18
-  bioguide: K000386
-- name: Brian Babin
+  bioguide: P000604
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Alan S. Lowenthal
   party: majority
   rank: 19
-  bioguide: B001291
-- name: Garret Graves
+  bioguide: L000579
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Mark DeSaulnier
   party: majority
   rank: 20
-  bioguide: G000577
-- name: David Rouzer
+  bioguide: D000623
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Stacey E. Plaskett
+  party: majority
+  rank: 21
+  bioguide: P000610
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Stephen F. Lynch
   party: majority
   rank: 22
-  bioguide: R000603
-- name: Mike Bost
+  bioguide: L000562
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Salud Carbajal
   party: majority
   rank: 23
-  bioguide: B001295
-- name: Randy K. Weber, Sr.
+  bioguide: C001112
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Anthony G. Brown
   party: majority
   rank: 24
-  bioguide: W000814
-- name: Doug LaMalfa
+  bioguide: B001304
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Adriano Espaillat
   party: majority
   rank: 25
-  bioguide: L000578
-- name: Bruce Westerman
+  bioguide: E000297
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Tom Malinowski
   party: majority
   rank: 26
-  bioguide: W000821
-- name: Lloyd Smucker
+  bioguide: M001203
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Greg Stanton
   party: majority
   rank: 27
-  bioguide: S001199
-- name: Paul Mitchell
+  bioguide: S001211
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Debbie Mucarsel-Powell
   party: majority
   rank: 28
-  bioguide: M001201
-- name: A. Drew Ferguson IV
+  bioguide: M001207
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Lizzie Fletcher
+  party: majority
+  rank: 29
+  bioguide: F000468
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Colin Allred
   party: majority
   rank: 30
-  bioguide: F000465
-- name: Brian J. Mast
+  bioguide: A000376
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Sharice Davids
   party: majority
   rank: 31
-  bioguide: M001199
-- name: Mike Gallagher
+  bioguide: D000629
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Abby Finkenauer
+  party: majority
+  rank: 32
+  bioguide: F000467
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Jesús G. García
   party: majority
   rank: 33
-  bioguide: G000579
-- name: Peter A. DeFazio
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: D000191
-- name: Eleanor Holmes Norton
-  party: minority
-  rank: 2
-  bioguide: N000147
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 3
-  bioguide: J000126
-- name: Elijah E. Cummings
-  party: minority
-  rank: 4
-  bioguide: C000984
-- name: Rick Larsen
-  party: minority
-  rank: 5
-  bioguide: L000560
-- name: Grace F. Napolitano
-  party: minority
-  rank: 7
-  bioguide: N000179
-- name: Daniel Lipinski
-  party: minority
-  rank: 8
-  bioguide: L000563
-- name: Steve Cohen
-  party: minority
-  rank: 9
-  bioguide: C001068
-- name: Albio Sires
-  party: minority
-  rank: 10
-  bioguide: S001165
-- name: John Garamendi
-  party: minority
-  rank: 11
-  bioguide: G000559
-- name: Henry C. "Hank" Johnson, Jr.
-  party: minority
-  rank: 12
-  bioguide: J000288
-- name: André Carson
-  party: minority
-  rank: 13
-  bioguide: C001072
-- name: Dina Titus
-  party: minority
-  rank: 15
-  bioguide: T000468
-- name: Sean Patrick Maloney
-  party: minority
-  rank: 16
-  bioguide: M001185
-- name: Lois Frankel
-  party: minority
-  rank: 18
-  bioguide: F000462
-- name: Cheri Bustos
-  party: minority
-  rank: 19
-  bioguide: B001286
-- name: Jared Huffman
-  party: minority
-  rank: 20
-  bioguide: H001068
-- name: Julia Brownley
-  party: minority
-  rank: 21
-  bioguide: B001285
-- name: Frederica S. Wilson
-  party: minority
-  rank: 22
-  bioguide: W000808
-- name: Donald M. Payne, Jr.
-  party: minority
-  rank: 23
-  bioguide: P000604
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 24
-  bioguide: L000579
-- name: Brenda L. Lawrence
-  party: minority
-  rank: 25
-  bioguide: L000581
-- name: Mark DeSaulnier
-  party: minority
-  rank: 26
-  bioguide: D000623
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 27
-  bioguide: P000610
+  bioguide: G000586
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Antonio Delgado
+  party: majority
+  rank: 34
+  bioguide: D000630
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Chris Pappas
+  party: majority
+  rank: 35
+  bioguide: P000614
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Angie Craig
+  party: majority
+  rank: 36
+  bioguide: C001119
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Harley Rouda
+  party: majority
+  rank: 37
+  bioguide: R000616
+  start_date: '2017-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 HSPW02:
-- name: Garret Graves
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: G000577
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 2
-  bioguide: C001087
-- name: Bob Gibbs
-  party: majority
-  rank: 3
-  bioguide: G000563
-- name: Daniel Webster
-  party: majority
-  rank: 4
-  bioguide: W000806
-- name: Thomas Massie
-  party: majority
-  rank: 5
-  bioguide: M001184
-- name: Rodney Davis
-  party: majority
-  rank: 6
-  bioguide: D000619
-- name: Rob Woodall
-  party: majority
-  rank: 8
-  bioguide: W000810
-- name: John Katko
-  party: majority
-  rank: 10
-  bioguide: K000386
-- name: Brian Babin
-  party: majority
-  rank: 11
-  bioguide: B001291
-- name: David Rouzer
-  party: majority
-  rank: 12
-  bioguide: R000603
-- name: Mike Bost
-  party: majority
-  rank: 13
-  bioguide: B001295
-- name: Randy K. Weber, Sr.
-  party: majority
-  rank: 14
-  bioguide: W000814
-- name: Doug LaMalfa
-  party: majority
-  rank: 15
-  bioguide: L000578
-- name: A. Drew Ferguson IV
-  party: majority
-  rank: 16
-  bioguide: F000465
-- name: Brian J. Mast
-  party: majority
-  rank: 17
-  bioguide: M001199
-- name: Grace F. Napolitano
+- name: Bruce Westerman
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: W000821
+  date: '2019-01-17'
+  source: https://republicans-transportation.house.gov/news/documentsingle.aspx?DocumentID=402958
+- name: Grace F. Napolitano
+  party: majority
+  rank: 1
+  title: Chair
   bioguide: N000179
-- name: Lois Frankel
-  party: minority
-  rank: 2
-  bioguide: F000462
-- name: Frederica S. Wilson
-  party: minority
-  rank: 3
-  bioguide: W000808
-- name: Jared Huffman
-  party: minority
-  rank: 4
-  bioguide: H001068
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 5
-  bioguide: L000579
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 6
-  bioguide: J000126
-- name: John Garamendi
-  party: minority
-  rank: 7
-  bioguide: G000559
-- name: Dina Titus
-  party: minority
-  rank: 8
-  bioguide: T000468
-- name: Sean Patrick Maloney
-  party: minority
-  rank: 9
-  bioguide: M001185
-- name: Cheri Bustos
-  party: minority
-  rank: 11
-  bioguide: B001286
-- name: Julia Brownley
-  party: minority
-  rank: 12
-  bioguide: B001285
-- name: Brenda L. Lawrence
-  party: minority
-  rank: 13
-  bioguide: L000581
+  start_date: '2019-01-24'
+  source: https://transportation.house.gov/news/press-releases/chairman-defazio-announces-subcommittee-chairs-for-the-116th-congress
 HSPW05:
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-- name: Sam Graves
-  party: majority
-  rank: 4
-  bioguide: G000546
-- name: Bob Gibbs
-  party: majority
-  rank: 5
-  bioguide: G000563
-- name: Daniel Webster
-  party: majority
-  rank: 6
-  bioguide: W000806
-- name: Thomas Massie
-  party: majority
-  rank: 8
-  bioguide: M001184
-- name: Mark Meadows
-  party: majority
-  rank: 9
-  bioguide: M001187
-- name: Scott Perry
-  party: majority
-  rank: 10
-  bioguide: P000605
-- name: Rodney Davis
-  party: majority
-  rank: 11
-  bioguide: D000619
-- name: Rob Woodall
-  party: majority
-  rank: 13
-  bioguide: W000810
-- name: Doug LaMalfa
-  party: majority
-  rank: 16
-  bioguide: L000578
-- name: Bruce Westerman
-  party: majority
-  rank: 17
-  bioguide: W000821
-- name: Lloyd Smucker
-  party: majority
-  rank: 18
-  bioguide: S001199
-- name: Paul Mitchell
-  party: majority
-  rank: 19
-  bioguide: M001201
-- name: Rick Larsen
+- name: Garret Graves
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: G000577
+  start_date: '2019-01-17'
+  source: https://republicans-transportation.house.gov/news/documentsingle.aspx?DocumentID=402958
+- name: Rick Larsen
+  party: majority
+  rank: 1
+  title: Chair
   bioguide: L000560
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 2
-  bioguide: J000126
-- name: Daniel Lipinski
-  party: minority
-  rank: 3
-  bioguide: L000563
-- name: André Carson
-  party: minority
-  rank: 4
-  bioguide: C001072
-- name: Cheri Bustos
-  party: minority
-  rank: 5
-  bioguide: B001286
-- name: Eleanor Holmes Norton
-  party: minority
-  rank: 6
-  bioguide: N000147
-- name: Dina Titus
-  party: minority
-  rank: 7
-  bioguide: T000468
-- name: Sean Patrick Maloney
-  party: minority
-  rank: 8
-  bioguide: M001185
-- name: Julia Brownley
-  party: minority
-  rank: 9
-  bioguide: B001285
-- name: Donald M. Payne, Jr.
-  party: minority
-  rank: 10
-  bioguide: P000604
-- name: Brenda L. Lawrence
-  party: minority
-  rank: 11
-  bioguide: L000581
-- name: Grace F. Napolitano
-  party: minority
-  rank: 13
-  bioguide: N000179
-- name: Steve Cohen
-  party: minority
-  rank: 14
-  bioguide: C001068
-- name: Henry C. "Hank" Johnson, Jr.
-  party: minority
-  rank: 15
-  bioguide: J000288
+  start_date: '2019-01-24'
+  source: https://transportation.house.gov/news/press-releases/chairman-defazio-announces-subcommittee-chairs-for-the-116th-congress
 HSPW07:
-- name: Brian J. Mast
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: M001199
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-- name: Garret Graves
-  party: majority
-  rank: 4
-  bioguide: G000577
-- name: David Rouzer
-  party: majority
-  rank: 5
-  bioguide: R000603
-- name: Randy K. Weber, Sr.
-  party: majority
-  rank: 6
-  bioguide: W000814
-- name: John Garamendi
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: G000559
-- name: Elijah E. Cummings
-  party: minority
-  rank: 2
-  bioguide: C000984
-- name: Rick Larsen
-  party: minority
-  rank: 3
-  bioguide: L000560
-- name: Jared Huffman
-  party: minority
-  rank: 4
-  bioguide: H001068
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 5
-  bioguide: L000579
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 6
-  bioguide: P000610
-HSPW12:
-- name: Sam Graves
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: G000546
-- name: Don Young
-  party: majority
-  rank: 2
-  bioguide: Y000033
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 5
-  bioguide: C001087
 - name: Bob Gibbs
-  party: majority
-  rank: 7
+  party: minority
+  rank: 1
+  title: Ranking Member
   bioguide: G000563
-- name: Thomas Massie
-  party: majority
-  rank: 9
-  bioguide: M001184
-- name: Mark Meadows
-  party: majority
-  rank: 10
-  bioguide: M001187
-- name: Scott Perry
-  party: majority
-  rank: 11
-  bioguide: P000605
-- name: Rodney Davis
-  party: majority
-  rank: 12
-  bioguide: D000619
-- name: Rob Woodall
-  party: majority
-  rank: 13
-  bioguide: W000810
-- name: John Katko
-  party: majority
-  rank: 14
-  bioguide: K000386
-- name: Brian Babin
-  party: majority
-  rank: 15
-  bioguide: B001291
-- name: Garret Graves
-  party: majority
-  rank: 16
-  bioguide: G000577
-- name: David Rouzer
-  party: majority
-  rank: 18
-  bioguide: R000603
-- name: Mike Bost
-  party: majority
-  rank: 19
-  bioguide: B001295
-- name: Doug LaMalfa
-  party: majority
-  rank: 20
-  bioguide: L000578
-- name: Bruce Westerman
-  party: majority
-  rank: 21
-  bioguide: W000821
-- name: Lloyd Smucker
-  party: majority
-  rank: 22
-  bioguide: S001199
-- name: Paul Mitchell
-  party: majority
-  rank: 23
-  bioguide: M001201
-- name: A. Drew Ferguson IV
-  party: majority
-  rank: 25
-  bioguide: F000465
-- name: Mike Gallagher
-  party: majority
-  rank: 26
-  bioguide: G000579
-- name: Eleanor Holmes Norton
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: N000147
-- name: Steve Cohen
-  party: minority
-  rank: 2
-  bioguide: C001068
-- name: Albio Sires
-  party: minority
-  rank: 3
-  bioguide: S001165
-- name: Dina Titus
-  party: minority
-  rank: 5
-  bioguide: T000468
+  start_date: '2019-01-17'
+  source: https://republicans-transportation.house.gov/news/documentsingle.aspx?DocumentID=402958
 - name: Sean Patrick Maloney
-  party: minority
-  rank: 6
+  party: majority
+  rank: 1
+  title: Chair
   bioguide: M001185
-- name: Jared Huffman
-  party: minority
-  rank: 8
-  bioguide: H001068
-- name: Julia Brownley
-  party: minority
-  rank: 9
-  bioguide: B001285
-- name: Alan S. Lowenthal
-  party: minority
-  rank: 10
-  bioguide: L000579
-- name: Brenda L. Lawrence
-  party: minority
-  rank: 11
-  bioguide: L000581
-- name: Mark DeSaulnier
-  party: minority
-  rank: 12
-  bioguide: D000623
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 13
-  bioguide: J000126
-- name: Grace F. Napolitano
-  party: minority
-  rank: 15
-  bioguide: N000179
-- name: Daniel Lipinski
-  party: minority
-  rank: 16
-  bioguide: L000563
-- name: Henry C. "Hank" Johnson, Jr.
-  party: minority
-  rank: 17
-  bioguide: J000288
-- name: Lois Frankel
-  party: minority
-  rank: 18
-  bioguide: F000462
-- name: Cheri Bustos
-  party: minority
-  rank: 19
-  bioguide: B001286
-- name: Frederica S. Wilson
-  party: minority
-  rank: 20
-  bioguide: W000808
-- name: Donald M. Payne, Jr.
-  party: minority
-  rank: 21
-  bioguide: P000604
-HSPW13:
-- name: Eric A. "Rick" Crawford
-  party: majority
-  rank: 2
-  bioguide: C001087
-- name: Mike Bost
-  party: majority
-  rank: 4
-  bioguide: B001295
-- name: A. Drew Ferguson IV
-  party: majority
-  rank: 6
-  bioguide: F000465
-- name: Brian J. Mast
-  party: majority
-  rank: 7
-  bioguide: M001199
-- name: Mike Gallagher
-  party: majority
-  rank: 8
-  bioguide: G000579
-- name: Dina Titus
+  start_date: '2019-01-24'
+  source: https://transportation.house.gov/news/press-releases/chairman-defazio-announces-subcommittee-chairs-for-the-116th-congress
+HSPW12:
+- name: Rodney Davis
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: T000468
-- name: Henry C. "Hank" Johnson, Jr.
-  party: minority
-  rank: 2
-  bioguide: J000288
+  bioguide: D000619
+  start_date: '2019-01-17'
+  source: https://republicans-transportation.house.gov/news/documentsingle.aspx?DocumentID=402958
 - name: Eleanor Holmes Norton
-  party: minority
-  rank: 3
+  party: majority
+  rank: 1
+  title: Chair
   bioguide: N000147
-- name: Albio Sires
-  party: minority
-  rank: 4
-  bioguide: S001165
-- name: Stacey E. Plaskett
-  party: minority
-  rank: 5
-  bioguide: P000610
-HSPW14:
-- name: Sam Graves
-  party: majority
-  rank: 3
-  bioguide: G000546
-- name: Daniel Webster
-  party: majority
-  rank: 5
-  bioguide: W000806
+  start_date: '2019-01-24'
+  source: https://transportation.house.gov/news/press-releases/chairman-defazio-announces-subcommittee-chairs-for-the-116th-congress
+HSPW13:
 - name: Mark Meadows
-  party: majority
-  rank: 6
+  party: minority
+  rank: 1
+  title: Ranking Member
   bioguide: M001187
-- name: Scott Perry
+  start_date: '2019-01-17'
+  source: https://republicans-transportation.house.gov/news/documentsingle.aspx?DocumentID=402958
+- name: Dina Titus
   party: majority
-  rank: 7
-  bioguide: P000605
-- name: John Katko
-  party: majority
-  rank: 10
-  bioguide: K000386
-- name: Brian Babin
-  party: majority
-  rank: 11
-  bioguide: B001291
-- name: Randy K. Weber, Sr.
-  party: majority
-  rank: 12
-  bioguide: W000814
-- name: Bruce Westerman
-  party: majority
-  rank: 13
-  bioguide: W000821
-- name: Lloyd Smucker
-  party: majority
-  rank: 14
-  bioguide: S001199
-- name: Paul Mitchell
-  party: majority
-  rank: 15
-  bioguide: M001201
-- name: Mike Gallagher
-  party: majority
-  rank: 18
-  bioguide: G000579
-- name: Donald M. Payne, Jr.
+  rank: 1
+  title: Chair
+  bioguide: T000468
+  start_date: '2019-01-24'
+  source: https://transportation.house.gov/news/press-releases/chairman-defazio-announces-subcommittee-chairs-for-the-116th-congress
+HSPW14:
+- name: Eric A. "Rick" Crawford
   party: minority
-  rank: 2
-  bioguide: P000604
-- name: Elijah E. Cummings
-  party: minority
-  rank: 3
-  bioguide: C000984
-- name: Steve Cohen
-  party: minority
-  rank: 4
-  bioguide: C001068
-- name: Albio Sires
-  party: minority
-  rank: 5
-  bioguide: S001165
-- name: John Garamendi
-  party: minority
-  rank: 6
-  bioguide: G000559
-- name: André Carson
-  party: minority
-  rank: 7
-  bioguide: C001072
-- name: Cheri Bustos
-  party: minority
-  rank: 10
-  bioguide: B001286
-- name: Frederica S. Wilson
-  party: minority
-  rank: 11
-  bioguide: W000808
-- name: Mark DeSaulnier
-  party: minority
-  rank: 12
-  bioguide: D000623
+  rank: 1
+  title: Ranking Member
+  bioguide: C001087
+  start_date: '2019-01-17'
+  source: https://republicans-transportation.house.gov/news/documentsingle.aspx?DocumentID=402958
 - name: Daniel Lipinski
-  party: minority
-  rank: 13
+  party: majority
+  rank: 1
+  title: Chair
   bioguide: L000563
-- name: Grace F. Napolitano
-  party: minority
-  rank: 14
-  bioguide: N000179
+  start_date: '2019-01-24'
+  source: https://transportation.house.gov/news/press-releases/chairman-defazio-announces-subcommittee-chairs-for-the-116th-congress
 HSRU:
 - name: James P. McGovern
   party: majority
   rank: 1
   title: Chair
   bioguide: M000312
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
 - name: Alcee L. Hastings
   party: majority
   rank: 2
   bioguide: H000324
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Norma J. Torres
   party: majority
   rank: 3
   bioguide: T000474
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Jamie Raskin
   party: majority
   rank: 4
   bioguide: R000606
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Mary Gay Scanlon
   party: majority
   rank: 5
   bioguide: S001205
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Joe Morelle
   party: majority
   rank: 6
   bioguide: M001206
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Donna Shalala
   party: majority
   rank: 7
   bioguide: S001206
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
 - name: Doris O. Matsui
   party: majority
   rank: 8
   bioguide: M001163
+  start_date: '2019-01-08'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/26/text
 - name: Ed Perlmutter
   party: majority
   rank: 9
   bioguide: P000593
+  start_date: '2019-01-08'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/26/text
 - name: Tom Cole
   party: minority
   rank: 1
   bioguide: C001053
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
 - name: Rob Woodall
   party: minority
   rank: 2
   bioguide: W000810
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Michael C. Burgess
   party: minority
   rank: 3
   bioguide: B001248
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 - name: Debbie Lesko
   party: minority
   rank: 4
   bioguide: L000589
-HSRU02:
-- name: Rob Woodall
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: W000810
-- name: Michael C. Burgess
-  party: majority
-  rank: 2
-  bioguide: B001248
-- name: Bradley Byrne
-  party: majority
-  rank: 3
-  bioguide: B001289
-- name: Dan Newhouse
-  party: majority
-  rank: 4
-  bioguide: N000189
-- name: Ken Buck
-  party: majority
-  rank: 5
-  bioguide: B001297
-- name: Alcee L. Hastings
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: H000324
-HSRU04:
-- name: Doug Collins
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001093
-- name: Bradley Byrne
-  party: majority
-  rank: 2
-  bioguide: B001289
-- name: Dan Newhouse
-  party: majority
-  rank: 3
-  bioguide: N000189
-- name: Liz Cheney
-  party: majority
-  rank: 4
-  bioguide: C001109
-- name: James P. McGovern
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M000312
-- name: Norma J. Torres
-  party: minority
-  rank: 2
-  bioguide: T000474
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
 HSSM:
 - name: Steve Chabot
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C000266
-- name: Steve King
-  party: majority
-  rank: 2
-  bioguide: K000362
-- name: Blaine Luetkemeyer
-  party: majority
-  rank: 3
-  bioguide: L000569
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 5
-  bioguide: R000600
-- name: Trent Kelly
-  party: majority
-  rank: 7
-  bioguide: K000388
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 9
-  bioguide: G000582
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 10
-  bioguide: F000466
-- name: Roger W. Marshall
-  party: majority
-  rank: 11
-  bioguide: M001198
-- name: Ralph Norman
-  party: majority
-  rank: 12
-  bioguide: N000190
-- name: John R. Curtis
-  party: majority
-  rank: 13
-  bioguide: C001114
-- name: Troy Balderson
-  party: majority
-  rank: 14
-  bioguide: B001306
-- name: Nydia M. Velázquez
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: V000081
-- name: Dwight Evans
+  bioguide: C000266
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Aumua Amata Coleman Radewagen
   party: minority
   rank: 2
-  bioguide: E000296
-- name: Stephanie N. Murphy
+  bioguide: R000600
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Trent Kelly
   party: minority
   rank: 3
-  bioguide: M001202
-- name: Al Lawson, Jr.
+  bioguide: K000388
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Troy Balderson
   party: minority
   rank: 4
-  bioguide: L000586
-- name: Yvette D. Clarke
+  bioguide: B001306
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Kevin Hern
   party: minority
   rank: 5
-  bioguide: C001067
-- name: Judy Chu
+  bioguide: H001082
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Jim Hagedorn
   party: minority
   rank: 6
-  bioguide: C001080
-- name: Alma S. Adams
+  bioguide: H001088
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Pete Stauber
   party: minority
   rank: 7
-  bioguide: A000370
-- name: Adriano Espaillat
+  bioguide: S001212
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Tim Burchett
   party: minority
   rank: 8
-  bioguide: E000297
-- name: Bradley Scott Schneider
+  bioguide: B001309
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Ross Spano
   party: minority
   rank: 9
-  bioguide: S001190
-HSSM23:
-- name: Steve King
-  party: majority
-  rank: 2
-  bioguide: K000362
-- name: Ralph Norman
-  party: majority
-  rank: 3
-  bioguide: N000190
-- name: Stephanie N. Murphy
+  bioguide: S001210
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: John Joyce
   party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: M001202
-- name: Yvette D. Clarke
-  party: minority
-  rank: 2
-  bioguide: C001067
-- name: Dwight Evans
-  party: minority
-  rank: 3
-  bioguide: E000296
-- name: Al Lawson, Jr.
-  party: minority
-  rank: 4
-  bioguide: L000586
-HSSM24:
-- name: Trent Kelly
+  rank: 10
+  bioguide: J000302
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/74/text
+- name: Nydia M. Velázquez
   party: majority
   rank: 1
   title: Chair
-  bioguide: K000388
-- name: Roger W. Marshall
+  bioguide: V000081
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Abby Finkenauer
+  party: majority
+  rank: 2
+  bioguide: F000467
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Jared Golden
   party: majority
   rank: 3
-  bioguide: M001198
-- name: Ralph Norman
+  bioguide: G000592
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Andy Kim
   party: majority
   rank: 4
-  bioguide: N000190
-- name: John R. Curtis
+  bioguide: K000394
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Jason Crow
   party: majority
   rank: 5
-  bioguide: C001114
-- name: Alma S. Adams
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: A000370
-HSSM25:
-- name: Steve King
-  party: majority
-  rank: 2
-  bioguide: K000362
-- name: Blaine Luetkemeyer
-  party: majority
-  rank: 3
-  bioguide: L000569
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 4
-  bioguide: R000600
-- name: John R. Curtis
-  party: majority
-  rank: 5
-  bioguide: C001114
-- name: Troy Balderson
+  bioguide: C001121
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Sharice Davids
   party: majority
   rank: 6
-  bioguide: B001306
-- name: Bradley Scott Schneider
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: S001190
-- name: Al Lawson, Jr.
-  party: minority
-  rank: 2
-  bioguide: L000586
-HSSM26:
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: R000600
-- name: Blaine Luetkemeyer
-  party: majority
-  rank: 2
-  bioguide: L000569
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 4
-  bioguide: G000582
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 5
-  bioguide: F000466
-- name: Roger W. Marshall
-  party: majority
-  rank: 6
-  bioguide: M001198
-- name: Al Lawson, Jr.
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000586
-- name: Adriano Espaillat
-  party: minority
-  rank: 2
-  bioguide: E000297
-HSSM27:
-- name: Trent Kelly
-  party: majority
-  rank: 3
-  bioguide: K000388
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 4
-  bioguide: G000582
-- name: Brian K. Fitzpatrick
-  party: majority
-  rank: 5
-  bioguide: F000466
-- name: Troy Balderson
-  party: majority
-  rank: 6
-  bioguide: B001306
-- name: Dwight Evans
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: E000296
+  bioguide: D000629
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
 - name: Judy Chu
-  party: minority
-  rank: 2
+  party: majority
+  rank: 7
   bioguide: C001080
-- name: Stephanie N. Murphy
-  party: minority
-  rank: 3
-  bioguide: M001202
-- name: Yvette D. Clarke
-  party: minority
-  rank: 4
-  bioguide: C001067
-HSSO:
-- name: Susan W. Brooks
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Marc A. Veasey
   party: majority
-  rank: 1
-  title: Chair
-  bioguide: B001284
-- name: Kenny Marchant
+  rank: 8
+  bioguide: V000131
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Dwight Evans
   party: majority
-  rank: 2
-  bioguide: M001158
-- name: John Ratcliffe
+  rank: 9
+  bioguide: E000296
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Bradley Scott Schneider
   party: majority
-  rank: 5
-  bioguide: R000601
-- name: Theodore E. Deutch
+  rank: 10
+  bioguide: S001190
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Adriano Espaillat
+  party: majority
+  rank: 11
+  bioguide: E000297
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Antonio Delgado
+  party: majority
+  rank: 12
+  bioguide: D000630
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Chrissy Houlahan
+  party: majority
+  rank: 13
+  bioguide: H001085
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+HSSM23:
+- name: Pete Stauber
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: S001212
+  start_date: '2019-02-04'
+  source: https://republicans-smallbusiness.house.gov/news/documentsingle.aspx?DocumentID=401235
+- name: Jared Golden
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: G000592
+  start_date: '2019-01-29'
+  source: https://smallbusiness.house.gov/press-release/velazquez-announces-small-business-subcommittee-chairs
+HSSM24:
+- name: Ross Spano
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001210
+  start_date: '2019-02-04'
+  source: https://republicans-smallbusiness.house.gov/news/documentsingle.aspx?DocumentID=401235
+- name: Judy Chu
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001080
+  start_date: '2019-01-29'
+  source: https://smallbusiness.house.gov/press-release/velazquez-announces-small-business-subcommittee-chairs
+HSSM25:
+- name: John Joyce
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: J000302
+  start_date: '2019-02-04'
+  source: https://republicans-smallbusiness.house.gov/news/documentsingle.aspx?DocumentID=401235
+- name: Abby Finkenauer
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: F000467
+  start_date: '2019-01-29'
+  source: https://smallbusiness.house.gov/press-release/velazquez-announces-small-business-subcommittee-chairs
+HSSM27:
+- name: Kevin Hern
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H001082
+  start_date: '2019-02-04'
+  source: https://republicans-smallbusiness.house.gov/news/documentsingle.aspx?DocumentID=401235
+- name: Andy Kim
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: K000394
+  start_date: '2019-01-29'
+  source: https://smallbusiness.house.gov/press-release/velazquez-announces-small-business-subcommittee-chairs
+HSSO:
+- name: Kenny Marchant
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001158
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/32/text
+- name: Theodore E. Deutch
+  party: majority
+  rank: 1
+  title: Chair
   bioguide: D000610
-- name: Yvette D. Clarke
-  party: minority
-  rank: 2
-  bioguide: C001067
-- name: Anthony G. Brown
-  party: minority
-  rank: 4
-  bioguide: B001304
-- name: Steve Cohen
-  party: minority
-  rank: 5
-  bioguide: C001068
+  start_date: '2019-01-09'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/31/text
 HSSY:
 - name: Frank D. Lucas
+  party: minority
+  rank: 1
+  bioguide: L000491
+  title: Ranking Member
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Mo Brooks
+  party: minority
+  rank: 2
+  bioguide: B001274
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Bill Posey
+  party: minority
+  rank: 3
+  bioguide: P000599
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Randy K. Weber, Sr.
+  party: minority
+  rank: 4
+  bioguide: W000814
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Brian Babin
+  party: minority
+  rank: 5
+  bioguide: B001291
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Andy Biggs
+  party: minority
+  rank: 6
+  bioguide: B001302
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Roger W. Marshall
+  party: minority
+  rank: 7
+  bioguide: M001198
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Neal P. Dunn
+  party: minority
+  rank: 8
+  bioguide: D000628
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Ralph Norman
+  party: minority
+  rank: 9
+  bioguide: N000190
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael Cloud
+  party: minority
+  rank: 10
+  bioguide: C001115
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Troy Balderson
+  party: minority
+  rank: 11
+  bioguide: B001306
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Pete Olson
+  party: minority
+  rank: 12
+  bioguide: O000168
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Anthony Gonzalez
+  party: minority
+  rank: 13
+  bioguide: G000588
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Michael Waltz
+  party: minority
+  rank: 14
+  bioguide: W000823
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: James Baird
+  party: minority
+  rank: 15
+  bioguide: B001307
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Eddie Bernice Johnson
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: J000126
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Zoe Lofgren
+  party: majority
+  rank: 2
+  bioguide: L000397
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Daniel Lipinski
   party: majority
   rank: 3
-  bioguide: L000491
-  title: Vice Chair
-- name: Mo Brooks
+  bioguide: L000563
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Suzanne Bonamici
   party: majority
   rank: 4
-  bioguide: B001274
-- name: Bill Posey
+  bioguide: B001278
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Ami Bera
+  party: majority
+  rank: 5
+  title: Vice Chair
+  bioguide: B001287
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Conor Lamb
   party: majority
   rank: 6
-  bioguide: P000599
-- name: Thomas Massie
+  bioguide: L000588
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Lizzie Fletcher
   party: majority
   rank: 7
-  bioguide: M001184
-- name: Randy K. Weber, Sr.
+  bioguide: F000468
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Haley M. Stevens
   party: majority
   rank: 8
-  bioguide: W000814
-- name: Brian Babin
+  bioguide: S001215
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Kendra S. Horn
+  party: majority
+  rank: 9
+  bioguide: H001083
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Mikie Sherrill
   party: majority
   rank: 10
-  bioguide: B001291
-- name: Ralph Lee Abraham
+  bioguide: S001207
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Brad Sherman
+  party: majority
+  rank: 11
+  bioguide: S000344
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Steve Cohen
   party: majority
   rank: 12
-  bioguide: A000374
-- name: Gary J. Palmer
+  bioguide: C001068
+  start_date: '2019-01-24'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/73/text
+- name: Jerry McNerney
   party: majority
   rank: 13
-  bioguide: P000609
-- name: Daniel Webster
+  bioguide: M001166
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Ed Perlmutter
   party: majority
   rank: 14
-  bioguide: W000806
-- name: Andy Biggs
+  bioguide: P000593
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Paul Tonko
   party: majority
   rank: 15
-  bioguide: B001302
-- name: Roger W. Marshall
+  bioguide: T000469
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Bill Foster
   party: majority
   rank: 16
-  bioguide: M001198
-- name: Neal P. Dunn
+  bioguide: F000454
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Donald S. Beyer, Jr.
   party: majority
   rank: 17
-  bioguide: D000628
-- name: Clay Higgins
+  bioguide: B001292
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Charlie Crist
   party: majority
   rank: 18
-  bioguide: H001077
-- name: Ralph Norman
+  bioguide: C001111
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Sean Casten
   party: majority
   rank: 19
-  bioguide: N000190
-- name: Debbie Lesko
+  bioguide: C001117
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Katie Hill
   party: majority
   rank: 20
-  bioguide: L000589
-- name: Michael Cloud
+  bioguide: H001087
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Ben McAdams
   party: majority
   rank: 21
-  bioguide: C001115
-- name: Troy Balderson
+  bioguide: M001209
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
+- name: Jennifer Wexton
   party: majority
   rank: 22
-  bioguide: B001306
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: J000126
-- name: Zoe Lofgren
-  party: minority
-  rank: 2
-  bioguide: L000397
-- name: Daniel Lipinski
-  party: minority
-  rank: 3
-  bioguide: L000563
-- name: Suzanne Bonamici
-  party: minority
-  rank: 4
-  bioguide: B001278
-- name: Ami Bera
-  party: minority
-  rank: 5
-  bioguide: B001287
-- name: Marc A. Veasey
-  party: minority
-  rank: 7
-  bioguide: V000131
-- name: Donald S. Beyer, Jr.
-  party: minority
-  rank: 8
-  bioguide: B001292
-- name: Jacky Rosen
-  party: minority
-  rank: 9
-  bioguide: R000608
-- name: Conor Lamb
-  party: minority
-  rank: 10
-  bioguide: L000588
-- name: Jerry McNerney
-  party: minority
-  rank: 11
-  bioguide: M001166
-- name: Ed Perlmutter
-  party: minority
-  rank: 12
-  bioguide: P000593
-- name: Paul Tonko
-  party: minority
-  rank: 13
-  bioguide: T000469
-- name: Bill Foster
-  party: minority
-  rank: 14
-  bioguide: F000454
-- name: Mark Takano
-  party: minority
-  rank: 15
-  bioguide: T000472
-- name: Charlie Crist
-  party: minority
-  rank: 17
-  bioguide: C001111
+  bioguide: W000825
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/67/text
 HSSY15:
-- name: Frank D. Lucas
-  party: majority
-  rank: 2
-  bioguide: L000491
-- name: Daniel Webster
-  party: majority
-  rank: 5
-  bioguide: W000806
-- name: Roger W. Marshall
-  party: majority
-  rank: 6
-  bioguide: M001198
-  title: Vice Chair
-- name: Debbie Lesko
-  party: majority
-  rank: 7
-  bioguide: L000589
-- name: Michael Cloud
-  party: majority
-  rank: 8
-  bioguide: C001115
-- name: Troy Balderson
-  party: majority
-  rank: 9
-  bioguide: B001306
-- name: Daniel Lipinski
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000563
-- name: Jacky Rosen
-  party: minority
-  rank: 3
-  bioguide: R000608
-- name: Suzanne Bonamici
-  party: minority
-  rank: 4
-  bioguide: B001278
-- name: Ami Bera
-  party: minority
-  rank: 5
-  bioguide: B001287
-- name: Donald S. Beyer, Jr.
-  party: minority
-  rank: 6
-  bioguide: B001292
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 7
-  bioguide: J000126
-  title: Ex Officio
-HSSY16:
-- name: Brian Babin
+- name: Haley M. Stevens
   party: majority
   rank: 1
   title: Chair
-  bioguide: B001291
-- name: Frank D. Lucas
-  party: majority
-  rank: 3
-  bioguide: L000491
-- name: Mo Brooks
-  party: majority
-  rank: 4
-  bioguide: B001274
-  title: Vice Chair
-- name: Thomas Massie
-  party: majority
-  rank: 6
-  bioguide: M001184
-- name: Bill Posey
-  party: majority
-  rank: 7
-  bioguide: P000599
-- name: Ralph Lee Abraham
-  party: majority
-  rank: 10
-  bioguide: A000374
-- name: Daniel Webster
-  party: majority
-  rank: 11
-  bioguide: W000806
-- name: Andy Biggs
-  party: majority
-  rank: 12
-  bioguide: B001302
-- name: Neal P. Dunn
-  party: majority
-  rank: 13
-  bioguide: D000628
-- name: Clay Higgins
-  party: majority
-  rank: 14
-  bioguide: H001077
-- name: Ami Bera
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001287
-- name: Zoe Lofgren
-  party: minority
-  rank: 2
-  bioguide: L000397
-- name: Donald S. Beyer, Jr.
-  party: minority
-  rank: 3
-  bioguide: B001292
-- name: Marc A. Veasey
-  party: minority
-  rank: 4
-  bioguide: V000131
+  bioguide: S001215
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
 - name: Daniel Lipinski
-  party: minority
-  rank: 5
-  bioguide: L000563
-- name: Ed Perlmutter
-  party: minority
-  rank: 6
-  bioguide: P000593
-- name: Charlie Crist
-  party: minority
-  rank: 7
-  bioguide: C001111
-- name: Bill Foster
-  party: minority
-  rank: 8
-  bioguide: F000454
-- name: Conor Lamb
-  party: minority
-  rank: 9
-  bioguide: L000588
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 11
-  bioguide: J000126
-  title: Ex Officio
-HSSY18:
-- name: Andy Biggs
   party: majority
-  rank: 1
-  title: Chair
-  bioguide: B001302
-- name: Bill Posey
-  party: majority
-  rank: 3
-  bioguide: P000599
-- name: Mo Brooks
-  party: majority
-  rank: 4
-  bioguide: B001274
-- name: Randy K. Weber, Sr.
-  party: majority
-  rank: 5
-  bioguide: W000814
-- name: Brian Babin
-  party: majority
-  rank: 6
-  bioguide: B001291
-- name: Gary J. Palmer
-  party: majority
-  rank: 7
-  bioguide: P000609
-- name: Clay Higgins
-  party: majority
-  rank: 8
-  bioguide: H001077
-- name: Ralph Norman
-  party: majority
-  rank: 9
-  bioguide: N000190
-  title: Vice Chair
-- name: Debbie Lesko
-  party: majority
-  rank: 10
-  bioguide: L000589
-- name: Suzanne Bonamici
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: B001278
-- name: Charlie Crist
-  party: minority
-  rank: 3
-  bioguide: C001111
-- name: Conor Lamb
-  party: minority
-  rank: 4
-  bioguide: L000588
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 8
-  bioguide: J000126
-  title: Ex Officio
-HSSY20:
-- name: Randy K. Weber, Sr.
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: W000814
-- name: Frank D. Lucas
-  party: majority
-  rank: 3
-  bioguide: L000491
-- name: Mo Brooks
-  party: majority
-  rank: 4
-  bioguide: B001274
-- name: Gary J. Palmer
-  party: majority
-  rank: 7
-  bioguide: P000609
-- name: Daniel Webster
-  party: majority
-  rank: 8
-  bioguide: W000806
-- name: Neal P. Dunn
-  party: majority
-  rank: 9
-  bioguide: D000628
-- name: Ralph Norman
-  party: majority
-  rank: 10
-  bioguide: N000190
-- name: Michael Cloud
-  party: majority
-  rank: 11
-  bioguide: C001115
-- name: Marc A. Veasey
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: V000131
-- name: Zoe Lofgren
-  party: minority
   rank: 2
-  bioguide: L000397
-- name: Daniel Lipinski
-  party: minority
-  rank: 3
   bioguide: L000563
-- name: Jacky Rosen
-  party: minority
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Mikie Sherrill
+  party: majority
+  rank: 3
+  bioguide: S001207
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Brad Sherman
+  party: majority
   rank: 4
-  bioguide: R000608
-- name: Jerry McNerney
-  party: minority
-  rank: 5
-  bioguide: M001166
+  bioguide: S000344
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
 - name: Paul Tonko
-  party: minority
-  rank: 6
+  party: majority
+  rank: 5
   bioguide: T000469
-- name: Bill Foster
-  party: minority
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Ben McAdams
+  party: majority
+  rank: 6
+  bioguide: M001209
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Steve Cohen
+  party: majority
   rank: 7
-  bioguide: F000454
-- name: Mark Takano
-  party: minority
+  bioguide: C001068
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Bill Foster
+  party: majority
   rank: 8
-  bioguide: T000472
-- name: Eddie Bernice Johnson
-  party: minority
-  rank: 9
-  bioguide: J000126
-  title: Ex Officio
-HSSY21:
-- name: Ralph Lee Abraham
+  bioguide: F000454
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+HSSY16:
+- name: Kendra S. Horn
   party: majority
   rank: 1
   title: Chair
-  bioguide: A000374
-- name: Bill Posey
+  bioguide: H001083
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Zoe Lofgren
   party: majority
   rank: 2
-  bioguide: P000599
-- name: Thomas Massie
+  bioguide: L000397
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Ami Bera
   party: majority
   rank: 3
-  bioguide: M001184
-- name: Roger W. Marshall
+  bioguide: B001287
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Ed Perlmutter
   party: majority
   rank: 4
-  bioguide: M001198
-- name: Clay Higgins
+  bioguide: P000593
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Donald S. Beyer, Jr.
   party: majority
   rank: 5
-  bioguide: H001077
-  title: Vice Chair
-- name: Ralph Norman
+  bioguide: B001292
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Charlie Crist
   party: majority
   rank: 6
-  bioguide: N000190
-- name: Troy Balderson
+  bioguide: C001111
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Katie Hill
   party: majority
   rank: 7
-  bioguide: B001306
-- name: Donald S. Beyer, Jr.
-  party: minority
+  bioguide: H001087
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Jennifer Wexton
+  party: majority
+  rank: 8
+  bioguide: W000825
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+HSSY18:
+- name: Lizzie Fletcher
+  party: majority
   rank: 1
-  title: Ranking Member
-  bioguide: B001292
-- name: Jerry McNerney
-  party: minority
+  title: Chair
+  bioguide: F000468
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Suzanne Bonamici
+  party: majority
   rank: 2
-  bioguide: M001166
-- name: Ed Perlmutter
-  party: minority
+  bioguide: B001278
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Conor Lamb
+  party: majority
   rank: 3
-  bioguide: P000593
-- name: Eddie Bernice Johnson
-  party: minority
+  bioguide: L000588
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Paul Tonko
+  party: majority
+  rank: 4
+  bioguide: T000469
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Charlie Crist
+  party: majority
+  rank: 5
+  bioguide: C001111
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Sean Casten
+  party: majority
   rank: 6
-  bioguide: J000126
-  title: Ex Officio
+  bioguide: C001117
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Ben McAdams
+  party: majority
+  rank: 7
+  bioguide: M001209
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Donald S. Beyer, Jr.
+  party: majority
+  rank: 8
+  bioguide: B001292
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+HSSY20:
+- name: Conor Lamb
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000588
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Daniel Lipinski
+  party: majority
+  rank: 2
+  bioguide: L000563
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Lizzie Fletcher
+  party: majority
+  rank: 3
+  bioguide: F000468
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Haley M. Stevens
+  party: majority
+  rank: 4
+  bioguide: S001215
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Kendra S. Horn
+  party: majority
+  rank: 5
+  bioguide: H001083
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Jerry McNerney
+  party: majority
+  rank: 6
+  bioguide: M001166
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Bill Foster
+  party: majority
+  rank: 7
+  bioguide: F000454
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Sean Casten
+  party: majority
+  rank: 8
+  bioguide: C001117
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+HSSY21:
+- name: Mikie Sherrill
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: S001207
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Suzanne Bonamici
+  party: majority
+  rank: 2
+  bioguide: B001278
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Steve Cohen
+  party: majority
+  rank: 3
+  bioguide: C001068
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Donald S. Beyer, Jr.
+  party: majority
+  rank: 4
+  bioguide: B001292
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
+- name: Jennifer Wexton
+  party: majority
+  rank: 5
+  bioguide: W000825
+  start_date: '2019-01-30'
+  source: https://science.house.gov/news/press-releases/science-committee-organizes-democratic-caucus-116th-congress
 HSVR:
 - name: David P. Roe
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000582
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
+- name: Gus M. Bilirakis
+  party: minority
+  rank: 2
+  bioguide: B001257
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Aumua Amata Coleman Radewagen
+  party: minority
+  rank: 3
+  bioguide: R000600
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mike Bost
+  party: minority
+  rank: 4
+  bioguide: B001295
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Neal P. Dunn
+  party: minority
+  rank: 5
+  bioguide: D000628
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jack Bergman
+  party: minority
+  rank: 6
+  bioguide: B001301
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Jim Banks
+  party: minority
+  rank: 7
+  bioguide: B001299
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Andy Barr
+  party: minority
+  rank: 8
+  bioguide: B001282
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Daniel Meuser
+  party: minority
+  rank: 9
+  bioguide: M001204
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Steven C. Watkins
+  party: minority
+  rank: 10
+  bioguide: W000824
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Chip Roy
+  party: minority
+  rank: 11
+  bioguide: R000614
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: W. Gregory Steube
+  party: minority
+  rank: 12
+  bioguide: S001214
+  start_date: '2019-01-23'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/68/text
+- name: Mark Takano
   party: majority
   rank: 1
   title: Chair
-  bioguide: R000582
-- name: Gus M. Bilirakis
+  bioguide: T000472
+  start_date: '2019-01-04'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/24/text
+- name: Julia Brownley
   party: majority
   rank: 2
-  bioguide: B001257
-- name: Bill Flores
+  bioguide: B001285
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Kathleen M. Rice
+  party: majority
+  rank: 3
+  bioguide: R000602
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Conor Lamb
   party: majority
   rank: 4
-  bioguide: F000461
-- name: Aumua Amata Coleman Radewagen
+  title: Vice Chair
+  bioguide: L000588
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Mike Levin
   party: majority
   rank: 5
-  bioguide: R000600
-- name: Mike Bost
+  bioguide: L000593
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Anthony Brindisi
   party: majority
   rank: 6
-  bioguide: B001295
-- name: Neal P. Dunn
+  bioguide: B001308
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Max Rose
+  party: majority
+  rank: 7
+  bioguide: R000613
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Chris Pappas
   party: majority
   rank: 8
-  bioguide: D000628
-- name: Jodey C. Arrington
+  bioguide: P000614
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Elaine G. Luria
   party: majority
   rank: 9
-  bioguide: A000375
-- name: Clay Higgins
+  bioguide: L000591
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Susie Lee
   party: majority
   rank: 10
-  bioguide: H001077
-- name: Jack Bergman
+  bioguide: L000590
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Joe Cunningham
   party: majority
   rank: 11
-  bioguide: B001301
-- name: Jim Banks
+  bioguide: C001122
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Gil Cisneros
   party: majority
   rank: 12
-  bioguide: B001299
-- name: Jenniffer González-Colón
+  bioguide: C001123
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Collin C. Peterson
   party: majority
   rank: 13
-  bioguide: G000582
-- name: Brian J. Mast
+  bioguide: P000258
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Gregorio Kilili Camacho Sablan
   party: majority
   rank: 14
-  bioguide: M001199
-- name: Mark Takano
-  party: minority
-  rank: 2
-  bioguide: T000472
-- name: Julia Brownley
-  party: minority
-  rank: 3
-  bioguide: B001285
-- name: Ann M. Kuster
-  party: minority
-  rank: 4
-  bioguide: K000382
-- name: Kathleen M. Rice
-  party: minority
-  rank: 6
-  bioguide: R000602
-- name: J. Luis Correa
-  party: minority
-  rank: 7
-  bioguide: C001110
-- name: Conor Lamb
-  party: minority
-  rank: 8
-  bioguide: L000588
-- name: Scott H. Peters
-  party: minority
-  rank: 10
-  bioguide: P000608
+  bioguide: S001177
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Colin Allred
+  party: majority
+  rank: 15
+  bioguide: A000376
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
+- name: Lauren Underwood
+  party: majority
+  rank: 16
+  bioguide: U000040
+  start_date: '2019-01-17'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/57/text
 HSVR03:
 - name: Neal P. Dunn
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: D000628
-- name: Gus M. Bilirakis
-  party: majority
-  rank: 2
-  bioguide: B001257
-- name: Bill Flores
-  party: majority
-  rank: 3
-  bioguide: F000461
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 4
-  bioguide: R000600
-- name: Clay Higgins
-  party: majority
-  rank: 5
-  bioguide: H001077
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 6
-  bioguide: G000582
-- name: Brian J. Mast
-  party: majority
-  rank: 7
-  bioguide: M001199
-- name: Julia Brownley
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: D000628
+  start_date: '2019-01-30'
+  source: https://republicans-veterans.house.gov/news/documentsingle.aspx?DocumentID=2330
+- name: Julia Brownley
+  party: majority
+  rank: 1
+  title: Chair
   bioguide: B001285
-- name: Mark Takano
-  party: minority
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Conor Lamb
+  party: majority
   rank: 2
-  bioguide: T000472
-- name: Ann M. Kuster
-  party: minority
-  rank: 3
-  bioguide: K000382
-- name: J. Luis Correa
-  party: minority
+  bioguide: L000588
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Mike Levin
+  party: majority
   rank: 5
-  bioguide: C001110
+  bioguide: L000593
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Anthony Brindisi
+  party: majority
+  rank: 4
+  bioguide: B001308
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Max Rose
+  party: majority
+  rank: 5
+  bioguide: R000613
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Gil Cisneros
+  party: majority
+  rank: 6
+  bioguide: C001123
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Collin C. Peterson
+  party: majority
+  rank: 7
+  bioguide: P000258
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
 HSVR08:
 - name: Jack Bergman
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: B001301
-- name: Mike Bost
-  party: majority
-  rank: 2
-  bioguide: B001295
-- name: Neal P. Dunn
-  party: majority
-  rank: 4
-  bioguide: D000628
-- name: Jodey C. Arrington
-  party: majority
-  rank: 5
-  bioguide: A000375
-- name: Jenniffer González-Colón
-  party: majority
-  rank: 6
-  bioguide: G000582
-- name: Ann M. Kuster
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: K000382
+  bioguide: B001301
+  start_date: '2019-01-30'
+  source: https://republicans-veterans.house.gov/news/documentsingle.aspx?DocumentID=2330
+- name: Chris Pappas
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: P000614
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
 - name: Kathleen M. Rice
-  party: minority
+  party: majority
   rank: 2
   bioguide: R000602
-- name: Scott H. Peters
-  party: minority
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Max Rose
+  party: majority
   rank: 3
-  bioguide: P000608
-- name: Conor Lamb
-  party: minority
+  bioguide: R000613
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Gil Cisneros
+  party: majority
   rank: 4
-  bioguide: L000588
+  bioguide: C001123
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Collin C. Peterson
+  party: majority
+  rank: 5
+  bioguide: P000258
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
 HSVR09:
 - name: Mike Bost
-  party: majority
+  party: minority
   rank: 1
-  title: Chair
+  title: Ranking Member
   bioguide: B001295
-- name: Aumua Amata Coleman Radewagen
-  party: majority
-  rank: 3
-  bioguide: R000600
-- name: Jack Bergman
-  party: majority
-  rank: 4
-  bioguide: B001301
-- name: Jim Banks
-  party: majority
-  rank: 5
-  bioguide: B001299
-- name: Julia Brownley
-  party: minority
-  rank: 2
-  bioguide: B001285
-- name: Conor Lamb
-  party: minority
-  rank: 3
-  bioguide: L000588
-HSVR10:
-- name: Jodey C. Arrington
+  start_date: '2019-01-30'
+  source: https://republicans-veterans.house.gov/news/documentsingle.aspx?DocumentID=2330
+- name: Elaine G. Luria
   party: majority
   rank: 1
   title: Chair
-  bioguide: A000375
-- name: Gus M. Bilirakis
+  bioguide: L000591
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Gil Cisneros
   party: majority
   rank: 2
-  bioguide: B001257
-- name: Bill Flores
+  bioguide: C001123
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Gregorio Kilili Camacho Sablan
   party: majority
   rank: 3
-  bioguide: F000461
-- name: Jim Banks
+  bioguide: S001177
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Colin Allred
   party: majority
   rank: 4
-  bioguide: B001299
-- name: Brian J. Mast
+  bioguide: A000376
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Lauren Underwood
   party: majority
   rank: 5
-  bioguide: M001199
-- name: Mark Takano
+  bioguide: U000040
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+HSVR10:
+- name: Gus M. Bilirakis
   party: minority
-  rank: 2
-  bioguide: T000472
-- name: J. Luis Correa
-  party: minority
-  rank: 3
-  bioguide: C001110
+  rank: 1
+  title: Ranking Member
+  bioguide: B001257
+  start_date: '2019-01-30'
+  source: https://republicans-veterans.house.gov/news/documentsingle.aspx?DocumentID=2330
+- name: Mike Levin
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000593
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
 - name: Kathleen M. Rice
-  party: minority
-  rank: 4
+  party: majority
+  rank: 2
   bioguide: R000602
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Anthony Brindisi
+  party: majority
+  rank: 3
+  bioguide: B001308
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Chris Pappas
+  party: majority
+  rank: 4
+  bioguide: P000614
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Elaine G. Luria
+  party: majority
+  rank: 5
+  bioguide: L000591
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Susie Lee
+  party: majority
+  rank: 6
+  bioguide: L000590
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Joe Cunningham
+  party: majority
+  rank: 7
+  bioguide: C001122
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
 HSVR11:
 - name: Jim Banks
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: B001299
-- name: Jack Bergman
-  party: majority
-  rank: 3
-  bioguide: B001301
-- name: Conor Lamb
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: L000588
-- name: Scott H. Peters
-  party: minority
+  bioguide: B001299
+  start_date: '2019-01-30'
+  source: https://republicans-veterans.house.gov/news/documentsingle.aspx?DocumentID=2330
+- name: Susie Lee
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000590
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Julia Brownley
+  party: majority
   rank: 2
-  bioguide: P000608
+  bioguide: B001285
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Conor Lamb
+  party: majority
+  rank: 3
+  bioguide: L000588
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
+- name: Joe Cunningham
+  party: majority
+  rank: 4
+  bioguide: C001122
+  start_date: '2019-01-31'
+  source: https://veterans.house.gov/news/press-releases/chairman-takano-announces-vice-chair-subcommittee-assignments-116th-congress
 HSWM:
 - name: Kevin Brady
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: B000755
-- name: Devin Nunes
-  party: majority
-  rank: 3
-  bioguide: N000181
-- name: Vern Buchanan
-  party: majority
-  rank: 6
-  bioguide: B001260
-- name: Adrian Smith
-  party: majority
-  rank: 7
-  bioguide: S001172
-- name: Kenny Marchant
-  party: majority
-  rank: 10
-  bioguide: M001158
-- name: Tom Reed
-  party: majority
-  rank: 12
-  bioguide: R000585
-- name: Mike Kelly
-  party: majority
-  rank: 13
-  bioguide: K000376
-- name: George Holding
-  party: majority
-  rank: 16
-  bioguide: H001065
-- name: Jason Smith
-  party: majority
-  rank: 17
-  bioguide: S001195
-- name: Tom Rice
-  party: majority
-  rank: 18
-  bioguide: R000597
-- name: David Schweikert
-  party: majority
-  rank: 19
-  bioguide: S001183
-- name: Jackie Walorski
-  party: majority
-  rank: 20
-  bioguide: W000813
-- name: Darin LaHood
-  party: majority
-  rank: 23
-  bioguide: L000585
-- name: Brad R. Wenstrup
-  party: majority
-  rank: 24
-  bioguide: W000815
-- name: Richard E. Neal
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: N000015
-- name: John Lewis
+  bioguide: B000755
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/8/text
+- name: Devin Nunes
+  party: minority
+  rank: 2
+  bioguide: N000181
+- name: Vern Buchanan
   party: minority
   rank: 3
-  bioguide: L000287
-- name: Lloyd Doggett
+  bioguide: B001260
+- name: Adrian Smith
   party: minority
   rank: 4
-  bioguide: D000399
-- name: Mike Thompson
+  bioguide: S001172
+- name: Kenny Marchant
   party: minority
   rank: 5
-  bioguide: T000460
-- name: John B. Larson
+  bioguide: M001158
+- name: Tom Reed
   party: minority
   rank: 6
-  bioguide: L000557
-- name: Earl Blumenauer
+  bioguide: R000585
+- name: Mike Kelly
   party: minority
   rank: 7
-  bioguide: B000574
-- name: Ron Kind
+  bioguide: K000376
+- name: George Holding
   party: minority
   rank: 8
-  bioguide: K000188
-- name: Bill Pascrell, Jr.
+  bioguide: H001065
+- name: Jason Smith
   party: minority
   rank: 9
-  bioguide: P000096
-- name: Danny K. Davis
+  bioguide: S001195
+- name: Tom Rice
+  party: minority
+  rank: 10
+  bioguide: R000597
+- name: David Schweikert
   party: minority
   rank: 11
-  bioguide: D000096
-- name: Linda T. Sánchez
+  bioguide: S001183
+- name: Jackie Walorski
   party: minority
   rank: 12
-  bioguide: S001156
-- name: Brian Higgins
+  bioguide: W000813
+- name: Darin LaHood
   party: minority
   rank: 13
-  bioguide: H001038
-- name: Terri A. Sewell
+  bioguide: L000585
+- name: Brad R. Wenstrup
   party: minority
   rank: 14
-  bioguide: S001185
-- name: Suzan K. DelBene
+  bioguide: W000815
+- name: Jodey C. Arrington
   party: minority
   rank: 15
-  bioguide: D000617
-- name: Judy Chu
+  bioguide: A000375
+- name: A. Drew Ferguson IV
   party: minority
   rank: 16
-  bioguide: C001080
-HSWM01:
-- name: Vern Buchanan
-  party: majority
-  rank: 3
-  bioguide: B001260
-- name: Mike Kelly
-  party: majority
-  rank: 4
-  bioguide: K000376
-- name: Tom Rice
-  party: majority
-  rank: 5
-  bioguide: R000597
-- name: David Schweikert
-  party: majority
-  rank: 6
-  bioguide: S001183
-- name: Darin LaHood
-  party: majority
-  rank: 7
-  bioguide: L000585
-- name: John B. Larson
+  bioguide: F000465
+- name: Ron Estes
   party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: L000557
-- name: Bill Pascrell, Jr.
-  party: minority
-  rank: 2
-  bioguide: P000096
-- name: Linda T. Sánchez
-  party: minority
-  rank: 4
-  bioguide: S001156
-HSWM02:
-- name: Devin Nunes
-  party: majority
-  rank: 3
-  bioguide: N000181
-- name: Vern Buchanan
-  party: majority
-  rank: 4
-  bioguide: B001260
-- name: Adrian Smith
-  party: majority
-  rank: 5
-  bioguide: S001172
-- name: Kenny Marchant
-  party: majority
-  rank: 7
-  bioguide: M001158
-- name: Tom Reed
-  party: majority
-  rank: 10
-  bioguide: R000585
-- name: Mike Kelly
-  party: majority
-  rank: 11
-  bioguide: K000376
-- name: Mike Thompson
-  party: minority
-  rank: 2
-  bioguide: T000460
-- name: Ron Kind
-  party: minority
-  rank: 3
-  bioguide: K000188
-- name: Earl Blumenauer
-  party: minority
-  rank: 4
-  bioguide: B000574
-- name: Brian Higgins
-  party: minority
-  rank: 5
-  bioguide: H001038
-- name: Terri A. Sewell
-  party: minority
-  rank: 6
-  bioguide: S001185
-- name: Judy Chu
-  party: minority
-  rank: 7
-  bioguide: C001080
-HSWM03:
-- name: Adrian Smith
+  rank: 17
+  bioguide: E000298
+- name: Richard E. Neal
   party: majority
   rank: 1
   title: Chair
-  bioguide: S001172
-- name: Jackie Walorski
+  bioguide: N000015
+  start_date: '2019-01-03'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/7/text
+- name: John Lewis
   party: majority
   rank: 2
-  bioguide: W000813
-- name: David Schweikert
+  bioguide: L000287
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Lloyd Doggett
+  party: majority
+  rank: 3
+  bioguide: D000399
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Mike Thompson
   party: majority
   rank: 4
-  bioguide: S001183
-- name: Darin LaHood
+  bioguide: T000460
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: John B. Larson
   party: majority
   rank: 5
-  bioguide: L000585
-- name: Brad R. Wenstrup
+  bioguide: L000557
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Earl Blumenauer
   party: majority
   rank: 6
-  bioguide: W000815
-- name: Danny K. Davis
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: D000096
-- name: Lloyd Doggett
-  party: minority
-  rank: 2
-  bioguide: D000399
-- name: Terri A. Sewell
-  party: minority
-  rank: 3
-  bioguide: S001185
-- name: Judy Chu
-  party: minority
-  rank: 4
-  bioguide: C001080
-HSWM04:
-- name: Devin Nunes
-  party: majority
-  rank: 2
-  bioguide: N000181
-- name: Mike Kelly
-  party: majority
-  rank: 4
-  bioguide: K000376
-- name: Tom Reed
-  party: majority
-  rank: 5
-  bioguide: R000585
-- name: George Holding
+  bioguide: B000574
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Ron Kind
   party: majority
   rank: 7
-  bioguide: H001065
-- name: Tom Rice
+  bioguide: K000188
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Bill Pascrell, Jr.
   party: majority
   rank: 8
-  bioguide: R000597
-- name: Kenny Marchant
+  bioguide: P000096
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Danny K. Davis
   party: majority
   rank: 9
-  bioguide: M001158
-- name: Jason Smith
+  bioguide: D000096
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Linda T. Sánchez
   party: majority
   rank: 10
-  bioguide: S001195
-- name: Bill Pascrell, Jr.
+  bioguide: S001156
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Brian Higgins
+  party: majority
+  rank: 11
+  bioguide: H001038
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Terri A. Sewell
+  party: majority
+  rank: 12
+  bioguide: S001185
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Suzan K. DelBene
+  party: majority
+  rank: 13
+  bioguide: D000617
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Judy Chu
+  party: majority
+  rank: 14
+  bioguide: C001080
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Gwen Moore
+  party: majority
+  rank: 15
+  bioguide: M001160
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Daniel T. Kildee
+  party: majority
+  rank: 16
+  bioguide: K000380
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Brendan F. Boyle
+  party: majority
+  rank: 17
+  bioguide: B001296
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Donald S. Beyer, Jr.
+  party: majority
+  rank: 18
+  bioguide: B001292
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Dwight Evans
+  party: majority
+  rank: 19
+  bioguide: E000296
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Bradley Scott Schneider
+  party: majority
+  rank: 20
+  bioguide: S001190
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Thomas R. Suozzi
+  party: majority
+  rank: 21
+  bioguide: S001201
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jimmy Panetta
+  party: majority
+  rank: 22
+  bioguide: P000613
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Stephanie N. Murphy
+  party: majority
+  rank: 23
+  bioguide: M001202
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Jimmy Gomez
+  party: majority
+  rank: 24
+  bioguide: G000585
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+- name: Steven Horsford
+  party: majority
+  rank: 25
+  bioguide: H001066
+  start_date: '2019-01-15'
+  source: https://www.congress.gov/bill/116th-congress/house-resolution/42/text
+HSWM01:
+- name: Tom Reed
   party: minority
   rank: 1
   title: Ranking Member
-  bioguide: P000096
-- name: Ron Kind
+  bioguide: R000585
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Jodey C. Arrington
   party: minority
   rank: 2
-  bioguide: K000188
-- name: Lloyd Doggett
+  bioguide: A000375
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: A. Drew Ferguson IV
   party: minority
   rank: 3
-  bioguide: D000399
-- name: Danny K. Davis
+  bioguide: F000465
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Ron Estes
+  party: minority
+  rank: 4
+  bioguide: E000298
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: John B. Larson
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: L000557
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Bill Pascrell, Jr.
+  party: majority
+  rank: 2
+  bioguide: P000096
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Linda T. Sánchez
+  party: majority
+  rank: 3
+  bioguide: S001156
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Brian Higgins
+  party: majority
+  rank: 4
+  bioguide: H001038
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Daniel T. Kildee
+  party: majority
+  rank: 5
+  bioguide: K000380
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Brendan F. Boyle
+  party: majority
+  rank: 6
+  bioguide: B001296
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Bradley Scott Schneider
+  party: majority
+  rank: 7
+  bioguide: S001190
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+HSWM02:
+- name: Devin Nunes
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: N000181
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Vern Buchanan
+  party: minority
+  rank: 2
+  bioguide: B001260
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Adrian Smith
+  party: minority
+  rank: 3
+  bioguide: S001172
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Kenny Marchant
+  party: minority
+  rank: 4
+  bioguide: M001158
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Tom Reed
   party: minority
   rank: 5
-  bioguide: D000096
-- name: Brian Higgins
+  bioguide: R000585
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Mike Kelly
   party: minority
   rank: 6
+  bioguide: K000376
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: George Holding
+  party: minority
+  rank: 7
+  bioguide: H001065
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Lloyd Doggett
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000399
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Mike Thompson
+  party: majority
+  rank: 2
+  bioguide: T000460
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Earl Blumenauer
+  party: majority
+  rank: 3
+  bioguide: B000574
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Ron Kind
+  party: majority
+  rank: 4
+  bioguide: K000188
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Brian Higgins
+  party: majority
+  rank: 5
   bioguide: H001038
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Terri A. Sewell
+  party: majority
+  rank: 6
+  bioguide: S001185
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Judy Chu
+  party: majority
+  rank: 7
+  bioguide: C001080
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Dwight Evans
+  party: majority
+  rank: 8
+  bioguide: E000296
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Bradley Scott Schneider
+  party: majority
+  rank: 9
+  bioguide: S001190
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Jimmy Gomez
+  party: majority
+  rank: 10
+  bioguide: G000585
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Steven Horsford
+  party: majority
+  rank: 11
+  bioguide: H001066
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+HSWM03:
+- name: Jackie Walorski
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000813
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Brad R. Wenstrup
+  party: minority
+  rank: 2
+  bioguide: W000815
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Ron Estes
+  party: minority
+  rank: 3
+  bioguide: E000298
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Darin LaHood
+  party: minority
+  rank: 4
+  bioguide: L000585
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Danny K. Davis
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: D000096
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Judy Chu
+  party: majority
+  rank: 2
+  bioguide: C001080
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Terri A. Sewell
+  party: majority
+  rank: 3
+  bioguide: S001185
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Gwen Moore
+  party: majority
+  rank: 4
+  bioguide: M001160
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Dwight Evans
+  party: majority
+  rank: 5
+  bioguide: E000296
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Stephanie N. Murphy
+  party: majority
+  rank: 6
+  bioguide: M001202
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Jimmy Gomez
+  party: majority
+  rank: 7
+  bioguide: G000585
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+HSWM04:
+- name: Vern Buchanan
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001260
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Devin Nunes
+  party: minority
+  rank: 2
+  bioguide: N000181
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: George Holding
+  party: minority
+  rank: 3
+  bioguide: H001065
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Tom Rice
+  party: minority
+  rank: 4
+  bioguide: R000597
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Kenny Marchant
+  party: minority
+  rank: 5
+  bioguide: M001158
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Jason Smith
+  party: minority
+  rank: 6
+  bioguide: S001195
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: David Schweikert
+  party: minority
+  rank: 7
+  bioguide: S001183
+  start_date: '2019-01-16'
+  source: https://gop-waysandmeans.house.gov/brady-announces-ways-and-means-republican-subcommittee-leaders-for-116th-congress/
+- name: Earl Blumenauer
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: B000574
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Bill Pascrell, Jr.
+  party: majority
+  rank: 2
+  bioguide: P000096
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Ron Kind
+  party: majority
+  rank: 3
+  bioguide: K000188
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Danny K. Davis
+  party: majority
+  rank: 4
+  bioguide: D000096
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Brian Higgins
+  party: majority
+  rank: 5
+  bioguide: H001038
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Terri A. Sewell
+  party: majority
+  rank: 6
+  bioguide: S001185
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Suzan K. DelBene
+  party: majority
+  rank: 7
+  bioguide: D000617
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Donald S. Beyer, Jr.
+  party: majority
+  rank: 8
+  bioguide: B001292
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Daniel T. Kildee
+  party: majority
+  rank: 9
+  bioguide: K000380
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Jimmy Panetta
+  party: majority
+  rank: 10
+  bioguide: P000613
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
+- name: Stephanie N. Murphy
+  party: majority
+  rank: 11
+  bioguide: M001202
+  start_date: '2019-01-16'
+  source: https://waysandmeans.house.gov/media-center/press-releases/neal-announces-ways-means-subcommittees-members-and-chairs
 HSWM05:
 - name: Vern Buchanan
   party: majority

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -1402,30 +1402,62 @@ HSAP01:
   rank: 1
   title: Chair
   bioguide: B000490
+  source: https://appropriations.house.gov/subcommittees/agriculture-rural-development-food-and-drug-administration-and-related-agencies-116th
 - name: Rosa L. DeLauro
   party: majority
   rank: 2
   bioguide: D000216
+  source: https://appropriations.house.gov/subcommittees/agriculture-rural-development-food-and-drug-administration-and-related-agencies-116th
 - name: Chellie Pingree
   party: majority
   rank: 3
   bioguide: P000597
+  source: https://appropriations.house.gov/subcommittees/agriculture-rural-development-food-and-drug-administration-and-related-agencies-116th
 - name: Mark Pocan
   party: majority
   rank: 4
   bioguide: P000607
+  source: https://appropriations.house.gov/subcommittees/agriculture-rural-development-food-and-drug-administration-and-related-agencies-116th
 - name: Barbara Lee
   party: majority
   rank: 5
   bioguide: L000551
+  source: https://appropriations.house.gov/subcommittees/agriculture-rural-development-food-and-drug-administration-and-related-agencies-116th
 - name: Betty McCollum
   party: majority
   rank: 6
   bioguide: M001143
+  source: https://appropriations.house.gov/subcommittees/agriculture-rural-development-food-and-drug-administration-and-related-agencies-116th
 - name: Henry Cuellar
   party: majority
   rank: 7
   bioguide: C001063
+  source: https://appropriations.house.gov/subcommittees/agriculture-rural-development-food-and-drug-administration-and-related-agencies-116th
+- name: Jeff Fortenberry
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: F000449
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Robert B. Aderholt
+  party: minority
+  rank: 2
+  bioguide: A000055
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Andy Harris
+  party: minority
+  rank: 3
+  bioguide: H001052
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: John R. Moolenaar
+  party: minority
+  rank: 4
+  bioguide: M001194
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP02:
 - name: Peter J. Visclosky
   party: majority
@@ -1472,6 +1504,49 @@ HSAP02:
   party: majority
   rank: 11
   bioguide: K000368
+- name: Ken Calvert
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C000059
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Harold Rogers
+  party: minority
+  rank: 2
+  bioguide: R000395
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Tom Cole
+  party: minority
+  rank: 3
+  bioguide: C001053
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Steve Womack
+  party: minority
+  rank: 4
+  bioguide: W000809
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Robert B. Aderholt
+  party: minority
+  rank: 5
+  bioguide: A000055
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: John R. Carter
+  party: minority
+  rank: 6
+  bioguide: C001051
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Mario Diaz-Balart
+  party: minority
+  rank: 7
+  bioguide: D000600
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP04:
 - name: Nita M. Lowey
   party: majority
@@ -1498,6 +1573,25 @@ HSAP04:
   party: majority
   rank: 6
   bioguide: T000474
+- name: Harold Rogers
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000395
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Jeff Fortenberry
+  party: minority
+  rank: 2
+  bioguide: F000449
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Martha Roby
+  party: minority
+  rank: 3
+  bioguide: R000591
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP06:
 - name: Betty McCollum
   party: majority
@@ -1528,6 +1622,31 @@ HSAP06:
   party: majority
   rank: 7
   bioguide: L000581
+- name: David P. Joyce
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: J000295
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Michael K. Simpson
+  party: minority
+  rank: 2
+  bioguide: S001148
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Chris Stewart
+  party: minority
+  rank: 3
+  bioguide: S001192
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Mark E. Amodei
+  party: minority
+  rank: 4
+  bioguide: A000369
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP07:
 - name: Rosa L. DeLauro
   party: majority
@@ -1562,6 +1681,37 @@ HSAP07:
   party: majority
   rank: 8
   bioguide: W000822
+- name: Tom Cole
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001053
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Andy Harris
+  party: minority
+  rank: 2
+  bioguide: H001052
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Jaime Herrera Beutler
+  party: minority
+  rank: 3
+  bioguide: H001056
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: John R. Moolenaar
+  party: minority
+  rank: 4
+  bioguide: M001194
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Tom Graves
+  party: minority
+  rank: 5
+  bioguide: G000560
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP10:
 - name: Marcy Kaptur
   party: majority
@@ -1592,6 +1742,31 @@ HSAP10:
   party: majority
   rank: 7
   bioguide: F000462
+- name: Michael K. Simpson
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001148
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Ken Calvert
+  party: minority
+  rank: 2
+  bioguide: C000059
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Charles J. "Chuck" Fleischmann
+  party: minority
+  rank: 3
+  bioguide: F000459
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Dan Newhouse
+  party: minority
+  rank: 4
+  bioguide: N000189
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP15:
 - name: Lucille Roybal-Allard
   party: majority
@@ -1622,6 +1797,31 @@ HSAP15:
   party: majority
   rank: 7
   bioguide: A000371
+- name: Charles J. "Chuck" Fleischmann
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: F000459
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Steven M. Palazzo
+  party: minority
+  rank: 2
+  bioguide: P000601
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Dan Newhouse
+  party: minority
+  rank: 3
+  bioguide: N000189
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: John H. Rutherford
+  party: minority
+  rank: 4
+  bioguide: R000609
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP18:
 - name: Debbie Wasserman Schultz
   party: majority
@@ -1652,6 +1852,31 @@ HSAP18:
   party: majority
   rank: 7
   bioguide: B001286
+- name: John R. Carter
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001051
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Martha Roby
+  party: minority
+  rank: 2
+  bioguide: R000591
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: John H. Rutherford
+  party: minority
+  rank: 3
+  bioguide: R000609
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Will Hurd
+  party: minority
+  rank: 4
+  bioguide: H001073
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP19:
 - name: José E. Serrano
   party: majority
@@ -1682,12 +1907,57 @@ HSAP19:
   party: majority
   rank: 7
   bioguide: K000009
+- name: Robert B. Aderholt
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: A000055
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Martha Roby
+  party: minority
+  rank: 2
+  bioguide: R000591
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Steven M. Palazzo
+  party: minority
+  rank: 3
+  bioguide: P000601
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Tom Graves
+  party: minority
+  rank: 4
+  bioguide: G000560
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP20:
 - name: Mario Diaz-Balart
   party: minority
   rank: 1
   title: Ranking Member
   bioguide: D000600
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Steve Womack
+  party: minority
+  rank: 2
+  bioguide: W000809
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: John H. Rutherford
+  party: minority
+  rank: 3
+  bioguide: R000609
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Will Hurd
+  party: minority
+  rank: 4
+  bioguide: H001073
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 - name: David E. Price
   party: majority
   rank: 1
@@ -1747,6 +2017,31 @@ HSAP23:
   party: majority
   rank: 7
   bioguide: K000368
+- name: Tom Graves
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000560
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Mark E. Amodei
+  party: minority
+  rank: 2
+  bioguide: A000369
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Chris Stewart
+  party: minority
+  rank: 3
+  bioguide: S001192
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: David P. Joyce
+  party: minority
+  rank: 4
+  bioguide: J000295
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAP24:
 - name: Tim Ryan
   party: majority
@@ -1765,6 +2060,19 @@ HSAP24:
   party: majority
   rank: 4
   bioguide: C001055
+- name: Jaime Herrera Beutler
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: H001056
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
+- name: Dan Newhouse
+  party: minority
+  rank: 2
+  bioguide: N000189
+  start_date: '2019-01-29'
+  source: https://republicans-appropriations.house.gov/news/documentsingle.aspx?DocumentID=395471
 HSAS:
 - name: Mac Thornberry
   party: minority

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -1266,8 +1266,6 @@
   - name: Children and Families
     thomas_id: '09'
     wikipedia: United States Senate Health Subcommittee on Children and Families
-  rss_url: http://www.help.senate.gov/rss/feed/chair/
-  minority_rss_url: http://www.help.senate.gov/rss/feed/ranking/
   wikipedia: United States Senate Committee on Health, Education, Labor, and Pensions
   jurisdiction: The Senate Committee on Health, Education, Labor, and Pensions has
     jurisdiction over most of the agencies, institutes, and programs of the Department
@@ -1335,7 +1333,6 @@
   url: http://www.sbc.senate.gov/
   thomas_id: SSSB
   senate_committee_id: SSSB
-  rss_url: http://www.sbc.senate.gov/public/?a=RSS.Feed
   wikipedia: United States Senate Committee on Small Business and Entrepreneurship
   jurisdiction: The Senate Committee on Small Business and Entrepreneurship has legislative
     jurisdiction over the Small Business Administration (SBA). The SBA is an independent

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -522,7 +522,7 @@
 - type: house
   name: House Committee on Transportation and Infrastructure
   url: https://transportation.house.gov/
-  minority_url: https://democrats-transportation.house.gov/
+  minority_url: https://republicans-transportation.house.gov/
   thomas_id: HSPW
   house_committee_id: PW
   subcommittees:
@@ -552,8 +552,6 @@
     phone: (202) 225-4360
   address: 2165 RHOB; Washington, DC 20515-6256
   phone: (202) 225-9446
-  rss_url: https://transportation.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-transportation.house.gov/rss.xml
   jurisdiction: 'The Transportation and Infrastructure Committee has jurisdiction
     over all modes of transportation: aviation, maritime and waterborne transportation,
     highways, bridges, mass transit, and railroads. The Committee also has jurisdiction
@@ -566,7 +564,7 @@
 - type: house
   name: House Committee on Rules
   url: https://rules.house.gov/
-  minority_url: https://democrats-rules.house.gov/
+  minority_url: https://republicans-rules.house.gov/
   thomas_id: HSRU
   house_committee_id: RU
   subcommittees:
@@ -580,7 +578,6 @@
     phone: (202) 225-9191
   address: H312 CAPITOL; Washington, DC 20515-6269
   phone: (202) 225-9191
-  minority_rss_url: https://democrats-rules.house.gov/rss.xml
   jurisdiction: The House Committee on Rules is commonly known as “The Speaker’s Committee”
     because it is the mechanism that the Speaker uses to maintain control of the House
     Floor. Because of the vast power wielded by the Rules Committee, its ratio has
@@ -593,34 +590,32 @@
 - type: house
   name: House Committee on Small Business
   url: https://smallbusiness.house.gov/
-  minority_url: https://democrats-smallbusiness.house.gov/
+  minority_url: https://republicans-smallbusiness.house.gov/
   thomas_id: HSSM
   house_committee_id: SM
   subcommittees:
-  - name: Contracting and Workforce
+  - name: Contracting and Infrastructure
     thomas_id: '23'
-    address: 2361 RHOB; Washington, DC 20515
-    phone: (202) 225-5821
+    address: 2069 RHOB; Washington, DC 20515
+    phone: (202) 225-4038
   - name: Investigations, Oversight and Regulations
     thomas_id: '24'
-    address: 2361 RHOB; Washington, DC 20515
-    phone: (202) 225-5821
-  - name: Agriculture, Energy and Trade
+    address: 2069 RHOB; Washington, DC 20515
+    phone: (202) 225-4038
+  - name: Rural Development, Agriculture, Trade, and Entrepreneurship
     thomas_id: '25'
-    address: 2361 RHOB; Washington, DC 20515
-    phone: (202) 225-5821
+    address: 2069 RHOB; Washington, DC 20515
+    phone: (202) 225-4038
   - name: Health and Technology
     thomas_id: '26'
-    address: 2361 RHOB; Washington, DC 20515
-    phone: (202) 225-5821
+    address: 2069 RHOB; Washington, DC 20515
+    phone: (202) 225-4038
   - name: Economic Growth, Tax and Capital Access
     thomas_id: '27'
-    address: 2361 RHOB; Washington, DC 20515
-    phone: (202) 225-5821
-  address: 2361 RHOB; Washington, DC 20515-6315
-  phone: (202) 225-5821
-  rss_url: https://smallbusiness.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-smallbusiness.house.gov/rss.xml
+    address: 2069 RHOB; Washington, DC 20515
+    phone: (202) 225-4038
+  address: 2069 RHOB; Washington, DC 20515-6315
+  phone: (202) 225-4038
   jurisdiction: The House Small Business Committee was established to protect and
     assist small businesses.  As such, the Committee has jurisdiction over matters
     related to small business financial aid, regulatory flexibility, and paperwork
@@ -634,7 +629,6 @@
   house_committee_id: SO
   address: 1015 LHOB; Washington, DC 20515-6328
   phone: (202) 225-7103
-  rss_url: https://ethics.house.gov/rss.xml
   jurisdiction: The House Committee on Ethics has the jurisdiction to administer travel,
     gift, financial disclosure, outside income, and other regulations; advise members
     and staff; issue advisory opinions and investigate potential ethics violations.
@@ -646,7 +640,7 @@
 - type: house
   name: House Committee on Science, Space, and Technology
   url: https://science.house.gov/
-  minority_url: https://democrats-science.house.gov/
+  minority_url: https://republicans-science.house.gov/
   thomas_id: HSSY
   house_committee_id: SY
   subcommittees:
@@ -654,7 +648,7 @@
     thomas_id: '20'
     address: 2319 RHOB; Washington, DC 20515
     phone: (202) 225-6371
-  - name: Oversight
+  - name: Investigations and Oversight
     thomas_id: '21'
     address: 2321 RHOB; Washington, DC 20515
     phone: (202) 225-6371
@@ -671,9 +665,7 @@
     address: 4220 OHOB; Washington, DC 20515
     phone: (202) 225-6371
   address: 2321 RHOB; Washington, DC 20515-6301
-  phone: (202) 225-6371
-  rss_url: https://science.house.gov/rss.xml
-  minority_rss_url: https://democrats-science.house.gov/rss.xml
+  phone: (202) 225-6375
   jurisdiction: The Committee on Science, Space, and Technology has a jurisdiction
     over a range of matters related to energy research and development, federally
     owned or operated non-military energy laboratories, astronautical research and
@@ -686,34 +678,32 @@
 - type: house
   name: House Committee on Veterans' Affairs
   url: https://veterans.house.gov/
-  minority_url: https://democrats-veterans.house.gov/
+  minority_url: https://republicans-veterans.house.gov/
   thomas_id: HSVR
   house_committee_id: VR
   subcommittees:
   - name: Disability Assistance and Memorial Affairs
     thomas_id: '09'
-    address: 338 CHOB; Washington, DC 20515
-    phone: (202) 225-9164
+    address: 3460 OHOB; Washington, DC 20515
+    phone: (202) 225-9756
   - name: Economic Opportunity
     thomas_id: '10'
-    address: 335 CHOB; Washington, DC 20515
-    phone: (202) 226-5491
+    address: 3460 OHOB; Washington, DC 20515
+    phone: (202) 225-9756
   - name: Health
     thomas_id: '03'
-    address: 337 CHOB; Washington, DC 20515
-    phone: (202) 225-9154
+    address: 3460 OHOB; Washington, DC 20515
+    phone: (202) 225-9756
   - name: Oversight and Investigations
     thomas_id: '08'
-    address: 337A CHOB; Washington, DC 20515
-    phone: (202) 225-3569
+    address: 3460 OHOB; Washington, DC 20515
+    phone: (202) 225-9756
   - name: Technology Modernization
     thomas_id: '11'
-    address: 337A CHOB; Washington, DC 20515
-    phone: (202) 225-3569
-  address: 335 CHOB; Washington, DC 20515-6335
-  phone: (202) 225-3527
-  rss_url: https://veterans.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-veterans.house.gov/rss.xml
+    address: 3460 OHOB; Washington, DC 20515
+    phone: (202) 225-9756
+  address: 3460 OHOB; Washington, DC 20515
+  phone: (202) 225-9756
   jurisdiction: The House Committee on Veterans' Affairs is the authorizing committee
     for the Department of Veterans Affairs (VA). The committee is responsible for
     recommending legislation expanding, curtailing, or fine-tuning existing laws relating
@@ -725,7 +715,7 @@
 - type: house
   name: House Committee on Ways and Means
   url: https://waysandmeans.house.gov/
-  minority_url: https://democrats-waysandmeans.house.gov/
+  minority_url: https://gop-waysandmeans.house.gov/
   thomas_id: HSWM
   house_committee_id: WM
   subcommittees:
@@ -733,7 +723,7 @@
     thomas_id: '02'
     address: 1104 LHOB; Washington, DC 20515
     phone: (202) 225-3943
-  - name: Human Resources
+  - name: Worker and Family Support
     thomas_id: '03'
     address: 1129 LHOB; Washington, DC 20515
     phone: (202) 225-1025
@@ -741,7 +731,7 @@
     thomas_id: '06'
     address: 2018 RHOB; Washington, DC 20515
     phone: (202) 225-9263
-  - name: Tax Policy
+  - name: Select Revenue Measures
     thomas_id: '05'
     address: 1136 LHOB; Washington, DC 20515
     phone: (202) 225-5522
@@ -753,9 +743,8 @@
     thomas_id: '04'
     address: 1103 LHOB; Washington, DC 20515
     phone: (202) 225-6649
-  address: 1102 LHOB; Washington, DC 20515-6348
+  address: 1139E LHOB; Washington, DC 20515-6348
   phone: (202) 225-3625
-  minority_rss_url: https://democrats-waysandmeans.house.gov/rss.xml
   jurisdiction: The Committee on Ways and Means is the chief tax-writing committee
     in the House of Representatives. The Committee derives a large share of its jurisdiction
     from Article I, Section VII of the U.S. Constitution, which declares, “All Bills

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -1042,14 +1042,14 @@
     thomas_id: '20'
     wikipedia: United States Senate Commerce Subcommittee on Consumer Protection,
       Product Safety, and Insurance
-  - name: Oceans, Atmosphere, Fisheries, and Coast Guard
+  - name: Science, Oceans, Fisheries, and Weather
     thomas_id: '22'
     wikipedia: United States Senate Commerce Subcommittee on Oceans, Atmosphere, Fisheries,
       and Coast Guard
   - name: Space, Science, and Competitiveness
     thomas_id: '24'
     wikipedia: United States Senate Commerce Subcommittee on Science and Space
-  - name: Surface Transportation and Merchant Marine Infrastructure, Safety and Security
+  - name: Transportation and Safety
     thomas_id: '25'
     wikipedia: United States Senate Commerce Subcommittee on Surface Transportation
       and Merchant Marine Infrastructure, Safety, and Security

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -409,11 +409,11 @@
     thomas_id: '06'
     address: 1522 LHOB; Washington, DC 20515
     phone: (202) 225-9297
-  - name: Federal Lands
+  - name: National Parks, Forests, and Public Lands
     thomas_id: '10'
     address: 1332 LHOB; Washington, DC 20515
     phone: (202) 226-7736
-  - name: Water, Power and Oceans
+  - name: Water, Oceans, and Wildlife
     thomas_id: '13'
     address: 4120 OHOB; Washington, DC 20515
     phone: (202) 225-8331
@@ -421,7 +421,7 @@
     thomas_id: '22'
     address: 140 CHOB; Washington, DC 20515
     phone: (202) 226-0200
-  - name: Indian, Insular and Alaska Native Affairs
+  - name: Indigenous Peoples of the United States
     thomas_id: '24'
     address: 4450 OHOB; Washington, DC 20515
     phone: (202) 226-9725
@@ -431,8 +431,6 @@
     phone: (202) 225-7107
   address: 1324 LHOB; Washington, DC 20515-6201
   phone: (202) 225-2761
-  rss_url: https://naturalresources.house.gov/news.xml
-  minority_rss_url: https://democrats-naturalresources.house.gov/rss.xml
   jurisdiction: The House Committee on Natural Resources considers legislation about
     American energy production, mineral lands and mining, fisheries and wildlife,
     public lands, oceans, Native Americans, irrigation and reclamation.
@@ -486,11 +484,11 @@
 - type: house
   name: House Committee on the Judiciary
   url: https://judiciary.house.gov/
-  minority_url: https://democrats-judiciary.house.gov/
+  minority_url: https://republicans-judiciary.house.gov/
   thomas_id: HSJU
   house_committee_id: JU
   subcommittees:
-  - name: The Constitution and Civil Justice
+  - name: Constitution, Civil Rights and Civil Liberties
     thomas_id: '10'
     address: 362 FHOB; Washington, DC 20515
     phone: (202) 225-2825
@@ -498,19 +496,19 @@
     thomas_id: '03'
     address: 6310 OHOB; Washington, DC 20515
     phone: (202) 225-5741
-  - name: Crime, Terrorism, Homeland Security, and Investigations
+  - name: Crime, Terrorism, and Homeland Security
     thomas_id: '08'
     address: 6340 OHOB; Washington, DC 20515
     phone: (202) 225-5727
-  - name: Immigration and Border Security
+  - name: Immigration and Citizenship
     thomas_id: '01'
     address: 6320 OHOB; Washington, DC 20515
     phone: (202) 225-3926
-  - name: Regulatory Reform, Commercial and Antitrust Law
+  - name: Antitrust, Commercial and Administrative Law
     thomas_id: '05'
     address: 6240 OHOB; Washington, DC 20515
     phone: (202) 226-7680
-  address: 2138 RHOB; Washington, DC 20515-6216
+  address: 2141 RHOB; Washington, DC 20515-6216
   phone: (202) 225-3951
   minority_rss_url: https://democrats-judiciary.house.gov/rss.xml
   jurisdiction: The Committee on the Judiciary has jurisdiction over matters relating

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -306,7 +306,10 @@
   minority_url: https://republicans-cha.house.gov/
   thomas_id: HSHA
   house_committee_id: HA
-  address: 1316 LHOB; Washington, DC 20515-6157
+  subcommittees:
+  - name: Elections
+    address: 1309 LHOB; Washington, DC 20515-6157
+  address: 1309 LHOB; Washington, DC 20515-6157
   phone: (202) 225-2061
   jurisdiction: The Committee on House Administration has legislative jurisdiction
     over the federal elections and the day-to-day operations of the House. The Committee's

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -1,7 +1,7 @@
 - type: house
   name: House Committee on Agriculture
   url: https://agriculture.house.gov/
-  minority_url: https://democrats-agriculture.house.gov/
+  minority_url: https://republicans-agriculture.house.gov
   thomas_id: HSAG
   house_committee_id: AG
   subcommittees:
@@ -31,15 +31,13 @@
     phone: (202) 225-2171
   address: 1301 LHOB; Washington, DC 20515-6001
   phone: (202) 225-2171
-  rss_url: https://agriculture.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-agriculture.house.gov/Rss.aspx?GroupID=1
+  rss_url: https://agriculture.house.gov/Rss.aspx?GroupID=1
   jurisdiction: The House Committee on Agriculture has legislative jurisdiction over
     agriculture, food, rural development, and forestry.
-  jurisdiction_source: https://agriculture.house.gov/issuesinfocus/
 - type: house
   name: House Committee on Appropriations
   url: https://appropriations.house.gov/
-  minority_url: https://democrats-appropriations.house.gov
+  minority_url: https://republicans-appropriations.house.gov/
   thomas_id: HSAP
   house_committee_id: AP
   subcommittees:
@@ -94,8 +92,6 @@
     phone: (202) 225-2141
   address: H305 CAPITOL; Washington, DC 20515-6015
   phone: (202) 225-2771
-  rss_url: https://appropriations.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-appropriations.house.gov/rss.xml
   jurisdiction: The House Committee on Appropriations is responsible for legislation
     allocating federal funds prior to expenditure from the treasury. Appropriations
     are generally limited to the levels set by the Budget Resolution drafted by the
@@ -106,7 +102,7 @@
 - type: house
   name: House Committee on Armed Services
   url: https://armedservices.house.gov/
-  minority_url: https://democrats-armedservices.house.gov/
+  minority_url: https://republicans-armedservices.house.gov/
   thomas_id: HSAS
   house_committee_id: AS
   subcommittees:
@@ -118,10 +114,6 @@
     thomas_id: '02'
     address: 2340 RHOB; Washington, DC 20515
     phone: (202) 225-7560
-  - name: Oversight and Investigations
-    thomas_id: '06'
-    address: 2119 RHOB; Washington, DC 20515
-    phone: (202) 226-5048
   - name: Readiness
     thomas_id: '03'
     address: 2340 RHOB; Washington, DC 20515
@@ -134,29 +126,27 @@
     thomas_id: '29'
     address: 2340 RHOB; Washington, DC 20515
     phone: (202) 225-1967
-  - name: Emerging Threats and Capabilities
+  - name: Intelligence, Emerging Threats and Capabilities
     thomas_id: '26'
     address: 2340 RHOB; Washington, DC 20515
     phone: (202) 226-2843
   address: 2216 RHOB; Washington, DC 20515-6035
   phone: (202) 225-4151
-  rss_url: https://armedservices.house.gov/index.cfm/rss/feed
-  minority_rss_url: https://democrats-armedservices.house.gov/index.cfm/rss/feed
   jurisdiction: The House Committee on Armed Services has legislative jurisdiction
     over military and defense.
   jurisdiction_source: https://armedservices.house.gov/about
 - type: house
   name: House Committee on Financial Services
   url: https://financialservices.house.gov/
-  minority_url: https://democrats-financialservices.house.gov/
+  minority_url: https://republicans-financialservices.house.gov/
   thomas_id: HSBA
   house_committee_id: BA
   subcommittees:
-  - name: Capital Markets, Securities, and Investment
+  - name: Investor Protection, Entrepreneurship, and Capital Markets
     thomas_id: '16'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
-  - name: Financial Institutions and Consumer Credit
+  - name: Consumer Protection and Financial Institutions
     thomas_id: '15'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
@@ -164,7 +154,7 @@
     thomas_id: '04'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
-  - name: Monetary Policy and Trade
+  - name: National Security, International Development and Monetary Policy
     thomas_id: '20'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
@@ -178,8 +168,6 @@
     phone: (202) 225-7502
   address: 2129 RHOB; Washington, DC 20515-6050
   phone: (202) 225-7502
-  rss_url: https://financialservices.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-financialservices.house.gov/news/rss.aspx
   jurisdiction: The House Financial Services Committee has jurisdiction over issues
     pertaining to the economy, the banking system, housing, insurance, and securities
     and exchanges. Additionally, the Committee also has jurisdiction over monetary

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -438,7 +438,7 @@
 - type: house
   name: House Permanent Select Committee on Intelligence
   url: https://intelligence.house.gov/
-  minority_url: https://democrats-intelligence.house.gov/
+  minority_url: https://republicans-intelligence.house.gov/
   thomas_id: HLIG
   house_committee_id: IG
   subcommittees:
@@ -472,8 +472,6 @@
     phone: (202) 225-4121
   address: HVC304 CAPITOL; Washington, DC 20515-6415
   phone: (202) 225-4121
-  rss_url: https://intelligence.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-intelligence.house.gov/news/rss.aspx
   jurisdiction: The United States House Permanent Select Committee on Intelligence
     (HPSCI) is a committee of the United States House of Representatives, currently
     chaired by Congressman Devin Nunes (California). Created in 1977, HPSCI is charged

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -303,13 +303,11 @@
 - type: house
   name: House Committee on House Administration
   url: https://cha.house.gov/
-  minority_url: https://democrats-cha.house.gov/
+  minority_url: https://republicans-cha.house.gov/
   thomas_id: HSHA
   house_committee_id: HA
-  address: 1309 LHOB; Washington, DC 20515-6157
-  phone: (202) 225-8281
-  rss_url: https://cha.house.gov/rss.xml
-  minority_rss_url: https://democrats-cha.house.gov/rss.xml
+  address: 1316 LHOB; Washington, DC 20515-6157
+  phone: (202) 225-2061
   jurisdiction: The Committee on House Administration has legislative jurisdiction
     over the federal elections and the day-to-day operations of the House. The Committee's
     jurisdiction over federal elections requires it to consider proposals to amend
@@ -321,37 +319,36 @@
 - type: house
   name: House Committee on Homeland Security
   url: https://homeland.house.gov/
-  minority_url: https://democrats-homeland.house.gov/
+  minority_url: https://republicans-homeland.house.gov/
   thomas_id: HSHM
   house_committee_id: HM
   subcommittees:
-  - name: Border and Maritime Security
+  - name: Border Security, Facilitation, and Operations
     thomas_id: '11'
-    address: 176 FHOB; Washington, DC 20515
-    phone: (202) 226-8417
-  - name: Emergency Preparedness, Response, and Communications
+    address: 117 FHOB; Washington, DC 20515
+    phone: (202) 226-2616
+  - name: Emergency Preparedness, Response, and Recovery
     thomas_id: '12'
-    address: 176 FHOB; Washington, DC 20515
-    phone: (202) 226-8417
-  - name: Cybersecurity and Infrastructure Protection
+    address: 117 FHOB; Washington, DC 20515
+    phone: (202) 226-2616
+  - name: Cybersecurity, Infrastructure Protection, and Innovation
     thomas_id: '08'
-    address: 176 FHOB; Washington, DC 20515
-    phone: (202) 226-8417
-  - name: Counterterrorism and Intelligence
+    address: 117 FHOB; Washington, DC 20515
+    phone: (202) 226-2616
+  - name: Intelligence and Counterterrorism
     thomas_id: '05'
-    address: 176 FHOB; Washington, DC 20515
-    phone: (202) 226-8417
-  - name: Oversight and Management Efficiency
+    address: 117 FHOB; Washington, DC 20515
+    phone: (202) 226-2616
+  - name: Oversight, Management, and Accountability
     thomas_id: '09'
-    address: 176 FHOB; Washington, DC 20515
-    phone: (202) 226-8417
-  - name: Transportation and Protective Security
+    address: 117 FHOB; Washington, DC 20515
+    phone: (202) 226-2616
+  - name: Transportation and Maritime Security
     thomas_id: '07'
-    address: 176 FHOB; Washington, DC 20515
-    phone: (202) 226-8417
-  address: 176 FHOB; Washington, DC 20515-6480
-  phone: (202) 226-8417
-  rss_url: https://homeland.house.gov/rss.xml
+    address: 117 FHOB; Washington, DC 20515
+    phone: (202) 226-2616
+  address: 117 FHOB; Washington, DC 20515-6480
+  phone: (202) 226-2616
   jurisdiction: The House Committee on Homeland Security has jurisdiction over matters
     related to national defense. It has six subcommittees on border and maritime security;
     counterterrorism and intelligence; cybersecurity and infrastructure protection;
@@ -362,11 +359,11 @@
 - type: house
   name: House Committee on Energy and Commerce
   url: https://energycommerce.house.gov/
-  minority_url: https://democrats-energycommerce.house.gov/
+  minority_url: https://republicans-energycommerce.house.gov/
   thomas_id: HSIF
   house_committee_id: IF
   subcommittees:
-  - name: Digital Commerce and Consumer Protection
+  - name: Consumer Protection and Commerce
     thomas_id: '17'
     address: 2125 RHOB; Washington, DC 20515
     phone: (202) 225-2927
@@ -386,13 +383,12 @@
     thomas_id: '02'
     address: 2125 RHOB; Washington, DC 20515
     phone: (202) 225-2927
-  - name: Environment
+  - name: Environment and Climate Change
     thomas_id: '18'
     address: 2125 RHOB; Washington, DC 20515
     phone: (202) 225-2927
   address: 2125 RHOB; Washington, DC 20515-6115
   phone: (202) 225-2927
-  rss_url: https://energycommerce.house.gov/rss.aspx
   jurisdiction: The House Committee on Energy and Commerce has legislative jurisdiction
     on matters related to telecommunications, consumer protection, food and drug safety,
     public health research, environmental quality, energy policy, and interstate and
@@ -405,7 +401,7 @@
 - type: house
   name: House Committee on Natural Resources
   url: https://naturalresources.house.gov/
-  minority_url: https://democrats-naturalresources.house.gov/
+  minority_url: https://republicans-naturalresources.house.gov/
   thomas_id: HSII
   house_committee_id: II
   subcommittees:

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -1038,7 +1038,7 @@
     thomas_id: '27'
     wikipedia: United States Senate Commerce Subcommittee on Competitiveness, Innovation,
       and Export Promotion
-  - name: Consumer Protection, Product Safety, Insurance, and Data Security
+  - name: Manufacturing, Trade, and Consumer Protection
     thomas_id: '20'
     wikipedia: United States Senate Commerce Subcommittee on Consumer Protection,
       Product Safety, and Insurance
@@ -1055,9 +1055,7 @@
       and Merchant Marine Infrastructure, Safety, and Security
   - name: Aviation Operations, Safety, and Security
     thomas_id: '01'
-    wikipedia: United States Senate Commerce Subcommittee on Aviation Operations,
-      Safety, and Security
-  rss_url: http://www.commerce.senate.gov/public/?a=RSS.Feed
+    wikipedia: United States Senate Commerce Subcommittee on Aviation and Space
   wikipedia: United States Senate Committee on Commerce, Science and Transportation
   jurisdiction: The Senate Committee on Commerce, Science, and Transportation has
     legislative jurisdiction on matters related to science and technology, oceans

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -196,8 +196,8 @@
   jurisdiction_source: https://budget.house.gov/about/
 - type: house
   name: House Committee on Education and Labor
-  url: https://edworkforce.house.gov/
-  minority_url: https://democrats-edworkforce.house.gov/
+  url: https://edlabor.house.gov/
+  minority_url: https://republicans-edlabor.house.gov/
   thomas_id: HSED
   house_committee_id: ED
   subcommittees:
@@ -209,7 +209,7 @@
     thomas_id: '02'
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
-  - name: Higher Education and Workforce Development
+  - name: Higher Education and Workforce Investment
     thomas_id: '13'
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
@@ -219,8 +219,6 @@
     phone: (202) 225-4527
   address: 2176 RHOB; Washington, DC 20515-6100
   phone: (202) 225-4527
-  rss_url: https://edworkforce.house.gov/news/rss.aspx
-  minority_rss_url: https://democrats-edworkforce.house.gov/rss.xml
   jurisdiction: The committee has legislative
     jurisdiction over matters related to higher and lower education, workforce development
     and protections, and health, employment, labor, and pensions.
@@ -228,7 +226,7 @@
 - type: house
   name: House Committee on Foreign Affairs
   url: https://foreignaffairs.house.gov/
-  minority_url: https://democrats-foreignaffairs.house.gov/
+  minority_url: https://republicans-foreignaffairs.house.gov/
   thomas_id: HSFA
   house_committee_id: FA
   subcommittees:
@@ -236,29 +234,28 @@
     thomas_id: '16'
     address: 5210 OHOB; Washington, DC 20515
     phone: (202) 226-7812
-  - name: Asia and the Pacific
+  - name: Asia, the Pacific, and Nonproliferation
     thomas_id: '05'
     address: 5190 OHOB; Washington, DC 20515
     phone: (202) 226-7825
-  - name: Europe, Eurasia, and Emerging Threats
+  - name: Europe, Eurasia, Energy, and the Environment
     thomas_id: '14'
     address: 5210 OHOB; Washington, DC 20515
     phone: (202) 226-6434
-  - name: Terrorism, Nonproliferation, and Trade
+  - name: Oversight and Investigations
     thomas_id: '18'
     address: 5100 OHOB; Washington, DC 20515
     phone: (202) 226-1500
-  - name: The Middle East and North Africa
+  - name: Middle East, North Africa, and International Terrorism
     thomas_id: '13'
     address: 5220 OHOB; Washington, DC 20515
     phone: (202) 225-3345
-  - name: The Western Hemisphere
+  - name: Western Hemisphere, Civilian Security, and Trade
     thomas_id: '07'
     address: 5100 OHOB; Washington, DC 20515
     phone: (202) 226-9980
   address: 2170 RHOB; Washington, DC 20515-6128
   phone: (202) 225-5021
-  rss_url: https://foreignaffairs.house.gov/rss.xml
   jurisdiction: The House Committee on Foreign Affairs considers legislation that
     impacts the diplomatic community, which includes the Department of State, the
     Agency for International Development, the Peace Corps, the United Nations, and
@@ -267,38 +264,36 @@
 - type: house
   name: House Committee on Oversight and Reform
   url: https://oversight.house.gov/
-  minority_url: https://democrats-oversight.house.gov/
+  minority_url: https://republicans-oversight.house.gov/
   thomas_id: HSGO
   house_committee_id: GO
   subcommittees:
   - name: Information Technology
     thomas_id: '25'
-    address: 2157 RHOB; Washington, DC 20515
+    address: 2471 RHOB; Washington, DC 20515
     phone: (202) 225-5074
   - name: Government Operations
     thomas_id: '24'
-    address: 2157 RHOB; Washington, DC 20515
+    address: 2471 RHOB; Washington, DC 20515
     phone: (202) 225-5074
   - name: National Security
     thomas_id: '06'
-    address: 2157 RHOB; Washington, DC 20515
+    address: 2471 RHOB; Washington, DC 20515
     phone: (202) 225-5074
   - name: Healthcare, Benefits, and Administrative Rules
     thomas_id: '27'
-    address: 2157 RHOB; Washington, DC 20515
+    address: 2471 RHOB; Washington, DC 20515
     phone: (202) 225-5074
-  - name: The Interior, Energy and Environment
+  - name: Environment
     thomas_id: '28'
-    address: 2157 RHOB; Washington, DC 20515
+    address: 2471 RHOB; Washington, DC 20515
     phone: (202) 225-5074
   - name: Intergovernmental Affairs
     thomas_id: '29'
-    address: 2157 RHOB; Washington, DC 20515
+    address: 2471 RHOB; Washington, DC 20515
     phone: (202) 225-5074
-  address: 2157 RHOB; Washington, DC 20515-6143
-  phone: (202) 225-5074
-  rss_url: https://oversight.house.gov/feed/
-  minority_rss_url: https://democrats-oversight.house.gov/rss.xml
+  address: 2471 RHOB; Washington, DC 20515-6143
+  phone: (202) 225-5051
   jurisdiction: The committee oversees the
     federal government and all of its agencies to ensure efficiency, effectiveness,
     and accountability. The Committee oversees government operations, health care,

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -308,6 +308,7 @@
   house_committee_id: HA
   subcommittees:
   - name: Elections
+    thomas_id: '01'
     address: 1309 LHOB; Washington, DC 20515-6157
   address: 1309 LHOB; Washington, DC 20515-6157
   phone: (202) 225-2061

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -38273,7 +38273,7 @@
     first: Gilbert
     middle: Ray
     last: Cisneros
-    official_full: Gilbert Ray Cisneros, Jr.
+    official_full: Gil Cisneros
   bio:
     gender: M
     birthday: '1971-02-12'


### PR DESCRIPTION
This PR updates House and Senate committee and subcommittee assignments for the 116th Congress. There are some important notes:

1. It adds a `start_date` and `source` attribute to assignments, tied to House/Senate resolutions announcing membership or committee press releases announcing subcommittee assignments. Both are optional.
2. There are a handful of committees and subcommittees without current assignments. These include all of the joint committees and some of the select committees (including House select committees on climate change and modernization of Congress). The new select committees also are not yet in the `committees_current.yaml` file.
3. There is one subcommittee, Elections of House Administration, that is new and does not yet have either a clerk code or what we call a `thomas_id`. I've temporarily called this subcommittee `HSHA01` with a thomas_id of `01`.
3. Where subcommittee assignments specifically mention Ex Officio roles for the full committee chair and ranking member, they are included.
4. Vacancies are not included.