### PR TITLE
Correct Sen. Padilla's special election term start date from Nov 9 to Dec 22

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40373,7 +40373,7 @@
   terms:
   - type: sen
     start: '2021-01-20'
-    end: '2022-11-08'
+    end: '2022-12-21'
     how: appointment
     state: CA
     class: 3
@@ -40385,7 +40385,7 @@
     url: https://www.padilla.senate.gov
     contact_form: https://www.padilla.senate.gov/contact/
   - type: sen
-    start: '2022-11-09'
+    start: '2022-12-22'
     end: '2023-01-03'
     how: special-election
     state: CA


### PR DESCRIPTION
He was re-sworn in... late last night? It's not clear exactly at what time, but ending the appointment term on Dec 21 and starting the special election term on Dec 22 seems right.

https://twitter.com/CraigCaplan/status/1605793306377584641