### PR TITLE
Update house websites script

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -9036,7 +9036,7 @@
     phone: 202-225-8104
     address: 202 Cannon House Office Building; Washington DC 20515-0518
     office: 202 Cannon House Office Building
-    url: http://eshoo.house.gov
+    url: https://eshoo.house.gov
     rss_url: http://eshoo.house.gov/index.php?format=feed&amp;type=rss
 - id:
     bioguide: F000459
@@ -16137,7 +16137,7 @@
     phone: 202-225-7163
     address: 2311 Rayburn House Office Building; Washington DC 20515-0506
     office: 2311 Rayburn House Office Building
-    url: http://matsui.house.gov
+    url: https://matsui.house.gov
     rss_url: http://matsui.house.gov/index.php?format=feed&amp;type=rss
   family:
   - name: Robert Matsui
@@ -35754,7 +35754,7 @@
     phone: 202-225-4035
     address: 1710 Longworth House Office Building; Washington DC 20515-0907
     office: 1710 Longworth House Office Building
-    url: https://stephaniemurphy.house.gov
+    url: https://murphy.house.gov
 - id:
     bioguide: S001200
     govtrack: 412695
@@ -37457,7 +37457,7 @@
     phone: 202-225-2301
     address: 1224 Longworth House Office Building; Washington DC 20515-3817
     office: 1224 Longworth House Office Building
-    url: https://lamb.house.gov/
+    url: https://lamb.house.gov
 - id:
     bioguide: L000589
     fec:
@@ -37496,7 +37496,7 @@
     phone: 202-225-4576
     address: 1113 Longworth House Office Building; Washington DC 20515-0308
     office: 1113 Longworth House Office Building
-    url: https://lesko.house.gov/
+    url: https://lesko.house.gov
 - id:
     bioguide: C001115
     fec:
@@ -37535,7 +37535,7 @@
     phone: 202-225-7742
     address: 1314 Longworth House Office Building; Washington DC 20515-4327
     office: 1314 Longworth House Office Building
-    url: https://cloud.house.gov/
+    url: https://cloud.house.gov
 - id:
     bioguide: B001306
     fec:
@@ -37574,7 +37574,7 @@
     phone: 202-225-5355
     address: 1221 Longworth House Office Building; Washington DC 20515-3512
     office: 1221 Longworth House Office Building
-    url: https://balderson.house.gov/
+    url: https://balderson.house.gov
 - id:
     bioguide: H001082
     fec:
@@ -37821,7 +37821,7 @@
     phone: 202-225-9894
     address: 1330 Longworth House Office Building; Washington DC 20515-2804
     office: 1330 Longworth House Office Building
-    url: http://horsford.house.gov
+    url: https://horsford.house.gov
     rss_url: http://horsford.house.gov/rss.xml
 - id:
     bioguide: K000368
@@ -37889,7 +37889,7 @@
     phone: 202-225-2542
     address: 309 Cannon House Office Building; Washington DC 20515-0302
     office: 309 Cannon House Office Building
-    url: http://kirkpatrick.house.gov
+    url: https://kirkpatrick.house.gov
     rss_url: http://kirkpatrick.house.gov/rss.xml
 - id:
     bioguide: S001211
@@ -37918,7 +37918,7 @@
     phone: 202-225-9888
     address: 128 Cannon House Office Building; Washington DC 20515-0309
     office: 128 Cannon House Office Building
-    url: https://stanton.house.gov/
+    url: https://stanton.house.gov
 - id:
     bioguide: H001090
     fec:
@@ -37946,7 +37946,7 @@
     phone: 202-225-4540
     address: 131 Cannon House Office Building; Washington DC 20515-0510
     office: 131 Cannon House Office Building
-    url: https://harder.house.gov/
+    url: https://harder.house.gov
 - id:
     bioguide: C001124
     fec:
@@ -37975,7 +37975,7 @@
     phone: 202-225-4695
     address: 1728 Longworth House Office Building; Washington DC 20515-0521
     office: 1728 Longworth House Office Building
-    url: https://cox.house.gov/
+    url: https://cox.house.gov
 - id:
     bioguide: H001087
     fec:
@@ -38002,7 +38002,7 @@
     phone: 202-225-1956
     address: 1130 Longworth House Office Building; Washington DC 20515-0525
     office: 1130 Longworth House Office Building
-    url: https://katiehill.house.gov/
+    url: https://katiehill.house.gov
 - id:
     bioguide: C001123
     fec:
@@ -38030,7 +38030,7 @@
     phone: 202-225-4111
     address: 431 Cannon House Office Building; Washington DC 20515-0539
     office: 431 Cannon House Office Building
-    url: https://cisneros.house.gov/
+    url: https://cisneros.house.gov
 - id:
     bioguide: P000618
     fec:
@@ -38057,7 +38057,7 @@
     phone: 202-225-5611
     address: 1117 Longworth House Office Building; Washington DC 20515-0545
     office: 1117 Longworth House Office Building
-    url: https://porter.house.gov/
+    url: https://porter.house.gov
 - id:
     bioguide: R000616
     fec:
@@ -38084,7 +38084,7 @@
     phone: 202-225-2415
     address: 2300 Rayburn House Office Building; Washington DC 20515-0548
     office: 2300 Rayburn House Office Building
-    url: https://rouda.house.gov/
+    url: https://rouda.house.gov
 - id:
     bioguide: L000593
     fec:
@@ -38111,7 +38111,7 @@
     phone: 202-225-3906
     address: 1626 Longworth House Office Building; Washington DC 20515-0549
     office: 1626 Longworth House Office Building
-    url: https://mikelevin.house.gov/
+    url: https://mikelevin.house.gov
 - id:
     bioguide: N000191
     fec:
@@ -38138,7 +38138,7 @@
     phone: 202-225-2161
     address: 1419 Longworth House Office Building; Washington DC 20515-0602
     office: 1419 Longworth House Office Building
-    url: https://neguse.house.gov/
+    url: https://neguse.house.gov
 - id:
     bioguide: C001121
     fec:
@@ -38165,7 +38165,7 @@
     phone: 202-225-7882
     address: 1229 Longworth House Office Building; Washington DC 20515-0606
     office: 1229 Longworth House Office Building
-    url: https://crow.house.gov/
+    url: https://crow.house.gov
 - id:
     bioguide: H001081
     fec:
@@ -38192,7 +38192,7 @@
     phone: 202-225-4476
     address: 1415 Longworth House Office Building; Washington DC 20515-0705
     office: 1415 Longworth House Office Building
-    url: https://hayes.house.gov/
+    url: https://hayes.house.gov
 - id:
     bioguide: W000823
     fec:
@@ -38218,7 +38218,7 @@
     phone: 202-225-2706
     address: 216 Cannon House Office Building; Washington DC 20515-0906
     office: 216 Cannon House Office Building
-    url: https://waltz.house.gov/
+    url: https://waltz.house.gov
 - id:
     bioguide: S001210
     fec:
@@ -38246,7 +38246,7 @@
     phone: 202-225-1252
     address: 224 Cannon House Office Building; Washington DC 20515-0915
     office: 224 Cannon House Office Building
-    url: https://spano.house.gov/
+    url: https://spano.house.gov
 - id:
     bioguide: S001214
     fec:
@@ -38275,7 +38275,7 @@
     phone: 202-225-5792
     address: 521 Cannon House Office Building; Washington DC 20515-0917
     office: 521 Cannon House Office Building
-    url: https://steube.house.gov/
+    url: https://steube.house.gov
 - id:
     bioguide: M001207
     fec:
@@ -38303,7 +38303,7 @@
     phone: 202-225-2778
     address: 114 Cannon House Office Building; Washington DC 20515-0926
     office: 114 Cannon House Office Building
-    url: https://mucarsel-powell.house.gov/
+    url: https://mucarsel-powell.house.gov
 - id:
     bioguide: S001206
     fec:
@@ -38332,7 +38332,7 @@
     phone: 202-225-3931
     address: 1320 Longworth House Office Building; Washington DC 20515-0927
     office: 1320 Longworth House Office Building
-    url: https://shalala.house.gov/
+    url: https://shalala.house.gov
 - id:
     bioguide: M001208
     fec:
@@ -38360,7 +38360,7 @@
     phone: 202-225-4501
     address: 1513 Longworth House Office Building; Washington DC 20515-1006
     office: 1513 Longworth House Office Building
-    url: https://mcbath.house.gov/
+    url: https://mcbath.house.gov
 - id:
     bioguide: S001204
     fec:
@@ -38388,7 +38388,7 @@
     phone: 202-225-1188
     address: 1632 Longworth House Office Building; Washington DC 20515-5301
     office: 1632 Longworth House Office Building
-    url: https://sannicolas.house.gov/
+    url: https://sannicolas.house.gov
 - id:
     bioguide: F000467
     fec:
@@ -38416,7 +38416,7 @@
     phone: 202-225-2911
     address: 124 Cannon House Office Building; Washington DC 20515-1501
     office: 124 Cannon House Office Building
-    url: https://finkenauer.house.gov/
+    url: https://finkenauer.house.gov
 - id:
     bioguide: A000378
     fec:
@@ -38444,7 +38444,7 @@
     phone: 202-225-5476
     address: 330 Cannon House Office Building; Washington DC 20515-1503
     office: 330 Cannon House Office Building
-    url: https://axne.house.gov/
+    url: https://axne.house.gov
 - id:
     bioguide: F000469
     fec:
@@ -38472,7 +38472,7 @@
     phone: 202-225-6611
     address: 1520 Longworth House Office Building; Washington DC 20515-1201
     office: 1520 Longworth House Office Building
-    url: https://fulcher.house.gov/
+    url: https://fulcher.house.gov
 - id:
     bioguide: G000586
     fec:
@@ -38501,7 +38501,7 @@
     phone: 202-225-8203
     address: 530 Cannon House Office Building; Washington DC 20515-1304
     office: 530 Cannon House Office Building
-    url: https://chuygarcia.house.gov/
+    url: https://chuygarcia.house.gov
 - id:
     bioguide: C001117
     fec:
@@ -38527,7 +38527,7 @@
     phone: 202-225-4561
     address: 429 Cannon House Office Building; Washington DC 20515-1306
     office: 429 Cannon House Office Building
-    url: https://casten.house.gov/
+    url: https://casten.house.gov
 - id:
     bioguide: U000040
     fec:
@@ -38554,7 +38554,7 @@
     phone: 202-225-2976
     address: 1118 Longworth House Office Building; Washington DC 20515-1314
     office: 1118 Longworth House Office Building
-    url: https://underwood.house.gov/
+    url: https://underwood.house.gov
 - id:
     bioguide: B001307
     fec:
@@ -38582,7 +38582,7 @@
     phone: 202-225-5037
     address: 532 Cannon House Office Building; Washington DC 20515-1404
     office: 532 Cannon House Office Building
-    url: https://baird.house.gov/
+    url: https://baird.house.gov
 - id:
     bioguide: P000615
     fec:
@@ -38609,7 +38609,7 @@
     phone: 202-225-3021
     address: 222 Cannon House Office Building; Washington DC 20515-1406
     office: 222 Cannon House Office Building
-    url: https://pence.house.gov/
+    url: https://pence.house.gov
 - id:
     bioguide: W000824
     fec:
@@ -38636,7 +38636,7 @@
     phone: 202-225-6601
     address: 1205 Longworth House Office Building; Washington DC 20515-1602
     office: 1205 Longworth House Office Building
-    url: https://watkins.house.gov/
+    url: https://watkins.house.gov
 - id:
     bioguide: D000629
     fec:
@@ -38664,7 +38664,7 @@
     phone: 202-225-2865
     address: 1541 Longworth House Office Building; Washington DC 20515-1603
     office: 1541 Longworth House Office Building
-    url: https://davids.house.gov/
+    url: https://davids.house.gov
 - id:
     bioguide: T000482
     fec:
@@ -38691,7 +38691,7 @@
     phone: 202-225-3411
     address: 1616 Longworth House Office Building; Washington DC 20515-2103
     office: 1616 Longworth House Office Building
-    url: https://trahan.house.gov/
+    url: https://trahan.house.gov
 - id:
     bioguide: P000617
     fec:
@@ -38719,7 +38719,7 @@
     phone: 202-225-5111
     address: 1108 Longworth House Office Building; Washington DC 20515-2107
     office: 1108 Longworth House Office Building
-    url: https://pressley.house.gov/
+    url: https://pressley.house.gov
 - id:
     bioguide: T000483
     fec:
@@ -38747,7 +38747,7 @@
     phone: 202-225-2721
     address: 1213 Longworth House Office Building; Washington DC 20515-2006
     office: 1213 Longworth House Office Building
-    url: https://trone.house.gov/
+    url: https://trone.house.gov
 - id:
     bioguide: S001208
     fec:
@@ -38775,7 +38775,7 @@
     phone: 202-225-4872
     address: 1531 Longworth House Office Building; Washington DC 20515-2208
     office: 1531 Longworth House Office Building
-    url: https://slotkin.house.gov/
+    url: https://slotkin.house.gov
 - id:
     bioguide: L000592
     fec:
@@ -38802,7 +38802,7 @@
     phone: 202-225-4961
     address: 228 Cannon House Office Building; Washington DC 20515-2209
     office: 228 Cannon House Office Building
-    url: https://andylevin.house.gov/
+    url: https://andylevin.house.gov
 - id:
     bioguide: S001215
     fec:
@@ -38831,7 +38831,7 @@
     phone: 202-225-8171
     address: 227 Cannon House Office Building; Washington DC 20515-2211
     office: 227 Cannon House Office Building
-    url: https://stevens.house.gov/
+    url: https://stevens.house.gov
 - id:
     bioguide: T000481
     fec:
@@ -38859,7 +38859,7 @@
     phone: 202-225-5126
     address: 1628 Longworth House Office Building; Washington DC 20515-2213
     office: 1628 Longworth House Office Building
-    url: https://tlaib.house.gov/
+    url: https://tlaib.house.gov
 - id:
     bioguide: H001088
     fec:
@@ -38886,7 +38886,7 @@
     phone: 202-225-2472
     address: 325 Cannon House Office Building; Washington DC 20515-2301
     office: 325 Cannon House Office Building
-    url: https://hagedorn.house.gov/
+    url: https://hagedorn.house.gov
 - id:
     bioguide: C001119
     fec:
@@ -38914,7 +38914,7 @@
     phone: 202-225-2271
     address: 1523 Longworth House Office Building; Washington DC 20515-2302
     office: 1523 Longworth House Office Building
-    url: https://craig.house.gov/
+    url: https://craig.house.gov
 - id:
     bioguide: P000616
     fec:
@@ -38941,7 +38941,7 @@
     phone: 202-225-2871
     address: 1305 Longworth House Office Building; Washington DC 20515-2303
     office: 1305 Longworth House Office Building
-    url: https://phillips.house.gov/
+    url: https://phillips.house.gov
 - id:
     bioguide: O000173
     fec:
@@ -38968,7 +38968,7 @@
     phone: 202-225-4755
     address: 1517 Longworth House Office Building; Washington DC 20515-2305
     office: 1517 Longworth House Office Building
-    url: https://omar.house.gov/
+    url: https://omar.house.gov
 - id:
     bioguide: S001212
     fec:
@@ -38995,7 +38995,7 @@
     phone: 202-225-6211
     address: 126 Cannon House Office Building; Washington DC 20515-2308
     office: 126 Cannon House Office Building
-    url: https://stauber.house.gov/
+    url: https://stauber.house.gov
 - id:
     bioguide: G000591
     fec:
@@ -39021,7 +39021,7 @@
     phone: 202-225-5031
     address: 230 Cannon House Office Building; Washington DC 20515-2403
     office: 230 Cannon House Office Building
-    url: https://guest.house.gov/
+    url: https://guest.house.gov
 - id:
     bioguide: A000377
     fec:
@@ -39048,7 +39048,7 @@
     phone: 202-225-2611
     address: 1004 Longworth House Office Building; Washington DC 20515-3400
     office: 1004 Longworth House Office Building
-    url: https://armstrong.house.gov/
+    url: https://armstrong.house.gov
 - id:
     bioguide: P000614
     fec:
@@ -39075,7 +39075,7 @@
     phone: 202-225-5456
     address: 323 Cannon House Office Building; Washington DC 20515-2901
     office: 323 Cannon House Office Building
-    url: https://pappas.house.gov/
+    url: https://pappas.house.gov
 - id:
     bioguide: V000133
     fec:
@@ -39103,7 +39103,7 @@
     phone: 202-225-6572
     address: 331 Cannon House Office Building; Washington DC 20515-3002
     office: 331 Cannon House Office Building
-    url: https://vandrew.house.gov/
+    url: https://vandrew.house.gov
 - id:
     bioguide: K000394
     fec:
@@ -39129,7 +39129,7 @@
     phone: 202-225-4765
     address: 1516 Longworth House Office Building; Washington DC 20515-3003
     office: 1516 Longworth House Office Building
-    url: https://kim.house.gov/
+    url: https://kim.house.gov
 - id:
     bioguide: M001203
     fec:
@@ -39158,7 +39158,7 @@
     phone: 202-225-5361
     address: 426 Cannon House Office Building; Washington DC 20515-3007
     office: 426 Cannon House Office Building
-    url: https://malinowski.house.gov/
+    url: https://malinowski.house.gov
 - id:
     bioguide: S001207
     fec:
@@ -39186,7 +39186,7 @@
     phone: 202-225-5034
     address: 1208 Longworth House Office Building; Washington DC 20515-3011
     office: 1208 Longworth House Office Building
-    url: https://sherrill.house.gov/
+    url: https://sherrill.house.gov
 - id:
     bioguide: H001080
     fec:
@@ -39214,7 +39214,7 @@
     phone: 202-225-6316
     address: 1237 Longworth House Office Building; Washington DC 20515-3101
     office: 1237 Longworth House Office Building
-    url: https://haaland.house.gov/
+    url: https://haaland.house.gov
 - id:
     bioguide: T000484
     fec:
@@ -39241,7 +39241,7 @@
     phone: 202-225-2365
     address: 430 Cannon House Office Building; Washington DC 20515-3102
     office: 430 Cannon House Office Building
-    url: http://torressmall.house.gov
+    url: https://torressmall.house.gov
 - id:
     bioguide: L000590
     fec:
@@ -39268,7 +39268,7 @@
     phone: 202-225-3252
     address: 522 Cannon House Office Building; Washington DC 20515-2803
     office: 522 Cannon House Office Building
-    url: https://susielee.house.gov/
+    url: https://susielee.house.gov
 - id:
     bioguide: R000613
     fec:
@@ -39294,7 +39294,7 @@
     phone: 202-225-3371
     address: 1529 Longworth House Office Building; Washington DC 20515-3211
     office: 1529 Longworth House Office Building
-    url: https://maxrose.house.gov/
+    url: https://maxrose.house.gov
 - id:
     bioguide: O000172
     fec:
@@ -39322,7 +39322,7 @@
     phone: 202-225-3965
     address: 229 Cannon House Office Building; Washington DC 20515-3214
     office: 229 Cannon House Office Building
-    url: https://ocasio-cortez.house.gov/
+    url: https://ocasio-cortez.house.gov
 - id:
     bioguide: D000630
     fec:
@@ -39348,7 +39348,7 @@
     phone: 202-225-5614
     address: 1007 Longworth House Office Building; Washington DC 20515-3219
     office: 1007 Longworth House Office Building
-    url: https://delgado.house.gov/
+    url: https://delgado.house.gov
 - id:
     bioguide: B001308
     fec:
@@ -39377,7 +39377,7 @@
     phone: 202-225-3665
     address: 329 Cannon House Office Building; Washington DC 20515-3222
     office: 329 Cannon House Office Building
-    url: https://brindisi.house.gov/
+    url: https://brindisi.house.gov
 - id:
     bioguide: G000588
     fec:
@@ -39404,7 +39404,7 @@
     phone: 202-225-3876
     address: 1023 Longworth House Office Building; Washington DC 20515-3516
     office: 1023 Longworth House Office Building
-    url: https://anthonygonzalez.house.gov/
+    url: https://anthonygonzalez.house.gov
 - id:
     bioguide: H001083
     fec:
@@ -39432,7 +39432,7 @@
     phone: 202-225-2132
     address: 415 Cannon House Office Building; Washington DC 20515-3605
     office: 415 Cannon House Office Building
-    url: https://horn.house.gov/
+    url: https://horn.house.gov
 - id:
     bioguide: D000631
     fec:
@@ -39460,7 +39460,7 @@
     phone: 202-225-4731
     address: 129 Cannon House Office Building; Washington DC 20515-3804
     office: 129 Cannon House Office Building
-    url: https://dean.house.gov/
+    url: https://dean.house.gov
 - id:
     bioguide: H001085
     fec:
@@ -39488,7 +39488,7 @@
     phone: 202-225-4315
     address: 1218 Longworth House Office Building; Washington DC 20515-3806
     office: 1218 Longworth House Office Building
-    url: https://houlahan.house.gov/
+    url: https://houlahan.house.gov
 - id:
     bioguide: M001204
     fec:
@@ -39516,7 +39516,7 @@
     phone: 202-225-6511
     address: 326 Cannon House Office Building; Washington DC 20515-3809
     office: 326 Cannon House Office Building
-    url: https://meuser.house.gov/
+    url: https://meuser.house.gov
 - id:
     bioguide: J000302
     fec:
@@ -39542,7 +39542,7 @@
     phone: 202-225-2431
     address: 1337 Longworth House Office Building; Washington DC 20515-3813
     office: 1337 Longworth House Office Building
-    url: https://johnjoyce.house.gov/
+    url: https://johnjoyce.house.gov
 - id:
     bioguide: R000610
     fec:
@@ -39570,7 +39570,7 @@
     phone: 202-225-2065
     address: 531 Cannon House Office Building; Washington DC 20515-3814
     office: 531 Cannon House Office Building
-    url: https://reschenthaler.house.gov/
+    url: https://reschenthaler.house.gov
 - id:
     bioguide: C001122
     fec:
@@ -39597,7 +39597,7 @@
     phone: 202-225-3176
     address: 423 Cannon House Office Building; Washington DC 20515-4001
     office: 423 Cannon House Office Building
-    url: https://cunningham.house.gov/
+    url: https://cunningham.house.gov
 - id:
     bioguide: T000480
     fec:
@@ -39626,7 +39626,7 @@
     phone: 202-225-6030
     address: 313 Cannon House Office Building; Washington DC 20515-4004
     office: 313 Cannon House Office Building
-    url: https://timmons.house.gov/
+    url: https://timmons.house.gov
 - id:
     bioguide: J000301
     fec:
@@ -39653,7 +39653,7 @@
     phone: 202-225-2801
     address: 1508 Longworth House Office Building; Washington DC 20515-4100
     office: 1508 Longworth House Office Building
-    url: https://dustyjohnson.house.gov/
+    url: https://dustyjohnson.house.gov
 - id:
     bioguide: B001309
     fec:
@@ -39681,7 +39681,7 @@
     phone: 202-225-5435
     address: 1122 Longworth House Office Building; Washington DC 20515-4202
     office: 1122 Longworth House Office Building
-    url: https://burchett.house.gov/
+    url: https://burchett.house.gov
 - id:
     bioguide: R000612
     fec:
@@ -39709,7 +39709,7 @@
     phone: 202-225-4231
     address: 1232 Longworth House Office Building; Washington DC 20515-4206
     office: 1232 Longworth House Office Building
-    url: https://johnrose.house.gov/
+    url: https://johnrose.house.gov
 - id:
     bioguide: G000590
     fec:
@@ -39766,7 +39766,7 @@
     phone: 202-225-6565
     address: 413 Cannon House Office Building; Washington DC 20515-4302
     office: 413 Cannon House Office Building
-    url: https://crenshaw.house.gov/
+    url: https://crenshaw.house.gov
 - id:
     bioguide: T000479
     fec:
@@ -39793,7 +39793,7 @@
     phone: 202-225-4201
     address: 1404 Longworth House Office Building; Washington DC 20515-4303
     office: 1404 Longworth House Office Building
-    url: https://vantaylor.house.gov/
+    url: https://vantaylor.house.gov
 - id:
     bioguide: G000589
     fec:
@@ -39821,7 +39821,7 @@
     phone: 202-225-3484
     address: 425 Cannon House Office Building; Washington DC 20515-4305
     office: 425 Cannon House Office Building
-    url: https://gooden.house.gov/
+    url: https://gooden.house.gov
 - id:
     bioguide: W000827
     fec:
@@ -39847,7 +39847,7 @@
     phone: 202-225-2002
     address: 428 Cannon House Office Building; Washington DC 20515-4306
     office: 428 Cannon House Office Building
-    url: https://wright.house.gov/
+    url: https://wright.house.gov
 - id:
     bioguide: F000468
     fec:
@@ -39875,7 +39875,7 @@
     phone: 202-225-2571
     address: 1429 Longworth House Office Building; Washington DC 20515-4307
     office: 1429 Longworth House Office Building
-    url: https://fletcher.house.gov/
+    url: https://fletcher.house.gov
 - id:
     bioguide: E000299
     fec:
@@ -39902,7 +39902,7 @@
     phone: 202-225-4831
     address: 1505 Longworth House Office Building; Washington DC 20515-4316
     office: 1505 Longworth House Office Building
-    url: https://escobar.house.gov/
+    url: https://escobar.house.gov
 - id:
     bioguide: R000614
     fec:
@@ -39929,7 +39929,7 @@
     phone: 202-225-4236
     address: 1319 Longworth House Office Building; Washington DC 20515-4321
     office: 1319 Longworth House Office Building
-    url: https://roy.house.gov/
+    url: https://roy.house.gov
 - id:
     bioguide: G000587
     fec:
@@ -39958,7 +39958,7 @@
     phone: 202-225-1688
     address: 1620 Longworth House Office Building; Washington DC 20515-4329
     office: 1620 Longworth House Office Building
-    url: https://sylviagarcia.house.gov/
+    url: https://sylviagarcia.house.gov
 - id:
     bioguide: A000376
     fec:
@@ -39986,7 +39986,7 @@
     phone: 202-225-2231
     address: 328 Cannon House Office Building; Washington DC 20515-4332
     office: 328 Cannon House Office Building
-    url: https://allred.house.gov/
+    url: https://allred.house.gov
 - id:
     bioguide: M001209
     fec:
@@ -40014,7 +40014,7 @@
     phone: 202-225-3011
     address: 130 Cannon House Office Building; Washington DC 20515-4404
     office: 130 Cannon House Office Building
-    url: https://mcadams.house.gov/
+    url: https://mcadams.house.gov
 - id:
     bioguide: L000591
     fec:
@@ -40043,7 +40043,7 @@
     phone: 202-225-4215
     address: 534 Cannon House Office Building; Washington DC 20515-4602
     office: 534 Cannon House Office Building
-    url: https://luria.house.gov/
+    url: https://luria.house.gov
 - id:
     bioguide: R000611
     fec:
@@ -40070,7 +40070,7 @@
     phone: 202-225-4711
     address: 1022 Longworth House Office Building; Washington DC 20515-4605
     office: 1022 Longworth House Office Building
-    url: https://riggleman.house.gov/
+    url: https://riggleman.house.gov
 - id:
     bioguide: C001118
     fec:
@@ -40098,7 +40098,7 @@
     phone: 202-225-5431
     address: 1009 Longworth House Office Building; Washington DC 20515-4606
     office: 1009 Longworth House Office Building
-    url: https://cline.house.gov/
+    url: https://cline.house.gov
 - id:
     bioguide: S001209
     fec:
@@ -40126,7 +40126,7 @@
     phone: 202-225-2815
     address: 1239 Longworth House Office Building; Washington DC 20515-4607
     office: 1239 Longworth House Office Building
-    url: https://spanberger.house.gov/
+    url: https://spanberger.house.gov
 - id:
     bioguide: W000825
     fec:
@@ -40154,7 +40154,7 @@
     phone: 202-225-5136
     address: 1217 Longworth House Office Building; Washington DC 20515-4610
     office: 1217 Longworth House Office Building
-    url: https://wexton.house.gov/
+    url: https://wexton.house.gov
 - id:
     bioguide: S001216
     fec:
@@ -40181,7 +40181,7 @@
     phone: 202-225-7761
     address: 1123 Longworth House Office Building; Washington DC 20515-4708
     office: 1123 Longworth House Office Building
-    url: https://schrier.house.gov/
+    url: https://schrier.house.gov
 - id:
     bioguide: S001213
     fec:
@@ -40207,7 +40207,7 @@
     phone: 202-225-3031
     address: 1408 Longworth House Office Building; Washington DC 20515-4901
     office: 1408 Longworth House Office Building
-    url: https://steil.house.gov/
+    url: https://steil.house.gov
 - id:
     bioguide: M001205
     fec:
@@ -40236,7 +40236,7 @@
     phone: 202-225-3452
     address: 1605 Longworth House Office Building; Washington DC 20515-4803
     office: 1605 Longworth House Office Building
-    url: https://miller.house.gov/
+    url: https://miller.house.gov
 - id:
     bioguide: S001217
     lis: S404
@@ -40476,3 +40476,4 @@
     state: PA
     district: 12
     party: Republican
+    url: https://keller.house.gov


### PR DESCRIPTION
The house_websites.py script was not finding any URLs due to a change in the HTML of the House directory page.

This change fixes the script, and updates current House member URLs based on the fixed script.

Most changes are just to remove a trailing slash or do http->https, but there are a few substantive changes as well.