### PR TITLE
Fix a typo and add a missing progress message in formatting script

### DIFF
--- a/scripts/alternate_bulk_formats.py
+++ b/scripts/alternate_bulk_formats.py
@@ -142,6 +142,7 @@ def generate_csv():
 
 def generate_district_office_csv():
 	filename = "legislators-district-offices.yaml"
+	print("Converting %s to CSV..." % filename)
 	legislators_offices = utils.load_data(filename)
 	fields = [
 		"bioguide", "thomas", "govtrack", "id", "address", "building",

--- a/scripts/alternate_bulk_formats.py
+++ b/scripts/alternate_bulk_formats.py
@@ -70,7 +70,7 @@ def generate_csv():
 	social = utils.load_data(yaml_social)
 
 	for filename in yamls:
-		print("Converting %s to YAML..." % filename)
+		print("Converting %s to CSV..." % filename)
 
 		legislators = utils.load_data(filename)
 


### PR DESCRIPTION
In the alternate bulk format script, we were printing that we were converting the files to YAML when we are really converting them to CSV. Also, one of the messages that said this was missing. 