### PR TITLE
icpsr ids - fix issue #601

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -36933,6 +36933,7 @@
     maplight: 2246
     google_entity_id: kg:/m/0gfgsrm
     opensecrets: N00040712
+    icpsr: 21750
   name:
     first: Ron
     last: Estes
@@ -36976,6 +36977,7 @@
     google_entity_id: kg:/m/030pb5p
     house_history: 15032448990
     maplight: 2247
+    icpsr: 21751
   name:
     first: Greg
     last: Gianforte
@@ -37019,6 +37021,7 @@
     google_entity_id: kg:/m/0f9kbx
     house_history: 15032448994
     maplight: 2248
+    icpsr: 21753
   name:
     first: Ralph
     last: Norman
@@ -37063,6 +37066,7 @@
     cspan: 108883
     house_history: 15032449022
     maplight: 2250
+    icpsr: 21754
   name:
     first: Jimmy
     last: Gomez
@@ -37103,6 +37107,7 @@
     ballotpedia: John Curtis (Utah)
     google_entity_id: kg:/m/0bmdhtb
     maplight: 2251
+    icpsr: 21755
   name:
     first: John
     last: Curtis
@@ -37275,6 +37280,7 @@
     ballotpedia: Conor Lamb
     google_entity_id: kg:/g/11gdj36kt1
     votesmart: 177656
+    icpsr: 21756
   name:
     first: Conor
     last: Lamb
@@ -37314,6 +37320,7 @@
     ballotpedia: Debbie Lesko
     google_entity_id: kg:/m/0zwmkgq
     votesmart: 106483
+    icpsr: 21757
   name:
     first: Debbie
     last: Lesko
@@ -37353,6 +37360,7 @@
     ballotpedia: Michael Cloud (Texas)
     opensecrets: N00041882
     votesmart: 177350
+    icpsr: 21758
   name:
     first: Michael
     last: Cloud
@@ -37392,6 +37400,7 @@
     ballotpedia: Troy Balderson
     google_entity_id: kg:/m/09ry4tm
     votesmart: 102781
+    icpsr: 21759
   name:
     first: Troy
     last: Balderson
@@ -37430,6 +37439,7 @@
     opensecrets: N00040829
     ballotpedia: Kevin Hern
     votesmart: 180004
+    icpsr: 21760
   name:
     first: Kevin
     middle: R.
@@ -37470,6 +37480,7 @@
     ballotpedia: Joseph Morelle
     google_entity_id: kg:/m/03d820m
     votesmart: 4362
+    icpsr: 21761
   name:
     first: Joseph
     middle: D.
@@ -37509,6 +37520,7 @@
     opensecrets: N00042706
     ballotpedia: Mary Gay Scanlon
     votesmart: 178890
+    icpsr: 21762
   name:
     first: Mary
     middle: Gay
@@ -37548,6 +37560,7 @@
     opensecrets: N00041997
     ballotpedia: Susan Wild
     votesmart: 178895
+    icpsr: 21763
   name:
     first: Susan
     middle: Ellis
@@ -37746,6 +37759,7 @@
     opensecrets: N00041750
     google_entity_id: kg:/m/0hgrxqb
     votesmart: 72030
+    icpsr: 21968
   name:
     first: Greg
     last: Stanton
@@ -37774,6 +37788,7 @@
     opensecrets: N00040853
     votesmart: 179326
     ballotpedia: Josh Harder
+    icpsr: 21930
   name:
     first: Josh
     last: Harder
@@ -37803,6 +37818,7 @@
     wikidata: Q59306065
     votesmart: 57197
     ballotpedia: TJ Cox
+    icpsr: 21909
   name:
     first: TJ
     last: Cox
@@ -37830,6 +37846,7 @@
     wikidata: Q58416634
     opensecrets: N00040644
     votesmart: 179354
+    icpsr: 21932
   name:
     first: Katie
     last: Hill
@@ -37857,6 +37874,7 @@
     wikipedia: Gil Cisneros
     wikidata: Q54958760
     votesmart: 179370
+    icpsr: 21907
   name:
     first: Gilbert
     middle: Ray
@@ -37885,6 +37903,7 @@
     wikidata: Q58754391
     opensecrets: N00040865
     votesmart: 179393
+    icpsr: 21954
   name:
     first: Katie
     last: Porter
@@ -37912,6 +37931,7 @@
     wikidata: Q58333597
     opensecrets: N00040666
     votesmart: 179404
+    icpsr: 21960
   name:
     first: Harley
     last: Rouda
@@ -37939,6 +37959,7 @@
     wikidata: Q55424854
     opensecrets: N00040667
     votesmart: 179416
+    icpsr: 21939
   name:
     first: Mike
     last: Levin
@@ -37966,6 +37987,7 @@
     wikidata: Q57242006
     opensecrets: N00041080
     votesmart: 151075
+    icpsr: 21948
   name:
     first: Joe
     last: Neguse
@@ -37993,6 +38015,7 @@
     opensecrets: N00040876
     wikidata: Q58323071
     votesmart: 180218
+    icpsr: 21912
   name:
     first: Jason
     last: Crow
@@ -38020,6 +38043,7 @@
     wikidata: Q24951316
     opensecrets: N00043421
     votesmart: 181744
+    icpsr: 21931
   name:
     first: Jahana
     last: Hayes
@@ -38046,6 +38070,7 @@
     wikipedia: Michael Waltz
     wikidata: Q55386653
     opensecrets: N00042403
+    icpsr: 21981
   name:
     first: Michael
     last: Waltz
@@ -38074,6 +38099,7 @@
     opensecrets: N00043319
     google_entity_id: kg:/m/0v3c060
     votesmart: 142164
+    icpsr: 21967
   name:
     first: Ross
     last: Spano
@@ -38102,6 +38128,7 @@
     opensecrets: N00042808
     google_entity_id: kg:/m/0k3lrh0
     votesmart: 117248
+    icpsr: 21971
   name:
     first: W.
     middle: Gregory
@@ -38131,6 +38158,7 @@
     opensecrets: N00041561
     votesmart: 173449
     ballotpedia: Debbie Mucarsel-Powell
+    icpsr: 21947
   name:
     first: Debbie
     last: Mucarsel-Powell
@@ -38159,6 +38187,7 @@
     opensecrets: N00042811
     google_entity_id: kg:/m/01v3vb
     votesmart: 182301
+    icpsr: 21963
   name:
     first: Donna
     middle: E.
@@ -38188,6 +38217,7 @@
     opensecrets: N00042813
     google_entity_id: kg:/g/11f647_0gj
     votesmart: 178538
+    icpsr: 21944
   name:
     first: Lucy
     last: McBath
@@ -38244,6 +38274,7 @@
     votesmart: 151127
     opensecrets: N00040888
     ballotpedia: Abby Finkenauer
+    icpsr: 21918
   name:
     first: Abby
     last: Finkenauer
@@ -38272,6 +38303,7 @@
     wikidata: Q58324150
     votesmart: 179226
     ballotpedia: Cindy Axne
+    icpsr: 21902
   name:
     first: Cynthia
     last: Axne
@@ -38300,6 +38332,7 @@
     google_entity_id: kg:/m/05h4vgh
     opensecrets: N00041335
     votesmart: 33091
+    icpsr: 21920
   name:
     first: Russ
     last: Fulcher
@@ -38328,6 +38361,7 @@
     opensecrets: N00042114
     google_entity_id: kg:/m/012c8r5x
     votesmart: 6261
+    icpsr: 21921
   name:
     first: Jesús
     middle: G.
@@ -38355,6 +38389,7 @@
     opensecrets: N00041338
     wikipedia: Sean Casten
     wikidata: Q55386655
+    icpsr: 21906
   name:
     first: Sean
     last: Casten
@@ -38382,6 +38417,7 @@
     wikidata: Q48471874
     opensecrets: N00041569
     votesmart: 177001
+    icpsr: 21979
   name:
     first: Lauren
     last: Underwood
@@ -38409,6 +38445,7 @@
     wikipedia: Jim Baird (American politician)
     wikidata: Q48813213
     votesmart: 86013
+    icpsr: 21903
   name:
     first: James
     middle: R.
@@ -38437,6 +38474,7 @@
     wikidata: Q52151577
     opensecrets: N00041956
     votesmart: 177876
+    icpsr: 21952
   name:
     first: Greg
     last: Pence
@@ -38463,6 +38501,7 @@
     wikipedia: Steve Watkins (politician)
     wikidata: Q60428824
     opensecrets: N00042126
+    icpsr: 21982
   name:
     first: Steven
     middle: C.
@@ -38492,6 +38531,7 @@
     wikidata: Q58322868
     votesmart: 181201
     ballotpedia: Sharice Davids
+    icpsr: 21914
   name:
     first: Sharice
     last: Davids
@@ -38519,6 +38559,7 @@
     wikidata: Q56486676
     opensecrets: N00041808
     votesmart: 182310
+    icpsr: 21977
   name:
     first: Lori
     last: Trahan
@@ -38547,6 +38588,7 @@
     opensecrets: N00042581
     google_entity_id: kg:/m/0bmh9vc
     votesmart: 122700
+    icpsr: 21955
   name:
     first: Ayanna
     last: Pressley
@@ -38574,6 +38616,7 @@
     wikipedia: David Trone
     wikidata: Q29446408
     votesmart: 167336
+    icpsr: 21978
   name:
     first: David
     middle: J.
@@ -38603,6 +38646,7 @@
     opensecrets: N00041357
     votesmart: 181080
     ballotpedia: Elissa Slotkin
+    icpsr: 21965
   name:
     first: Elissa
     last: Slotkin
@@ -38630,6 +38674,7 @@
     wikidata: Q4760938
     opensecrets: N00042149
     votesmart: 66287
+    icpsr: 21940
   name:
     first: Andy
     last: Levin
@@ -38658,6 +38703,7 @@
     opensecrets: N00040915
     votesmart: 181092
     ballotpedia: Haley Stevens
+    icpsr: 21972
   name:
     first: Haley
     middle: M.
@@ -38687,6 +38733,7 @@
     opensecrets: N00042649
     google_entity_id: kg:/m/059_x6c
     votesmart: 105368
+    icpsr: 21975
   name:
     first: Rashida
     last: Tlaib
@@ -38714,6 +38761,7 @@
     wikidata: Q58494532
     opensecrets: N00031390
     votesmart: 146027
+    icpsr: 21929
   name:
     first: Jim
     last: Hagedorn
@@ -38742,6 +38790,7 @@
     wikidata: Q58324174
     votesmart: 166261
     ballotpedia: Angie Craig
+    icpsr: 21910
   name:
     first: Angie
     last: Craig
@@ -38769,6 +38818,7 @@
     wikidata: Q58323131
     opensecrets: N00041134
     votesmart: 181357
+    icpsr: 21953
   name:
     first: Dean
     last: Phillips
@@ -38796,6 +38846,7 @@
     wikidata: Q26436159
     opensecrets: N00043581
     votesmart: 171628
+    icpsr: 21950
   name:
     first: Ilhan
     last: Omar
@@ -38823,6 +38874,7 @@
     wikidata: Q55955746
     opensecrets: N00041511
     votesmart: 159954
+    icpsr: 21969
   name:
     first: Pete
     last: Stauber
@@ -38849,6 +38901,7 @@
     wikipedia: Michael Guest (politician)
     wikidata: Q60428645
     opensecrets: N00042458
+    icpsr: 21927
   name:
     first: Michael
     last: Guest
@@ -38876,6 +38929,7 @@
     wikipedia: Kelly Armstrong
     wikidata: Q50362353
     votesmart: 139338
+    icpsr: 21901
   name:
     first: Kelly
     last: Armstrong
@@ -38903,6 +38957,7 @@
     wikidata: Q5107684
     opensecrets: N00042161
     google_entity_id: kg:/m/0nd3t8z
+    icpsr: 21951
   name:
     first: Chris
     last: Pappas
@@ -38931,6 +38986,7 @@
     opensecrets: N00042164
     google_entity_id: kg:/m/08h3sl
     votesmart: 24685
+    icpsr: 21980
   name:
     first: Jefferson
     last: Van Drew
@@ -38957,6 +39013,7 @@
     wikipedia: Andy Kim (politician)
     wikidata: Q55639180
     opensecrets: N00041370
+    icpsr: 21937
   name:
     first: Andy
     last: Kim
@@ -38986,6 +39043,7 @@
     google_entity_id: kg:/g/11cmhw_v1s
     votesmart: 179645
     ballotpedia: Tom Malinowski
+    icpsr: 21942
   name:
     first: Tom
     last: Malinowski
@@ -39014,6 +39072,7 @@
     opensecrets: N00041154
     votesmart: 179651
     ballotpedia: Mikie Sherrill
+    icpsr: 21964
   name:
     first: Mikie
     last: Sherrill
@@ -39041,6 +39100,7 @@
     wikidata: Q54860790
     opensecrets: N00040933
     votesmart: 149368
+    icpsr: 21928
   name:
     first: Debra
     middle: A.
@@ -39069,6 +39129,7 @@
     wikipedia: Xochitl Torres Small
     wikidata: Q58399761
     votesmart: 177978
+    icpsr: 21976
   name:
     first: Xochitl
     last: Torres Small
@@ -39096,6 +39157,7 @@
     wikipedia: Susie Lee
     wikidata: Q58333611
     votesmart: 169344
+    icpsr: 21938
   name:
     first: Susie
     last: Lee
@@ -39122,6 +39184,7 @@
     wikipedia: Max Rose (politician)
     wikidata: Q56046860
     opensecrets: N00041588
+    icpsr: 21958
   name:
     first: Max
     last: Rose
@@ -39150,6 +39213,7 @@
     opensecrets: N00041162
     votesmart: 180416
     ballotpedia: Alexandria Ocasio-Cortez
+    icpsr: 21949
   name:
     first: Alexandria
     last: Ocasio-Cortez
@@ -39176,6 +39240,7 @@
     wikipedia: Antonio Delgado (politician)
     wikidata: Q60428696
     opensecrets: N00040741
+    icpsr: 21916
   name:
     first: Antonio
     last: Delgado
@@ -39205,6 +39270,7 @@
     google_entity_id: kg:/m/0hhqfyc
     votesmart: 135258
     ballotpedia: Anthony Brindisi
+    icpsr: 21904
   name:
     first: Anthony
     last: Brindisi
@@ -39232,6 +39298,7 @@
     wikidata: Q3487172
     opensecrets: N00041690
     google_entity_id: kg:/m/0gznlq
+    icpsr: 21924
   name:
     first: Anthony
     last: Gonzalez
@@ -39259,6 +39326,7 @@
     wikidata: Q58323559
     opensecrets: N00041394
     votesmart: 180018
+    icpsr: 21933
   name:
     first: Kendra
     middle: S.
@@ -39288,6 +39356,7 @@
     opensecrets: N00042894
     google_entity_id: kg:/m/0nfwmy_
     votesmart: 136484
+    icpsr: 21915
   name:
     first: Madeleine
     last: Dean
@@ -39316,6 +39385,7 @@
     opensecrets: N00040949
     votesmart: 178893
     ballotpedia: Chrissy Houlahan
+    icpsr: 21934
   name:
     first: Chrissy
     last: Houlahan
@@ -39344,6 +39414,7 @@
     opensecrets: N00029416
     google_entity_id: kg:/m/03wf1q3
     votesmart: 102438
+    icpsr: 21945
   name:
     first: Daniel
     last: Meuser
@@ -39370,6 +39441,7 @@
     wikipedia: John Joyce (American politician)
     wikidata: Q60428839
     opensecrets: N00043242
+    icpsr: 21936
   name:
     first: John
     last: Joyce
@@ -39398,6 +39470,7 @@
     opensecrets: N00041871
     google_entity_id: kg:/g/11bwn3bsvm
     votesmart: 166004
+    icpsr: 21956
   name:
     first: Guy
     last: Reschenthaler
@@ -39425,6 +39498,7 @@
     wikidata: Q58993183
     opensecrets: N00041400
     votesmart: 179601
+    icpsr: 21913
   name:
     first: Joe
     last: Cunningham
@@ -39453,6 +39527,7 @@
     opensecrets: N00042715
     google_entity_id: kg:/g/11g6ns21_f
     votesmart: 168923
+    icpsr: 21974
   name:
     first: William
     middle: R.
@@ -39481,6 +39556,7 @@
     wikidata: Q30015838
     opensecrets: N00040559
     votesmart: 48307
+    icpsr: 21935
   name:
     first: Dusty
     last: Johnson
@@ -39509,6 +39585,7 @@
     wikidata: Q7803244
     google_entity_id: kg:/m/03yt07
     votesmart: 24379
+    icpsr: 21905
   name:
     first: Tim
     last: Burchett
@@ -39536,6 +39613,7 @@
     wikidata: Q33044040
     opensecrets: N00041599
     votesmart: 180452
+    icpsr: 21959
   name:
     first: John
     middle: W.
@@ -39565,6 +39643,7 @@
     opensecrets: N00041873
     google_entity_id: kg:/m/09rx6jq
     votesmart: 139030
+    icpsr: 21926
   name:
     first: Mark
     middle: E.
@@ -39594,6 +39673,7 @@
     opensecrets: N00042224
     google_entity_id: kg:/g/11fk40sjyz
     votesmart: 177270
+    icpsr: 21911
   name:
     first: Dan
     last: Crenshaw
@@ -39621,6 +39701,7 @@
     wikidata: Q7913689
     opensecrets: N00027709
     google_entity_id: kg:/m/0f9kk3
+    icpsr: 21973
   name:
     first: Van
     last: Taylor
@@ -39649,6 +39730,7 @@
     opensecrets: N00042237
     google_entity_id: kg:/m/0jkx4bp
     votesmart: 177282
+    icpsr: 21925
   name:
     first: Lance
     last: Gooden
@@ -39675,6 +39757,7 @@
     wikipedia: Ron Wright (politician)
     wikidata: Q60428775
     opensecrets: N00042240
+    icpsr: 21984
   name:
     first: Ron
     last: Wright
@@ -39703,6 +39786,7 @@
     votesmart: 177031
     opensecrets: N00041194
     ballotpedia: Lizzie Pannill Fletcher
+    icpsr: 21919
   name:
     first: Lizzie
     last: Fletcher
@@ -39730,6 +39814,7 @@
     wikidata: Q52274267
     votesmart: 99345
     opensecrets: N00041702
+    icpsr: 21917
   name:
     first: Veronica
     last: Escobar
@@ -39757,6 +39842,7 @@
     wikidata: Q58333615
     opensecrets: N00042268
     votesmart: 177319
+    icpsr: 21961
   name:
     first: Chip
     last: Roy
@@ -39785,6 +39871,7 @@
     opensecrets: N00042282
     google_entity_id: kg:/m/0ryt4bt
     votesmart: 49734
+    icpsr: 21922
   name:
     first: Sylvia
     middle: R.
@@ -39813,6 +39900,7 @@
     wikipedia: Colin Allred
     wikidata: Q5144845
     votesmart: 177357
+    icpsr: 21900
   name:
     first: Colin
     middle: Z.
@@ -39842,6 +39930,7 @@
     opensecrets: N00042013
     google_entity_id: kg:/m/0bbv3kw
     votesmart: 117512
+    icpsr: 21943
   name:
     first: Ben
     last: McAdams
@@ -39870,6 +39959,7 @@
     votesmart: 179677
     opensecrets: N00042293
     ballotpedia: Elaine Luria
+    icpsr: 21941
   name:
     first: Elaine
     middle: G.
@@ -39898,6 +39988,7 @@
     wikidata: Q28086149
     opensecrets: N00043541
     votesmart: 181445
+    icpsr: 21957
   name:
     first: Denver
     last: Riggleman
@@ -39926,6 +40017,7 @@
     wikidata: Q4885439
     google_entity_id: kg:/m/04yf6mk
     votesmart: 50959
+    icpsr: 21908
   name:
     first: Ben
     last: Cline
@@ -39953,6 +40045,7 @@
     wikidata: Q55603085
     opensecrets: N00041418
     votesmart: 179682
+    icpsr: 21966
   name:
     first: Abigail
     middle: Davis
@@ -39982,6 +40075,7 @@
     opensecrets: N00041002
     google_entity_id: kg:/m/0_flt0x
     votesmart: 147013
+    icpsr: 21983
   name:
     first: Jennifer
     last: Wexton
@@ -40009,6 +40103,7 @@
     wikidata: Q58333616
     opensecrets: N00041606
     votesmart: 181124
+    icpsr: 21962
   name:
     first: Kim
     last: Schrier
@@ -40035,6 +40130,7 @@
     wikipedia: Bryan Steil
     wikidata: Q58494431
     opensecrets: N00043379
+    icpsr: 21970
   name:
     first: Bryan
     last: Steil
@@ -40063,6 +40159,7 @@
     opensecrets: N00041542
     google_entity_id: kg:/m/0102fnyn
     votesmart: 52123
+    icpsr: 21946
   name:
     first: Carol
     middle: D.
@@ -40094,6 +40191,7 @@
     ballotpedia: Rick Scott
     google_entity_id: kg:/m/0btx2g
     votesmart: 124204
+    icpsr: 41903
   name:
     first: Rick
     last: Scott
@@ -40126,6 +40224,7 @@
     lis: S397
     google_entity_id: kg:/g/11f2ckdwty
     votesmart: 148564
+    icpsr: 41900
   name:
     first: Mike
     last: Braun
@@ -40158,6 +40257,7 @@
     lis: S399
     google_entity_id: kg:/g/11bwy_95zy
     votesmart: 169716
+    icpsr: 41901
   name:
     first: Joshua
     last: Hawley
@@ -40191,6 +40291,7 @@
     lis: S401
     google_entity_id: kg:/m/0271_s
     votesmart: 21942
+    icpsr: 41902
   name:
     first: Mitt
     last: Romney
@@ -40279,6 +40380,7 @@
     wikidata: Q41694157
     opensecrets: N00041668
     votesmart: 151420
+    icpsr: 21923
   name:
     first: Jared
     middle: Forrest
@@ -40307,6 +40409,7 @@
     wikidata: Q5495642
     opensecrets: N00044065
     votesmart: 119553
+    icpsr: 21985
   name:
     first: Fred
     last: Keller
@@ -40334,6 +40437,7 @@
     wikipedia: Dan Bishop
     wikidata: Q20090301
     ballotpedia: Dan Bishop
+    icpsr: 21986
   name:
     first: Dan
     last: Bishop
@@ -40362,6 +40466,7 @@
     wikipedia: Greg Murphy (politician)
     wikidata: Q23074266
     ballotpedia: Gregory Murphy
+    icpsr: 21987
   name:
     first: Gregory
     middle: Francis

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -61,11 +61,36 @@ def run():
 
     read_files = [("sen",senate_data),("rep",house_data)]
     print("Running for congress " + congress)
-    for read_file in read_files:
+    for read_file_chamber,read_file_content in read_files:
         for data_file in data_files:
             for legislator in data_file[0]:
                 num_matches = 0
                 write_id = ""
+                # this can't run unless we've already collected a bioguide for this person
+                bioguide = legislator["id"].get("bioguide", None)
+                # if we've limited this to just one bioguide, skip over everyone else
+                if only_bioguide and (bioguide != only_bioguide):
+                    continue
+                #if not in currently read chamber, skip
+                chamber = legislator['terms'][len(legislator['terms'])-1]['type']
+                if chamber != read_file_chamber:
+                    continue
+
+                #only run for selected congress
+                latest_congress = utils.congress_from_legislative_year(utils.legislative_year(parse_date(legislator['terms'][len(legislator['terms'])-1]['start'])))
+                if chamber == "sen":
+                    congresses = [latest_congress,latest_congress+1,latest_congress+2]
+                else:
+                    congresses =[latest_congress]
+
+                if int(congress) not in congresses:
+                    continue
+
+                # pull data to match from yaml
+
+                last_name = legislator['name']['last'].upper()
+                state = utils.states[legislator['terms'][len(legislator['terms'])-1]['state']].upper()[:7].strip()
+
             #     # # this can't run unless we've already collected a bioguide for this person
             #     bioguide = legislator["id"].get("bioguide", None)
             #     # if we've limited this to just one bioguide, skip over everyone else

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -96,6 +96,13 @@ def run():
                 content_as_file = StringIO(read_file_content)
                 content_parsed = csv.reader(content_as_file, delimiter=',')
 
+                # loop through congress members in read file, see if one matches the current legislator
+                for icpsr_member in content_parsed:
+                    # ensure unique match bassed of bioguide id
+                    if bioguide == icpsr_member[10]:
+                        num_matches += 1
+                        write_id = int(icpsr_member[2])
+
 
             #     # # this can't run unless we've already collected a bioguide for this person
             #     bioguide = legislator["id"].get("bioguide", None)

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -33,18 +33,18 @@ def run():
     legislators = load_data("legislators-historical.yaml")
     data_files.append((legislators,"legislators-historical.yaml"))
 
-    #load roll call data. Will need to be updated (possibly) for 114th+ congresses, since it is unclear what the URl format will be
+    # load member data from vote view
     if congress == None:
         raise Exception("the --congress flag is required")
-    elif congress == "113":
-        url_senate = "http://amypond.sscnet.ucla.edu/rollcall/static/S113.ord"
-        url_house = "http://amypond.sscnet.ucla.edu/rollcall/static/H113.ord"
-    elif int(congress) <10 and int(congress) >0:
-        url_senate = "ftp://voteview.com/dtaord/sen0%skh.ord" % congress
-        url_house = "ftp://voteview.com/dtaord/hou0%skh.ord" % congress
-    elif int(congress) < 113 and int(congress) >= 10:
-        url_senate = "ftp://voteview.com/dtaord/sen%skh.ord" % congress
-        url_house = "ftp://voteview.com/dtaord/hou%skh.ord" % congress
+    elif int(congress) < 10 and int(congress) > 0:
+        url_senate = "https://voteview.com/static/data/out/members/S00%s_members.csv" % congress
+        url_house = "https://voteview.com/static/data/out/members/H00%s_members.csv" % congress
+    elif int(congress) < 100 and int(congress) >= 10:
+        url_senate = "https://voteview.com/static/data/out/members/S0%s_members.csv" % congress
+        url_house = "https://voteview.com/static/data/out/members/H0%s_members.csv" % congress
+    elif int(congress) >= 100:
+        url_senate = "https://voteview.com/static/data/out/members/S%s_members.csv" % congress
+        url_house = "https://voteview.com/static/data/out/members/H%s_members.csv" % congress
     else:
         raise Exception("no data for congress " + congress)
 

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -66,62 +66,62 @@ def run():
             for legislator in data_file[0]:
                 num_matches = 0
                 write_id = ""
-                # # this can't run unless we've already collected a bioguide for this person
-                bioguide = legislator["id"].get("bioguide", None)
-                # if we've limited this to just one bioguide, skip over everyone else
-                if only_bioguide and (bioguide != only_bioguide):
-                    continue
-                #if not in currently read chamber, skip
-                chamber = legislator['terms'][len(legislator['terms'])-1]['type']
-                if chamber != read_file[1]:
-                    continue
-
-                #only run for selected congress
-                latest_congress = utils.congress_from_legislative_year(utils.legislative_year(parse_date(legislator['terms'][len(legislator['terms'])-1]['start'])))
-                if chamber == "sen":
-                    congresses = [latest_congress,latest_congress+1,latest_congress+2]
-                else:
-                    congresses =[latest_congress]
-
-                if int(congress) not in congresses:
-                    continue
-
-                # pull data to match from yaml
-
-                last_name_unicode = legislator['name']['last'].upper().strip().replace('\'','')
-                last_name = unicodedata.normalize('NFD', str(last_name_unicode)).encode('ascii', 'ignore')
-                state = utils.states[legislator['terms'][len(legislator['terms'])-1]['state']].upper()[:7].strip()
-                # select icpsr source data based on more recent chamber
-
-                lines = read_file[0].split('\n')
-                for line in lines:
-                    # parse source data
-                    icpsr_state = line[12:20].strip()
-                    icpsr_name = line[21:].strip().strip(string.digits).strip()
-                    icpsr_id = line[3:8].strip()
-
-                    #ensure unique match
-                    if icpsr_name[:8] == last_name[:8] and state == icpsr_state:
-                        num_matches += 1
-                        write_id = icpsr_id
-                #skip if icpsr id is currently in data
-                if "icpsr" in legislator["id"]:
-                    if write_id == legislator["id"]["icpsr"] or write_id == "":
-                        continue
-                    elif write_id != legislator["id"]["icpsr"] and write_id != "":
-                        error_log.writerow(["Incorrect_ID","NA",last_name[:8],state,"NA",legislator["id"]["icpsr"],write_id])
-                        print("ID updated for %s" % last_name)
-                if num_matches == 1:
-                    legislator['id']['icpsr'] = int(write_id)
-                else:
-                    if state == 'GUAM' or state == 'PUERTO' or state == "VIRGIN" or state == "DISTRIC" or state == "AMERICA" or state == "NORTHER" or state == "PHILIPP":
-                        error_log.writerow(["Non_1_match_number",str(num_matches),last_name[:8],state,"Y","NA","NA"])
-                    else:
-                        print(str(num_matches) + " matches found for "+ last_name[:8] + ", " + state + " in congress " + str(congress))
-                        error_log.writerow(["Non_1_match_number",str(num_matches),last_name,state,"N","NA","NA"])
-
-
-            save_data(data_file[0], data_file[1])
+            #     # # this can't run unless we've already collected a bioguide for this person
+            #     bioguide = legislator["id"].get("bioguide", None)
+            #     # if we've limited this to just one bioguide, skip over everyone else
+            #     if only_bioguide and (bioguide != only_bioguide):
+            #         continue
+            #     #if not in currently read chamber, skip
+            #     chamber = legislator['terms'][len(legislator['terms'])-1]['type']
+            #     if chamber != read_file[1]:
+            #         continue
+            #
+            #     #only run for selected congress
+            #     latest_congress = utils.congress_from_legislative_year(utils.legislative_year(parse_date(legislator['terms'][len(legislator['terms'])-1]['start'])))
+            #     if chamber == "sen":
+            #         congresses = [latest_congress,latest_congress+1,latest_congress+2]
+            #     else:
+            #         congresses =[latest_congress]
+            #
+            #     if int(congress) not in congresses:
+            #         continue
+            #
+            #     # pull data to match from yaml
+            #
+            #     last_name_unicode = legislator['name']['last'].upper().strip().replace('\'','')
+            #     last_name = unicodedata.normalize('NFD', str(last_name_unicode)).encode('ascii', 'ignore')
+            #     state = utils.states[legislator['terms'][len(legislator['terms'])-1]['state']].upper()[:7].strip()
+            #     # select icpsr source data based on more recent chamber
+            #
+            #     lines = read_file[0].split('\n')
+            #     for line in lines:
+            #         # parse source data
+            #         icpsr_state = line[12:20].strip()
+            #         icpsr_name = line[21:].strip().strip(string.digits).strip()
+            #         icpsr_id = line[3:8].strip()
+            #
+            #         #ensure unique match
+            #         if icpsr_name[:8] == last_name[:8] and state == icpsr_state:
+            #             num_matches += 1
+            #             write_id = icpsr_id
+            #     #skip if icpsr id is currently in data
+            #     if "icpsr" in legislator["id"]:
+            #         if write_id == legislator["id"]["icpsr"] or write_id == "":
+            #             continue
+            #         elif write_id != legislator["id"]["icpsr"] and write_id != "":
+            #             error_log.writerow(["Incorrect_ID","NA",last_name[:8],state,"NA",legislator["id"]["icpsr"],write_id])
+            #             print("ID updated for %s" % last_name)
+            #     if num_matches == 1:
+            #         legislator['id']['icpsr'] = int(write_id)
+            #     else:
+            #         if state == 'GUAM' or state == 'PUERTO' or state == "VIRGIN" or state == "DISTRIC" or state == "AMERICA" or state == "NORTHER" or state == "PHILIPP":
+            #             error_log.writerow(["Non_1_match_number",str(num_matches),last_name[:8],state,"Y","NA","NA"])
+            #         else:
+            #             print(str(num_matches) + " matches found for "+ last_name[:8] + ", " + state + " in congress " + str(congress))
+            #             error_log.writerow(["Non_1_match_number",str(num_matches),last_name,state,"N","NA","NA"])
+            #
+            #
+            # save_data(data_file[0], data_file[1])
 
     ## the following three lines can be run as a separate script to update icpsr id's for all historical congresses
     # import os

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -9,9 +9,7 @@
 
 import utils
 from utils import load_data, save_data, parse_date
-import string
 import csv
-import unicodedata
 from io import StringIO
 
 def run():

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -12,6 +12,7 @@ from utils import load_data, save_data, parse_date
 import string
 import csv
 import unicodedata
+from io import StringIO
 
 def run():
 
@@ -90,6 +91,11 @@ def run():
 
                 last_name = legislator['name']['last'].upper()
                 state = utils.states[legislator['terms'][len(legislator['terms'])-1]['state']].upper()[:7].strip()
+
+                # convert read_file_content str to file object, then parse as csv file
+                content_as_file = StringIO(read_file_content)
+                content_parsed = csv.reader(content_as_file, delimiter=',')
+
 
             #     # # this can't run unless we've already collected a bioguide for this person
             #     bioguide = legislator["id"].get("bioguide", None)

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -103,63 +103,25 @@ def run():
                         num_matches += 1
                         write_id = int(icpsr_member[2])
 
+                # skip if icpsr id is currently in data
+                if "icpsr" in legislator["id"]:
+                    if write_id == legislator["id"]["icpsr"] or write_id == "":
+                        continue
+                    elif write_id != legislator["id"]["icpsr"] and write_id != "":
+                        error_log.writerow(["Incorrect_ID","NA",last_name[:8],state,"NA",legislator["id"]["icpsr"],write_id])
+                        print("ID updated for %s" % last_name)
 
-            #     # # this can't run unless we've already collected a bioguide for this person
-            #     bioguide = legislator["id"].get("bioguide", None)
-            #     # if we've limited this to just one bioguide, skip over everyone else
-            #     if only_bioguide and (bioguide != only_bioguide):
-            #         continue
-            #     #if not in currently read chamber, skip
-            #     chamber = legislator['terms'][len(legislator['terms'])-1]['type']
-            #     if chamber != read_file[1]:
-            #         continue
-            #
-            #     #only run for selected congress
-            #     latest_congress = utils.congress_from_legislative_year(utils.legislative_year(parse_date(legislator['terms'][len(legislator['terms'])-1]['start'])))
-            #     if chamber == "sen":
-            #         congresses = [latest_congress,latest_congress+1,latest_congress+2]
-            #     else:
-            #         congresses =[latest_congress]
-            #
-            #     if int(congress) not in congresses:
-            #         continue
-            #
-            #     # pull data to match from yaml
-            #
-            #     last_name_unicode = legislator['name']['last'].upper().strip().replace('\'','')
-            #     last_name = unicodedata.normalize('NFD', str(last_name_unicode)).encode('ascii', 'ignore')
-            #     state = utils.states[legislator['terms'][len(legislator['terms'])-1]['state']].upper()[:7].strip()
-            #     # select icpsr source data based on more recent chamber
-            #
-            #     lines = read_file[0].split('\n')
-            #     for line in lines:
-            #         # parse source data
-            #         icpsr_state = line[12:20].strip()
-            #         icpsr_name = line[21:].strip().strip(string.digits).strip()
-            #         icpsr_id = line[3:8].strip()
-            #
-            #         #ensure unique match
-            #         if icpsr_name[:8] == last_name[:8] and state == icpsr_state:
-            #             num_matches += 1
-            #             write_id = icpsr_id
-            #     #skip if icpsr id is currently in data
-            #     if "icpsr" in legislator["id"]:
-            #         if write_id == legislator["id"]["icpsr"] or write_id == "":
-            #             continue
-            #         elif write_id != legislator["id"]["icpsr"] and write_id != "":
-            #             error_log.writerow(["Incorrect_ID","NA",last_name[:8],state,"NA",legislator["id"]["icpsr"],write_id])
-            #             print("ID updated for %s" % last_name)
-            #     if num_matches == 1:
-            #         legislator['id']['icpsr'] = int(write_id)
-            #     else:
-            #         if state == 'GUAM' or state == 'PUERTO' or state == "VIRGIN" or state == "DISTRIC" or state == "AMERICA" or state == "NORTHER" or state == "PHILIPP":
-            #             error_log.writerow(["Non_1_match_number",str(num_matches),last_name[:8],state,"Y","NA","NA"])
-            #         else:
-            #             print(str(num_matches) + " matches found for "+ last_name[:8] + ", " + state + " in congress " + str(congress))
-            #             error_log.writerow(["Non_1_match_number",str(num_matches),last_name,state,"N","NA","NA"])
-            #
-            #
-            # save_data(data_file[0], data_file[1])
+                if num_matches == 1:
+                    legislator['id']['icpsr'] = int(write_id)
+                else:
+                    if state == 'GUAM' or state == 'PUERTO' or state == "VIRGIN" or state == "DISTRIC" or state == "AMERICA" or state == "NORTHER" or state == "PHILIPP":
+                        print('error: non 1 match')
+                        error_log.writerow(["Non_1_match_number",str(num_matches),last_name[:8],state,"Y","NA","NA"])
+                    else:
+                        print(str(num_matches) + " matches found for "+ last_name[:8] + ", " + state + " in congress " + str(congress))
+                        error_log.writerow(["Non_1_match_number",str(num_matches),last_name,state,"N","NA","NA"])
+
+            save_data(data_file[0], data_file[1])
 
     ## the following three lines can be run as a separate script to update icpsr id's for all historical congresses
     # import os

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -59,12 +59,13 @@ def run():
 
 
 
-    read_files = [(senate_data,"sen"),(house_data,"rep")]
+    read_files = [("sen",senate_data),("rep",house_data)]
     print("Running for congress " + congress)
     for read_file in read_files:
         for data_file in data_files:
             for legislator in data_file[0]:
                 num_matches = 0
+                write_id = ""
                 # # this can't run unless we've already collected a bioguide for this person
                 bioguide = legislator["id"].get("bioguide", None)
                 # if we've limited this to just one bioguide, skip over everyone else
@@ -92,7 +93,6 @@ def run():
                 state = utils.states[legislator['terms'][len(legislator['terms'])-1]['state']].upper()[:7].strip()
                 # select icpsr source data based on more recent chamber
 
-                write_id = ""
                 lines = read_file[0].split('\n')
                 for line in lines:
                     # parse source data

--- a/scripts/icpsr_ids.py
+++ b/scripts/icpsr_ids.py
@@ -54,7 +54,7 @@ def run():
     house_destination = "icpsr/source/house_rollcall%s.txt" % congress
     house_data = utils.download(url_house, house_destination, force)
 
-    error_log = csv.writer(open("cache/errors/mismatch/mismatch_%s.csv" % congress, "wb"))
+    error_log = csv.writer(open("cache/errors/mismatch/mismatch_%s.csv" % congress, "w"))
     error_log.writerow(["error_type","matches","icpsr_name","icpsr_state","is_territory","old_id","new_id"])
 
 


### PR DESCRIPTION
Fixes #601
Current urls for getting Vote View data are being depreciated. This PR updates the urls in icpsr_ids.py script to adhere to new format. Script also had to be updated to handle the new data being returned by Vote View. Ran the script and updated icpsr ids for legislators-current.yaml. Now, the icpsr_ids.py script correctly queries Vote View and sets the icpsr id for current and historical legislators (based off congress number passed to script). 