### PR TITLE
Added House standing full committee assignments

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -2853,3 +2853,3390 @@ JCSE:
   rank: 4
   bioguide: T000476
   chamber: senate
+HSAG:
+- name: David Scott
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: S001157
+- name: Glenn Thompson
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: T000467
+- name: Jim Costa
+  party: majority
+  rank: 2
+  bioguide: C001059
+- name: Austin Scott
+  party: minority
+  rank: 2
+  bioguide: S001189
+- name: Jim McGovern
+  party: majority
+  rank: 3
+  bioguide: M000312
+- name: Rick Crawford
+  party: minority
+  rank: 3
+  bioguide: C001087
+- name: Filemon Vela
+  party: majority
+  rank: 4
+  bioguide: V000132
+- name: Scott DesJarlais
+  party: minority
+  rank: 4
+  bioguide: D000616
+- name: Alma Adams
+  party: majority
+  rank: 5
+  bioguide: A000370
+- name: Vicky Hartzler
+  party: minority
+  rank: 5
+  bioguide: H001053
+- name: Abigail Spanberger
+  party: majority
+  rank: 6
+  bioguide: S001209
+- name: Doug LaMalfa
+  party: minority
+  rank: 6
+  bioguide: L000578
+- name: Jahana Hayes
+  party: majority
+  rank: 7
+  bioguide: H001081
+- name: Rodney Davis
+  party: minority
+  rank: 7
+  bioguide: D000619
+- name: Antonio Delgado
+  party: majority
+  rank: 8
+  bioguide: D000630
+- name: Rick Allen
+  party: minority
+  rank: 8
+  bioguide: A000372
+- name: Bobby L. Rush
+  party: majority
+  rank: 9
+  bioguide: R000515
+- name: David Rouzer
+  party: minority
+  rank: 9
+  bioguide: R000603
+- name: Chellie Pingree
+  party: majority
+  rank: 10
+  bioguide: P000597
+- name: Trent Kelly
+  party: minority
+  rank: 10
+  bioguide: K000388
+- name: Gregorio Kilili Camacho Sablan
+  party: majority
+  rank: 11
+  bioguide: S001177
+- name: Don Bacon
+  party: minority
+  rank: 11
+  bioguide: B001298
+- name: Ann McLane Kuster
+  party: majority
+  rank: 12
+  bioguide: K000382
+- name: Dusty Johnson
+  party: minority
+  rank: 12
+  bioguide: J000301
+- name: Cheri Bustos
+  party: majority
+  rank: 13
+  bioguide: B001286
+- name: James Baird
+  party: minority
+  rank: 13
+  bioguide: B001307
+- name: Sean Patrick Maloney
+  party: majority
+  rank: 14
+  bioguide: M001185
+- name: Jim Hagedorn
+  party: minority
+  rank: 14
+  bioguide: H001088
+- name: Stacey Plaskett
+  party: majority
+  rank: 15
+  bioguide: P000610
+- name: Chris Jacobs
+  party: minority
+  rank: 15
+  bioguide: J000020
+- name: Tom O'Halleran
+  party: majority
+  rank: 16
+  bioguide: O000171
+- name: Troy Balderson
+  party: minority
+  rank: 16
+  bioguide: B001306
+- name: Salud Carbajal
+  party: majority
+  rank: 17
+  bioguide: C001112
+- name: Michael Cloud
+  party: minority
+  rank: 17
+  bioguide: C001115
+- name: Ro Khanna
+  party: majority
+  rank: 18
+  bioguide: K000389
+- name: Tracey Mann
+  party: minority
+  rank: 18
+  bioguide: M000871
+- name: Al Lawson
+  party: majority
+  rank: 19
+  bioguide: L000586
+- name: Randy Feenstra
+  party: minority
+  rank: 19
+  bioguide: F000446
+- name: J. Luis Correa
+  party: majority
+  rank: 20
+  bioguide: C001110
+- name: Mary Miller
+  party: minority
+  rank: 20
+  bioguide: M001211
+- name: Angie Craig
+  party: majority
+  rank: 21
+  bioguide: C001119
+- name: Barry Moore
+  party: minority
+  rank: 21
+  bioguide: M001212
+- name: Josh Harder
+  party: majority
+  rank: 22
+  bioguide: H001090
+- name: Kat Cammack
+  party: minority
+  rank: 22
+  bioguide: C001039
+- name: Cynthia Axne
+  party: majority
+  rank: 23
+  bioguide: A000378
+- name: Michelle Fischbach
+  party: minority
+  rank: 23
+  bioguide: F000470
+- name: Kim Schrier
+  party: majority
+  rank: 24
+  bioguide: S001216
+- name: Jimmy Panetta
+  party: majority
+  rank: 25
+  bioguide: P000613
+- name: Ann Kirkpatrick
+  party: majority
+  rank: 26
+  bioguide: K000368
+HSAP:
+- name: Rosa DeLauro
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: D000216
+- name: Kay Granger
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000377
+- name: Marcy Kaptur
+  party: majority
+  rank: 2
+  bioguide: K000009
+- name: Harold Rogers
+  party: minority
+  rank: 2
+  bioguide: R000395
+- name: David E. Price
+  party: majority
+  rank: 3
+  bioguide: P000523
+- name: Robert B. Aderholt
+  party: minority
+  rank: 3
+  bioguide: A000055
+- name: Lucille Roybal-Allard
+  party: majority
+  rank: 4
+  bioguide: R000486
+- name: Mike Simpson
+  party: minority
+  rank: 4
+  bioguide: S001148
+- name: Sanford D. Bishop Jr.
+  party: majority
+  rank: 5
+  bioguide: B000490
+- name: John Carter
+  party: minority
+  rank: 5
+  bioguide: C001051
+- name: Barbara Lee
+  party: majority
+  rank: 6
+  bioguide: L000551
+- name: Ken Calvert
+  party: minority
+  rank: 6
+  bioguide: C000059
+- name: Betty McCollum
+  party: majority
+  rank: 7
+  bioguide: M001143
+- name: Tom Cole
+  party: minority
+  rank: 7
+  bioguide: C001053
+- name: Tim Ryan
+  party: majority
+  rank: 8
+  bioguide: R000577
+- name: Mario Diaz-Balart
+  party: minority
+  rank: 8
+  bioguide: D000600
+- name: C.A. Dutch Ruppersberger
+  party: majority
+  rank: 9
+  bioguide: R000576
+- name: Steve Womack
+  party: minority
+  rank: 9
+  bioguide: W000809
+- name: Debbie Wasserman Schultz
+  party: majority
+  rank: 10
+  bioguide: W000797
+- name: Jeff Fortenberry
+  party: minority
+  rank: 10
+  bioguide: F000449
+- name: Henry Cuellar
+  party: majority
+  rank: 11
+  bioguide: C001063
+- name: Chuck Fleischmann
+  party: minority
+  rank: 11
+  bioguide: F000459
+- name: Chellie Pingree
+  party: majority
+  rank: 12
+  bioguide: P000597
+- name: Jaime Herrera Beutler
+  party: minority
+  rank: 12
+  bioguide: H001056
+- name: Mike Quigley
+  party: majority
+  rank: 13
+  bioguide: Q000023
+- name: Dave Joyce
+  party: minority
+  rank: 13
+  bioguide: J000295
+- name: Derek Kilmer
+  party: majority
+  rank: 14
+  bioguide: K000381
+- name: Andy Harris
+  party: minority
+  rank: 14
+  bioguide: H001052
+- name: Matt Cartwright
+  party: majority
+  rank: 15
+  bioguide: C001090
+- name: Mark Amodei
+  party: minority
+  rank: 15
+  bioguide: A000369
+- name: Grace Meng
+  party: majority
+  rank: 16
+  bioguide: M001188
+- name: Chris Stewart
+  party: minority
+  rank: 16
+  bioguide: S001192
+- name: Mark Pocan
+  party: majority
+  rank: 17
+  bioguide: P000607
+- name: Steven Palazzo
+  party: minority
+  rank: 17
+  bioguide: P000601
+- name: Katherine Clark
+  party: majority
+  rank: 18
+  bioguide: C001101
+- name: David Valadao
+  party: minority
+  rank: 18
+  bioguide: V000129
+- name: Pete Aguilar
+  party: majority
+  rank: 19
+  bioguide: A000371
+- name: Dan Newhouse
+  party: minority
+  rank: 19
+  bioguide: N000189
+- name: Lois Frankel
+  party: majority
+  rank: 20
+  bioguide: F000462
+- name: John Moolenaar
+  party: minority
+  rank: 20
+  bioguide: M001194
+- name: Cheri Bustos
+  party: majority
+  rank: 21
+  bioguide: B001286
+- name: John Rutherford
+  party: minority
+  rank: 21
+  bioguide: R000609
+- name: Bonnie Watson Coleman
+  party: majority
+  rank: 22
+  bioguide: W000822
+- name: Ben Cline
+  party: minority
+  rank: 22
+  bioguide: C001118
+- name: Brenda Lawrence
+  party: majority
+  rank: 23
+  bioguide: L000581
+- name: Guy Reschenthaler
+  party: minority
+  rank: 23
+  bioguide: R000610
+- name: Norma Torres
+  party: majority
+  rank: 24
+  bioguide: T000474
+- name: Mike Garcia
+  party: minority
+  rank: 24
+  bioguide: G000061
+- name: Charlie Crist
+  party: majority
+  rank: 25
+  bioguide: C001111
+- name: Ashley Hinson
+  party: minority
+  rank: 25
+  bioguide: H001091
+- name: Ann Kirkpatrick
+  party: majority
+  rank: 26
+  bioguide: K000368
+- name: Tony Gonzales
+  party: minority
+  rank: 26
+  bioguide: G000594
+- name: Ed Case
+  party: majority
+  rank: 27
+  bioguide: C001055
+- name: Adriano Espaillat
+  party: majority
+  rank: 28
+  bioguide: E000297
+- name: Josh Harder
+  party: majority
+  rank: 29
+  bioguide: H001090
+- name: Jennifer Wexton
+  party: majority
+  rank: 30
+  bioguide: W000825
+- name: David Trone
+  party: majority
+  rank: 31
+  bioguide: T000483
+- name: Lauren Underwood
+  party: majority
+  rank: 32
+  bioguide: U000040
+- name: Susie Lee
+  party: majority
+  rank: 33
+  bioguide: L000590
+HSAS:
+- name: Adam Smith
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: S000510
+- name: Mike D. Rogers
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: R000575
+- name: Jim Langevin
+  party: majority
+  rank: 2
+  bioguide: L000559
+- name: Joe Wilson
+  party: minority
+  rank: 2
+  bioguide: W000795
+- name: Rick Larsen
+  party: majority
+  rank: 3
+  bioguide: L000560
+- name: Michael R. Turner
+  party: minority
+  rank: 3
+  bioguide: T000463
+- name: Jim Cooper
+  party: majority
+  rank: 4
+  bioguide: C000754
+- name: Doug Lamborn
+  party: minority
+  rank: 4
+  bioguide: L000564
+- name: Joe Courtney
+  party: majority
+  rank: 5
+  bioguide: C001069
+- name: Robert J. Wittman
+  party: minority
+  rank: 5
+  bioguide: W000804
+- name: John Garamendi
+  party: majority
+  rank: 6
+  bioguide: G000559
+- name: Vicky Hartzler
+  party: minority
+  rank: 6
+  bioguide: H001053
+- name: Jackie Speier
+  party: majority
+  rank: 7
+  bioguide: S001175
+- name: Austin Scott
+  party: minority
+  rank: 7
+  bioguide: S001189
+- name: Donald W. Norcross
+  party: majority
+  rank: 8
+  bioguide: N000188
+- name: Mo Brooks
+  party: minority
+  rank: 8
+  bioguide: B001274
+- name: Ruben Gallego
+  party: majority
+  rank: 9
+  bioguide: G000574
+- name: Sam Graves
+  party: minority
+  rank: 9
+  bioguide: G000546
+- name: Seth Moulton
+  party: majority
+  rank: 10
+  bioguide: M001196
+- name: Elise Stefanik
+  party: minority
+  rank: 10
+  bioguide: S001196
+- name: Salud Carbajal
+  party: majority
+  rank: 11
+  bioguide: C001112
+- name: Scott DesJarlais
+  party: minority
+  rank: 11
+  bioguide: D000616
+- name: Anthony Brown
+  party: majority
+  rank: 12
+  bioguide: B001304
+- name: Trent Kelly
+  party: minority
+  rank: 12
+  bioguide: K000388
+- name: Ro Khanna
+  party: majority
+  rank: 13
+  bioguide: K000389
+- name: Mike Gallagher
+  party: minority
+  rank: 13
+  bioguide: G000579
+- name: Bill Keating
+  party: majority
+  rank: 14
+  bioguide: K000375
+- name: Matt Gaetz
+  party: minority
+  rank: 14
+  bioguide: G000578
+- name: Filemon Vela
+  party: majority
+  rank: 15
+  bioguide: V000132
+- name: Don Bacon
+  party: minority
+  rank: 15
+  bioguide: B001298
+- name: Andy Kim
+  party: majority
+  rank: 16
+  bioguide: K000394
+- name: Jim Banks
+  party: minority
+  rank: 16
+  bioguide: B001299
+- name: Chrissy Houlahan
+  party: majority
+  rank: 17
+  bioguide: H001085
+- name: Liz Cheney
+  party: minority
+  rank: 17
+  bioguide: C001109
+- name: Jason Crow
+  party: majority
+  rank: 18
+  bioguide: C001121
+- name: Jack Bergman
+  party: minority
+  rank: 18
+  bioguide: B001301
+- name: Elissa Slotkin
+  party: majority
+  rank: 19
+  bioguide: S001208
+- name: Michael Waltz
+  party: minority
+  rank: 19
+  bioguide: W000823
+- name: Mikie Sherrill
+  party: majority
+  rank: 20
+  bioguide: S001207
+- name: Mike Johnson
+  party: minority
+  rank: 20
+  bioguide: J000299
+- name: Veronica Escobar
+  party: majority
+  rank: 21
+  bioguide: E000299
+- name: Mark Green
+  party: minority
+  rank: 21
+  bioguide: G000590
+- name: Jared Golden
+  party: majority
+  rank: 22
+  bioguide: G000592
+- name: Stephanie Bice
+  party: minority
+  rank: 22
+  bioguide: B000740
+- name: Elaine Luria
+  party: majority
+  rank: 23
+  bioguide: L000591
+- name: Scott Franklin
+  party: minority
+  rank: 23
+  bioguide: F000472
+- name: Joe Morelle
+  party: majority
+  rank: 24
+  bioguide: M001206
+- name: Lisa McClain
+  party: minority
+  rank: 24
+  bioguide: M001136
+- name: Sara Jacobs
+  party: majority
+  rank: 25
+  bioguide: J000305
+- name: Ronny Jackson
+  party: minority
+  rank: 25
+  bioguide: J000304
+- name: Kaialiʻi Kahele
+  party: majority
+  rank: 26
+  bioguide: K000396
+- name: Jerry Carl
+  party: minority
+  rank: 26
+  bioguide: C001054
+- name: Marilyn Strickland
+  party: majority
+  rank: 27
+  bioguide: S001159
+- name: Blake Moore
+  party: minority
+  rank: 27
+  bioguide: M001213
+- name: Marc Veasey
+  party: majority
+  rank: 28
+  bioguide: V000131
+- name: Pat Fallon
+  party: minority
+  rank: 28
+  bioguide: F000246
+- name: Jimmy Panetta
+  party: majority
+  rank: 29
+  bioguide: P000613
+- name: Stephanie Murphy
+  party: majority
+  rank: 30
+  bioguide: M001202
+HSBA:
+- name: Maxine Waters
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: W000187
+- name: Patrick T. McHenry
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001156
+- name: Carolyn B. Maloney
+  party: majority
+  rank: 2
+  bioguide: M000087
+- name: Frank D. Lucas
+  party: minority
+  rank: 2
+  bioguide: L000491
+- name: Nydia M. Velázquez
+  party: majority
+  rank: 3
+  bioguide: V000081
+- name: Bill Posey
+  party: minority
+  rank: 3
+  bioguide: P000599
+- name: Brad Sherman
+  party: majority
+  rank: 4
+  bioguide: S000344
+- name: Blaine Luetkemeyer
+  party: minority
+  rank: 4
+  bioguide: L000569
+- name: Gregory W. Meeks
+  party: majority
+  rank: 5
+  bioguide: M001137
+- name: Bill Huizenga
+  party: minority
+  rank: 5
+  bioguide: H001058
+- name: Al Green
+  party: majority
+  rank: 6
+  bioguide: G000553
+- name: Steve Stivers
+  party: minority
+  rank: 6
+  bioguide: S001187
+- name: Emanuel Cleaver II
+  party: majority
+  rank: 7
+  bioguide: C001061
+- name: Ann Wagner
+  party: minority
+  rank: 7
+  bioguide: W000812
+- name: Ed Perlmutter
+  party: majority
+  rank: 8
+  bioguide: P000593
+- name: Andy Barr
+  party: minority
+  rank: 8
+  bioguide: B001282
+- name: Jim Himes
+  party: majority
+  rank: 9
+  bioguide: H001047
+- name: Roger Williams
+  party: minority
+  rank: 9
+  bioguide: W000816
+- name: Bill Foster
+  party: majority
+  rank: 10
+  bioguide: F000454
+- name: French Hill
+  party: minority
+  rank: 10
+  bioguide: H001072
+- name: Joyce Beatty
+  party: majority
+  rank: 11
+  bioguide: B001281
+- name: Tom Emmer
+  party: minority
+  rank: 11
+  bioguide: E000294
+- name: Juan Vargas
+  party: majority
+  rank: 12
+  bioguide: V000130
+- name: Lee Zeldin
+  party: minority
+  rank: 12
+  bioguide: Z000017
+- name: Josh Gottheimer
+  party: majority
+  rank: 13
+  bioguide: G000583
+- name: Barry Loudermilk
+  party: minority
+  rank: 13
+  bioguide: L000583
+- name: Vicente Gonzalez
+  party: majority
+  rank: 14
+  bioguide: G000581
+- name: Alex Mooney
+  party: minority
+  rank: 14
+  bioguide: M001195
+- name: Al Lawson
+  party: majority
+  rank: 15
+  bioguide: L000586
+- name: Warren Davidson
+  party: minority
+  rank: 15
+  bioguide: D000626
+- name: Michael San Nicolas
+  party: majority
+  rank: 16
+  bioguide: S001204
+- name: Ted Budd
+  party: minority
+  rank: 16
+  bioguide: B001305
+- name: Cynthia Axne
+  party: majority
+  rank: 17
+  bioguide: A000378
+- name: David Kustoff
+  party: minority
+  rank: 17
+  bioguide: K000392
+- name: Sean Casten
+  party: majority
+  rank: 18
+  bioguide: C001117
+- name: Trey Hollingsworth
+  party: minority
+  rank: 18
+  bioguide: H001074
+- name: Ayanna Pressley
+  party: majority
+  rank: 19
+  bioguide: P000617
+- name: Anthony Gonzalez
+  party: minority
+  rank: 19
+  bioguide: G000588
+- name: Ritchie Torres
+  party: majority
+  rank: 20
+  bioguide: T000486
+- name: John Rose
+  party: minority
+  rank: 20
+  bioguide: R000612
+- name: David Scott
+  party: majority
+  rank: 21
+  bioguide: S001157
+- name: Bryan Steil
+  party: minority
+  rank: 21
+  bioguide: S001213
+- name: Stephen F. Lynch
+  party: majority
+  rank: 22
+  bioguide: L000562
+- name: Lance Gooden
+  party: minority
+  rank: 22
+  bioguide: G000589
+- name: Alma Adams
+  party: majority
+  rank: 23
+  bioguide: A000370
+- name: William Timmons
+  party: minority
+  rank: 23
+  bioguide: T000480
+- name: Rashida Tlaib
+  party: majority
+  rank: 24
+  bioguide: T000481
+- name: Van Taylor
+  party: minority
+  rank: 24
+  bioguide: T000479
+- name: Madeleine Dean
+  party: majority
+  rank: 25
+  bioguide: D000631
+- name: Alexandria Ocasio-Cortez
+  party: majority
+  rank: 26
+  bioguide: O000172
+- name: Jesús García
+  party: majority
+  rank: 27
+  bioguide: G000586
+- name: Sylvia Garcia
+  party: majority
+  rank: 28
+  bioguide: G000587
+- name: Nikema Williams
+  party: majority
+  rank: 29
+  bioguide: W000788
+- name: Jake Auchincloss
+  party: majority
+  rank: 30
+  bioguide: A000148
+HSBU:
+- name: John Yarmuth
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: Y000062
+- name: Jason Smith
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: S001195
+- name: Hakeem Jeffries
+  party: majority
+  rank: 2
+  bioguide: J000294
+- name: Trent Kelly
+  party: minority
+  rank: 2
+  bioguide: K000388
+- name: Brian Higgins
+  party: majority
+  rank: 3
+  bioguide: H001038
+- name: Tom McClintock
+  party: minority
+  rank: 3
+  bioguide: M001177
+- name: Brendan Boyle
+  party: majority
+  rank: 4
+  bioguide: B001296
+- name: Glenn Grothman
+  party: minority
+  rank: 4
+  bioguide: G000576
+- name: Lloyd Doggett
+  party: majority
+  rank: 5
+  bioguide: D000399
+- name: Lloyd Smucker
+  party: minority
+  rank: 5
+  bioguide: S001199
+- name: David E. Price
+  party: majority
+  rank: 6
+  bioguide: P000523
+- name: Chris Jacobs
+  party: minority
+  rank: 6
+  bioguide: J000020
+- name: Jan Schakowsky
+  party: majority
+  rank: 7
+  bioguide: S001145
+- name: Michael C. Burgess
+  party: minority
+  rank: 7
+  bioguide: B001248
+- name: Dan Kildee
+  party: majority
+  rank: 8
+  bioguide: K000380
+- name: Buddy Carter
+  party: minority
+  rank: 8
+  bioguide: C001103
+- name: Joe Morelle
+  party: majority
+  rank: 9
+  bioguide: M001206
+- name: Marjorie Taylor Greene
+  party: minority
+  rank: 9
+  bioguide: G000596
+- name: Ben Cline
+  party: minority
+  rank: 9
+  bioguide: C001118
+- name: Steven Horsford
+  party: majority
+  rank: 10
+  bioguide: H001066
+- name: Ashley Hinson
+  party: minority
+  rank: 10
+  bioguide: H001091
+- name: Barbara Lee
+  party: majority
+  rank: 11
+  bioguide: L000551
+- name: Robert Good
+  party: minority
+  rank: 11
+  bioguide: G000595
+- name: Judy Chu
+  party: majority
+  rank: 12
+  bioguide: C001080
+- name: Byron Donalds
+  party: minority
+  rank: 12
+  bioguide: D000032
+- name: Stacey Plaskett
+  party: majority
+  rank: 13
+  bioguide: P000610
+- name: Jay Obernolte
+  party: minority
+  rank: 13
+  bioguide: O000019
+- name: Jennifer Wexton
+  party: majority
+  rank: 14
+  bioguide: W000825
+- name: Randy Feenstra
+  party: minority
+  rank: 14
+  bioguide: F000446
+- name: Robert C. Scott
+  party: majority
+  rank: 15
+  bioguide: S000185
+- name: Lauren Boebert
+  party: minority
+  rank: 15
+  bioguide: B000825
+- name: Sheila Jackson Lee
+  party: majority
+  rank: 16
+  bioguide: J000032
+- name: Jim Cooper
+  party: majority
+  rank: 17
+  bioguide: C000754
+- name: Albio Sires
+  party: majority
+  rank: 18
+  bioguide: S001165
+- name: Scott Peters
+  party: majority
+  rank: 19
+  bioguide: P000608
+- name: Seth Moulton
+  party: majority
+  rank: 20
+  bioguide: M001196
+- name: Pramila Jayapal
+  party: majority
+  rank: 21
+  bioguide: J000298
+HSCN: []
+HSED:
+- name: Robert C. Scott
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: S000185
+- name: Virginia Foxx
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: F000450
+- name: Raúl M. Grijalva
+  party: majority
+  rank: 2
+  bioguide: G000551
+- name: Joe Wilson
+  party: minority
+  rank: 2
+  bioguide: W000795
+- name: Joe Courtney
+  party: majority
+  rank: 3
+  bioguide: C001069
+- name: Glenn Thompson
+  party: minority
+  rank: 3
+  bioguide: T000467
+- name: Gregorio Kilili Camacho Sablan
+  party: majority
+  rank: 4
+  bioguide: S001177
+- name: Tim Walberg
+  party: minority
+  rank: 4
+  bioguide: W000798
+- name: Frederica Wilson
+  party: majority
+  rank: 5
+  bioguide: W000808
+- name: Glenn Grothman
+  party: minority
+  rank: 5
+  bioguide: G000576
+- name: Suzanne Bonamici
+  party: majority
+  rank: 6
+  bioguide: B001278
+- name: Elise Stefanik
+  party: minority
+  rank: 6
+  bioguide: S001196
+- name: Mark Takano
+  party: majority
+  rank: 7
+  bioguide: T000472
+- name: Rick Allen
+  party: minority
+  rank: 7
+  bioguide: A000372
+- name: Alma Adams
+  party: majority
+  rank: 8
+  bioguide: A000370
+- name: Jim Banks
+  party: minority
+  rank: 8
+  bioguide: B001299
+- name: Mark DeSaulnier
+  party: majority
+  rank: 9
+  bioguide: D000623
+- name: James Comer
+  party: minority
+  rank: 9
+  bioguide: C001108
+- name: Donald W. Norcross
+  party: majority
+  rank: 10
+  bioguide: N000188
+- name: Russ Fulcher
+  party: minority
+  rank: 10
+  bioguide: F000469
+- name: Pramila Jayapal
+  party: majority
+  rank: 11
+  bioguide: J000298
+- name: Ron Wright
+  party: minority
+  rank: 11
+  bioguide: W000827
+- name: Fred Keller
+  party: minority
+  rank: 11
+  bioguide: K000395
+- name: Joe Morelle
+  party: majority
+  rank: 12
+  bioguide: M001206
+- name: Greg Murphy
+  party: minority
+  rank: 12
+  bioguide: M001210
+- name: Susan Wild
+  party: majority
+  rank: 13
+  bioguide: W000826
+- name: Mariannette Miller-Meeks
+  party: minority
+  rank: 13
+  bioguide: M001215
+- name: Lucy McBath
+  party: majority
+  rank: 14
+  bioguide: M001208
+- name: Burgess Owens
+  party: minority
+  rank: 14
+  bioguide: O000086
+- name: Jahana Hayes
+  party: majority
+  rank: 15
+  bioguide: H001081
+- name: Robert Good
+  party: minority
+  rank: 15
+  bioguide: G000595
+- name: Andy Levin
+  party: majority
+  rank: 16
+  bioguide: L000592
+- name: Lisa McClain
+  party: minority
+  rank: 16
+  bioguide: M001136
+- name: Ilhan Omar
+  party: majority
+  rank: 17
+  bioguide: O000173
+- name: Diana Harshbarger
+  party: minority
+  rank: 17
+  bioguide: H001086
+- name: Haley Stevens
+  party: majority
+  rank: 18
+  bioguide: S001215
+- name: Marjorie Taylor Greene
+  party: minority
+  rank: 18
+  bioguide: G000596
+- name: Mary Miller
+  party: minority
+  rank: 18
+  bioguide: M001211
+- name: Teresa Leger Fernandez
+  party: majority
+  rank: 19
+  bioguide: L000273
+- name: Victoria Spartz
+  party: minority
+  rank: 19
+  bioguide: S000929
+- name: Mondaire Jones
+  party: majority
+  rank: 20
+  bioguide: J000306
+- name: Scott Fitzgerald
+  party: minority
+  rank: 20
+  bioguide: F000471
+- name: Kathy Manning
+  party: majority
+  rank: 21
+  bioguide: M001135
+- name: Madison Cawthorn
+  party: minority
+  rank: 21
+  bioguide: C001104
+- name: Frank Mrvan
+  party: majority
+  rank: 22
+  bioguide: M001214
+- name: Michelle Steel
+  party: minority
+  rank: 22
+  bioguide: S001135
+- name: Jamaal Bowman
+  party: majority
+  rank: 23
+  bioguide: B001223
+- name: Mark Pocan
+  party: majority
+  rank: 24
+  bioguide: P000607
+- name: Joaquín Castro
+  party: majority
+  rank: 25
+  bioguide: C001091
+- name: Mikie Sherrill
+  party: majority
+  rank: 26
+  bioguide: S001207
+- name: John Yarmuth
+  party: majority
+  rank: 27
+  bioguide: Y000062
+- name: Adriano Espaillat
+  party: majority
+  rank: 28
+  bioguide: E000297
+- name: Kweisi Mfume
+  party: majority
+  rank: 29
+  bioguide: M000687
+HSFA:
+- name: Gregory W. Meeks
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: M001137
+- name: Michael McCaul
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001157
+- name: Brad Sherman
+  party: majority
+  rank: 2
+  bioguide: S000344
+- name: Christopher H. Smith
+  party: minority
+  rank: 2
+  bioguide: S000522
+- name: Albio Sires
+  party: majority
+  rank: 3
+  bioguide: S001165
+- name: Steven J. Chabot
+  party: minority
+  rank: 3
+  bioguide: C000266
+- name: Gerald E. Connolly
+  party: majority
+  rank: 4
+  bioguide: C001078
+- name: Joe Wilson
+  party: minority
+  rank: 4
+  bioguide: W000795
+- name: Ted Deutch
+  party: majority
+  rank: 5
+  bioguide: D000610
+- name: Scott Perry
+  party: minority
+  rank: 5
+  bioguide: P000605
+- name: Karen Bass
+  party: majority
+  rank: 6
+  bioguide: B001270
+- name: Darrell Issa
+  party: minority
+  rank: 6
+  bioguide: I000056
+- name: Bill Keating
+  party: majority
+  rank: 7
+  bioguide: K000375
+- name: Adam Kinzinger
+  party: minority
+  rank: 7
+  bioguide: K000378
+- name: David Cicilline
+  party: majority
+  rank: 8
+  bioguide: C001084
+- name: Lee Zeldin
+  party: minority
+  rank: 8
+  bioguide: Z000017
+- name: Ami Bera
+  party: majority
+  rank: 9
+  bioguide: B001287
+- name: Ann Wagner
+  party: minority
+  rank: 9
+  bioguide: W000812
+- name: Joaquín Castro
+  party: majority
+  rank: 10
+  bioguide: C001091
+- name: Brian Mast
+  party: minority
+  rank: 10
+  bioguide: M001199
+- name: Dina Titus
+  party: majority
+  rank: 11
+  bioguide: T000468
+- name: Brian Fitzpatrick
+  party: minority
+  rank: 11
+  bioguide: F000466
+- name: Ted Lieu
+  party: majority
+  rank: 12
+  bioguide: L000582
+- name: Ken Buck
+  party: minority
+  rank: 12
+  bioguide: B001297
+- name: Susan Wild
+  party: majority
+  rank: 13
+  bioguide: W000826
+- name: Tim Burchett
+  party: minority
+  rank: 13
+  bioguide: B001309
+- name: Dean Phillips
+  party: majority
+  rank: 14
+  bioguide: P000616
+- name: Mark Green
+  party: minority
+  rank: 14
+  bioguide: G000590
+- name: Ilhan Omar
+  party: majority
+  rank: 15
+  bioguide: O000173
+- name: Andy Barr
+  party: minority
+  rank: 15
+  bioguide: B001282
+- name: Colin Allred
+  party: majority
+  rank: 16
+  bioguide: A000376
+- name: Greg Steube
+  party: minority
+  rank: 16
+  bioguide: S001214
+- name: Andy Levin
+  party: majority
+  rank: 17
+  bioguide: L000592
+- name: Daniel Meuser
+  party: minority
+  rank: 17
+  bioguide: M001204
+- name: Abigail Spanberger
+  party: majority
+  rank: 18
+  bioguide: S001209
+- name: Claudia Tenney
+  party: minority
+  rank: 18
+  bioguide: T000478
+- name: Chrissy Houlahan
+  party: majority
+  rank: 19
+  bioguide: H001085
+- name: August Pfluger
+  party: minority
+  rank: 19
+  bioguide: P000048
+- name: Tom Malinowski
+  party: majority
+  rank: 20
+  bioguide: M001203
+- name: Nicole Malliotakis
+  party: minority
+  rank: 20
+  bioguide: M000317
+- name: Andy Kim
+  party: majority
+  rank: 21
+  bioguide: K000394
+- name: Peter Meijer
+  party: minority
+  rank: 21
+  bioguide: M001186
+- name: Sara Jacobs
+  party: majority
+  rank: 22
+  bioguide: J000305
+- name: Ronny Jackson
+  party: minority
+  rank: 22
+  bioguide: J000304
+- name: Kathy Manning
+  party: majority
+  rank: 23
+  bioguide: M001135
+- name: Young Kim
+  party: minority
+  rank: 23
+  bioguide: K000397
+- name: Jim Costa
+  party: majority
+  rank: 24
+  bioguide: C001059
+- name: Maria Elvira Salazar
+  party: minority
+  rank: 24
+  bioguide: S000168
+- name: Juan Vargas
+  party: majority
+  rank: 25
+  bioguide: V000130
+- name: Vicente Gonzalez
+  party: majority
+  rank: 26
+  bioguide: G000581
+- name: Brad Schneider
+  party: majority
+  rank: 27
+  bioguide: S001190
+HSGO:
+- name: Carolyn B. Maloney
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: M000087
+- name: James Comer
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001108
+- name: Eleanor Holmes Norton
+  party: majority
+  rank: 2
+  bioguide: N000147
+- name: Jim Jordan
+  party: minority
+  rank: 2
+  bioguide: J000289
+- name: Stephen F. Lynch
+  party: majority
+  rank: 3
+  bioguide: L000562
+- name: Paul Gosar
+  party: minority
+  rank: 3
+  bioguide: G000565
+- name: Jim Cooper
+  party: majority
+  rank: 4
+  bioguide: C000754
+- name: Virginia Foxx
+  party: minority
+  rank: 4
+  bioguide: F000450
+- name: Gerald E. Connolly
+  party: majority
+  rank: 5
+  bioguide: C001078
+- name: Jody Hice
+  party: minority
+  rank: 5
+  bioguide: H001071
+- name: Raja Krishnamoorthi
+  party: majority
+  rank: 6
+  bioguide: K000391
+- name: Glenn Grothman
+  party: minority
+  rank: 6
+  bioguide: G000576
+- name: Jamie Raskin
+  party: majority
+  rank: 7
+  bioguide: R000606
+- name: Michael Cloud
+  party: minority
+  rank: 7
+  bioguide: C001115
+- name: Ro Khanna
+  party: majority
+  rank: 8
+  bioguide: K000389
+- name: Bob Gibbs
+  party: minority
+  rank: 8
+  bioguide: G000563
+- name: Kweisi Mfume
+  party: majority
+  rank: 9
+  bioguide: M000687
+- name: Clay Higgins
+  party: minority
+  rank: 9
+  bioguide: H001077
+- name: Alexandria Ocasio-Cortez
+  party: majority
+  rank: 10
+  bioguide: O000172
+- name: Ralph Norman
+  party: minority
+  rank: 10
+  bioguide: N000190
+- name: Rashida Tlaib
+  party: majority
+  rank: 11
+  bioguide: T000481
+- name: Pete Sessions
+  party: minority
+  rank: 11
+  bioguide: S000250
+- name: Katie Porter
+  party: majority
+  rank: 12
+  bioguide: P000618
+- name: Fred Keller
+  party: minority
+  rank: 12
+  bioguide: K000395
+- name: Cori Bush
+  party: majority
+  rank: 13
+  bioguide: B001224
+- name: Andy Biggs
+  party: minority
+  rank: 13
+  bioguide: B001302
+- name: Danny K. Davis
+  party: majority
+  rank: 14
+  bioguide: D000096
+- name: Andrew Clyde
+  party: minority
+  rank: 14
+  bioguide: C001116
+- name: Debbie Wasserman Schultz
+  party: majority
+  rank: 15
+  bioguide: W000797
+- name: Nancy Mace
+  party: minority
+  rank: 15
+  bioguide: M000194
+- name: Peter Welch
+  party: majority
+  rank: 16
+  bioguide: W000800
+- name: Scott Franklin
+  party: minority
+  rank: 16
+  bioguide: F000472
+- name: Hank Johnson
+  party: majority
+  rank: 17
+  bioguide: J000288
+- name: Jake LaTurner
+  party: minority
+  rank: 17
+  bioguide: L000266
+- name: John Sarbanes
+  party: majority
+  rank: 18
+  bioguide: S001168
+- name: Pat Fallon
+  party: minority
+  rank: 18
+  bioguide: F000246
+- name: Jackie Speier
+  party: majority
+  rank: 19
+  bioguide: S001175
+- name: Yvette Herrell
+  party: minority
+  rank: 19
+  bioguide: H001084
+- name: Robin Kelly
+  party: majority
+  rank: 20
+  bioguide: K000385
+- name: Byron Donalds
+  party: minority
+  rank: 20
+  bioguide: D000032
+- name: Brenda Lawrence
+  party: majority
+  rank: 21
+  bioguide: L000581
+- name: Mark DeSaulnier
+  party: majority
+  rank: 22
+  bioguide: D000623
+- name: Jimmy Gomez
+  party: majority
+  rank: 23
+  bioguide: G000585
+- name: Ayanna Pressley
+  party: majority
+  rank: 24
+  bioguide: P000617
+HSHA:
+- name: Zoe Lofgren
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: L000397
+- name: Rodney Davis
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: D000619
+- name: Jamie Raskin
+  party: majority
+  rank: 2
+  bioguide: R000606
+- name: Barry Loudermilk
+  party: minority
+  rank: 2
+  bioguide: L000583
+- name: G. K. Butterfield
+  party: majority
+  rank: 3
+  bioguide: B001251
+- name: Bryan Steil
+  party: minority
+  rank: 3
+  bioguide: S001213
+- name: Pete Aguilar
+  party: majority
+  rank: 4
+  bioguide: A000371
+- name: Mary Gay Scanlon
+  party: majority
+  rank: 5
+  bioguide: S001205
+- name: Teresa Leger Fernandez
+  party: majority
+  rank: 6
+  bioguide: L000273
+HSHM:
+- name: Bennie Thompson
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: T000193
+- name: John Katko
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: K000386
+- name: Sheila Jackson Lee
+  party: majority
+  rank: 2
+  bioguide: J000032
+- name: Michael McCaul
+  party: minority
+  rank: 2
+  bioguide: M001157
+- name: Jim Langevin
+  party: majority
+  rank: 3
+  bioguide: L000559
+- name: Clay Higgins
+  party: minority
+  rank: 3
+  bioguide: H001077
+- name: Donald M. Payne Jr.
+  party: majority
+  rank: 4
+  bioguide: P000604
+- name: Michael Guest
+  party: minority
+  rank: 4
+  bioguide: G000591
+- name: J. Luis Correa
+  party: majority
+  rank: 5
+  bioguide: C001110
+- name: Dan Bishop
+  party: minority
+  rank: 5
+  bioguide: B001311
+- name: Elissa Slotkin
+  party: majority
+  rank: 6
+  bioguide: S001208
+- name: Jefferson Van Drew
+  party: minority
+  rank: 6
+  bioguide: V000133
+- name: Emanuel Cleaver II
+  party: majority
+  rank: 7
+  bioguide: C001061
+- name: Ralph Norman
+  party: minority
+  rank: 7
+  bioguide: N000190
+- name: Al Green
+  party: majority
+  rank: 8
+  bioguide: G000553
+- name: Mariannette Miller-Meeks
+  party: minority
+  rank: 8
+  bioguide: M001215
+- name: Yvette D. Clarke
+  party: majority
+  rank: 9
+  bioguide: C001067
+- name: Diana Harshbarger
+  party: minority
+  rank: 9
+  bioguide: H001086
+- name: Eric Swalwell
+  party: majority
+  rank: 10
+  bioguide: S001193
+- name: Andrew Clyde
+  party: minority
+  rank: 10
+  bioguide: C001116
+- name: Dina Titus
+  party: majority
+  rank: 11
+  bioguide: T000468
+- name: Carlos Giménez
+  party: minority
+  rank: 11
+  bioguide: G000593
+- name: Bonnie Watson Coleman
+  party: majority
+  rank: 12
+  bioguide: W000822
+- name: Jake LaTurner
+  party: minority
+  rank: 12
+  bioguide: L000266
+- name: Kathleen Rice
+  party: majority
+  rank: 13
+  bioguide: R000602
+- name: Peter Meijer
+  party: minority
+  rank: 13
+  bioguide: M001186
+- name: Val Demings
+  party: majority
+  rank: 14
+  bioguide: D000627
+- name: Kat Cammack
+  party: minority
+  rank: 14
+  bioguide: C001039
+- name: Nanette Barragán
+  party: majority
+  rank: 15
+  bioguide: B001300
+- name: August Pfluger
+  party: minority
+  rank: 15
+  bioguide: P000048
+- name: Josh Gottheimer
+  party: majority
+  rank: 16
+  bioguide: G000583
+- name: Andrew Garbarino
+  party: minority
+  rank: 16
+  bioguide: G000597
+- name: Elaine Luria
+  party: majority
+  rank: 17
+  bioguide: L000591
+- name: Tom Malinowski
+  party: majority
+  rank: 18
+  bioguide: M001203
+- name: Ritchie Torres
+  party: majority
+  rank: 19
+  bioguide: T000486
+HSIF:
+- name: Frank Pallone
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: P000034
+- name: Cathy McMorris Rodgers
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: M001159
+- name: Bobby L. Rush
+  party: majority
+  rank: 2
+  bioguide: R000515
+- name: Fred Upton
+  party: minority
+  rank: 2
+  bioguide: U000031
+- name: Anna G. Eshoo
+  party: majority
+  rank: 3
+  bioguide: E000215
+- name: Michael C. Burgess
+  party: minority
+  rank: 3
+  bioguide: B001248
+- name: Diana DeGette
+  party: majority
+  rank: 4
+  bioguide: D000197
+- name: Steve Scalise
+  party: minority
+  rank: 4
+  bioguide: S001176
+- name: Mike Doyle
+  party: majority
+  rank: 5
+  bioguide: D000482
+- name: Robert E. Latta
+  party: minority
+  rank: 5
+  bioguide: L000566
+- name: Jan Schakowsky
+  party: majority
+  rank: 6
+  bioguide: S001145
+- name: Brett Guthrie
+  party: minority
+  rank: 6
+  bioguide: G000558
+- name: G. K. Butterfield
+  party: majority
+  rank: 7
+  bioguide: B001251
+- name: David McKinley
+  party: minority
+  rank: 7
+  bioguide: M001180
+- name: Doris Matsui
+  party: majority
+  rank: 8
+  bioguide: M001163
+- name: Adam Kinzinger
+  party: minority
+  rank: 8
+  bioguide: K000378
+- name: Kathy Castor
+  party: majority
+  rank: 9
+  bioguide: C001066
+- name: Morgan Griffith
+  party: minority
+  rank: 9
+  bioguide: G000568
+- name: John Sarbanes
+  party: majority
+  rank: 10
+  bioguide: S001168
+- name: Gus Bilirakis
+  party: minority
+  rank: 10
+  bioguide: B001257
+- name: Jerry McNerney
+  party: majority
+  rank: 11
+  bioguide: M001166
+- name: Bill Johnson
+  party: minority
+  rank: 11
+  bioguide: J000292
+- name: Peter Welch
+  party: majority
+  rank: 12
+  bioguide: W000800
+- name: Billy Long
+  party: minority
+  rank: 12
+  bioguide: L000576
+- name: Paul Tonko
+  party: majority
+  rank: 13
+  bioguide: T000469
+- name: Larry Bucshon
+  party: minority
+  rank: 13
+  bioguide: B001275
+- name: Yvette D. Clarke
+  party: majority
+  rank: 14
+  bioguide: C001067
+- name: Markwayne Mullin
+  party: minority
+  rank: 14
+  bioguide: M001190
+- name: Kurt Schrader
+  party: majority
+  rank: 15
+  bioguide: S001180
+- name: Richard Hudson
+  party: minority
+  rank: 15
+  bioguide: H001067
+- name: Tony Cárdenas
+  party: majority
+  rank: 16
+  bioguide: C001097
+- name: Tim Walberg
+  party: minority
+  rank: 16
+  bioguide: W000798
+- name: Raul Ruiz
+  party: majority
+  rank: 17
+  bioguide: R000599
+- name: Buddy Carter
+  party: minority
+  rank: 17
+  bioguide: C001103
+- name: Scott Peters
+  party: majority
+  rank: 18
+  bioguide: P000608
+- name: Jeffrey Duncan
+  party: minority
+  rank: 18
+  bioguide: D000615
+- name: Debbie Dingell
+  party: majority
+  rank: 19
+  bioguide: D000624
+- name: Gary Palmer
+  party: minority
+  rank: 19
+  bioguide: P000609
+- name: Marc Veasey
+  party: majority
+  rank: 20
+  bioguide: V000131
+- name: Neal Dunn
+  party: minority
+  rank: 20
+  bioguide: D000628
+- name: Ann McLane Kuster
+  party: majority
+  rank: 21
+  bioguide: K000382
+- name: John Curtis
+  party: minority
+  rank: 21
+  bioguide: C001114
+- name: Robin Kelly
+  party: majority
+  rank: 22
+  bioguide: K000385
+- name: Debbie Lesko
+  party: minority
+  rank: 22
+  bioguide: L000589
+- name: Nanette Barragán
+  party: majority
+  rank: 23
+  bioguide: B001300
+- name: Greg Pence
+  party: minority
+  rank: 23
+  bioguide: P000615
+- name: A. Donald McEachin
+  party: majority
+  rank: 24
+  bioguide: M001200
+- name: Dan Crenshaw
+  party: minority
+  rank: 24
+  bioguide: C001120
+- name: Lisa Blunt Rochester
+  party: majority
+  rank: 25
+  bioguide: B001303
+- name: John Joyce
+  party: minority
+  rank: 25
+  bioguide: J000302
+- name: Darren Soto
+  party: majority
+  rank: 26
+  bioguide: S001200
+- name: Kelly Armstrong
+  party: minority
+  rank: 26
+  bioguide: A000377
+- name: Tom O'Halleran
+  party: majority
+  rank: 27
+  bioguide: O000171
+- name: Kathleen Rice
+  party: majority
+  rank: 28
+  bioguide: R000602
+- name: Angie Craig
+  party: majority
+  rank: 29
+  bioguide: C001119
+- name: Kim Schrier
+  party: majority
+  rank: 30
+  bioguide: S001216
+- name: Lori Trahan
+  party: majority
+  rank: 31
+  bioguide: T000482
+- name: Lizzie Fletcher
+  party: majority
+  rank: 32
+  bioguide: F000468
+HSIG: []
+HSII:
+- name: Raúl M. Grijalva
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: G000551
+- name: Bruce Westerman
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000821
+- name: Grace F. Napolitano
+  party: majority
+  rank: 2
+  bioguide: N000179
+- name: Don Young
+  party: minority
+  rank: 2
+  bioguide: Y000033
+- name: Jim Costa
+  party: majority
+  rank: 3
+  bioguide: C001059
+- name: Louie Gohmert
+  party: minority
+  rank: 3
+  bioguide: G000552
+- name: Gregorio Kilili Camacho Sablan
+  party: majority
+  rank: 4
+  bioguide: S001177
+- name: Doug Lamborn
+  party: minority
+  rank: 4
+  bioguide: L000564
+- name: Jared Huffman
+  party: majority
+  rank: 5
+  bioguide: H001068
+- name: Robert J. Wittman
+  party: minority
+  rank: 5
+  bioguide: W000804
+- name: Alan Lowenthal
+  party: majority
+  rank: 6
+  bioguide: L000579
+- name: Tom McClintock
+  party: minority
+  rank: 6
+  bioguide: M001177
+- name: Ruben Gallego
+  party: majority
+  rank: 7
+  bioguide: G000574
+- name: Paul Gosar
+  party: minority
+  rank: 7
+  bioguide: G000565
+- name: Joe Neguse
+  party: majority
+  rank: 8
+  bioguide: N000191
+- name: Garret Graves
+  party: minority
+  rank: 8
+  bioguide: G000577
+- name: Mike Levin
+  party: majority
+  rank: 9
+  bioguide: L000593
+- name: Jody Hice
+  party: minority
+  rank: 9
+  bioguide: H001071
+- name: Katie Porter
+  party: majority
+  rank: 10
+  bioguide: P000618
+- name: Amata Coleman Radewagen
+  party: minority
+  rank: 10
+  bioguide: R000600
+- name: Teresa Leger Fernandez
+  party: majority
+  rank: 11
+  bioguide: L000273
+- name: Daniel Webster
+  party: minority
+  rank: 11
+  bioguide: W000806
+- name: Nydia M. Velázquez
+  party: majority
+  rank: 12
+  bioguide: V000081
+- name: Jenniffer González-Colón
+  party: minority
+  rank: 12
+  bioguide: G000582
+- name: Diana DeGette
+  party: majority
+  rank: 13
+  bioguide: D000197
+- name: Russ Fulcher
+  party: minority
+  rank: 13
+  bioguide: F000469
+- name: Julia Brownley
+  party: majority
+  rank: 14
+  bioguide: B001285
+- name: Pete Stauber
+  party: minority
+  rank: 14
+  bioguide: S001212
+- name: Debbie Dingell
+  party: majority
+  rank: 15
+  bioguide: D000624
+- name: Tom Tiffany
+  party: minority
+  rank: 15
+  bioguide: T000165
+- name: A. Donald McEachin
+  party: majority
+  rank: 16
+  bioguide: M001200
+- name: Jerry Carl
+  party: minority
+  rank: 16
+  bioguide: C001054
+- name: Darren Soto
+  party: majority
+  rank: 17
+  bioguide: S001200
+- name: Matt Rosendale
+  party: minority
+  rank: 17
+  bioguide: R000103
+- name: Michael San Nicolas
+  party: majority
+  rank: 18
+  bioguide: S001204
+- name: Blake Moore
+  party: minority
+  rank: 18
+  bioguide: M001213
+- name: Jesús García
+  party: majority
+  rank: 19
+  bioguide: G000586
+- name: Yvette Herrell
+  party: minority
+  rank: 19
+  bioguide: H001084
+- name: Ed Case
+  party: majority
+  rank: 20
+  bioguide: C001055
+- name: Lauren Boebert
+  party: minority
+  rank: 20
+  bioguide: B000825
+- name: Betty McCollum
+  party: majority
+  rank: 21
+  bioguide: M001143
+- name: Jay Obernolte
+  party: minority
+  rank: 21
+  bioguide: O000019
+- name: Steve Cohen
+  party: majority
+  rank: 22
+  bioguide: C001068
+- name: Cliff Bentz
+  party: minority
+  rank: 22
+  bioguide: B000668
+- name: Paul Tonko
+  party: majority
+  rank: 23
+  bioguide: T000469
+- name: Rashida Tlaib
+  party: majority
+  rank: 24
+  bioguide: T000481
+- name: Doris Matsui
+  party: majority
+  rank: 25
+  bioguide: M001163
+- name: Lori Trahan
+  party: majority
+  rank: 26
+  bioguide: T000482
+HSJU:
+- name: Jerrold Nadler
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: N000002
+- name: Jim Jordan
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: J000289
+- name: Zoe Lofgren
+  party: majority
+  rank: 2
+  bioguide: L000397
+- name: Steven J. Chabot
+  party: minority
+  rank: 2
+  bioguide: C000266
+- name: Sheila Jackson Lee
+  party: majority
+  rank: 3
+  bioguide: J000032
+- name: Louie Gohmert
+  party: minority
+  rank: 3
+  bioguide: G000552
+- name: Steve Cohen
+  party: majority
+  rank: 4
+  bioguide: C001068
+- name: Darrell Issa
+  party: minority
+  rank: 4
+  bioguide: I000056
+- name: Hank Johnson
+  party: majority
+  rank: 5
+  bioguide: J000288
+- name: Ken Buck
+  party: minority
+  rank: 5
+  bioguide: B001297
+- name: Ted Deutch
+  party: majority
+  rank: 6
+  bioguide: D000610
+- name: Matt Gaetz
+  party: minority
+  rank: 6
+  bioguide: G000578
+- name: Karen Bass
+  party: majority
+  rank: 7
+  bioguide: B001270
+- name: Mike Johnson
+  party: minority
+  rank: 7
+  bioguide: J000299
+- name: Hakeem Jeffries
+  party: majority
+  rank: 8
+  bioguide: J000294
+- name: Andy Biggs
+  party: minority
+  rank: 8
+  bioguide: B001302
+- name: David Cicilline
+  party: majority
+  rank: 9
+  bioguide: C001084
+- name: Tom McClintock
+  party: minority
+  rank: 9
+  bioguide: M001177
+- name: Eric Swalwell
+  party: majority
+  rank: 10
+  bioguide: S001193
+- name: Greg Steube
+  party: minority
+  rank: 10
+  bioguide: S001214
+- name: Ted Lieu
+  party: majority
+  rank: 11
+  bioguide: L000582
+- name: Tom Tiffany
+  party: minority
+  rank: 11
+  bioguide: T000165
+- name: Jamie Raskin
+  party: majority
+  rank: 12
+  bioguide: R000606
+- name: Thomas Massie
+  party: minority
+  rank: 12
+  bioguide: M001184
+- name: Pramila Jayapal
+  party: majority
+  rank: 13
+  bioguide: J000298
+- name: Chip Roy
+  party: minority
+  rank: 13
+  bioguide: R000614
+- name: Val Demings
+  party: majority
+  rank: 14
+  bioguide: D000627
+- name: Dan Bishop
+  party: minority
+  rank: 14
+  bioguide: B001311
+- name: J. Luis Correa
+  party: majority
+  rank: 15
+  bioguide: C001110
+- name: Michelle Fischbach
+  party: minority
+  rank: 15
+  bioguide: F000470
+- name: Mary Gay Scanlon
+  party: majority
+  rank: 16
+  bioguide: S001205
+- name: Victoria Spartz
+  party: minority
+  rank: 16
+  bioguide: S000929
+- name: Sylvia Garcia
+  party: majority
+  rank: 17
+  bioguide: G000587
+- name: Scott Fitzgerald
+  party: minority
+  rank: 17
+  bioguide: F000471
+- name: Joe Neguse
+  party: majority
+  rank: 18
+  bioguide: N000191
+- name: Cliff Bentz
+  party: minority
+  rank: 18
+  bioguide: B000668
+- name: Lucy McBath
+  party: majority
+  rank: 19
+  bioguide: M001208
+- name: Burgess Owens
+  party: minority
+  rank: 19
+  bioguide: O000086
+- name: Greg Stanton
+  party: majority
+  rank: 20
+  bioguide: S001211
+- name: Madeleine Dean
+  party: majority
+  rank: 21
+  bioguide: D000631
+- name: Veronica Escobar
+  party: majority
+  rank: 22
+  bioguide: E000299
+- name: Mondaire Jones
+  party: majority
+  rank: 23
+  bioguide: J000306
+- name: Deborah Ross
+  party: majority
+  rank: 24
+  bioguide: R000305
+- name: Cori Bush
+  party: majority
+  rank: 25
+  bioguide: B001224
+HSMH: []
+HSPW:
+- name: Peter A. DeFazio
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: D000191
+- name: Sam Graves
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000546
+- name: Eleanor Holmes Norton
+  party: majority
+  rank: 2
+  bioguide: N000147
+- name: Don Young
+  party: minority
+  rank: 2
+  bioguide: Y000033
+- name: Eddie Bernice Johnson
+  party: majority
+  rank: 3
+  bioguide: J000126
+- name: Rick Crawford
+  party: minority
+  rank: 3
+  bioguide: C001087
+- name: Rick Larsen
+  party: majority
+  rank: 4
+  bioguide: L000560
+- name: Bob Gibbs
+  party: minority
+  rank: 4
+  bioguide: G000563
+- name: Grace F. Napolitano
+  party: majority
+  rank: 5
+  bioguide: N000179
+- name: Daniel Webster
+  party: minority
+  rank: 5
+  bioguide: W000806
+- name: Steve Cohen
+  party: majority
+  rank: 6
+  bioguide: C001068
+- name: Thomas Massie
+  party: minority
+  rank: 6
+  bioguide: M001184
+- name: Albio Sires
+  party: majority
+  rank: 7
+  bioguide: S001165
+- name: Scott Perry
+  party: minority
+  rank: 7
+  bioguide: P000605
+- name: John Garamendi
+  party: majority
+  rank: 8
+  bioguide: G000559
+- name: Rodney Davis
+  party: minority
+  rank: 8
+  bioguide: D000619
+- name: Hank Johnson
+  party: majority
+  rank: 9
+  bioguide: J000288
+- name: John Katko
+  party: minority
+  rank: 9
+  bioguide: K000386
+- name: André Carson
+  party: majority
+  rank: 10
+  bioguide: C001072
+- name: Brian Babin
+  party: minority
+  rank: 10
+  bioguide: B001291
+- name: Dina Titus
+  party: majority
+  rank: 11
+  bioguide: T000468
+- name: Garret Graves
+  party: minority
+  rank: 11
+  bioguide: G000577
+- name: Sean Patrick Maloney
+  party: majority
+  rank: 12
+  bioguide: M001185
+- name: David Rouzer
+  party: minority
+  rank: 12
+  bioguide: R000603
+- name: Jared Huffman
+  party: majority
+  rank: 13
+  bioguide: H001068
+- name: Mike Bost
+  party: minority
+  rank: 13
+  bioguide: B001295
+- name: Julia Brownley
+  party: majority
+  rank: 14
+  bioguide: B001285
+- name: Randy Weber
+  party: minority
+  rank: 14
+  bioguide: W000814
+- name: Frederica Wilson
+  party: majority
+  rank: 15
+  bioguide: W000808
+- name: Doug LaMalfa
+  party: minority
+  rank: 15
+  bioguide: L000578
+- name: Donald M. Payne Jr.
+  party: majority
+  rank: 16
+  bioguide: P000604
+- name: Bruce Westerman
+  party: minority
+  rank: 16
+  bioguide: W000821
+- name: Alan Lowenthal
+  party: majority
+  rank: 17
+  bioguide: L000579
+- name: Brian Mast
+  party: minority
+  rank: 17
+  bioguide: M001199
+- name: Mark DeSaulnier
+  party: majority
+  rank: 18
+  bioguide: D000623
+- name: Mike Gallagher
+  party: minority
+  rank: 18
+  bioguide: G000579
+- name: Stephen F. Lynch
+  party: majority
+  rank: 19
+  bioguide: L000562
+- name: Brian Fitzpatrick
+  party: minority
+  rank: 19
+  bioguide: F000466
+- name: Salud Carbajal
+  party: majority
+  rank: 20
+  bioguide: C001112
+- name: Jenniffer González-Colón
+  party: minority
+  rank: 20
+  bioguide: G000582
+- name: Anthony Brown
+  party: majority
+  rank: 21
+  bioguide: B001304
+- name: Troy Balderson
+  party: minority
+  rank: 21
+  bioguide: B001306
+- name: Tom Malinowski
+  party: majority
+  rank: 22
+  bioguide: M001203
+- name: Pete Stauber
+  party: minority
+  rank: 22
+  bioguide: S001212
+- name: Greg Stanton
+  party: majority
+  rank: 23
+  bioguide: S001211
+- name: Tim Burchett
+  party: minority
+  rank: 23
+  bioguide: B001309
+- name: Colin Allred
+  party: majority
+  rank: 24
+  bioguide: A000376
+- name: Dusty Johnson
+  party: minority
+  rank: 24
+  bioguide: J000301
+- name: Sharice Davids
+  party: majority
+  rank: 25
+  bioguide: D000629
+- name: Jefferson Van Drew
+  party: minority
+  rank: 25
+  bioguide: V000133
+- name: Jesús García
+  party: majority
+  rank: 26
+  bioguide: G000586
+- name: Michael Guest
+  party: minority
+  rank: 26
+  bioguide: G000591
+- name: Antonio Delgado
+  party: majority
+  rank: 27
+  bioguide: D000630
+- name: Troy Nehls
+  party: minority
+  rank: 27
+  bioguide: N000026
+- name: Chris Pappas
+  party: majority
+  rank: 28
+  bioguide: P000614
+- name: Nancy Mace
+  party: minority
+  rank: 28
+  bioguide: M000194
+- name: Conor Lamb
+  party: majority
+  rank: 29
+  bioguide: L000588
+- name: Nicole Malliotakis
+  party: minority
+  rank: 29
+  bioguide: M000317
+- name: Seth Moulton
+  party: majority
+  rank: 30
+  bioguide: M001196
+- name: Beth Van Duyne
+  party: minority
+  rank: 30
+  bioguide: V000134
+- name: Jake Auchincloss
+  party: majority
+  rank: 31
+  bioguide: A000148
+- name: Carlos Giménez
+  party: minority
+  rank: 31
+  bioguide: G000593
+- name: Carolyn Bourdeaux
+  party: majority
+  rank: 32
+  bioguide: B001312
+- name: Michelle Steel
+  party: minority
+  rank: 32
+  bioguide: S001135
+- name: Kaialiʻi Kahele
+  party: majority
+  rank: 33
+  bioguide: K000396
+- name: Marilyn Strickland
+  party: majority
+  rank: 34
+  bioguide: S001159
+- name: Nikema Williams
+  party: majority
+  rank: 35
+  bioguide: W000788
+- name: Marie Newman
+  party: majority
+  rank: 36
+  bioguide: N000192
+HSRU:
+- name: Jim McGovern
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: M000312
+- name: Tom Cole
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: C001053
+- name: Alcee L. Hastings
+  party: majority
+  rank: 2
+  bioguide: H000324
+- name: Michael C. Burgess
+  party: minority
+  rank: 2
+  bioguide: B001248
+- name: Norma Torres
+  party: majority
+  rank: 3
+  bioguide: T000474
+- name: Guy Reschenthaler
+  party: minority
+  rank: 3
+  bioguide: R000610
+- name: Debbie Lesko
+  party: minority
+  rank: 3
+  bioguide: L000589
+- name: Ed Perlmutter
+  party: majority
+  rank: 4
+  bioguide: P000593
+- name: Michelle Fischbach
+  party: minority
+  rank: 4
+  bioguide: F000470
+- name: Jamie Raskin
+  party: majority
+  rank: 5
+  bioguide: R000606
+- name: Mary Gay Scanlon
+  party: majority
+  rank: 6
+  bioguide: S001205
+- name: Joe Morelle
+  party: majority
+  rank: 7
+  bioguide: M001206
+- name: Mark DeSaulnier
+  party: majority
+  rank: 8
+  bioguide: D000623
+- name: Deborah Ross
+  party: majority
+  rank: 9
+  bioguide: R000305
+HSSM:
+- name: Nydia M. Velázquez
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: V000081
+- name: Blaine Luetkemeyer
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000569
+- name: Jared Golden
+  party: majority
+  rank: 2
+  bioguide: G000592
+- name: Jim Hagedorn
+  party: minority
+  rank: 2
+  bioguide: H001088
+- name: Jason Crow
+  party: majority
+  rank: 3
+  bioguide: C001121
+- name: Pete Stauber
+  party: minority
+  rank: 3
+  bioguide: S001212
+- name: Sharice Davids
+  party: majority
+  rank: 4
+  bioguide: D000629
+- name: Roger Williams
+  party: minority
+  rank: 4
+  bioguide: W000816
+- name: Kweisi Mfume
+  party: majority
+  rank: 5
+  bioguide: M000687
+- name: Daniel Meuser
+  party: minority
+  rank: 5
+  bioguide: M001204
+- name: Dean Phillips
+  party: majority
+  rank: 6
+  bioguide: P000616
+- name: Claudia Tenney
+  party: minority
+  rank: 6
+  bioguide: T000478
+- name: Marie Newman
+  party: majority
+  rank: 7
+  bioguide: N000192
+- name: Andrew Garbarino
+  party: minority
+  rank: 7
+  bioguide: G000597
+- name: Carolyn Bourdeaux
+  party: majority
+  rank: 8
+  bioguide: B001312
+- name: Young Kim
+  party: minority
+  rank: 8
+  bioguide: K000397
+- name: Judy Chu
+  party: majority
+  rank: 9
+  bioguide: C001080
+- name: Beth Van Duyne
+  party: minority
+  rank: 9
+  bioguide: V000134
+- name: Scott Peters
+  party: majority
+  rank: 10
+  bioguide: P000608
+- name: Byron Donalds
+  party: minority
+  rank: 10
+  bioguide: D000032
+- name: Dwight Evans
+  party: majority
+  rank: 11
+  bioguide: E000296
+- name: Maria Elvira Salazar
+  party: minority
+  rank: 11
+  bioguide: S000168
+- name: Antonio Delgado
+  party: majority
+  rank: 12
+  bioguide: D000630
+- name: Scott Fitzgerald
+  party: minority
+  rank: 12
+  bioguide: F000471
+- name: Chrissy Houlahan
+  party: majority
+  rank: 13
+  bioguide: H001085
+- name: Andy Kim
+  party: majority
+  rank: 14
+  bioguide: K000394
+- name: Angie Craig
+  party: majority
+  rank: 15
+  bioguide: C001119
+HSSO:
+- name: Ted Deutch
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: D000610
+- name: Jackie Walorski
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: W000813
+- name: Susan Wild
+  party: majority
+  rank: 2
+  bioguide: W000826
+- name: Michael Guest
+  party: minority
+  rank: 2
+  bioguide: G000591
+- name: Dean Phillips
+  party: majority
+  rank: 3
+  bioguide: P000616
+- name: Dave Joyce
+  party: minority
+  rank: 3
+  bioguide: J000295
+- name: Veronica Escobar
+  party: majority
+  rank: 4
+  bioguide: E000299
+- name: John Rutherford
+  party: minority
+  rank: 4
+  bioguide: R000609
+- name: Mondaire Jones
+  party: majority
+  rank: 5
+  bioguide: J000306
+- name: Kelly Armstrong
+  party: minority
+  rank: 5
+  bioguide: A000377
+HSSY:
+- name: Eddie Bernice Johnson
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: J000126
+- name: Frank D. Lucas
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: L000491
+- name: Zoe Lofgren
+  party: majority
+  rank: 2
+  bioguide: L000397
+- name: Mo Brooks
+  party: minority
+  rank: 2
+  bioguide: B001274
+- name: Suzanne Bonamici
+  party: majority
+  rank: 3
+  bioguide: B001278
+- name: Bill Posey
+  party: minority
+  rank: 3
+  bioguide: P000599
+- name: Ami Bera
+  party: majority
+  rank: 4
+  bioguide: B001287
+- name: Randy Weber
+  party: minority
+  rank: 4
+  bioguide: W000814
+- name: Haley Stevens
+  party: majority
+  rank: 5
+  bioguide: S001215
+- name: Brian Babin
+  party: minority
+  rank: 5
+  bioguide: B001291
+- name: Mikie Sherrill
+  party: majority
+  rank: 6
+  bioguide: S001207
+- name: Anthony Gonzalez
+  party: minority
+  rank: 6
+  bioguide: G000588
+- name: Jamaal Bowman
+  party: majority
+  rank: 7
+  bioguide: B001223
+- name: Michael Waltz
+  party: minority
+  rank: 7
+  bioguide: W000823
+- name: Brad Sherman
+  party: majority
+  rank: 8
+  bioguide: S000344
+- name: James Baird
+  party: minority
+  rank: 8
+  bioguide: B001307
+- name: Ed Perlmutter
+  party: majority
+  rank: 9
+  bioguide: P000593
+- name: Pete Sessions
+  party: minority
+  rank: 9
+  bioguide: S000250
+- name: Jerry McNerney
+  party: majority
+  rank: 10
+  bioguide: M001166
+- name: Daniel Webster
+  party: minority
+  rank: 10
+  bioguide: W000806
+- name: Paul Tonko
+  party: majority
+  rank: 11
+  bioguide: T000469
+- name: Mike Garcia
+  party: minority
+  rank: 11
+  bioguide: G000061
+- name: Bill Foster
+  party: majority
+  rank: 12
+  bioguide: F000454
+- name: Stephanie Bice
+  party: minority
+  rank: 12
+  bioguide: B000740
+- name: Donald W. Norcross
+  party: majority
+  rank: 13
+  bioguide: N000188
+- name: Young Kim
+  party: minority
+  rank: 13
+  bioguide: K000397
+- name: Donald Beyer
+  party: majority
+  rank: 14
+  bioguide: B001292
+- name: Randy Feenstra
+  party: minority
+  rank: 14
+  bioguide: F000446
+- name: Charlie Crist
+  party: majority
+  rank: 15
+  bioguide: C001111
+- name: Jake LaTurner
+  party: minority
+  rank: 15
+  bioguide: L000266
+- name: Sean Casten
+  party: majority
+  rank: 16
+  bioguide: C001117
+- name: Carlos Giménez
+  party: minority
+  rank: 16
+  bioguide: G000593
+- name: Conor Lamb
+  party: majority
+  rank: 17
+  bioguide: L000588
+- name: Jay Obernolte
+  party: minority
+  rank: 17
+  bioguide: O000019
+- name: Deborah Ross
+  party: majority
+  rank: 18
+  bioguide: R000305
+- name: Peter Meijer
+  party: minority
+  rank: 18
+  bioguide: M001186
+- name: Gwen Moore
+  party: majority
+  rank: 19
+  bioguide: M001160
+- name: Dan Kildee
+  party: majority
+  rank: 20
+  bioguide: K000380
+- name: Susan Wild
+  party: majority
+  rank: 21
+  bioguide: W000826
+- name: Lizzie Fletcher
+  party: majority
+  rank: 22
+  bioguide: F000468
+HSVR:
+- name: Mark Takano
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: T000472
+- name: Mike Bost
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B001295
+- name: Julia Brownley
+  party: majority
+  rank: 2
+  bioguide: B001285
+- name: Amata Coleman Radewagen
+  party: minority
+  rank: 2
+  bioguide: R000600
+- name: Conor Lamb
+  party: majority
+  rank: 3
+  bioguide: L000588
+- name: Jack Bergman
+  party: minority
+  rank: 3
+  bioguide: B001301
+- name: Mike Levin
+  party: majority
+  rank: 4
+  bioguide: L000593
+- name: Jim Banks
+  party: minority
+  rank: 4
+  bioguide: B001299
+- name: Chris Pappas
+  party: majority
+  rank: 5
+  bioguide: P000614
+- name: Chip Roy
+  party: minority
+  rank: 5
+  bioguide: R000614
+- name: Elaine Luria
+  party: majority
+  rank: 6
+  bioguide: L000591
+- name: Greg Murphy
+  party: minority
+  rank: 6
+  bioguide: M001210
+- name: Frank Mrvan
+  party: majority
+  rank: 7
+  bioguide: M001214
+- name: Tracey Mann
+  party: minority
+  rank: 7
+  bioguide: M000871
+- name: Gregorio Kilili Camacho Sablan
+  party: majority
+  rank: 8
+  bioguide: S001177
+- name: Barry Moore
+  party: minority
+  rank: 8
+  bioguide: M001212
+- name: Lauren Underwood
+  party: majority
+  rank: 9
+  bioguide: U000040
+- name: Nancy Mace
+  party: minority
+  rank: 9
+  bioguide: M000194
+- name: Colin Allred
+  party: majority
+  rank: 10
+  bioguide: A000376
+- name: Madison Cawthorn
+  party: minority
+  rank: 10
+  bioguide: C001104
+- name: Lois Frankel
+  party: majority
+  rank: 11
+  bioguide: F000462
+- name: Troy Nehls
+  party: minority
+  rank: 11
+  bioguide: N000026
+- name: Anthony Brown
+  party: majority
+  rank: 12
+  bioguide: B001304
+- name: Matt Rosendale
+  party: minority
+  rank: 12
+  bioguide: R000103
+- name: Elissa Slotkin
+  party: majority
+  rank: 13
+  bioguide: S001208
+- name: Mariannette Miller-Meeks
+  party: minority
+  rank: 13
+  bioguide: M001215
+- name: David Trone
+  party: majority
+  rank: 14
+  bioguide: T000483
+- name: Marcy Kaptur
+  party: majority
+  rank: 15
+  bioguide: K000009
+- name: Raul Ruiz
+  party: majority
+  rank: 16
+  bioguide: R000599
+- name: Ruben Gallego
+  party: majority
+  rank: 17
+  bioguide: G000574
+HSWM:
+- name: Richard E. Neal
+  party: majority
+  rank: 1
+  title: Chairman
+  bioguide: N000015
+- name: Kevin Brady
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: B000755
+- name: Lloyd Doggett
+  party: majority
+  rank: 2
+  bioguide: D000399
+- name: Devin Nunes
+  party: minority
+  rank: 2
+  bioguide: N000181
+- name: Mike Thompson
+  party: majority
+  rank: 3
+  bioguide: T000460
+- name: Vern Buchanan
+  party: minority
+  rank: 3
+  bioguide: B001260
+- name: John B. Larson
+  party: majority
+  rank: 4
+  bioguide: L000557
+- name: Adrian Smith
+  party: minority
+  rank: 4
+  bioguide: S001172
+- name: Earl Blumenauer
+  party: majority
+  rank: 5
+  bioguide: B000574
+- name: Tom Reed
+  party: minority
+  rank: 5
+  bioguide: R000585
+- name: Ron Kind
+  party: majority
+  rank: 6
+  bioguide: K000188
+- name: Mike Kelly
+  party: minority
+  rank: 6
+  bioguide: K000376
+- name: Bill Pascrell Jr.
+  party: majority
+  rank: 7
+  bioguide: P000096
+- name: Jason Smith
+  party: minority
+  rank: 7
+  bioguide: S001195
+- name: Danny K. Davis
+  party: majority
+  rank: 8
+  bioguide: D000096
+- name: Tom Rice
+  party: minority
+  rank: 8
+  bioguide: R000597
+- name: Linda T. Sánchez
+  party: majority
+  rank: 9
+  bioguide: S001156
+- name: David Schweikert
+  party: minority
+  rank: 9
+  bioguide: S001183
+- name: Brian Higgins
+  party: majority
+  rank: 10
+  bioguide: H001038
+- name: Jackie Walorski
+  party: minority
+  rank: 10
+  bioguide: W000813
+- name: Terri Sewell
+  party: majority
+  rank: 11
+  bioguide: S001185
+- name: Darin M. LaHood
+  party: minority
+  rank: 11
+  bioguide: L000585
+- name: Suzan K. DelBene
+  party: majority
+  rank: 12
+  bioguide: D000617
+- name: Brad Wenstrup
+  party: minority
+  rank: 12
+  bioguide: W000815
+- name: Judy Chu
+  party: majority
+  rank: 13
+  bioguide: C001080
+- name: Jodey Arrington
+  party: minority
+  rank: 13
+  bioguide: A000375
+- name: Gwen Moore
+  party: majority
+  rank: 14
+  bioguide: M001160
+- name: A. Drew Ferguson
+  party: minority
+  rank: 14
+  bioguide: F000465
+- name: Dan Kildee
+  party: majority
+  rank: 15
+  bioguide: K000380
+- name: Ron Estes
+  party: minority
+  rank: 15
+  bioguide: E000298
+- name: Brendan Boyle
+  party: majority
+  rank: 16
+  bioguide: B001296
+- name: Lloyd Smucker
+  party: minority
+  rank: 16
+  bioguide: S001199
+- name: Donald Beyer
+  party: majority
+  rank: 17
+  bioguide: B001292
+- name: Kevin Hern
+  party: minority
+  rank: 17
+  bioguide: H001082
+- name: Dwight Evans
+  party: majority
+  rank: 18
+  bioguide: E000296
+- name: Carol Miller
+  party: minority
+  rank: 18
+  bioguide: M001205
+- name: Brad Schneider
+  party: majority
+  rank: 19
+  bioguide: S001190
+- name: Thomas Suozzi
+  party: majority
+  rank: 20
+  bioguide: S001201
+- name: Jimmy Panetta
+  party: majority
+  rank: 21
+  bioguide: P000613
+- name: Stephanie Murphy
+  party: majority
+  rank: 22
+  bioguide: M001202
+- name: Jimmy Gomez
+  party: majority
+  rank: 23
+  bioguide: G000585
+- name: Steven Horsford
+  party: majority
+  rank: 24
+  bioguide: H001066
+- name: Stacey Plaskett
+  party: majority
+  rank: 25
+  bioguide: P000610

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -3892,7 +3892,69 @@ HSBU:
   party: majority
   rank: 21
   bioguide: J000298
-HSCN: []
+HSCN:
+- name: Kathy Castor
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001066
+- name: Suzanne Bonamici
+  party: majority
+  rank: 2
+  bioguide: B001278
+- name: Julia Brownley
+  party: majority
+  rank: 3
+  bioguide: B001285
+- name: Sean Casten
+  party: majority
+  rank: 4
+  bioguide: C001117
+- name: Jared Huffman
+  party: majority
+  rank: 5
+  bioguide: H001068
+- name: Mike Levin
+  party: majority
+  rank: 6
+  bioguide: L000593
+- name: A. Donald McEachin
+  party: majority
+  rank: 7
+  bioguide: M001200
+- name: Joe Neguse
+  party: majority
+  rank: 8
+  bioguide: N000191
+- name: Veronica Escobar
+  party: majority
+  rank: 9
+  bioguide: E000299
+- name: Garret Graves
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000577
+- name: H. Morgan Griffith
+  party: minority
+  rank: 2
+  bioguide: G000568
+- name: Gary J. Palmer
+  party: minority
+  rank: 3
+  bioguide: P000609
+- name: Earl L. "Buddy" Carter
+  party: minority
+  rank: 4
+  bioguide: C001103
+- name: Carol D. Miller
+  party: minority
+  rank: 5
+  bioguide: M001205
+- name: Kelly Armstrong
+  party: minority
+  rank: 6
+  bioguide: A000377
 HSED:
 - name: Robert C. Scott
   party: majority
@@ -5278,7 +5340,53 @@ HSJU:
   party: majority
   rank: 25
   bioguide: B001224
-HSMH: []
+HSMH:
+- name: Derek Kilmer
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: K000381
+- name: Emanuel Cleaver
+  party: majority
+  rank: 2
+  bioguide: C001061
+- name: Zoe Lofgren
+  party: majority
+  rank: 3
+  bioguide: L000397
+- name: Ed Perlmutter
+  party: majority
+  rank: 4
+  bioguide: P000593
+- name: Dean Phillips
+  party: majority
+  rank: 5
+  bioguide: P000616
+- name: Nikema Williams
+  party: majority
+  rank: 6
+  bioguide: W000788
+- name: William R. Timmons IV
+  party: minority
+  rank: 1
+  title: Vice Chair
+  bioguide: T000480
+- name: Rodney Davis
+  party: minority
+  rank: 2
+  bioguide: D000619
+- name: Robert E. Latta
+  party: minority
+  rank: 3
+  bioguide: L000566
+- name: Guy Reschenthaler
+  party: minority
+  rank: 4
+  bioguide: R000610
+- name: Beth Van Duyne
+  party: minority
+  rank: 5
+  bioguide: V000134
 HSPW:
 - name: Peter A. DeFazio
   party: majority
@@ -6228,69 +6336,6 @@ HSWM:
   party: majority
   rank: 25
   bioguide: P000610
-HSCN:
-- name: Kathy Castor
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: C001066
-- name: Suzanne Bonamici
-  party: majority
-  rank: 2
-  bioguide: B001278
-- name: Julia Brownley
-  party: majority
-  rank: 3
-  bioguide: B001285
-- name: Sean Casten
-  party: majority
-  rank: 4
-  bioguide: C001117
-- name: Jared Huffman
-  party: majority
-  rank: 5
-  bioguide: H001068
-- name: Mike Levin
-  party: majority
-  rank: 6
-  bioguide: L000593
-- name: A. Donald McEachin
-  party: majority
-  rank: 7
-  bioguide: M001200
-- name: Joe Neguse
-  party: majority
-  rank: 8
-  bioguide: N000191
-- name: Veronica Escobar
-  party: majority
-  rank: 9
-  bioguide: E000299
-- name: Garret Graves
-  party: minority
-  rank: 1
-  title: Ranking Member
-  bioguide: G000577
-- name: H. Morgan Griffith
-  party: minority
-  rank: 2
-  bioguide: G000568
-- name: Gary J. Palmer
-  party: minority
-  rank: 3
-  bioguide: P000609
-- name: Earl L. "Buddy" Carter
-  party: minority
-  rank: 4
-  bioguide: C001103
-- name: Carol D. Miller
-  party: minority
-  rank: 5
-  bioguide: M001205
-- name: Kelly Armstrong
-  party: minority
-  rank: 6
-  bioguide: A000377
 HLIG:
 - name: Adam B. Schiff
   party: majority
@@ -6302,50 +6347,3 @@ HLIG:
   rank: 1
   title: Ranking Member
   bioguide: N000181
-HSMH:
-- name: Derek Kilmer
-  party: majority
-  rank: 1
-  title: Chair
-  bioguide: K000381
-- name: Emanuel Cleaver
-  party: majority
-  rank: 2
-  bioguide: C001061
-- name: Zoe Lofgren
-  party: majority
-  rank: 3
-  bioguide: L000397
-- name: Ed Perlmutter
-  party: majority
-  rank: 4
-  bioguide: P000593
-- name: Dean Phillips
-  party: majority
-  rank: 5
-  bioguide: P000616
-- name: Nikema Williams
-  party: majority
-  rank: 6
-  bioguide: W000788
-- name: William R. Timmons IV
-  party: minority
-  rank: 1
-  title: Vice Chair
-  bioguide: T000480
-- name: Rodney Davis
-  party: minority
-  rank: 2
-  bioguide: D000619
-- name: Robert E. Latta
-  party: minority
-  rank: 3
-  bioguide: L000566
-- name: Guy Reschenthaler
-  party: minority
-  rank: 4
-  bioguide: R000610
-- name: Beth Van Duyne
-  party: minority
-  rank: 5
-  bioguide: V000134

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -6228,3 +6228,124 @@ HSWM:
   party: majority
   rank: 25
   bioguide: P000610
+HSCN:
+- name: Kathy Castor
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: C001066
+- name: Suzanne Bonamici
+  party: majority
+  rank: 2
+  bioguide: B001278
+- name: Julia Brownley
+  party: majority
+  rank: 3
+  bioguide: B001285
+- name: Sean Casten
+  party: majority
+  rank: 4
+  bioguide: C001117
+- name: Jared Huffman
+  party: majority
+  rank: 5
+  bioguide: H001068
+- name: Mike Levin
+  party: majority
+  rank: 6
+  bioguide: L000593
+- name: A. Donald McEachin
+  party: majority
+  rank: 7
+  bioguide: M001200
+- name: Joe Neguse
+  party: majority
+  rank: 8
+  bioguide: N000191
+- name: Veronica Escobar
+  party: majority
+  rank: 9
+  bioguide: E000299
+- name: Garret Graves
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: G000577
+- name: H. Morgan Griffith
+  party: minority
+  rank: 2
+  bioguide: G000568
+- name: Gary J. Palmer
+  party: minority
+  rank: 3
+  bioguide: P000609
+- name: Earl L. "Buddy" Carter
+  party: minority
+  rank: 4
+  bioguide: C001103
+- name: Carol D. Miller
+  party: minority
+  rank: 5
+  bioguide: M001205
+- name: Kelly Armstrong
+  party: minority
+  rank: 6
+  bioguide: A000377
+HLIG:
+- name: Adam B. Schiff
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: S001150
+- name: Devin Nunes
+  party: minority
+  rank: 1
+  title: Ranking Member
+  bioguide: N000181
+HSMH:
+- name: Derek Kilmer
+  party: majority
+  rank: 1
+  title: Chair
+  bioguide: K000381
+- name: Emanuel Cleaver
+  party: majority
+  rank: 2
+  bioguide: C001061
+- name: Zoe Lofgren
+  party: majority
+  rank: 3
+  bioguide: L000397
+- name: Ed Perlmutter
+  party: majority
+  rank: 4
+  bioguide: P000593
+- name: Dean Phillips
+  party: majority
+  rank: 5
+  bioguide: P000616
+- name: Nikema Williams
+  party: majority
+  rank: 6
+  bioguide: W000788
+- name: William R. Timmons IV
+  party: minority
+  rank: 1
+  title: Vice Chair
+  bioguide: T000480
+- name: Rodney Davis
+  party: minority
+  rank: 2
+  bioguide: D000619
+- name: Robert E. Latta
+  party: minority
+  rank: 3
+  bioguide: L000566
+- name: Guy Reschenthaler
+  party: minority
+  rank: 4
+  bioguide: R000610
+- name: Beth Van Duyne
+  party: minority
+  rank: 5
+  bioguide: V000134

--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -3816,10 +3816,6 @@ HSBU:
   party: majority
   rank: 9
   bioguide: M001206
-- name: Marjorie Taylor Greene
-  party: minority
-  rank: 9
-  bioguide: G000596
 - name: Ben Cline
   party: minority
   rank: 9
@@ -3984,10 +3980,6 @@ HSED:
   party: majority
   rank: 11
   bioguide: J000298
-- name: Ron Wright
-  party: minority
-  rank: 11
-  bioguide: W000827
 - name: Fred Keller
   party: minority
   rank: 11
@@ -4044,10 +4036,6 @@ HSED:
   party: majority
   rank: 18
   bioguide: S001215
-- name: Marjorie Taylor Greene
-  party: minority
-  rank: 18
-  bioguide: G000596
 - name: Mary Miller
   party: minority
   rank: 18


### PR DESCRIPTION
This is based off [this Clerk document](https://clerk.house.gov/committee_info/scsoal.pdf) plus several subsequent House resolutions naming members. It does not include Marjorie Taylor Greene, who was removed from two committees, or Ron Wright, who died in early February. It also is currently missing the House select committees (Intel, Climate and Modernization) and House assignments to joint committees.

If folks want to wait until we get those to merge, that's ok with me.