### PR TITLE
Fixed family members with " or ' in the name

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -17500,7 +17500,7 @@
     office: 1236 Longworth House Office Building
     phone: 202-225-4965
   family:
-  - name: "Thomas D'Alesandro Jr."
+  - name: Thomas D'Alesandro Jr.
     relation: daughter
 - id:
     bioguide: P000593

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -17500,7 +17500,7 @@
     office: 1236 Longworth House Office Building
     phone: 202-225-4965
   family:
-  - name: Thomas D?Alesandro Jr.
+  - name: "Thomas D'Alesandro Jr."
     relation: daughter
 - id:
     bioguide: P000593


### PR DESCRIPTION
These two records display `?` where they should have `"` or `'`.