### PR TITLE
Update Twitter accounts

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -704,8 +704,8 @@
     thomas: '02082'
     govtrack: 412492
   social:
-    twitter: RandPaul
-    twitter_id: 216881337
+    twitter: SenRandPaul
+    twitter_id: 1298624375692894210
     facebook: SenatorRandPaul
     youtube: SenatorRandPaul
     youtube_id: UCeM9I-20oWUs8daIIpsNHoQ
@@ -1367,11 +1367,11 @@
     thomas: '00583'
     govtrack: 300055
   social:
-    twitter: InhofePress
+    twitter: JimInhofe
+    twitter_id: 7270292
     facebook: jiminhofe
     youtube: jiminhofepressoffice
     youtube_id: UCk3W3ilX8vGG-300qzNpG7w
-    twitter_id: 20546536
 - id:
     bioguide: H001061
     thomas: '02079'
@@ -4732,3 +4732,10 @@
   social:
     twitter: Congressman_JVD
     twitter_id: 1468677099594698757
+- id:
+    bioguide: V000129
+    thomas: '02105'
+    govtrack: 412515
+  social:
+    twitter: RepDavidValadao
+    twitter_id: 1128514404

--- a/scripts/data/social_media_blacklist.csv
+++ b/scripts/data/social_media_blacklist.csv
@@ -80,3 +80,5 @@ instagram,^housegop$,house gop conference
 instagram,^en_US$,junk
 instagram,^rep$,junk
 instagram,^t51$,junk
+twitter,^home$,junk
+twitter,^intent$,junk


### PR DESCRIPTION
Add account for Rep. David G. Valadao.

Update accounts for Sen. Rand Paul and Sen. James M. Inhofe.

Add 'home' and 'intent' to Twitter blocklist.

----

Justification:
* [\@RepDavidValadao](https://twitter.com/RepDavidValadao) links to Valadao's House website, which links back.
* [\@SenRandPaul](https://twitter.com/SenRandPaul) identifies itself as an official government account and links to Paul's Senate website, which links back. [\@RandPaul](https://twitter.com/RandPaul), on the other hand, links to Paul's campaign website.
* [\@JimInhofe](https://twitter.com/JimInhofe) links to Inhofe's Senate website, which links back. [\@InhofePress](https://twitter.com/InhofePress) also links to it. His campaign account appears to be [\@inhofeforsenate](https://twitter.com/inhofeforsenate).

Not included in this update:
* Sen. Mitch McConnell maintains two different accounts: [\@LeaderMcConnell](https://twitter.com/LeaderMcConnell) for his role as Republican leader and [\@McConnellPress](https://twitter.com/McConnellPress) for his role as the senator from KY. Each links to its corresponding Senate website, which links back.
* Rep. Jamaal Bowman appears to be conflating his official and campaign accounts. [\@RepBowman](https://twitter.com/RepBowman) appears to be his official account, which links to his House website (via linktree), but his House website links to [\@JamaalBowmanNY](https://twitter.com/JamaalBowmanNY), which in turn links to his campaign website (via myurls).
* It is not clear whether Sen. Roger Marshall has an official account. [\@SenatorMarshall](https://twitter.com/SenatorMarshall) has been stripped of all information and [\@RogerMarshallMD](https://twitter.com/RogerMarshallMD) does not link to any websites. However, Marshall's Senate website does link to the latter.