### PR TITLE
Update Jimmy Gomez LA phone

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -11093,8 +11093,7 @@
     zip: '90017'
     latitude: 34.0569399
     longitude: -118.2618953
-    fax: 213-481-1425
-    phone: 213-481-1427
+    phone: 213-481-1425
 - id:
     bioguide: N000190
     govtrack: 412738


### PR DESCRIPTION
Per https://gomez.house.gov/contact/officeinformation.htm, the phone number for the office has changed. There's no fax line listed.