### PR TITLE
Update Portland office number for Collins

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -1556,7 +1556,7 @@
     zip: '04101'
     latitude: 43.6566885
     longitude: -70.2551294
-    phone: 207-780-3575
+    phone: 207-618-5560
 - id:
     bioguide: C001047
     govtrack: 400061


### PR DESCRIPTION
Per her site, the Portland office number has changed: https://www.collins.senate.gov/contact