### PR TITLE
Add Mastodon handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Each record has two sections: `id` and `social`. The `id` section identifies the
 * instagram: The current official Instagram handle of the legislator.
 * instagram_id: The numeric ID of the current official Instagram handle of the legislator.
 * facebook: The username of the current official Facebook presence of the legislator.
+* mastodon: The current Mastodon handle (@username@instance) of the legislator.
 
 Several legislators do not have an assigned YouTube username.  In these cases, only the youtube_id field is populated.
 

--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -320,6 +320,7 @@
     youtube: CongressmanMThompson
     youtube_id: UC6pGbtqHZYZmScFGSz5bbdg
     twitter_id: 303861808
+    mastodon: '@repthompson@mastodon.social'
 - id:
     bioguide: T000250
     thomas: '01534'
@@ -732,6 +733,7 @@
     youtube: congresswomanpingree
     youtube_id: UCLKaWFM7I84WcreDRhhhkVg
     twitter_id: 14984637
+    mastodon: '@chelliepingree@mastodon.social'
 - id:
     bioguide: P000595
     thomas: '01929'
@@ -829,6 +831,7 @@
     youtube: EleanorHNorton
     youtube_id: UChRrAXUGylfxJjbquC6aUjQ
     twitter_id: 23600262
+    mastodon: '@CongresswomanNorton@Mastodon.social'
 - id:
     bioguide: N000015
     thomas: '00854'
@@ -1416,6 +1419,7 @@
     facebook: CongressmanJimHimes
     youtube: congressmanhimes
     youtube_id: UCCeB6czh6nhCHxOMCk_V4yA
+    mastodon: '@RepJimHimes@mastodon.social'
 - id:
     bioguide: H001046
     thomas: '01937'
@@ -1538,6 +1542,7 @@
     youtube: raulgrijalvaaz07
     youtube_id: UC8JZLnXS21bhNbcvpoM8O7g
     twitter_id: 28602948
+    mastodon: '@RepRaulGrijalva@mastodon.social'
 - id:
     bioguide: G000386
     thomas: '00457'
@@ -2674,6 +2679,7 @@
     instagram: joaquincastrotx
     instagram_id: 378492005
     twitter_id: 231510077
+    mastodon: '@Joaquincastrotx@mastodon.social'
 - id:
     bioguide: W000815
     thomas: '02152'
@@ -2966,6 +2972,7 @@
     twitter_id: 2916086925
     instagram: repadams
     youtube_id: UCPI9ao1Cr1nxEUD2r-usRjQ
+    mastodon: '@RepAdams@mastodon.social'
 - id:
     bioguide: M001194
     govtrack: 412634
@@ -3111,6 +3118,7 @@
     twitter_id: 236279233
     youtube_id: UCvWY4qKP6--o3pIJY7hhKDg
     instagram: repnormatorres
+    mastodon: '@repnormatorres@mstdn.social'
 - id:
     bioguide: S001197
     govtrack: 412671
@@ -3259,6 +3267,7 @@
     twitter_id: 2962868158
     instagram: repdonbeyer
     youtube_id: UCPJGVbOVcAVGiBwq8qr_T9w
+    mastodon: '@RepDonBeyer@mas.to'
 - id:
     bioguide: G000576
     govtrack: 412661
@@ -3520,6 +3529,7 @@
     twitter_id: 815733290955112448
     instagram: repjayapal
     youtube_id: UCmyD0_-2Oowkfwc_Raghclw
+    mastodon: '@RepJayapal@mastodon.social '
 - id:
     bioguide: F000466
     govtrack: 412721
@@ -4002,6 +4012,7 @@
   social:
     twitter: RepLoriTrahan
     twitter_id: 1079802482640019456
+    mastodon: '@RepLoriTrahan@mastodon.social'
 - id:
     bioguide: T000483
   social:
@@ -4072,6 +4083,7 @@
   social:
     twitter: RepCasten
     twitter_id: 1083472286089396224
+    mastodon: '@RepCasten@mastodon.social'
 - id:
     bioguide: M001203
   social:
@@ -4266,6 +4278,7 @@
   social:
     twitter: RepBowman
     twitter_id: 1344389506963808264
+    mastodon: '@repbowman@mastodon.social'
 - id:
     bioguide: M000317
     govtrack: 456837
@@ -4494,6 +4507,7 @@
   social:
     twitter: RepTeresaLF
     twitter_id: 1345147845926670337
+    mastodon: '@RepTeresaLF@mastodon.social'
 - id:
     bioguide: O000019
     govtrack: 456801
@@ -4578,6 +4592,7 @@
   social:
     twitter: RepShontelBrown
     twitter_id: 1456381091598700556
+    mastodon: '@RepShontelBrown@mastodon.social'
 - id:
     bioguide: C001116
     govtrack: 456813

--- a/scripts/alternate_bulk_formats.py
+++ b/scripts/alternate_bulk_formats.py
@@ -60,9 +60,11 @@ def generate_csv():
 	#pulled from legislators-social-media.yaml
 	social_media_fields = [
 	("twitter", "twitter"),
+	("twitter_id", "twitter_id"),
 	("facebook", "facebook"),
 	("youtube", "youtube"),
-	("youtube_id", "youtube_id")
+	("youtube_id", "youtube_id"),
+	("mastodon", "mastodon")
 	]
 
 


### PR DESCRIPTION
From @danielschuman's spreadsheet at https://docs.google.com/spreadsheets/d/1egupogzhZgPgcM1NcIxBC4iW2xgvs1qJPAG568YaCuY/edit#gid=1071805829. Only confirmed accounts are added.

The CSV file of legislators is updated to include the Mastodon handles in a new column, and numeric Twitter IDs are added for completeness.