### PR TITLE
House Ways and Means Committee has a more up-to-date YouTube channel.

### DIFF
--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -808,7 +808,7 @@
     agreements, and the bonded debt of the United States. It also oversees revenue-related
     aspects of the Social Security system, Medicare, and social services programs.
   jurisdiction_source: https://waysandmeans.house.gov/history/
-  youtube_id: UCrz_XV52yquSiXvyjdh03Fw
+  youtube_id: UCfGqG11uB0JKgDxnF-GWQZg
 - type: house
   name: House Select Committee on the Climate Crisis
   thomas_id: HSCN


### PR DESCRIPTION
Apparently there are two W&M YouTube channels (named the same, with one name using an ampersand and one using an 'and') to which the majority is uploading videos. This one is where they are uploading the hearings, so I think it makes more sense to include this one in the dataset.

Perhaps in the future, it might be useful to make this data field an array of channel IDs of any related YouTube channels instead of just one.