### PR TITLE
Add 'Jim' nickname to Rep. James Himes

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -10517,6 +10517,7 @@
     google_entity_id: kg:/m/03w9x9v
   name:
     first: James
+    nickname: Jim
     middle: A.
     last: Himes
     official_full: James A. Himes


### PR DESCRIPTION
He uses Jim on official documents, but the logic I am trying to follow nowadays is if the person's legal first name is recognizable as them, then the legal first name stays in the first name field.