### PR TITLE
Update contact info

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -37995,7 +37995,7 @@
     first: Gilbert
     middle: Ray
     last: Cisneros
-    official_full: Gil Cisneros
+    official_full: Gilbert Ray Cisneros, Jr.
   bio:
     gender: M
     birthday: '1971-02-12'
@@ -38449,7 +38449,7 @@
     first: Jesús
     middle: G.
     last: García
-    official_full: Jesús G. García
+    official_full: Jesús G. "Chuy" García
   bio:
     gender: M
     birthday: '1956-04-12'
@@ -38579,7 +38579,7 @@
     first: Steven
     middle: C.
     last: Watkins
-    official_full: Steven C. Watkins, Jr.
+    official_full: Steve Watkins
   bio:
     gender: M
     birthday: '1976-09-18'

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -3616,8 +3616,8 @@
     party: Republican
     state_rank: junior
     url: https://www.blackburn.senate.gov
-    address: B40B Dirksen Senate Office Building Washington DC 20510
-    office: B40b Dirksen Senate Office Building
+    address: 357 Dirksen Senate Office Building Washington DC 20510
+    office: 357 Dirksen Senate Office Building
     phone: 202-224-3344
     contact_form: https://www.blackburn.senate.gov/contact_marsha
 - id:
@@ -29699,8 +29699,8 @@
     url: https://www.warren.senate.gov
     rss_url: http://www.warren.senate.gov/rss/?p=hot_topic
     contact_form: https://www.warren.senate.gov/?p=email_senator
-    address: 317 Hart Senate Office Building Washington DC 20510
-    office: 317 Hart Senate Office Building
+    address: 309 Hart Senate Office Building Washington DC 20510
+    office: 309 Hart Senate Office Building
     phone: 202-224-4543
 - id:
     govtrack: 412543
@@ -30321,11 +30321,11 @@
     class: 1
     party: Republican
     state_rank: junior
-    url: https://www.senate.gov/senators/116thCongress/CramerKevin.htm
+    url: https://www.cramer.senate.gov
     address: B40C Dirksen Senate Office Building Washington DC 20510
     office: B40c Dirksen Senate Office Building
     phone: 202-224-2043
-    contact_form: ''
+    contact_form: https://www.cramer.senate.gov/contact_kevin
 - id:
     bioguide: F000463
     thomas: '02179'
@@ -32181,8 +32181,8 @@
     state_rank: junior
     url: https://www.booker.senate.gov
     phone: 202-224-3224
-    address: 359 Dirksen Senate Office Building Washington DC 20510
-    office: 359 Dirksen Senate Office Building
+    address: 717 Hart Senate Office Building Washington DC 20510
+    office: 717 Hart Senate Office Building
     contact_form: https://www.booker.senate.gov/?p=contact
     fax: 202-224-8378
 - id:
@@ -34497,8 +34497,8 @@
     state_rank: junior
     party: Republican
     url: https://www.sullivan.senate.gov
-    address: 702 Hart Senate Office Building Washington DC 20510
-    office: 702 Hart Senate Office Building
+    address: 302 Hart Senate Office Building Washington DC 20510
+    office: 302 Hart Senate Office Building
     phone: 202-224-3004
     contact_form: https://www.sullivan.senate.gov/contact/email
 - id:
@@ -34572,8 +34572,8 @@
     state_rank: junior
     party: Republican
     url: https://www.ernst.senate.gov/public
-    address: 111 Russell Senate Office Building Washington DC 20510
-    office: 111 Russell Senate Office Building
+    address: 730 Hart Senate Office Building Washington DC 20510
+    office: 730 Hart Senate Office Building
     phone: 202-224-3254
     contact_form: https://www.ernst.senate.gov/public/index.cfm/contact
 - id:
@@ -35075,8 +35075,8 @@
     class: 3
     state_rank: junior
     party: Republican
-    address: 383 Russell Senate Office Building Washington DC 20510
-    office: 383 Russell Senate Office Building
+    address: 416 Russell Senate Office Building Washington DC 20510
+    office: 416 Russell Senate Office Building
     phone: 202-224-4623
     url: https://www.kennedy.senate.gov/public
     contact_form: https://www.kennedy.senate.gov/public/email-me
@@ -35112,8 +35112,8 @@
     class: 3
     state_rank: junior
     party: Democrat
-    address: 330 Hart Senate Office Building Washington DC 20510
-    office: 330 Hart Senate Office Building
+    address: 324 Hart Senate Office Building Washington DC 20510
+    office: 324 Hart Senate Office Building
     phone: 202-224-3324
     url: https://www.hassan.senate.gov
     contact_form: https://www.hassan.senate.gov/content/contact-senator
@@ -35147,8 +35147,8 @@
     class: 3
     state_rank: senior
     party: Democrat
-    address: 204 Russell Senate Office Building Washington DC 20510
-    office: 204 Russell Senate Office Building
+    address: 516 Hart Senate Office Building Washington DC 20510
+    office: 516 Hart Senate Office Building
     phone: 202-224-3542
     url: https://www.cortezmasto.senate.gov
     contact_form: https://www.cortezmasto.senate.gov/contact
@@ -37305,8 +37305,8 @@
     class: 2
     party: Democrat
     state_rank: junior
-    address: 326 Russell Senate Office Building Washington DC 20510
-    office: 326 Russell Senate Office Building
+    address: 330 Hart Senate Office Building Washington DC 20510
+    office: 330 Hart Senate Office Building
     phone: 202-224-4124
     url: https://www.jones.senate.gov
     contact_form: https://www.jones.senate.gov/content/contact-senator
@@ -37355,8 +37355,8 @@
     class: 2
     party: Democrat
     state_rank: junior
-    address: 309 Hart Senate Office Building Washington DC 20510
-    office: 309 Hart Senate Office Building
+    address: 720 Hart Senate Office Building Washington DC 20510
+    office: 720 Hart Senate Office Building
     phone: 202-224-5641
     url: https://www.smith.senate.gov
     contact_form: https://www.smith.senate.gov/content/contact-senator
@@ -37405,8 +37405,8 @@
     state_rank: junior
     url: https://www.hydesmith.senate.gov
     contact_form: https://www.hydesmith.senate.gov/content/contact-senator
-    address: G12 Dirksen Senate Office Building Washington DC 20510
-    office: G12 Dirksen Senate Office Building
+    address: 702 Hart Senate Office Building Washington DC 20510
+    office: 702 Hart Senate Office Building
     phone: 202-224-5054
 - id:
     bioguide: L000588
@@ -40162,11 +40162,11 @@
     class: 1
     party: Republican
     state_rank: junior
-    url: https://www.senate.gov/senators/116thCongress/ScottRick.htm
+    url: https://www.rickscott.senate.gov
     address: 716 Hart Senate Office Building Washington DC 20510
     office: 716 Hart Senate Office Building
     phone: 202-224-5274
-    contact_form: mailto:help@rickscott.senate.gov
+    contact_form: https://www.rickscott.senate.gov/contact_rick
 - id:
     bioguide: B001310
     fec:
@@ -40194,8 +40194,8 @@
     party: Republican
     state_rank: junior
     url: https://www.braun.senate.gov
-    address: B85 Russell Senate Office Building Washington DC 20510
-    office: B85 Russell Senate Office Building
+    address: 374 Russell Senate Office Building Washington DC 20510
+    office: 374 Russell Senate Office Building
     phone: 202-224-4814
     contact_form: http://www.braun.senate.gov/contact-mike
 - id:
@@ -40224,11 +40224,11 @@
     class: 1
     party: Republican
     state_rank: junior
-    url: https://www.senate.gov/senators/116thCongress/HawleyJosh.htm
+    url: https://www.hawley.senate.gov
     address: B40A Dirksen Senate Office Building Washington DC 20510
     office: B40a Dirksen Senate Office Building
     phone: 202-224-6154
-    contact_form: mailto:senator@hawley.senate.gov
+    contact_form: https://www.hawley.senate.gov/contact-senator-hawley
 - id:
     bioguide: R000615
     fec:


### PR DESCRIPTION
This PR includes updated contact information for both House and Senate members as produced by the scripts `scripts/senate_contacts.py` and `scripts/house_contacts.py` respectively.

I had originally run the senate script because I noticed that Joni Ernst's office was outdated, and then I found that there were a handful of Senate offices that had changed, in addition to URLs and emails.

The House updates only include changes to members' full names.

I hand-audited roughly 50% of the office/URL changes to validate.