### PR TITLE
corrections for Senate Commerce subcommittee on Aviation and Space

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -14716,46 +14716,52 @@ SSCM01:
   bioguide: T000250
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
-- name: Tammy Duckworth
+- name: Kyrsten Sinema
   party: minority
   rank: 1
   title: Ranking Member
+  bioguide: S001191
+  start_date: '2019-01-24'
+  source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
+- name: Tammy Duckworth
+  party: minority
+  rank: 2
   bioguide: D000622
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Amy Klobuchar
   party: minority
-  rank: 2
+  rank: 3
   bioguide: K000367
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Gary C. Peters
   party: minority
-  rank: 3
+  rank: 4
   bioguide: P000595
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jacky Rosen
   party: minority
-  rank: 4
+  rank: 5
   bioguide: R000608
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Brian Schatz
   party: minority
-  rank: 5
+  rank: 6
   bioguide: S001194
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Jon Tester
   party: minority
-  rank: 6
+  rank: 7
   bioguide: T000464
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5
 - name: Tom Udall
   party: minority
-  rank: 7
+  rank: 8
   bioguide: U000039
   start_date: '2019-01-24'
   source: https://www.commerce.senate.gov/public/index.cfm/pressreleases?ID=928E144C-B9C8-478A-92B7-29C5B270ECA5

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -1056,7 +1056,7 @@
     thomas_id: '25'
     wikipedia: United States Senate Commerce Subcommittee on Surface Transportation
       and Merchant Marine Infrastructure, Safety, and Security
-  - name: Aviation Operations, Safety, and Security
+  - name: Aviation and Space
     thomas_id: '01'
     wikipedia: United States Senate Commerce Subcommittee on Aviation and Space
   wikipedia: United States Senate Committee on Commerce, Science and Transportation


### PR DESCRIPTION
The subcommittee's name was changed and the press release with assignments appears to have been mistranscribed.

This was reported to GovTrack by a user.