### PR TITLE
Add missing Open Secrets Candidate IDs

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -37997,6 +37997,7 @@
     fec:
     - H8CA39174
     govtrack: 412757
+    opensecrets: N00041464
     wikipedia: Gil Cisneros
     wikidata: Q54958760
     votesmart: 179370
@@ -38354,6 +38355,7 @@
     fec:
     - H8GU01020
     govtrack: 412770
+    opensecrets: N00042619
     wikipedia: Michael San Nicolas
     wikidata: Q16221559
     google_entity_id: kg:/m/0wy0mjt
@@ -38409,6 +38411,7 @@
     fec:
     - H8IA03124
     govtrack: 412772
+    opensecrets: N00041104
     wikipedia: Cindy Axne
     wikidata: Q58324150
     votesmart: 179226
@@ -38493,6 +38496,7 @@
     fec:
     - H8IL06139
     govtrack: 412775
+    opensecrets: N00041338
     wikipedia: Sean Casten
     wikidata: Q55386655
   name:
@@ -38545,6 +38549,7 @@
     fec:
     - H8IN04199
     govtrack: 412777
+    opensecrets: N00041954
     wikipedia: Jim Baird (American politician)
     wikidata: Q48813213
     votesmart: 86013
@@ -38626,6 +38631,7 @@
     fec:
     - H8KS03155
     govtrack: 412780
+    opensecrets: N00042626
     wikipedia: Sharice Davids
     wikidata: Q58322868
     votesmart: 181201
@@ -38708,6 +38714,7 @@
     fec:
     - H6MD08549
     govtrack: 412783
+    opensecrets: N00039122
     wikipedia: David Trone
     wikidata: Q29446408
     votesmart: 167336
@@ -38874,6 +38881,7 @@
     fec:
     - H6MN02131
     govtrack: 412789
+    opensecrets: N00037039
     wikipedia: Angie Craig
     wikidata: Q58324174
     votesmart: 166261
@@ -39008,6 +39016,7 @@
     fec:
     - H8ND00096
     govtrack: 412794
+    opensecrets: N00042868
     wikipedia: Kelly Armstrong
     wikidata: Q50362353
     votesmart: 139338
@@ -39200,6 +39209,7 @@
     fec:
     - H8NM02248
     govtrack: 412801
+    opensecrets: N00042467
     wikipedia: Xochitl Torres Small
     wikidata: Q58399761
     votesmart: 177978
@@ -39226,6 +39236,7 @@
     fec:
     - H8NV03200
     govtrack: 412802
+    opensecrets: N00037247
     wikipedia: Susie Lee
     wikidata: Q58333611
     votesmart: 169344
@@ -39332,6 +39343,7 @@
     fec:
     - H8NY22151
     govtrack: 412806
+    opensecrets: N00041385
     wikipedia: Anthony Brindisi
     wikidata: Q4772153
     google_entity_id: kg:/m/0hhqfyc
@@ -39636,6 +39648,7 @@
     fec:
     - H8TN02119
     govtrack: 412817
+    opensecrets: N00041594
     wikipedia: Tim Burchett
     wikidata: Q7803244
     google_entity_id: kg:/m/03yt07
@@ -39940,6 +39953,7 @@
     fec:
     - H8TX32098
     govtrack: 412828
+    opensecrets: N00040989
     wikipedia: Colin Allred
     wikidata: Q5144845
     votesmart: 177357
@@ -40051,6 +40065,7 @@
     fec:
     - H8VA06104
     govtrack: 412832
+    opensecrets: N00042296
     wikipedia: Ben Cline
     wikidata: Q4885439
     google_entity_id: kg:/m/04yf6mk
@@ -40217,6 +40232,7 @@
     fec:
     - S8FL00273
     govtrack: 412838
+    opensecrets: N00043290
     wikipedia: Rick Scott
     wikidata: Q439729
     ballotpedia: Rick Scott
@@ -40247,6 +40263,7 @@
     fec:
     - S8IN00171
     govtrack: 412839
+    opensecrets: N00041731
     wikipedia: Mike Braun
     wikidata: Q42804470
     ballotpedia: Mike Braun
@@ -40278,6 +40295,7 @@
     fec:
     - S8MO00160
     govtrack: 412840
+    opensecrets: N00041620
     wikipedia: Josh Hawley
     wikidata: Q23020745
     ballotpedia: Josh Hawley
@@ -40310,6 +40328,7 @@
     - S8UT00176
     - S4MA00143
     govtrack: 412841
+    opensecrets: N00000286
     wikipedia: Mitt Romney
     wikidata: Q4496
     ballotpedia: Mitt Romney


### PR DESCRIPTION
I noticed that 19 of the current legislators were missing Open Secrets IDs, so I added them from the list of IDs available from Open Secrets [here](https://www.opensecrets.org/open-data/api-documentation). Please let me know if there's anything else I need to do, I'd be happy to help.