### PR TITLE
Add district offices for NC

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -15934,3 +15934,31 @@
     state: PA
     zip: '17701'
     phone: 570-322-3961
+- id:
+    bioguide: B001311
+    govtrack: 412844
+  offices:
+  - id: B001311-monroe
+    address: 300 N Main Street
+    city: Monroe
+    state: NC
+    zip: '28112'
+    phone: 740-218-5300
+    fax: 844-273-1255
+- id:
+    bioguide: M001210
+    govtrack: 412845
+  offices:
+  - id: M001210-greenville
+    address: 1105 Corporate Drive
+    suite: Suite C
+    city: Greenville
+    state: NC
+    zip: '27858'
+    phone: 252-931-1003
+  - id: M001210-jacksonville
+    address: 234 Northwest Corridor Blvd.
+    city: Jacksonville
+    state: NC
+    zip: '28540'
+    phone: 910-937-6929


### PR DESCRIPTION
Looked up and added offices for Gregory F. Murphy and Dan Bishop.
Fixes error due to missing them, and being in office more than 60 days

Signed-off-by: Tom Scanlan <tompscanlan@gmail.com>

Fixes these errors:
``` bash
$  python3 test/validate.py
legislators-current.yaml:A000367:terms[4](2019-01-03 to 2021-01-03) caucus: ~
 when party is Independent.
Vacancy in CA district 25 .
Vacancy in MD district 7 .
Vacancy in NY district 27 .
Vacancy in WI district 7 .
M001210 [NC rep] Gregory F. Murphy (https://gregmurphy.house.gov/)
    ERROR: No offices

B001311 [NC rep] Dan Bishop (https://danbishop.house.gov/)
    ERROR: No offices
```

Now should be:

``` bash
$ python3 test/validate.py
legislators-current.yaml:A000367:terms[4](2019-01-03 to 2021-01-03) caucus: ~
 when party is Independent.
Vacancy in CA district 25 .
Vacancy in MD district 7 .
Vacancy in NY district 27 .
Vacancy in WI district 7 .
```