### PR TITLE
edit senator tillis first name

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -28495,9 +28495,9 @@
     icpsr: 41504
     ballotpedia: Thom Tillis (North Carolina)
   name:
-    first: Thom
+    first: Thomas
     last: Tillis
-    official_full: Thom Tillis
+    official_full: Thomas Tillis
   bio:
     gender: M
     birthday: '1960-08-30'


### PR DESCRIPTION
It looks to me like Sen Tillis's first name is Thomas per https://bioguide.congress.gov/search/bio/T000476

Noticed this while joining a custom dataset with a dataset from this repo. This repo is great by the way, thanks.