### PR TITLE
fix circleci config to run deploy step again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,4 +33,4 @@ workflows:
       - deploy:
           filters:
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
it looks like the branch filter was left as master despite the name changing to main