### PR TITLE
Updated Rubio district offices

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -9463,7 +9463,6 @@
     zip: '32801'
     latitude: 28.5400755
     longitude: -81.3780508
-    fax: 407-423-0941
     phone: 407-254-2573
   - id: R000595-palm_beach_gardens
     address: 4580 PGA Blvd.
@@ -9472,9 +9471,8 @@
     state: FL
     zip: '33418'
     latitude: 26.8380427
-    longitude: -80.11140940000001
+    longitude: -80.1114094
     phone: 561-775-3360
-    fax: 866-630-7106
   - id: R000595-pensacola
     address: 700 S. Palafox St.
     suite: Suite 125

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -9494,16 +9494,14 @@
     longitude: -84.281289
     phone: 850-599-9100
   - id: R000595-tampa
-    address: 801 N. Florida Ave.
-    suite: Suite 1130
-    building: Sam M. Gibbons U.S. Courthouse
+    address: 501 E. Polk St
+    suite: Suite 601
     city: Tampa
     state: FL
     zip: '33602'
-    latitude: 27.9514709
-    longitude: -82.4604482
-    phone: 813-853-1099
-    fax: 866-630-7106
+    latitude: 27.9511694
+    longitude: -82.459228
+    phone: 813-947-6288
 - id:
     bioguide: R000597
     govtrack: 412572


### PR DESCRIPTION
Tampa changed locations + phone, cleaned up some other unlisted fax numbers for the rest of the locations.

From: https://www.rubio.senate.gov/public/index.cfm/contact