### PR TITLE
Change Sinema's party to Independent but caucusing with Democrats

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -25083,7 +25083,14 @@
     end: '2025-01-03'
     state: AZ
     class: 1
-    party: Democrat
+    party: Independent
+    caucus: Democrat
+    party_affiliations:
+    - end: '2022-12-08'
+      party: Democrat
+    - start: '2022-12-09'
+      party: Independent
+      caucus: Democrat
     state_rank: senior
     url: https://www.sinema.senate.gov
     address: 317 Hart Senate Office Building Washington DC 20510


### PR DESCRIPTION
It's being widely reported today that Sinema has registered as an Independent. Although she hasn't said explicitly about caucusing with Democrats, Politico reports that she intends to get committee assignments from Democrats, which almost certainly means caucusing with the Dems. She also almost certainly voted in the Dem caucus leadership election a few days ago (since there was no reporting that she didn't).

https://www.politico.com/news/2022/12/09/sinema-arizona-senate-independent-00073216