### PR TITLE
Add Open Secrets identifier for Jake Ellzey

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40901,6 +40901,7 @@
     bioguide: E000071
     fec:
     - H8TX06266
+    opensecrets: N00042243
     govtrack: 456862
     wikipedia: Jake Ellzey
     wikidata: Q105061782


### PR DESCRIPTION
Added an identifier for Jake Ellzey based on [his Open Secrets page](https://www.opensecrets.org/members-of-congress/jake-ellzey/summary?cid=N00042243&cycle=2022).