### PR TITLE
feat: Update no longer standing committees from 117th Congress

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -1875,7 +1875,6 @@ HSSY:
 HSAS29: []
 HSAS35: []
 HSSY16: []
-HSCN: []
 HSIF:
 - name: Cathy McMorris Rodgers
   party: majority
@@ -4773,7 +4772,6 @@ HSHA:
   party: majority
   rank: 8
   bioguide: D000632
-HSIJ: []
 JSLC:
 - name: Amy Klobuchar
   party: majority
@@ -4808,7 +4806,6 @@ JSPR:
   rank: 1
   bioguide: W000437
   chamber: senate
-HSMH: []
 HSWM03:
 - name: Darin LaHood
   party: majority
@@ -5311,7 +5308,6 @@ HSHM09:
   rank: 5
   bioguide: C001132
 HSFA07: []
-HSEF: []
 HSRU02: []
 HSED07: []
 HSHM12:

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -843,25 +843,6 @@
     aspects of the Social Security system, Medicare, and social services programs.
   jurisdiction_source: https://waysandmeans.house.gov/history/
   youtube_id: UCrz_XV52yquSiXvyjdh03Fw
-- type: house
-  name: House Select Committee on the Climate Crisis
-  thomas_id: HSCN
-  thomas_id_comment: since it's not on Congress.gov, it doesn't have an ID, but GovTrack
-    needs it
-  house_committee_id: CN
-  address: 359 FHOB; Washington, DC 20515
-  phone: (202) 225-1106
-  youtube_id: UCqTxfzU6vYZ2-DW-y5jYvdQ
-- type: house
-  name: House Select Committee on the Modernization of Congress
-  url: https://modernizecongress.house.gov/
-  thomas_id: HSMH
-  thomas_id_comment: since it's not on Congress.gov, it doesn't have an ID, but GovTrack
-    needs it
-  house_committee_id: MH
-  address: 164 CHOB; Washington, DC 20515
-  phone: (202) 225-1530
-  youtube_id: UCECZaLBqABxBqN7VdtZ5sCA
 - type: joint
   name: Commission on Security and Cooperation in Europe
   url: http://www.csce.gov/
@@ -1502,19 +1483,6 @@
   name: House Select Subcommittee on the Coronavirus Pandemic
   address: TBD RHOB; Washington, DC 20515
   phone: (202) 225-4400
-- type: house
-  thomas_id: HSEF
-  house_committee_id: EF
-  name: House Select Committee on Economic Disparity and Fairness in Growth
-  address: 3470 OHOB; Washington, DC 20024
-  phone: (202) 225-5990
-- type: house
-  thomas_id: HSIJ
-  house_committee_id: IJ
-  name: House Select Committee to Investigate the January 6th Attack on the United
-    States Capitol
-  address: TBD TBD; Washington, DC 20515
-  phone: (202) 225-7800
 - type: house
   thomas_id: HSFD
   house_committee_id: FD

--- a/committees-historical.yaml
+++ b/committees-historical.yaml
@@ -9004,6 +9004,39 @@
       112: Emergency Preparedness, Response, and Communications
       113: Emergency Preparedness, Response, and Communications
       114: Emergency Preparedness, Response, and Communications
+- type: house
+  name: House Select Committee on the Climate Crisis
+  thomas_id: HSCN
+  house_committee_id: CN
+  names:
+    117: Climate Crisis
+  congresses:
+  - 117
+- type: house
+  name: House Select Committee on Economic Disparity and Fairness in Growth
+  thomas_id: HSEF
+  house_committee_id: EF
+  names:
+    117: Economic Disparity and Fairness in Growth
+  congresses:
+  - 117
+- type: house
+  name: House Select Committee on the Modernization of Congress
+  thomas_id: HSMH
+  house_committee_id: MH
+  names:
+    117: Modernization of Congress
+  congresses:
+  - 117
+- type: house
+  name: House Select Committee to Investigate the January 6th Attack on the United
+    States Capitol
+  thomas_id: HSIJ
+  house_committee_id: IJ
+  names:
+    117: Investigate the January 6th Attack on the United States Capitol
+  congresses:
+  - 117
 - type: senate
   name: Commission on Security and Cooperation in Europe (Helsinki Commission)
   thomas_id: JCSE


### PR DESCRIPTION
Following the conversation on https://github.com/unitedstates/congress-legislators/issues/875. I'm updating manually the files to reflect the current committees on 118th Congress.

This commit updates the `committees-current.yaml` file and `committees-historical.yaml` file to reflect the committees no longer standing from the 117th Congress.

This update was made manually.