### PR TITLE
Replace unsafe `pyyaml` loader with `SafeLoader`

### DIFF
--- a/scripts/contact_forms.py
+++ b/scripts/contact_forms.py
@@ -63,7 +63,7 @@ def contact_steps_for(bioguide):
     response = urlopen(base_url.format(bioguide=bioguide))
     if response.code == 404:
         raise LegislatorNotFoundError("%s not found in unitedstates/contact-congress!" % bioguide)
-    return yaml.load(response.read())
+    return yaml.load(response.read(), Loader=yaml.SafeLoader)
 
 
 class LegislatorNotFoundError(Exception):

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,5 +1,7 @@
 # Helpful functions for finding data about members and committees
 
+import yaml
+
 CURRENT_CONGRESS = 115
 states = {
         'AK': 'Alaska',
@@ -86,7 +88,7 @@ from email.mime.text import MIMEText
 # returns None if it's not there, and this should always be handled gracefully
 path = "email/config.yml"
 if os.path.exists(path):
-  email_settings = yaml.load(open(path, 'r')).get('email', None)
+  email_settings = yaml.load(open(path, 'r'), Loader=yaml.SafeLoader).get('email', None)
 else:
   email_settings = None
 


### PR DESCRIPTION
The default loaders in PyYAML are not safe to use with untrusted data. They potentially make your application vulnerable to arbitrary code execution attacks. If you open a YAML file from an untrusted source, and the file is loaded with the default loader, an attacker could execute arbitrary code on your machine.

This codemod hardens all [`yaml.load()`](https://pyyaml.org/wiki/PyYAMLDocumentation) calls against such attacks by replacing the default loader with `yaml.SafeLoader`. This is the recommended loader for loading untrusted data. For most use cases it functions as a drop-in replacement for the default loader.

Calling `yaml.load()` without an explicit loader argument is equivalent to calling it with `Loader=yaml.Loader`, which is unsafe. This usage [has been deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input\)-Deprecation) since PyYAML 5.1. This codemod will add an explicit `SafeLoader` argument to all `yaml.load()` calls that don't use an explicit loader.

The changes from this codemod look like the following:
```diff
  import yaml
  data = b'!!python/object/apply:subprocess.Popen \\n- ls'
- deserialized_data = yaml.load(data, yaml.Loader)
+ deserialized_data = yaml.load(data, Loader=yaml.SafeLoader)
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data](https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data)
  * [https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/harden-pyyaml](https://docs.pixee.ai/codemods/python/pixee_python_harden-pyyaml)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fcongress-legislators%7C23f750fb7cfa27713651acb15ec800d862323e40)

<!--{"type":"DRIP","codemod":"pixee:python/harden-pyyaml"}-->