### PR TITLE
Add missing titles for Ranking Members

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -5688,6 +5688,7 @@ HSHM:
 - name: Mike Rogers
   party: minority
   rank: 1
+  title: Ranking Member
   bioguide: R000575
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text
@@ -8036,6 +8037,7 @@ HSJU:
 - name: Doug Collins
   party: minority
   rank: 1
+  title: Ranking Member
   bioguide: C001093
   start_date: '2019-01-04'
   source: https://www.congress.gov/bill/116th-congress/house-resolution/25/text


### PR DESCRIPTION
https://homeland.house.gov/about/committee-membership show Mike Rogers
as the ranking member for the House Committee on Homeland Security
(HSHM) and https://judiciary.house.gov/about/members shows Doug Collins
as the ranking member for House Committee on the Judiciary (HSJU).