### PR TITLE
#886 - Update/defunct or dup committees

### DIFF
--- a/committee-membership-current.yaml
+++ b/committee-membership-current.yaml
@@ -3912,7 +3912,6 @@ HSAG16:
   party: majority
   rank: 14
   bioguide: A000379
-HLIG05: []
 HLIG06:
 - name: Brian K. Fitzpatrick
   party: majority
@@ -5671,7 +5670,6 @@ HSGO06:
   party: majority
   rank: 11
   bioguide: P000605
-HSGO28: []
 HSII06:
 - name: Pete Stauber
   party: majority
@@ -5991,7 +5989,6 @@ HSJU:
   party: majority
   rank: 25
   bioguide: F000478
-HSGO02: []
 HSGO24:
 - name: Pete Sessions
   party: majority
@@ -8017,7 +8014,6 @@ HSGO05:
   party: majority
   rank: 9
   bioguide: L000600
-HSRU05: []
 HSAP04:
 - name: Mario Diaz-Balart
   party: majority
@@ -8065,7 +8061,6 @@ HSAP04:
   party: majority
   rank: 7
   bioguide: C001054
-HLIG10: []
 HSHM:
 - name: Mark E. Green
   party: majority
@@ -8240,7 +8235,6 @@ HSHM05:
   party: majority
   rank: 5
   bioguide: C001132
-HLIG08: []
 HSJU05:
 - name: Thomas Massie
   party: majority
@@ -8993,7 +8987,6 @@ HSWM06:
   party: majority
   rank: 8
   bioguide: M000317
-HSBA15: []
 HSFA13:
 - name: Joe Wilson
   party: majority
@@ -9210,7 +9203,6 @@ HSRU04:
   party: majority
   rank: 5
   bioguide: H001093
-HSSM26: []
 HSED10:
 - name: Kevin Kiley
   party: majority
@@ -9505,7 +9497,6 @@ HSRU02:
   party: majority
   rank: 5
   bioguide: L000600
-HSED07: []
 HSHM12:
 - name: Anthony D’Esposito
   party: majority
@@ -9740,7 +9731,6 @@ HSSM23:
   party: minority
   rank: 5
   bioguide: T000488
-HSSM25: []
 HSBA09:
 - name: Bill Huizenga
   party: majority
@@ -9793,7 +9783,6 @@ HSBA09:
   party: majority
   rank: 7
   bioguide: O000175
-HSBA13: []
 HSHM08:
 - name: Andrew R. Garbarino
   party: majority

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -682,10 +682,10 @@
   #  thomas_id: '25'
   #  address: 2361 RHOB; Washington, DC 20515
   #  phone: (202) 225-4038
-  - name: Innovation, Entrepreneurship, and Workforce Development
-    thomas_id: '26'
-    address: 2361 RHOB; Washington, DC 20515
-    phone: (202) 225-4038
+  #- name: Innovation, Entrepreneurship, and Workforce Development
+  #  thomas_id: '26'
+  #  address: 2361 RHOB; Washington, DC 20515
+  #  phone: (202) 225-4038
   - name: Economic Growth, Tax, and Capital Access
     thomas_id: '27'
     address: 2361 RHOB; Washington, DC 20515
@@ -1136,25 +1136,25 @@
   thomas_id: SSCM
   senate_committee_id: SSCM
   subcommittees:
-  - name: Communications, Technology, Innovation, and the Internet
-    thomas_id: '26'
-    wikipedia: United States Senate Commerce Subcommittee on Communications, Technology,
-      and the Internet
-  - name: Tourism, Competitiveness, and Innovation
-    thomas_id: '27'
-    wikipedia: United States Senate Commerce Subcommittee on Competitiveness, Innovation,
-      and Export Promotion
-  - thomas_id: '28'
-    name: Aviation and Space
-    wikipedia: United States Senate Commerce Subcommittee on Aviation and Space
-  - thomas_id: '29'
-    name: Manufacturing, Trade, and Consumer Protection
-  - thomas_id: '30'
-    name: Science, Oceans, Fisheries, and Weather
-  - thomas_id: '31'
-    name: Security
-  - thomas_id: '32'
-    name: Transportation and Safety
+  #- name: Communications, Technology, Innovation, and the Internet
+  #  thomas_id: '26'
+  #  wikipedia: United States Senate Commerce Subcommittee on Communications, Technology,
+  #    and the Internet
+  #- name: Tourism, Competitiveness, and Innovation
+  #  thomas_id: '27'
+  #  wikipedia: United States Senate Commerce Subcommittee on Competitiveness, Innovation,
+  #    and Export Promotion
+  #- thomas_id: '28'
+  #  name: Aviation and Space
+  #  wikipedia: United States Senate Commerce Subcommittee on Aviation and Space
+  #- thomas_id: '29'
+  #  name: Manufacturing, Trade, and Consumer Protection
+  #- thomas_id: '30'
+  #  name: Science, Oceans, Fisheries, and Weather
+  #- thomas_id: '31'
+  #  name: Security
+  #- thomas_id: '32'
+  #  name: Transportation and Safety
   - thomas_id: '33'
     name: Aviation Safety, Operations, and Innovation
   - thomas_id: '34'
@@ -1217,13 +1217,13 @@
     thomas_id: '09'
     wikipedia: United States Senate Environment and Public Works Subcommittee on Superfund,
       Toxics and Environmental Health
-  - thomas_id: '16'
-    name: Green Jobs and the New Economy
-    wikipedia: United States Senate Environment and Public Works Subcommittee on Green
-      Jobs and the New Economy
-  - thomas_id: '18'
-    name: Oversight
-    wikipedia: United States Senate Environment and Public Works Subcommittee on Oversight
+  #- thomas_id: '16'
+  #  name: Green Jobs and the New Economy
+  #  wikipedia: United States Senate Environment and Public Works Subcommittee on Green
+  #    Jobs and the New Economy
+  #- thomas_id: '18'
+  #  name: Oversight
+  #  wikipedia: United States Senate Environment and Public Works Subcommittee on Oversight
   - thomas_id: '08'
     name: Transportation and Infrastructure
     wikipedia: United States Senate Environment and Public Works Subcommittee on Transportation
@@ -1284,17 +1284,17 @@
   thomas_id: SSFR
   senate_committee_id: SSFR
   subcommittees:
-  - name: International Development and Foreign Assistance, Economic Affairs, International
-      Environmental Protection, and Peace Corps
-    thomas_id: '12'
-    wikipedia: United States Senate Foreign Relations Subcommittee on International
-      Development and Foreign Assistance, Economic Affairs and International Environmental
-      Protection, and Peace Corps
-  - name: International Operations and Organizations, Human Rights, Democracy, and
-      Global Women's Issues
-    thomas_id: '13'
-    wikipedia: United States Senate Foreign Relations Subcommittee on International
-      Operations and Organizations, Human Rights, Democracy and Global Women's Issues
+  #- name: International Development and Foreign Assistance, Economic Affairs, International
+  #    Environmental Protection, and Peace Corps
+  #  thomas_id: '12'
+  #  wikipedia: United States Senate Foreign Relations Subcommittee on International
+  #    Development and Foreign Assistance, Economic Affairs and International Environmental
+  #    Protection, and Peace Corps
+  #- name: International Operations and Organizations, Human Rights, Democracy, and
+  #    Global Women's Issues
+  #  thomas_id: '13'
+  #  wikipedia: United States Senate Foreign Relations Subcommittee on International
+  #    Operations and Organizations, Human Rights, Democracy and Global Women's Issues
   - name: Europe and Regional Security Cooperation
     thomas_id: '01'
     wikipedia: United States Senate Foreign Relations Subcommittee on European Affairs
@@ -1345,16 +1345,16 @@
   - thomas_id: '01'
     name: Permanent Subcommittee on Investigations
     wikipedia: United States Senate Homeland Security Permanent Subcommittee on Investigations
-  - thomas_id: '17'
-    name: Emergency Management, Intergovernmental Relations, and the District of Columbia
-  - thomas_id: '15'
-    name: Financial and Contracting Oversight
-  - thomas_id: '16'
-    name: the Efficiency and Effectiveness of Federal Programs and the Federal Workforce
-  - thomas_id: '18'
-    name: Federal Spending Oversight and Emergency Management
-  - thomas_id: '19'
-    name: Regulatory Affairs and Federal Management
+  #- thomas_id: '17'
+  #  name: Emergency Management, Intergovernmental Relations, and the District of Columbia
+  #- thomas_id: '15'
+  #  name: Financial and Contracting Oversight
+  #- thomas_id: '16'
+  #  name: the Efficiency and Effectiveness of Federal Programs and the Federal Workforce
+  #- thomas_id: '18'
+  #  name: Federal Spending Oversight and Emergency Management
+  #- thomas_id: '19'
+  #  name: Regulatory Affairs and Federal Management
   - thomas_id: '20'
     name: Emerging Threats and Spending Oversight
   - thomas_id: '22'

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -215,7 +215,7 @@
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
   - name: Health, Employment, Labor, and Pensions
-    thomas_id: '20'
+    thomas_id: '02'
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
   - name: Higher Education and Workforce Development

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -153,10 +153,6 @@
     thomas_id: '16'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
-  #- name:  Consumer Protection and Financial Institutions
-  #  thomas_id: '15'
-  #  address: 2129 RHOB; Washington, DC 20515
-  #  phone: (202) 225-4247
   - name: Housing and Insurance
     thomas_id: '04'
     address: 2129 RHOB; Washington, DC 20515
@@ -169,10 +165,6 @@
     thomas_id: '01'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
-  #- name: Diversity and Inclusion
-  #  thomas_id: '13'
-  #  address: 2129 RHOB; Washington, DC 20515
-  #  phone: (202) 225-4247
   - name: Financial Institutions and Monetary Policy
     thomas_id: '20'
     address: 2129 RHOB; Washington, DC 20515
@@ -234,10 +226,6 @@
     thomas_id: '10'
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
-  #- name: Civil Rights and Human Services
-  #  thomas_id: '07'
-  #  address: 2176 RHOB; Washington, DC 20515
-  #  phone: (202) 225-3725
   address: 2176 RHOB; Washington, DC 20515-6100
   phone: (202) 225-4527
   jurisdiction: The committee has legislative jurisdiction over matters related to
@@ -295,10 +283,6 @@
   thomas_id: HSGO
   house_committee_id: GO
   subcommittees:
-  #- name: Information Technology
-  #  thomas_id: '25'
-  #  address: 2471 RHOB; Washington, DC 20515
-  #  phone: (202) 225-5074
   - name: Government Operations and the Federal Workforce
     thomas_id: '24'
     address: 2157 RHOB; Washington, DC 20515
@@ -311,18 +295,6 @@
     thomas_id: '27'
     address: 2157 RHOB; Washington, DC 20515
     phone: (202) 225-5074
-  #- name: Environment
-  #  thomas_id: '28'
-  #  address: 6440 OHOB; Washington, DC 20515
-  #  phone: (202) 225-5051
-  #- name: Intergovernmental Affairs
-  #  thomas_id: '29'
-  #  address: 2471 RHOB; Washington, DC 20515
-  #  phone: (202) 225-5074
-  #- name: Civil Rights and Civil Liberties
-  #  thomas_id: '02'
-  #  address: 6440 OHOB; Washington, DC 20515
-  #  phone: (202) 225-5051
   - name: Economic Growth, Energy Policy, and Regulatory Affairs
     thomas_id: '05'
     address: 2157 RHOB; Washington, DC 20515
@@ -346,9 +318,6 @@
   thomas_id: HSHA
   house_committee_id: HA
   subcommittees:
-  #- name: Elections
-  #  thomas_id: '01'
-  #  address: 1309 LHOB; Washington, DC 20515-6157
   - name: Elections
     thomas_id: '08'
     address: 1309 LHOB; Washington, DC 20515
@@ -475,10 +444,6 @@
     thomas_id: '13'
     address: 1522 LHOB; Washington, DC 20515
     phone: (202) 225-8331
-  #- name: Fisheries, Wildlife, Oceans and Insular Affairs
-  #  thomas_id: '22'
-  #  address: 140 CHOB; Washington, DC 20515
-  #  phone: (202) 226-0200
   - name: Indian and Insular Affairs
     thomas_id: '24'
     address: 1328 LHOB; Washington, DC 20515
@@ -505,14 +470,6 @@
     thomas_id: '09'
     address: HVC304 CAPITOL; Washington, DC 20515
     phone: (202) 225-4121
-  #- name: Counterterrorism, Counterintelligence, and Counterproliferation
-  #  thomas_id: '05'
-  #  address: HVC304 CAPITOL; Washington, DC 20515
-  #  phone: (202) 225-7690
-  #- name: Intelligence Modernization and Readiness
-  #  thomas_id: '08'
-  #  address: HVC304 CAPITOL; Washington, DC 20515
-  #  phone: (202) 225-7690
   - name: Central Intelligence Agency
     thomas_id: '01'
     address: HVC304 CAPITOL; Washington, DC 20515
@@ -521,10 +478,6 @@
     thomas_id: '02'
     address: HVC304 CAPITOL; Washington, DC 20515
     phone: (202) 225-4121
-  #- name: Emerging Threats
-  #  thomas_id: '03'
-  #  address: HVC304 CAPITOL; Washington, DC 20515-6415
-  #  phone: (202) 225-4121
   - name: Defense Intelligence and Overhead Architecture
     thomas_id: '04'
     address: HVC304 CAPITOL; Washington, DC 20515
@@ -533,10 +486,6 @@
     thomas_id: '06'
     address: HVC304 CAPITOL; Washington, DC 20515
     phone: (202) 225-4121
-  #- name: Strategic Technologies and Advanced Research
-  #  thomas_id: '10'
-  #  address: HVC304 CAPITOL; Washington, DC 20515
-  #  phone: (202) 225-7690
   address: HVC304 CAPITOL; Washington, DC 20515-6415
   phone: (202) 225-4121
   jurisdiction: The United States House Permanent Select Committee on Intelligence
@@ -647,10 +596,6 @@
     thomas_id: '04'
     address: H312 CAPITOL; Washington, DC 20515
     phone: (202) 225-9191
-  #- name: Expedited Procedures
-  #  thomas_id: '05'
-  #  address: H312 CAPITOL; Washington, DC 20515
-  #  phone: (202) 225-9091
   address: H312 CAPITOL; Washington, DC 20515-6269
   phone: (202) 225-9191
   jurisdiction: The House Committee on Rules is commonly known as “The Speaker’s Committee”
@@ -678,14 +623,6 @@
     thomas_id: '24'
     address: 2361 RHOB; Washington, DC 20515
     phone: (202) 225-5821
-  #- name: Underserved, Agricultural, and Rural Business Development
-  #  thomas_id: '25'
-  #  address: 2361 RHOB; Washington, DC 20515
-  #  phone: (202) 225-4038
-  #- name: Innovation, Entrepreneurship, and Workforce Development
-  #  thomas_id: '26'
-  #  address: 2361 RHOB; Washington, DC 20515
-  #  phone: (202) 225-4038
   - name: Economic Growth, Tax, and Capital Access
     thomas_id: '27'
     address: 2361 RHOB; Washington, DC 20515
@@ -1136,25 +1073,6 @@
   thomas_id: SSCM
   senate_committee_id: SSCM
   subcommittees:
-  #- name: Communications, Technology, Innovation, and the Internet
-  #  thomas_id: '26'
-  #  wikipedia: United States Senate Commerce Subcommittee on Communications, Technology,
-  #    and the Internet
-  #- name: Tourism, Competitiveness, and Innovation
-  #  thomas_id: '27'
-  #  wikipedia: United States Senate Commerce Subcommittee on Competitiveness, Innovation,
-  #    and Export Promotion
-  #- thomas_id: '28'
-  #  name: Aviation and Space
-  #  wikipedia: United States Senate Commerce Subcommittee on Aviation and Space
-  #- thomas_id: '29'
-  #  name: Manufacturing, Trade, and Consumer Protection
-  #- thomas_id: '30'
-  #  name: Science, Oceans, Fisheries, and Weather
-  #- thomas_id: '31'
-  #  name: Security
-  #- thomas_id: '32'
-  #  name: Transportation and Safety
   - thomas_id: '33'
     name: Aviation Safety, Operations, and Innovation
   - thomas_id: '34'
@@ -1217,13 +1135,6 @@
     thomas_id: '09'
     wikipedia: United States Senate Environment and Public Works Subcommittee on Superfund,
       Toxics and Environmental Health
-  #- thomas_id: '16'
-  #  name: Green Jobs and the New Economy
-  #  wikipedia: United States Senate Environment and Public Works Subcommittee on Green
-  #    Jobs and the New Economy
-  #- thomas_id: '18'
-  #  name: Oversight
-  #  wikipedia: United States Senate Environment and Public Works Subcommittee on Oversight
   - thomas_id: '08'
     name: Transportation and Infrastructure
     wikipedia: United States Senate Environment and Public Works Subcommittee on Transportation
@@ -1284,17 +1195,6 @@
   thomas_id: SSFR
   senate_committee_id: SSFR
   subcommittees:
-  #- name: International Development and Foreign Assistance, Economic Affairs, International
-  #    Environmental Protection, and Peace Corps
-  #  thomas_id: '12'
-  #  wikipedia: United States Senate Foreign Relations Subcommittee on International
-  #    Development and Foreign Assistance, Economic Affairs and International Environmental
-  #    Protection, and Peace Corps
-  #- name: International Operations and Organizations, Human Rights, Democracy, and
-  #    Global Women's Issues
-  #  thomas_id: '13'
-  #  wikipedia: United States Senate Foreign Relations Subcommittee on International
-  #    Operations and Organizations, Human Rights, Democracy and Global Women's Issues
   - name: Europe and Regional Security Cooperation
     thomas_id: '01'
     wikipedia: United States Senate Foreign Relations Subcommittee on European Affairs
@@ -1345,16 +1245,6 @@
   - thomas_id: '01'
     name: Permanent Subcommittee on Investigations
     wikipedia: United States Senate Homeland Security Permanent Subcommittee on Investigations
-  #- thomas_id: '17'
-  #  name: Emergency Management, Intergovernmental Relations, and the District of Columbia
-  #- thomas_id: '15'
-  #  name: Financial and Contracting Oversight
-  #- thomas_id: '16'
-  #  name: the Efficiency and Effectiveness of Federal Programs and the Federal Workforce
-  #- thomas_id: '18'
-  #  name: Federal Spending Oversight and Emergency Management
-  #- thomas_id: '19'
-  #  name: Regulatory Affairs and Federal Management
   - thomas_id: '20'
     name: Emerging Threats and Spending Oversight
   - thomas_id: '22'

--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -153,10 +153,10 @@
     thomas_id: '16'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
-  - name: Consumer Protection and Financial Institutions
-    thomas_id: '15'
-    address: 2129 RHOB; Washington, DC 20515
-    phone: (202) 225-4247
+  #- name:  Consumer Protection and Financial Institutions
+  #  thomas_id: '15'
+  #  address: 2129 RHOB; Washington, DC 20515
+  #  phone: (202) 225-4247
   - name: Housing and Insurance
     thomas_id: '04'
     address: 2129 RHOB; Washington, DC 20515
@@ -169,10 +169,10 @@
     thomas_id: '01'
     address: 2129 RHOB; Washington, DC 20515
     phone: (202) 225-7502
-  - name: Diversity and Inclusion
-    thomas_id: '13'
-    address: 2129 RHOB; Washington, DC 20515
-    phone: (202) 225-4247
+  #- name: Diversity and Inclusion
+  #  thomas_id: '13'
+  #  address: 2129 RHOB; Washington, DC 20515
+  #  phone: (202) 225-4247
   - name: Financial Institutions and Monetary Policy
     thomas_id: '20'
     address: 2129 RHOB; Washington, DC 20515
@@ -223,7 +223,7 @@
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
   - name: Health, Employment, Labor, and Pensions
-    thomas_id: '02'
+    thomas_id: '20'
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
   - name: Higher Education and Workforce Development
@@ -234,10 +234,10 @@
     thomas_id: '10'
     address: 2176 RHOB; Washington, DC 20515
     phone: (202) 225-4527
-  - name: Civil Rights and Human Services
-    thomas_id: '07'
-    address: 2176 RHOB; Washington, DC 20515
-    phone: (202) 225-3725
+  #- name: Civil Rights and Human Services
+  #  thomas_id: '07'
+  #  address: 2176 RHOB; Washington, DC 20515
+  #  phone: (202) 225-3725
   address: 2176 RHOB; Washington, DC 20515-6100
   phone: (202) 225-4527
   jurisdiction: The committee has legislative jurisdiction over matters related to
@@ -295,10 +295,10 @@
   thomas_id: HSGO
   house_committee_id: GO
   subcommittees:
-  - name: Information Technology
-    thomas_id: '25'
-    address: 2471 RHOB; Washington, DC 20515
-    phone: (202) 225-5074
+  #- name: Information Technology
+  #  thomas_id: '25'
+  #  address: 2471 RHOB; Washington, DC 20515
+  #  phone: (202) 225-5074
   - name: Government Operations and the Federal Workforce
     thomas_id: '24'
     address: 2157 RHOB; Washington, DC 20515
@@ -311,18 +311,18 @@
     thomas_id: '27'
     address: 2157 RHOB; Washington, DC 20515
     phone: (202) 225-5074
-  - name: Environment
-    thomas_id: '28'
-    address: 6440 OHOB; Washington, DC 20515
-    phone: (202) 225-5051
-  - name: Intergovernmental Affairs
-    thomas_id: '29'
-    address: 2471 RHOB; Washington, DC 20515
-    phone: (202) 225-5074
-  - name: Civil Rights and Civil Liberties
-    thomas_id: '02'
-    address: 6440 OHOB; Washington, DC 20515
-    phone: (202) 225-5051
+  #- name: Environment
+  #  thomas_id: '28'
+  #  address: 6440 OHOB; Washington, DC 20515
+  #  phone: (202) 225-5051
+  #- name: Intergovernmental Affairs
+  #  thomas_id: '29'
+  #  address: 2471 RHOB; Washington, DC 20515
+  #  phone: (202) 225-5074
+  #- name: Civil Rights and Civil Liberties
+  #  thomas_id: '02'
+  #  address: 6440 OHOB; Washington, DC 20515
+  #  phone: (202) 225-5051
   - name: Economic Growth, Energy Policy, and Regulatory Affairs
     thomas_id: '05'
     address: 2157 RHOB; Washington, DC 20515
@@ -346,9 +346,9 @@
   thomas_id: HSHA
   house_committee_id: HA
   subcommittees:
-  - name: Elections
-    thomas_id: '01'
-    address: 1309 LHOB; Washington, DC 20515-6157
+  #- name: Elections
+  #  thomas_id: '01'
+  #  address: 1309 LHOB; Washington, DC 20515-6157
   - name: Elections
     thomas_id: '08'
     address: 1309 LHOB; Washington, DC 20515
@@ -475,10 +475,10 @@
     thomas_id: '13'
     address: 1522 LHOB; Washington, DC 20515
     phone: (202) 225-8331
-  - name: Fisheries, Wildlife, Oceans and Insular Affairs
-    thomas_id: '22'
-    address: 140 CHOB; Washington, DC 20515
-    phone: (202) 226-0200
+  #- name: Fisheries, Wildlife, Oceans and Insular Affairs
+  #  thomas_id: '22'
+  #  address: 140 CHOB; Washington, DC 20515
+  #  phone: (202) 226-0200
   - name: Indian and Insular Affairs
     thomas_id: '24'
     address: 1328 LHOB; Washington, DC 20515
@@ -505,14 +505,14 @@
     thomas_id: '09'
     address: HVC304 CAPITOL; Washington, DC 20515
     phone: (202) 225-4121
-  - name: Counterterrorism, Counterintelligence, and Counterproliferation
-    thomas_id: '05'
-    address: HVC304 CAPITOL; Washington, DC 20515
-    phone: (202) 225-7690
-  - name: Intelligence Modernization and Readiness
-    thomas_id: '08'
-    address: HVC304 CAPITOL; Washington, DC 20515
-    phone: (202) 225-7690
+  #- name: Counterterrorism, Counterintelligence, and Counterproliferation
+  #  thomas_id: '05'
+  #  address: HVC304 CAPITOL; Washington, DC 20515
+  #  phone: (202) 225-7690
+  #- name: Intelligence Modernization and Readiness
+  #  thomas_id: '08'
+  #  address: HVC304 CAPITOL; Washington, DC 20515
+  #  phone: (202) 225-7690
   - name: Central Intelligence Agency
     thomas_id: '01'
     address: HVC304 CAPITOL; Washington, DC 20515
@@ -521,10 +521,10 @@
     thomas_id: '02'
     address: HVC304 CAPITOL; Washington, DC 20515
     phone: (202) 225-4121
-  - name: Emerging Threats
-    thomas_id: '03'
-    address: HVC304 CAPITOL; Washington, DC 20515-6415
-    phone: (202) 225-4121
+  #- name: Emerging Threats
+  #  thomas_id: '03'
+  #  address: HVC304 CAPITOL; Washington, DC 20515-6415
+  #  phone: (202) 225-4121
   - name: Defense Intelligence and Overhead Architecture
     thomas_id: '04'
     address: HVC304 CAPITOL; Washington, DC 20515
@@ -533,10 +533,10 @@
     thomas_id: '06'
     address: HVC304 CAPITOL; Washington, DC 20515
     phone: (202) 225-4121
-  - name: Strategic Technologies and Advanced Research
-    thomas_id: '10'
-    address: HVC304 CAPITOL; Washington, DC 20515
-    phone: (202) 225-7690
+  #- name: Strategic Technologies and Advanced Research
+  #  thomas_id: '10'
+  #  address: HVC304 CAPITOL; Washington, DC 20515
+  #  phone: (202) 225-7690
   address: HVC304 CAPITOL; Washington, DC 20515-6415
   phone: (202) 225-4121
   jurisdiction: The United States House Permanent Select Committee on Intelligence
@@ -647,10 +647,10 @@
     thomas_id: '04'
     address: H312 CAPITOL; Washington, DC 20515
     phone: (202) 225-9191
-  - name: Expedited Procedures
-    thomas_id: '05'
-    address: H312 CAPITOL; Washington, DC 20515
-    phone: (202) 225-9091
+  #- name: Expedited Procedures
+  #  thomas_id: '05'
+  #  address: H312 CAPITOL; Washington, DC 20515
+  #  phone: (202) 225-9091
   address: H312 CAPITOL; Washington, DC 20515-6269
   phone: (202) 225-9191
   jurisdiction: The House Committee on Rules is commonly known as “The Speaker’s Committee”
@@ -678,10 +678,10 @@
     thomas_id: '24'
     address: 2361 RHOB; Washington, DC 20515
     phone: (202) 225-5821
-  - name: Underserved, Agricultural, and Rural Business Development
-    thomas_id: '25'
-    address: 2361 RHOB; Washington, DC 20515
-    phone: (202) 225-4038
+  #- name: Underserved, Agricultural, and Rural Business Development
+  #  thomas_id: '25'
+  #  address: 2361 RHOB; Washington, DC 20515
+  #  phone: (202) 225-4038
   - name: Innovation, Entrepreneurship, and Workforce Development
     thomas_id: '26'
     address: 2361 RHOB; Washington, DC 20515


### PR DESCRIPTION
I did a manual audit of #886 and indeed, it looks the committees missing members are no longer listed in applicable house/senate websites.

Wasn't sure if `committees-historical.yaml` should be manually updated in concert (I'm not _currently_ using it).