### PR TITLE
Correct FEC ID for Susie Lee

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -39245,7 +39245,7 @@
 - id:
     bioguide: L000590
     fec:
-    - H8NV03200
+    - H6NV04020
     govtrack: 412802
     opensecrets: N00037247
     wikipedia: Susie Lee


### PR DESCRIPTION
I opted to change the existing ID, rather than add another, because I couldn't find H8NV03200 (the existing value) via search on fec.gov, and most representatives have just one ID per body of government. If it's preferable to keep the existing one as well, please let me know and I will make that change.