### PR TITLE
Revise Rep. Cawthorn's first name to Madison

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40136,8 +40136,7 @@
     google_entity_id: kg:/g/11jcrrfg9t
     ballotpedia: Madison Cawthorn
   name:
-    first: David
-    nickname: Madison
+    first: Madison
     last: Cawthorn
     official_full: Madison Cawthorn
   bio:


### PR DESCRIPTION
Per 1c13038c407069393bd578009cb025700e57da2c, our policy is to make the first name field of legislators a name that would be recognized by the general public as the legislator's first name, even if it is not the legislator's legal first name, especially to follow the legislator's preferred first name in the Bioguide or House/Senate websites (which show "Madison" in this case).