### PR TITLE
Add missing Senate FEC ID's

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -3519,6 +3519,7 @@
     votesmart: 25186
     fec:
     - H2TN06030
+    - S8TN00337
     cspan: 31226
     wikipedia: Marsha Blackburn
     house_history: 10385
@@ -28024,6 +28025,7 @@
     wikipedia: Kyrsten Sinema
     fec:
     - H2AZ09019
+    - S8AZ00197
     ballotpedia: Kyrsten Sinema
     maplight: 1733
     icpsr: 21300
@@ -30268,6 +30270,7 @@
     fec:
     - H0ND01026
     - H6ND00074
+    - S8ND00120
     opensecrets: N00004614
     ballotpedia: Kevin Cramer
     maplight: 1779
@@ -36547,6 +36550,7 @@
     votesmart: 169471
     fec:
     - H6NV03139
+    - S8NV00156
     opensecrets: N00038734
     maplight: 2227
     google_entity_id: kg:/g/11cntnvwkg


### PR DESCRIPTION
Four current senators were missing Senate FEC ID's. Each of these had (correct but outdated) House of Represenatives FEC ID's, which may help explain why it went unnoticed by the scripts.