### PR TITLE
legislators-current.yaml: add url

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40476,3 +40476,4 @@
     state: PA
     district: 12
     party: Republican
+    url: https://keller.house.gov


### PR DESCRIPTION
fixes circle-ci:
> legislators-current.yaml:K000395:terms[0](2019-06-03 to 2021-01-03) Term is missing a website url.