### PR TITLE
YouTube channel IDs for House and Senate committees, where applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Additional fields are present on current committee entries (that is, in `committ
 * phone: The phone number of the committee.
 * rss_url: The URL for the committee's RSS feed.
 * minority_rss_url: The URL for the committee's minority party website's RSS feed.
+* youtube_id: The YouTube channel ID of the committee (if it exists)
 
 Two additional fields are present on committees and subcommmittees in the `committees-historical.yaml` file:
 

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -34,6 +34,7 @@
   rss_url: https://agriculture.house.gov/Rss.aspx?GroupID=1
   jurisdiction: The House Committee on Agriculture has legislative jurisdiction over
     agriculture, food, rural development, and forestry.
+  youtube_id: UCOWh2WJxPywHIaccDWb8Mvg
 - type: house
   name: House Committee on Appropriations
   url: https://appropriations.house.gov/
@@ -99,6 +100,7 @@
     spending bills, which are sometimes needed in the middle of a fiscal year to compensate
     for emergency expenses.
   jurisdiction_source: https://appropriations.house.gov/about/
+  youtube_id: UCMaSlF09S0fpoRshS2t_7XA
 - type: house
   name: House Committee on Armed Services
   url: https://armedservices.house.gov/
@@ -135,6 +137,7 @@
   jurisdiction: The House Committee on Armed Services has legislative jurisdiction
     over military and defense.
   jurisdiction_source: https://armedservices.house.gov/about
+  youtube_id: UCD506yORW2voSanqEgLOUIQ
 - type: house
   name: House Committee on Financial Services
   url: https://financialservices.house.gov/
@@ -176,6 +179,7 @@
     its oversight of the Federal Reserve Board and individual reserve banks, the Treasury,
     the production and distribution of currency, and the Nation’s capital markets.
   jurisdiction_source: https://financialservices.house.gov/about/
+  youtube_id: UCiGw0gRK-daU7Xv4oDMr9Hg
 - type: house
   name: House Committee on the Budget
   url: https://budget.house.gov/
@@ -194,6 +198,7 @@
     of violations to the budget, and by working with other committees, such as the
     Committee on Appropriations, to prevent potential violations.
   jurisdiction_source: https://budget.house.gov/about/
+  youtube_id: UCwzia2rpHJkowAXK-IF9E0w
 - type: house
   name: House Committee on Education and Labor
   url: https://edlabor.house.gov/
@@ -227,6 +232,7 @@
     higher and lower education, workforce development and protections, and health,
     employment, labor, and pensions.
   jurisdiction_source: https://edworkforce.house.gov/committee/subcommitteesjurisdictions.htm
+  youtube_id: UCqAHNOSUqn0OByR-4vF81FQ
 - type: house
   name: House Committee on Foreign Affairs
   url: https://foreignaffairs.house.gov/
@@ -265,6 +271,7 @@
     Agency for International Development, the Peace Corps, the United Nations, and
     the enforcement of the Arms Export Control Act.
   jurisdiction_source: https://foreignaffairs.house.gov/about/
+  youtube_id: UCXCjgHrMgPEqDvCmPc9BbJA
 - type: house
   name: House Committee on Oversight and Reform
   url: https://oversight.house.gov/
@@ -311,6 +318,7 @@
     government operations, health care, information technology, interior, energy and
     environment, national security, and intergovernmental affairs.
   jurisdiction_source: https://oversight.house.gov/about/
+  youtube_id: UCXSlyao4qkUFiPqghptHtZA
 - type: house
   name: House Committee on House Administration
   url: https://cha.house.gov/
@@ -335,6 +343,7 @@
     committees and members of Congress. It also oversees several federal organizations
     such as the Library of Congress and Smithsonian Institution.
   jurisdiction_source: https://cha.house.gov/about
+  youtube_id: UCTO94zQwJNB_gmud-4IyZXA
 - type: house
   name: House Committee on Homeland Security
   url: https://homeland.house.gov/
@@ -375,6 +384,7 @@
     efficiency; and transportation and protective security. The Committee was created
     in 2002 in the aftermath of the September 11th, 2001 attacks.
   jurisdiction_source: https://homeland.house.gov/subcommittee/full_committee/
+  youtube_id: UC6Vg3_8RRaIVLJFyo7WZfzA
 - type: house
   name: House Committee on Energy and Commerce
   url: https://energycommerce.house.gov/
@@ -417,6 +427,7 @@
     Trade Commission, the Food and Drug Administration, and the Federal Communications
     Commission.
   jurisdiction_source: https://energycommerce.house.gov/committee-history/
+  youtube_id: UCCbD3bkHRcwiBsaL1lWE_QQ
 - type: house
   name: House Committee on Natural Resources
   url: https://naturalresources.house.gov/
@@ -454,6 +465,7 @@
     American energy production, mineral lands and mining, fisheries and wildlife,
     public lands, oceans, Native Americans, irrigation and reclamation.
   jurisdiction_source: https://naturalresources.house.gov/about/
+  youtube_id: UCB6LGE5-_i-xxtZxk1_SeTg
 - type: house
   name: House Permanent Select Committee on Intelligence
   url: https://intelligence.house.gov/
@@ -506,6 +518,7 @@
     intelligence and intelligence-related activities of the following seventeen elements
     of the U.S. Government—and the Military Intelligence Program.
   jurisdiction_source: https://intelligence.house.gov/about/history-and-jurisdiction.htm
+  youtube_id: UCMF5z6BIrwwQTtcj2cacBPw
 - type: house
   name: House Committee on the Judiciary
   url: https://judiciary.house.gov/
@@ -544,6 +557,7 @@
     amendments, and more. The Committee oversees the Departments of Justice and Homeland
     Security.
   jurisdiction_source: https://judiciary.house.gov/about-the-committee/
+  youtube_id: UCVvv3JRCVQAl6ovogDum4hA
 - type: house
   name: House Committee on Transportation and Infrastructure
   url: https://transportation.house.gov/
@@ -586,6 +600,7 @@
     of economically depressed rural and urban areas, disaster preparedness and response,
     and hazardous materials transportation.'
   jurisdiction_source: https://transportation.house.gov/about/history.htm
+  youtube_id: UChc8bTPtZgTZDDLJ6UWJgxA
 - type: house
   name: House Committee on Rules
   url: https://rules.house.gov/
@@ -616,6 +631,7 @@
     changes to the standing rules of the House, or measures that contain special rules,
     such as the expedited procedures in trade legislation.
   jurisdiction_source: https://rules.house.gov/about
+  youtube_id: UC3LTS2HRaURCmt_kkWorvFw
 - type: house
   name: House Committee on Small Business
   url: https://smallbusiness.house.gov/
@@ -651,6 +667,7 @@
     reduction. Additionally, the House Small Business Committee has  oversight and
     legislative authority over the Small Business Administration (SBA) and its programs.
   jurisdiction_source: https://smallbusiness.house.gov/about/rulesandjurisdiction.htm
+  youtube_id: UCnYcuO2JQhVbnCR8ltmSacQ
 - type: house
   name: House Committee on Ethics
   url: https://ethics.house.gov/
@@ -666,6 +683,7 @@
     of each party. Also, unlike other committees, the day-to-day work of the Committee
     on Ethics is conducted by a staff that is nonpartisan by rule.
   jurisdiction_source: https://ethics.house.gov/about/committee-history
+  youtube_id: UCxZOzbhWkBPEimMti0NBvQQ
 - type: house
   name: House Committee on Science, Space, and Technology
   url: https://science.house.gov/
@@ -704,6 +722,7 @@
     National Weather Service. It also reviews laws, programs, and Government activities
     relating to non-military research and development to report back to the House.
   jurisdiction_source: https://science.house.gov/about/jurisdiction
+  youtube_id: UCtoUE3dJ-mLUo5dwGs7hXOw
 - type: house
   name: House Committee on Veterans' Affairs
   url: https://veterans.house.gov/
@@ -741,6 +760,7 @@
     that VA is not administering laws as Congress intended, then it is addressed through
     the hearing process and legislation.
   jurisdiction_source: https://veterans.house.gov/about/history.htm
+  youtube_id: UCvI8xjyh45-XAJbfPcjUdbQ
 - type: house
   name: House Committee on Ways and Means
   url: https://waysandmeans.house.gov/
@@ -782,6 +802,7 @@
     agreements, and the bonded debt of the United States. It also oversees revenue-related
     aspects of the Social Security system, Medicare, and social services programs.
   jurisdiction_source: https://waysandmeans.house.gov/history/
+  youtube_id: UCrz_XV52yquSiXvyjdh03Fw
 - type: house
   name: House Select Committee on the Climate Crisis
   thomas_id: HSCN
@@ -790,6 +811,7 @@
   house_committee_id: CN
   address: 359 FHOB; Washington, DC 20515
   phone: (202) 225-1106
+  youtube_id: UCqTxfzU6vYZ2-DW-y5jYvdQ
 - type: house
   name: House Select Committee on the Modernization of Congress
   url: https://modernizecongress.house.gov/
@@ -799,12 +821,14 @@
   house_committee_id: MH
   address: 226 CHOB; Washington, DC 20515
   phone: (202) 225-1530
+  youtube_id: UCECZaLBqABxBqN7VdtZ5sCA
 - type: joint
   name: Commission on Security and Cooperation in Europe
   url: http://www.csce.gov/
   thomas_id: JCSE
   senate_committee_id: JCSE
   wikipedia: Commission on Security and Cooperation in Europe
+  youtube_id: UCtFO3w68Kumz7tRyspaqF2g
 - type: joint
   name: Joint Economic Committee
   url: http://www.jec.senate.gov/
@@ -813,6 +837,7 @@
   rss_url: http://www.jec.senate.gov/republicans/public/?a=RSS.Feed
   minority_rss_url: http://www.jec.senate.gov/public/?a=RSS.Feed
   wikipedia: Joint Economic Committee
+  youtube_id: UCbNWSrKyYBP5iIZKT35LSGA
 - type: joint
   name: Joint Committee on the Library
   url: https://cha.house.gov/jointcommittees/joint-committee-library
@@ -846,6 +871,7 @@
     programs. The Caucus has held numerous hearings over the years and has issued
     a number of reports on U.S. narcotics control policy.
   jurisdiction_source: http://www.drugcaucus.senate.gov/content/about
+  youtube_id: UCD6CIIrqCTE08ZXPCzhoNyA
 - type: senate
   name: Senate Select Committee on Ethics
   url: http://www.ethics.senate.gov/
@@ -875,6 +901,7 @@
     American Indians, Native Hawaiians, or Alaska Natives is under the jurisdiction
     of the Committee.
   jurisdiction_source: https://www.indian.senate.gov/about/history
+  youtube_id: UCyrk47CduR0_u8fF-YV66Ig
 - type: senate
   name: Senate Select Committee on Intelligence
   url: http://www.intelligence.senate.gov/
@@ -1142,6 +1169,7 @@
     Indian affairs, public lands and their renewable resources, surface mining, territories
     and insular possessions, and water resources.
   jurisdiction_source: https://www.energy.senate.gov/public/index.cfm/jurisdiction
+  youtube_id: UChLTzGO2KEkdBlJ22pOccjA
 - type: senate
   name: Senate Committee on Environment and Public Works
   url: http://www.epw.senate.gov/
@@ -1179,6 +1207,7 @@
     jurisdiction on matters related to environmental protection, resource utilization
     and conservation, and public infrastructure.
   jurisdiction_source: https://www.epw.senate.gov/public/index.cfm/committee-jurisdiction
+  youtube_id: UCqMG6uXhoBo_nHcJN9XrLKw
 - type: senate
   name: Senate Committee on Finance
   url: http://www.finance.senate.gov/
@@ -1216,6 +1245,7 @@
     Program (CHIP), Temporary Assistance to Needy Families (TANF) and other health
     and human services programs financed by a specific tax or trust fund.
   jurisdiction_source: https://www.ethics.senate.gov/public/index.cfm/jurisdiction
+  youtube_id: UCqy51oGHjollKBBWV4_iRgQ
 - type: senate
   name: Senate Committee on Foreign Relations
   url: http://www.foreign.senate.gov/
@@ -1309,6 +1339,7 @@
     municipalities, and between the U.S. and international organizations of which
     the U.S. is a member.
   jurisdiction_source: https://www.hsgac.senate.gov/about/jurisdiction
+  youtube_id: UCKJISmkvK8tn0kFiCaIzUwQ
 - type: senate
   name: Senate Committee on Health, Education, Labor, and Pensions
   url: http://www.help.senate.gov/
@@ -1412,3 +1443,4 @@
     as matters relating to the vocational rehabilitation, education, medical care,
     civil relief, and civilian readjustment of veterans.
   jurisdiction_source: https://www.veterans.senate.gov/about
+  youtube_id: UCKJISmkvK8tn0kFiCaIzUwQ


### PR DESCRIPTION
I found these useful for a project and thought it would save others time if they were incorporated into the base repo.

Although legislators' social media accounts are in a separate yaml file, I suggest putting the committees' YouTube channel ID directly on the current committees list both for convenience and since it does not need to be updated with the same frequency as the legislators list.

Also worth noting that Senate committees largely do not have YouTube channels, but in cases where I could find those I added them, too.