### PR TITLE
Add nickname for Barry Moore

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40176,6 +40176,7 @@
     first: Felix
     middle: Barry
     last: Moore
+    nickname: Barry
     official_full: Barry Moore
   bio:
     gender: M


### PR DESCRIPTION
AL 2's Felix Barry Moore goes by Barry Moore. While this is already reflected in `official_full`, for other legislators this field is very formal. We've been using the nickname + last to construct a more casual name, I think this change fits with the convention in the rest of the file.