### PR TITLE
Update CircleCI docker image to Python 3.8, drop -browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.5-browsers
+      - image: circleci/python:3.8
     steps:
       # Set up.
       - checkout
@@ -19,7 +19,7 @@ jobs:
   # on the repo, which is not CircleCI's default.
   deploy:
     docker:
-      - image: circleci/python:3.5-browsers
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run: sudo pip install -r scripts/requirements.txt


### PR DESCRIPTION
There was a probably-transient error in #723. This probably has nothing to do with that, but is probably a good idea anyway.