### PR TITLE
add Rep. Murphy, Rep. Bishop

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40480,3 +40480,57 @@
     address: 1717 Longworth House Office Building; Washington DC 20515-3812
     office: 1717 Longworth House Office Building
     phone: 202-225-3731
+- id:
+    bioguide: B001311
+    fec:
+    - H0NC09187
+    govtrack: 412844
+    opensecrets: N00044335
+    wikipedia: Dan Bishop
+    wikidata: Q20090301
+    ballotpedia: Dan Bishop
+  name:
+    first: Dan
+    last: Bishop
+  bio:
+    gender: M
+    birthday: '1964-07-01'
+  terms:
+  - type: rep
+    start: '2019-09-17'
+    end: '2021-01-03'
+    state: NC
+    district: 9
+    party: Republican
+    url: https://danbishop.house.gov/
+    contact_form: https://danbishop.house.gov/contact/email
+    address: 132 Cannon House Office Building; Washington DC 20515-3309
+    office: 132 Cannon House Office Building
+    phone: 202-225-1976
+- id:
+    bioguide: M001210
+    fec:
+    - H0NC03172
+    govtrack: 412845
+    opensecrets: N00044027
+    wikipedia: Greg Murphy (politician)
+    wikidata: Q23074266
+    ballotpedia: Gregory Murphy
+  name:
+    first: Gregory
+    middle: Francis
+    last: Murphy
+  bio:
+    gender: M
+  terms:
+  - type: rep
+    start: '2019-09-17'
+    end: '2021-01-03'
+    state: NC
+    district: 3
+    party: Republican
+    url: https://gregmurphy.house.gov/
+    contact_form: https://gregmurphy.house.gov/contact/email
+    address: 2333 Rayburn House Office Building; Washington DC 20515-3303
+    office: 2333 Rayburn House Office Building
+    phone: 202-225-3415

--- a/misc/new-member-template.yaml
+++ b/misc/new-member-template.yaml
@@ -16,7 +16,7 @@
     lis: S999              # not assigned until there is a Senate roll call vote
     fec:                   # http://fec.gov/finance/disclosure/candcmte_info.shtml
     - H1XX99999            #   (you're looking for a Candidate ID)
-    govtrack: 456789       # you may assign the next available integer
+    govtrack: 456789       # you may assign the next available integer (try: `(echo -n "1+"; git grep -h govtrack: *.yaml | sort | tail -1 | sed "s/ *govtrack: //") | bc`)
     opensecrets: N00099999 # http://www.opensecrets.org/
     votesmart: 159999      # http://votesmart.org/
     icpsr: 99999           # not knowable until voteview.org publishes roll call raw data


### PR DESCRIPTION
Neither one is on Bioguide yet. I guessed Murphy's bioguide ID from the next available M number; GPO bill XML is already giving the id for Biship. Bishop's birthday is from Wikipedia; Murphy's birthday is omitted --- I can't find a source.

address/office/phone is from running house_contacts.py.