### PR TITLE
Use Safe Parsers in `lxml` Parsing Functions

### DIFF
--- a/scripts/committee_membership.py
+++ b/scripts/committee_membership.py
@@ -64,7 +64,7 @@ def run():
           members.remove(m)
 
     r = download("http://clerk.house.gov/xml/lists/MemberData.xml", "clerk_xml", force)
-    dom = lxml.etree.fromstring(r.encode("latin-1")) # must be bytes to parse if there is an encoding declaration inside the string
+    dom = lxml.etree.fromstring(r.encode("latin-1"), parser=lxml.etree.XMLParser(resolve_entities=False)) # must be bytes to parse if there is an encoding declaration inside the string
 
     # Update committee metadata.
     def update_house_committee_metadata(xml_cx, cx, parentdict, is_subcommittee):
@@ -194,7 +194,7 @@ def run():
       committee_url = "https://www.senate.gov/general/committee_membership/committee_memberships_%s.xml" % id
 
       body3 = download(committee_url, "committees/membership/senate/%s.xml" % id, force)
-      dom = lxml.etree.fromstring(body3.encode("utf8")) # must be bytes to parse if there is an encoding declaration inside the string
+      dom = lxml.etree.fromstring(body3.encode("utf8"), parser=lxml.etree.XMLParser(resolve_entities=False)) # must be bytes to parse if there is an encoding declaration inside the string
 
       cx["name"] = normalize_text(dom.xpath("committees/committee_name")[0].text)
       if id[0] != "J" and id[0:2] != 'SC':

--- a/scripts/historical_committees.py
+++ b/scripts/historical_committees.py
@@ -58,7 +58,7 @@ def run():
         for name in z.namelist():
           if name.startswith('BILLSTATUS'):
             with z.open(name) as xml_file:
-              bill_status = lxml.etree.parse(xml_file)
+              bill_status = lxml.etree.parse(xml_file, parser=lxml.etree.XMLParser(resolve_entities=False))
               committees =  bill_status.xpath('//billCommittees/item')
               for committee in committees:
                 code = str(committee.xpath('./systemCode/text()')[0])

--- a/scripts/senate_contacts.py
+++ b/scripts/senate_contacts.py
@@ -37,7 +37,7 @@ def run():
 
 	url = "https://www.senate.gov/general/contact_information/senators_cfm.xml"
 	body = download(url, "legislators/senate.xml", force, { "binary": True })
-	dom = lxml.etree.parse(io.BytesIO(body)) # file has an <?xml declaration and so must be parsed as a bytes array
+	dom = lxml.etree.parse(io.BytesIO(body), parser=lxml.etree.XMLParser(resolve_entities=False)) # file has an <?xml declaration and so must be parsed as a bytes array
 	for node in dom.xpath("member"):
 		bioguide_id = str(node.xpath("string(bioguide_id)")).strip()
 		member_full = node.xpath("string(member_full)")
@@ -128,7 +128,7 @@ def run():
 
 	url = "https://www.senate.gov/legislative/LIS_MEMBER/cvc_member_data.xml"
 	body = download(url, "legislators/senate_cvc.xml", force)
-	dom = lxml.etree.parse(io.StringIO(body))
+	dom = lxml.etree.parse(io.StringIO(body), parser=lxml.etree.XMLParser(resolve_entities=False))
 	for node in dom.getroot():
 		if node.tag == "lastUpdate":
 			date, time = node.getchildren()

--- a/scripts/wikipedia_ids.py
+++ b/scripts/wikipedia_ids.py
@@ -48,7 +48,7 @@ def run():
 
 				# load the XML
 				print("Getting %s pages (%d...)" % (template, len(page_titles)))
-				dom = lxml.etree.fromstring(utils.download(url, None, True)) # can't cache eicontinue probably
+				dom = lxml.etree.fromstring(utils.download(url, None, True), parser=lxml.etree.XMLParser(resolve_entities=False)) # can't cache eicontinue probably
 
 				for pgname in dom.xpath("query/embeddedin/ei/@title"):
 					page_titles.add(pgname)
@@ -85,7 +85,7 @@ def run():
 		# and then use XPath to get the raw page text.
 		url = "http://en.wikipedia.org/w/api.php?action=query&titles=" + urllib.parse.quote(p.encode("utf8")) + "&export&exportnowrap"
 		cache_path = "legislators/wikipedia/pages/" + p
-		dom = lxml.etree.fromstring(utils.download(url, cache_path, not cache))
+		dom = lxml.etree.fromstring(utils.download(url, cache_path, not cache), parser=lxml.etree.XMLParser(resolve_entities=False))
 		page_content = dom.xpath("string(mw:page/mw:revision/mw:text)", namespaces={ "mw": "http://www.mediawiki.org/xml/export-0.8/" })
 
 		# Build a dict for the IDs that we want to insert into our files.


### PR DESCRIPTION
This codemod sets the `parser` parameter in calls to  `lxml.etree.parse`  and `lxml.etree.fromstring` if omitted or set to `None` (the default value). Unfortunately, the default `parser=None` means `lxml` will rely on an unsafe parser, making your code potentially vulnerable to entity expansion attacks and external entity (XXE) attacks.

The changes look as follows:

```diff
  import lxml.etree
- lxml.etree.parse("path_to_file")
- lxml.etree.fromstring("xml_str")
+ lxml.etree.parse("path_to_file", parser=lxml.etree.XMLParser(resolve_entities=False))
+ lxml.etree.fromstring("xml_str", parser=lxml.etree.XMLParser(resolve_entities=False))
```

<details>
  <summary>More reading</summary>

  * [https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser)
  * [https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing)
  * [https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/safe-lxml-parsing](https://docs.pixee.ai/codemods/python/pixee_python_safe-lxml-parsing)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fcongress-legislators%7Ca313bc9f6f7a88d98da15e6273021c3df43fc8c2)

<!--{"type":"DRIP","codemod":"pixee:python/safe-lxml-parsing"}-->