### PR TITLE
Remove extra space from subcommittee name

### DIFF
--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -42,8 +42,8 @@
   thomas_id: HSAP
   house_committee_id: AP
   subcommittees:
-  - name: ' Agriculture, Rural Development, Food and Drug Administration, and Related
-      Agencies'
+  - name: Agriculture, Rural Development, Food and Drug Administration, and Related
+      Agencies
     thomas_id: '01'
     address: 2362A RHOB; Washington, DC 20515
     phone: (202) 225-2638


### PR DESCRIPTION
I'm a maintainer of Open States & this has been causing some issues with our `update` workflows, other committee names that need new lines are like the fixed code style like [this subcommittee](https://github.com/NewAgeAirbender/congress-legislators/blob/901859c9e5a0927f38d3f2cd4cf2e8bbb701459d/committees-current.yaml#L1216)