### PR TITLE
Add OpenSecrets ids to about 65 legislators; correct FEC id for Sara …

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -39641,6 +39641,7 @@
     lis: S412
     fec:
     - S0AL00230
+    opensecrets: N00044434
     govtrack: 456796
     wikidata: Q7819948
     wikipedia: Tommy Tuberville
@@ -39673,6 +39674,7 @@
     lis: S408
     fec:
     - S0CO00575
+    opensecrets: N00044206
     govtrack: 456797
     wikidata: Q430518
     wikipedia: John Hickenlooper
@@ -39704,6 +39706,7 @@
     lis: S407
     fec:
     - S0TN00169
+    opensecrets: N00045369
     govtrack: 456798
     wikidata: Q27734214
     wikipedia: Bill Hagerty (politician)
@@ -39735,6 +39738,7 @@
     bioguide: C001054
     fec:
     - H0AL01055
+    opensecrets: N00044245
     govtrack: 456799
     wikidata: Q102277702
     wikipedia: Jerry Carl
@@ -39763,6 +39767,7 @@
     bioguide: M001212
     fec:
     - H8AL02171
+    opensecrets: N00041295
     govtrack: 456800
     wikidata: Q63198048
     wikipedia: Barry Moore (Alabama politician)
@@ -39789,6 +39794,7 @@
     bioguide: O000019
     fec:
     - H0CA08135
+    opensecrets: N00045377
     govtrack: 456801
     wikidata: Q16849797
     wikipedia: Jay Obernolte
@@ -39817,6 +39823,7 @@
     bioguide: K000397
     fec:
     - H8CA39240
+    opensecrets: N00042386
     govtrack: 456802
     wikidata: Q19662859
     wikipedia: Young Kim
@@ -39845,6 +39852,7 @@
     bioguide: S001135
     fec:
     - H0CA48198
+    opensecrets: N00044501
     govtrack: 456803
     wikidata: Q6837200
     wikipedia: Michelle Steel
@@ -39871,7 +39879,8 @@
 - id:
     bioguide: J000305
     fec:
-    - H0CA53115
+    - H8CA49074
+    opensecrets: N00042081
     govtrack: 456804
     wikidata: Q50825637
     wikipedia: Sara Jacobs
@@ -39898,6 +39907,7 @@
     bioguide: B000825
     fec:
     - H0CO03165
+    opensecrets: N00045974
     govtrack: 456805
     wikidata: Q96761544
     wikipedia: Lauren Boebert
@@ -39926,6 +39936,7 @@
     bioguide: C001039
     fec:
     - H0FL03175
+    opensecrets: N00045978
     govtrack: 456806
     wikidata: Q98523243
     wikipedia: Kat Cammack
@@ -39953,6 +39964,7 @@
     bioguide: F000472
     fec:
     - H0FL15104
+    opensecrets: N00046760
     govtrack: 456807
     wikidata: Q101198561
     wikipedia: Scott Franklin (politician)
@@ -39980,6 +39992,7 @@
     bioguide: D000032
     fec:
     - H0FL19205
+    opensecrets: N00034016
     govtrack: 456808
     wikidata: Q59726216
     wikipedia: Byron Donalds
@@ -40007,6 +40020,7 @@
     bioguide: G000593
     fec:
     - H0FL26036
+    opensecrets: N00046394
     govtrack: 456809
     wikidata: Q5041653
     wikipedia: Carlos A. Giménez
@@ -40036,6 +40050,7 @@
     bioguide: S000168
     fec:
     - H8FL27185
+    opensecrets: N00042810
     govtrack: 456810
     wikidata: Q6003715
     wikipedia: Maria Elvira Salazar
@@ -40064,6 +40079,7 @@
     bioguide: W000788
     fec:
     - H0GA05301
+    opensecrets: N00047361
     govtrack: 456811
     wikidata: Q56486570
     wikipedia: Nikema Williams
@@ -40092,6 +40108,7 @@
     bioguide: B001312
     fec:
     - H8GA07201
+    opensecrets: N00041791
     govtrack: 456812
     wikidata: Q58333638
     wikipedia: Carolyn Bourdeaux
@@ -40119,6 +40136,7 @@
     bioguide: C001116
     fec:
     - H0GA09246
+    opensecrets: N00046654
     govtrack: 456813
     wikidata: Q102277679
     wikipedia: Andrew Clyde
@@ -40146,6 +40164,7 @@
     bioguide: G000596
     fec:
     - H0GA06192
+    opensecrets: N00044701
     govtrack: 456814
     wikidata: Q98380406
     wikipedia: Marjorie Taylor Greene
@@ -40174,6 +40193,7 @@
     bioguide: K000396
     fec:
     - H0HI02155
+    opensecrets: N00044007
     govtrack: 456815
     wikidata: Q28861508
     wikipedia: Kai Kahele
@@ -40200,6 +40220,7 @@
     bioguide: H001091
     fec:
     - H0IA01174
+    opensecrets: N00044521
     govtrack: 456816
     wikidata: Q60713905
     wikipedia: Ashley Hinson
@@ -40228,6 +40249,7 @@
     bioguide: M001215
     fec:
     - H8IA02043
+    opensecrets: N00029495
     govtrack: 456817
     wikidata: Q58495662
     wikipedia: Mariannette Miller-Meeks
@@ -40257,6 +40279,7 @@
     bioguide: F000446
     fec:
     - H0IA04145
+    opensecrets: N00044011
     govtrack: 456818
     wikidata: Q7292187
     wikipedia: Randy Feenstra
@@ -40286,6 +40309,7 @@
     bioguide: N000192
     fec:
     - H8IL03102
+    opensecrets: N00040891
     govtrack: 456819
     wikidata: Q47960940
     wikipedia: Marie Newman
@@ -40312,6 +40336,7 @@
     bioguide: M001211
     fec:
     - H0IL15129
+    opensecrets: N00045703
     govtrack: 456820
     wikidata: Q101204553
     wikipedia: Mary Miller (politician)
@@ -40339,6 +40364,7 @@
     bioguide: M001214
     fec:
     - H0IN01150
+    opensecrets: N00045905
     govtrack: 456821
     wikidata: Q96077897
     wikipedia: Frank J. Mrvan
@@ -40366,6 +40392,7 @@
     bioguide: S000929
     fec:
     - H0IN05326
+    opensecrets: N00046537
     govtrack: 456822
     wikidata: Q44059867
     wikipedia: Victoria Spartz
@@ -40392,6 +40419,7 @@
     bioguide: M000871
     fec:
     - H0KS01123
+    opensecrets: N00030743
     govtrack: 456823
     wikidata: Q48767554
     wikipedia: Tracey Mann
@@ -40419,6 +40447,7 @@
     bioguide: L000266
     fec:
     - H0KS02188
+    opensecrets: N00044232
     govtrack: 456824
     wikidata: Q16731273
     wikipedia: Jake LaTurner
@@ -40446,6 +40475,7 @@
     bioguide: A000148
     fec:
     - H0MA04192
+    opensecrets: N00045506
     govtrack: 456825
     wikidata: Q101196632
     wikipedia: Jake Auchincloss
@@ -40473,6 +40503,7 @@
     bioguide: M001186
     fec:
     - H0MI03308
+    opensecrets: N00044884
     govtrack: 456826
     wikidata: Q96419165
     wikipedia: Peter Meijer
@@ -40500,6 +40531,7 @@
     bioguide: M001136
     fec:
     - H0MI10287
+    opensecrets: N00045730
     govtrack: 456827
     wikidata: Q102184540
     wikipedia: Lisa McClain
@@ -40528,6 +40560,7 @@
     bioguide: F000470
     fec:
     - H0MN07091
+    opensecrets: N00045251
     govtrack: 456828
     wikidata: Q6837025
     wikipedia: Michelle Fischbach
@@ -40556,6 +40589,7 @@
     bioguide: B001224
     fec:
     - H8MO01143
+    opensecrets: N00039373
     govtrack: 456829
     wikidata: Q98084800
     wikipedia: Cori Bush
@@ -40583,6 +40617,7 @@
     bioguide: R000103
     fec:
     - H4MT00050
+    opensecrets: N00035517
     govtrack: 456830
     wikidata: Q6791163
     wikipedia: Matt Rosendale
@@ -40613,6 +40648,7 @@
     bioguide: R000305
     fec:
     - H0NC02125
+    opensecrets: N00038565
     govtrack: 456831
     wikidata: Q5248285
     wikipedia: Deborah K. Ross
@@ -40641,6 +40677,7 @@
     bioguide: M001135
     fec:
     - H8NC13067
+    opensecrets: N00042159
     govtrack: 456832
     wikidata: Q101136890
     wikipedia: Kathy Manning
@@ -40668,6 +40705,7 @@
     bioguide: C001104
     fec:
     - H0NC11233
+    opensecrets: N00046252
     govtrack: 456833
     wikidata: Q96633736
     wikipedia: Madison Cawthorn
@@ -40696,6 +40734,7 @@
     bioguide: H001084
     fec:
     - H8NM02156
+    opensecrets: N00041454
     govtrack: 456834
     wikidata: Q16225780
     wikipedia: Yvette Herrell
@@ -40724,6 +40763,7 @@
     bioguide: L000273
     fec:
     - H0NM03102
+    opensecrets: N00044559
     govtrack: 456835
     wikidata: Q96054905
     wikipedia: Teresa Leger Fernandez
@@ -40750,6 +40790,7 @@
     bioguide: G000597
     fec:
     - H0NY02234
+    opensecrets: N00046030
     govtrack: 456836
     wikidata: Q21257859
     wikipedia: Andrew Garbarino
@@ -40777,6 +40818,7 @@
     bioguide: M000317
     fec:
     - H0NY11078
+    opensecrets: N00044040
     govtrack: 456837
     wikidata: Q7030112
     wikipedia: Nicole Malliotakis
@@ -40803,6 +40845,7 @@
     bioguide: T000486
     fec:
     - H0NY15160
+    opensecrets: N00044346
     govtrack: 456838
     wikidata: Q16205227
     wikipedia: Ritchie Torres
@@ -40831,6 +40874,7 @@
     bioguide: B001223
     fec:
     - H0NY16143
+    opensecrets: N00044790
     govtrack: 456839
     wikidata: Q96419280
     wikipedia: Jamaal Bowman
@@ -40858,6 +40902,7 @@
     bioguide: J000306
     fec:
     - H0NY17174
+    opensecrets: N00044908
     govtrack: 456840
     wikidata: Q96781248
     wikipedia: Mondaire Jones
@@ -40885,6 +40930,7 @@
     bioguide: B000740
     fec:
     - H0OK05205
+    opensecrets: N00044579
     govtrack: 456841
     wikidata: Q60190894
     wikipedia: Stephanie Bice
@@ -40913,6 +40959,7 @@
     bioguide: B000668
     fec:
     - H0OR02127
+    opensecrets: N00045773
     govtrack: 456842
     wikidata: Q5132536
     wikipedia: Cliff Bentz
@@ -40940,6 +40987,7 @@
     bioguide: M000194
     fec:
     - H0SC01394
+    opensecrets: N00035670
     govtrack: 456843
     wikidata: Q6962831
     wikipedia: Nancy Mace
@@ -40968,6 +41016,7 @@
     bioguide: H001086
     fec:
     - H0TN01118
+    opensecrets: N00046688
     govtrack: 456844
     wikidata: Q101197341
     wikipedia: Diana Harshbarger
@@ -40994,6 +41043,7 @@
     bioguide: F000246
     fec:
     - H0TX04219
+    opensecrets: N00047264
     govtrack: 456845
     wikidata: Q16196923
     wikipedia: Pat Fallon
@@ -41022,6 +41072,7 @@
     bioguide: P000048
     fec:
     - H0TX11230
+    opensecrets: N00045421
     govtrack: 456846
     wikidata: Q101196462
     wikipedia: August Pfluger
@@ -41050,6 +41101,7 @@
     bioguide: J000304
     fec:
     - H0TX13228
+    opensecrets: N00046055
     govtrack: 456847
     wikidata: Q47270118
     wikipedia: Ronny Jackson
@@ -41078,6 +41130,7 @@
     bioguide: N000026
     fec:
     - H0TX22302
+    opensecrets: N00046067
     govtrack: 456848
     wikidata: Q96741441
     wikipedia: Troy Nehls
@@ -41107,6 +41160,7 @@
     bioguide: G000594
     fec:
     - H0TX35015
+    opensecrets: N00044592
     govtrack: 456849
     wikidata: ''
     google_entity_id: kg:/g/11fs52clcr
@@ -41134,6 +41188,7 @@
     bioguide: V000134
     fec:
     - H0TX24209
+    opensecrets: N00045167
     govtrack: 456850
     wikidata: Q66309702
     wikipedia: Beth Van Duyne
@@ -41163,6 +41218,7 @@
     bioguide: M001213
     fec:
     - H0UT01205
+    opensecrets: N00046598
     govtrack: 456851
     wikidata: Q101196971
     wikipedia: Blake Moore
@@ -41190,6 +41246,7 @@
     bioguide: O000086
     fec:
     - H0UT04076
+    opensecrets: N00045812
     govtrack: 456852
     wikidata: Q4998602
     wikipedia: Burgess Owens
@@ -41218,6 +41275,7 @@
     bioguide: G000595
     fec:
     - H0VA05160
+    opensecrets: N00045557
     govtrack: 456853
     wikidata: Q103850475
     wikipedia: Bob Good
@@ -41246,6 +41304,7 @@
     bioguide: S001159
     fec:
     - H0WA10034
+    opensecrets: N00046320
     govtrack: 456854
     wikidata: Q1898180
     wikipedia: Marilyn Strickland
@@ -41272,6 +41331,7 @@
     bioguide: F000471
     fec:
     - H0WI05113
+    opensecrets: N00045434
     govtrack: 456855
     wikidata: Q7436650
     wikipedia: Scott L. Fitzgerald
@@ -41299,6 +41359,9 @@
 - id:
     bioguide: P000145
     lis: S413
+    fec:
+    - S2CA00955
+    opensecrets: N00047888
     govtrack: 456856
     wikipedia: Alex Padilla
     wikidata: Q4717593
@@ -41331,6 +41394,7 @@
     fec:
     - H8GA06195
     - S8GA00180
+    opensecrets: N00040675
     govtrack: 456857
     wikipedia: Jon Ossoff
     wikidata: Q28839536
@@ -41360,6 +41424,7 @@
     lis: S415
     fec:
     - S0GA00559
+    opensecrets: N00046489
     govtrack: 456858
     wikipedia: Raphael Warnock
     wikidata: Q84146599
@@ -41432,6 +41497,7 @@
     bioguide: L000595
     fec:
     - H2LA05126
+    opensecrets: N00047972
     govtrack: 456859
     wikipedia: Julia Letlow
     wikidata: Q106089241
@@ -41458,6 +41524,7 @@
     bioguide: C001125
     fec:
     - H2LA02149
+    opensecrets: N00025766
     govtrack: 456860
     wikipedia: Troy Carter (politician)
     wikidata: Q7846787
@@ -41485,6 +41552,7 @@
     bioguide: S001218
     fec:
     - H2NM01144
+    opensecrets: N00047871
     govtrack: 456861
     wikipedia: Melanie Stansbury
     wikidata: Q96184996


### PR DESCRIPTION
…Jacobs

-- Roughly 65 legislators had no -id/opensecrets entry; added them using data from the OpenSecrets website (CRP_IDs.xls, downloaded from https://www.opensecrets.org/resources/create/data_doc.php).
-- Corrected the fec id (-id/-fec) for Sara Jacobs; the previous id is not listed by the fec.