### PR TITLE
Add missing IDs for Twitter handles

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -4539,7 +4539,7 @@
     bioguide: M001197
   social:
     twitter: SenMcSallyAZ
-    twitter_id:
+    twitter_id: 2964949642
 - id:
     bioguide: A000378
   social:

--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -491,6 +491,7 @@
     youtube_id: UC-fbzxBSiC98eAE2goaANVQ
     instagram: kilili_sablan
     twitter: Kilili_Sablan
+    twitter_id: 926446070812602371
 - id:
     bioguide: S001176
     thomas: '01892'
@@ -852,6 +853,7 @@
     govtrack: 412492
   social:
     twitter: RandPaul
+    twitter_id: 216881337
     facebook: SenatorRandPaul
     youtube: SenatorRandPaul
     youtube_id: UCeM9I-20oWUs8daIIpsNHoQ
@@ -1586,6 +1588,7 @@
     govtrack: 412741
   social:
     twitter: sendougjones
+    twitter_id: 941080085121175552
     facebook: senatordougjones
     youtube_id: UCL8akobkoN2lB5U3kaEjdBw
 - id:
@@ -3289,6 +3292,7 @@
     youtube: senatorklobuchar
     youtube_id: UCvdeJsDsV51tFb_hVqvtYGA
     twitter: SenAmyKlobuchar
+    twitter_id: 22044727
 - id:
     bioguide: C001097
     thomas: '02107'
@@ -3413,6 +3417,7 @@
     govtrack: 412742
   social:
     twitter: SenTinaSmith
+    twitter_id: 941000686275387392
     facebook: USSenTinaSmith
 - id:
     bioguide: S001195
@@ -4394,6 +4399,7 @@
   social:
     facebook: RepJohnCurtis
     twitter: RepJohnCurtis
+    twitter_id: 931614483050414080
     youtube_id: UChAQ4MD-HigmGnImSoAKBVA
     instagram: repjohncurtis
 - id:
@@ -4401,6 +4407,7 @@
     govtrack: 412743
   social:
     twitter: SenHydeSmith
+    twitter_id: 983348251972816896
     youtube_id: UCJHxkJhGST0NTlkzJHWV03Q
     instagram: sencindyhydesmith
 - id:
@@ -4484,6 +4491,7 @@
     govtrack: 412559
   social:
     twitter: RepHorsford
+    twitter_id: 389840566
 - id:
     bioguide: H001082
     govtrack: 412748
@@ -4526,10 +4534,12 @@
     bioguide: R000615
   social:
     twitter: SenatorRomney
+    twitter_id: 1078693601356509184
 - id:
     bioguide: M001197
   social:
     twitter: SenMcSallyAZ
+    twitter_id:
 - id:
     bioguide: A000378
   social:
@@ -4684,6 +4694,7 @@
     bioguide: S001216
   social:
     twitter: RepKimSchrier
+    twitter_id: 1080462532815532032
 - id:
     bioguide: T000479
   social:
@@ -4733,6 +4744,7 @@
     bioguide: K000368
   social:
     twitter: RepKirkpatrick
+    twitter_id: 1081240074946252801
 - id:
     bioguide: H001081
   social:


### PR DESCRIPTION
This PR adds missing Twitter IDs only for legislators who already have
a Twitter handle present in the data. I don't know if these are campaign
accounts or not; these are just the IDs for accounts that are already
there.