### PR TITLE
Added rss_url checker to house_websites

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -2522,7 +2522,7 @@
     district: 4
     party: Republican
     url: https://aderholt.house.gov
-    rss_url: http://aderholt.house.gov/common/rss//index.cfm?rss=20
+    rss_url: https://aderholt.house.gov/rss.xml
     address: 266 Cannon House Office Building Washington DC 20515-0104
     office: 266 Cannon House Office Building
     phone: 202-225-4876
@@ -2831,7 +2831,7 @@
     district: 12
     party: Republican
     url: https://bilirakis.house.gov
-    rss_url: http://bilirakis.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://bilirakis.house.gov/rss.xml
     address: 2306 Rayburn House Office Building Washington DC 20515-0912
     office: 2306 Rayburn House Office Building
     phone: 202-225-5755
@@ -3001,7 +3001,7 @@
     district: 2
     party: Democrat
     url: https://bishop.house.gov
-    rss_url: http://bishop.house.gov/rss.xml
+    rss_url: https://bishop.house.gov/rss.xml
     address: 2407 Rayburn House Office Building Washington DC 20515-1002
     office: 2407 Rayburn House Office Building
     phone: 202-225-3631
@@ -3277,7 +3277,7 @@
     district: 3
     party: Democrat
     url: https://blumenauer.house.gov
-    rss_url: http://blumenauer.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://blumenauer.house.gov/rss.xml
     address: 1111 Longworth House Office Building Washington DC 20515-3703
     office: 1111 Longworth House Office Building
     phone: 202-225-4811
@@ -3805,7 +3805,7 @@
     district: 26
     party: Republican
     url: https://burgess.house.gov
-    rss_url: http://burgess.house.gov/news/rss.aspx
+    rss_url: https://burgess.house.gov/news/rss.aspx
     address: 2161 Rayburn House Office Building Washington DC 20515-4326
     office: 2161 Rayburn House Office Building
     phone: 202-225-7772
@@ -3971,7 +3971,7 @@
     district: 41
     party: Republican
     url: https://calvert.house.gov
-    rss_url: http://calvert.house.gov/news/rss.aspx
+    rss_url: https://calvert.house.gov/rss.xml
     address: 2205 Rayburn House Office Building Washington DC 20515-0541
     office: 2205 Rayburn House Office Building
     phone: 202-225-1986
@@ -4210,7 +4210,7 @@
     district: 7
     party: Democrat
     url: https://carson.house.gov
-    rss_url: http://carson.house.gov/index.php?option=com_bca-rss-syndicator&amp;feed_id=1
+    rss_url: https://carson.house.gov/rss.xml
     address: 2135 Rayburn House Office Building Washington DC 20515-1407
     office: 2135 Rayburn House Office Building
     phone: 202-225-4011
@@ -4669,7 +4669,7 @@
     district: 28
     party: Democrat
     url: https://chu.house.gov
-    rss_url: http://chu.house.gov/rss.xml
+    rss_url: https://chu.house.gov/rss.xml
     address: 2423 Rayburn House Office Building Washington DC 20515-0528
     office: 2423 Rayburn House Office Building
     phone: 202-225-5464
@@ -4919,7 +4919,7 @@
     district: 5
     party: Democrat
     url: https://cleaver.house.gov
-    rss_url: http://cleaver.house.gov/rss.xml
+    rss_url: https://cleaver.house.gov/rss.xml
     address: 2217 Rayburn House Office Building Washington DC 20515-2505
     office: 2217 Rayburn House Office Building
     phone: 202-225-4535
@@ -5098,7 +5098,7 @@
     district: 6
     party: Democrat
     url: https://clyburn.house.gov
-    rss_url: http://clyburn.house.gov/rss.xml
+    rss_url: https://clyburn.house.gov/feed/
     address: 274 Cannon House Office Building Washington DC 20515-4006
     office: 274 Cannon House Office Building
     phone: 202-225-3315
@@ -5222,7 +5222,7 @@
     district: 9
     party: Democrat
     url: https://cohen.house.gov
-    rss_url: http://cohen.house.gov/rss.xml
+    rss_url: https://cohen.house.gov/rss.xml
     address: 2268 Rayburn House Office Building Washington DC 20515-4209
     office: 2268 Rayburn House Office Building
     phone: 202-225-3265
@@ -5357,7 +5357,7 @@
     district: 4
     party: Republican
     url: https://cole.house.gov
-    rss_url: http://cole.house.gov/rss.xml
+    rss_url: https://cole.house.gov/rss.xml
     address: 2207 Rayburn House Office Building Washington DC 20515-3604
     office: 2207 Rayburn House Office Building
     phone: 202-225-6165
@@ -5599,7 +5599,7 @@
     district: 21
     party: Democrat
     url: https://costa.house.gov
-    rss_url: http://costa.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://costa.house.gov/rss.xml
     address: 2081 Rayburn House Office Building Washington DC 20515-0521
     office: 2081 Rayburn House Office Building
     phone: 202-225-3341
@@ -5720,7 +5720,7 @@
     district: 2
     party: Democrat
     url: https://courtney.house.gov
-    rss_url: http://courtney.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://courtney.house.gov/rss.xml
     address: 2449 Rayburn House Office Building Washington DC 20515-0702
     office: 2449 Rayburn House Office Building
     phone: 202-225-2076
@@ -6207,7 +6207,7 @@
     district: 7
     party: Democrat
     url: https://davis.house.gov
-    rss_url: http://davis.house.gov/index.php?format=feed&type=rss
+    rss_url: https://davis.house.gov/rss.xml
     address: 2159 Rayburn House Office Building Washington DC 20515-1307
     office: 2159 Rayburn House Office Building
     phone: 202-225-5006
@@ -6361,7 +6361,7 @@
     district: 1
     party: Democrat
     url: https://degette.house.gov
-    rss_url: http://degette.house.gov/index.php?option=com_ninjarsssyndicator&amp;feed_id=1&amp;format=raw
+    rss_url: https://degette.house.gov/rss.xml
     address: 2111 Rayburn House Office Building Washington DC 20515-0601
     office: 2111 Rayburn House Office Building
     phone: 202-225-4431
@@ -6533,7 +6533,7 @@
     district: 3
     party: Democrat
     url: https://delauro.house.gov
-    rss_url: http://delauro.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://delauro.house.gov/rss.xml
     address: 2413 Rayburn House Office Building Washington DC 20515-0703
     office: 2413 Rayburn House Office Building
     phone: 202-225-3661
@@ -6639,7 +6639,7 @@
     district: 4
     party: Republican
     url: https://desjarlais.house.gov
-    rss_url: http://desjarlais.house.gov/news/rss.aspx
+    rss_url: https://desjarlais.house.gov/?a=RSS.Feed
     address: 2304 Rayburn House Office Building Washington DC 20515-4204
     office: 2304 Rayburn House Office Building
     phone: 202-225-6831
@@ -6774,7 +6774,7 @@
     district: 26
     party: Republican
     url: https://mariodiazbalart.house.gov
-    rss_url: http://mariodiazbalart.house.gov/rss.xml
+    rss_url: https://mariodiazbalart.house.gov/rss.xml
     address: 374 Cannon House Office Building Washington DC 20515-0926
     office: 374 Cannon House Office Building
     phone: 202-225-4211
@@ -6937,7 +6937,7 @@
     district: 37
     party: Democrat
     url: https://doggett.house.gov
-    rss_url: http://doggett.house.gov/index.php/component/ninjarsssyndicator/?feed_id=1&amp;format=raw
+    rss_url: https://doggett.house.gov/rss.xml
     address: 2307 Rayburn House Office Building Washington DC 20515-0001
     office: 2307 Rayburn House Office Building
     phone: 202-225-4865
@@ -7043,7 +7043,7 @@
     district: 3
     party: Republican
     url: https://jeffduncan.house.gov
-    rss_url: http://jeffduncan.house.gov/rss.xml
+    rss_url: https://jeffduncan.house.gov/rss.xml
     address: 2229 Rayburn House Office Building Washington DC 20515-4003
     office: 2229 Rayburn House Office Building
     phone: 202-225-5301
@@ -7209,7 +7209,7 @@
     district: 16
     party: Democrat
     url: https://eshoo.house.gov
-    rss_url: http://eshoo.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://eshoo.house.gov/rss.xml
     address: 272 Cannon House Office Building Washington DC 20515-0516
     office: 272 Cannon House Office Building
     phone: 202-225-8104
@@ -7317,7 +7317,7 @@
     district: 3
     party: Republican
     url: https://fleischmann.house.gov
-    rss_url: http://fleischmann.house.gov/rss.xml
+    rss_url: https://fleischmann.house.gov/rss.xml
     address: 2187 Rayburn House Office Building Washington DC 20515-4203
     office: 2187 Rayburn House Office Building
     phone: 202-225-3271
@@ -7558,7 +7558,7 @@
     district: 8
     party: Democrat
     url: https://garamendi.house.gov
-    rss_url: http://garamendi.house.gov/rss.xml
+    rss_url: https://garamendi.house.gov/rss.xml
     address: 2004 Rayburn House Office Building Washington DC 20515-0508
     office: 2004 Rayburn House Office Building
     phone: 202-225-1880
@@ -8087,7 +8087,7 @@
     district: 6
     party: Republican
     url: https://graves.house.gov
-    rss_url: http://graves.house.gov/common/rss/index.cfm?rss=25
+    rss_url: https://graves.house.gov/rss.xml
     address: 1135 Longworth House Office Building Washington DC 20515-2506
     office: 1135 Longworth House Office Building
     phone: 202-225-7041
@@ -8214,7 +8214,7 @@
     district: 9
     party: Democrat
     url: https://algreen.house.gov
-    rss_url: http://algreen.house.gov/rss.xml
+    rss_url: https://algreen.house.gov/rss.xml
     address: 2347 Rayburn House Office Building Washington DC 20515-4309
     office: 2347 Rayburn House Office Building
     phone: 202-225-7508
@@ -8677,7 +8677,7 @@
     district: 1
     party: Republican
     url: https://harris.house.gov
-    rss_url: http://harris.house.gov/rss.xml
+    rss_url: https://harris.house.gov/rss.xml
     address: 1536 Longworth House Office Building Washington DC 20515-2001
     office: 1536 Longworth House Office Building
     phone: 202-225-5311
@@ -9243,7 +9243,7 @@
     district: 5
     party: Democrat
     url: https://hoyer.house.gov
-    rss_url: http://hoyer.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://hoyer.house.gov/rss.xml
     address: 1705 Longworth House Office Building Washington DC 20515-2005
     office: 1705 Longworth House Office Building
     phone: 202-225-4131
@@ -9473,7 +9473,7 @@
     district: 4
     party: Democrat
     url: https://hankjohnson.house.gov
-    rss_url: http://hankjohnson.house.gov/rss.xml
+    rss_url: https://hankjohnson.house.gov/rss.xml
     address: 2240 Rayburn House Office Building Washington DC 20515-1004
     office: 2240 Rayburn House Office Building
     phone: 202-225-1605
@@ -9659,7 +9659,7 @@
     district: 4
     party: Republican
     url: https://jordan.house.gov
-    rss_url: http://jordan.house.gov/news/rss.aspx
+    rss_url: https://jordan.house.gov/rss.xml
     address: 2056 Rayburn House Office Building Washington DC 20515-3504
     office: 2056 Rayburn House Office Building
     phone: 202-225-2676
@@ -9854,7 +9854,7 @@
     district: 9
     party: Democrat
     url: https://kaptur.house.gov
-    rss_url: http://kaptur.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://kaptur.house.gov/rss.xml
     address: 2186 Rayburn House Office Building Washington DC 20515-3509
     office: 2186 Rayburn House Office Building
     phone: 202-225-4146
@@ -9961,7 +9961,7 @@
     district: 9
     party: Democrat
     url: https://keating.house.gov
-    rss_url: http://keating.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://keating.house.gov/rss.xml
     address: 2351 Rayburn House Office Building Washington DC 20515-2109
     office: 2351 Rayburn House Office Building
     phone: 202-225-3111
@@ -10067,7 +10067,7 @@
     district: 16
     party: Republican
     url: https://kelly.house.gov
-    rss_url: http://kelly.house.gov/rss.xml
+    rss_url: https://kelly.house.gov/rss.xml
     address: 1707 Longworth House Office Building Washington DC 20515-3816
     office: 1707 Longworth House Office Building
     phone: 202-225-5406
@@ -10188,7 +10188,7 @@
     district: 5
     party: Republican
     url: https://lamborn.house.gov
-    rss_url: http://lamborn.house.gov/news-rss-graphic/news-rss-graphic/
+    rss_url: https://lamborn.house.gov/rss.xml
     address: 2371 Rayburn House Office Building Washington DC 20515-0605
     office: 2371 Rayburn House Office Building
     phone: 202-225-4422
@@ -10562,7 +10562,7 @@
     district: 1
     party: Democrat
     url: https://larson.house.gov
-    rss_url: http://www.larson.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://larson.house.gov/rss.xml
     address: 1501 Longworth House Office Building Washington DC 20515-0701
     office: 1501 Longworth House Office Building
     phone: 202-225-2265
@@ -11062,7 +11062,7 @@
     district: 18
     party: Democrat
     url: https://lofgren.house.gov
-    rss_url: http://lofgren.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://lofgren.house.gov/rss.xml
     address: 1401 Longworth House Office Building Washington DC 20515-0518
     office: 1401 Longworth House Office Building
     phone: 202-225-3072
@@ -11926,7 +11926,7 @@
     district: 7
     party: Democrat
     url: https://matsui.house.gov
-    rss_url: http://matsui.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://matsui.house.gov/rss.xml
     address: 2311 Rayburn House Office Building Washington DC 20515-0507
     office: 2311 Rayburn House Office Building
     phone: 202-225-7163
@@ -12055,6 +12055,7 @@
     address: 2300 Rayburn House Office Building Washington DC 20515-4310
     office: 2300 Rayburn House Office Building
     phone: 202-225-2401
+    rss_url: https://mccaul.house.gov/rss.xml
 - id:
     bioguide: M001177
     thomas: '01908'
@@ -12166,7 +12167,7 @@
     district: 5
     party: Republican
     url: https://mcclintock.house.gov
-    rss_url: http://mcclintock.house.gov/atom.xml
+    rss_url: https://mcclintock.house.gov/rss.xml
     address: 2256 Rayburn House Office Building Washington DC 20515-0505
     office: 2256 Rayburn House Office Building
     phone: 202-225-2511
@@ -12308,7 +12309,7 @@
     district: 4
     party: Democrat
     url: https://mccollum.house.gov
-    rss_url: http://mccollum.house.gov/rss.xml
+    rss_url: https://mccollum.house.gov/rss.xml
     address: 2426 Rayburn House Office Building Washington DC 20515-2304
     office: 2426 Rayburn House Office Building
     phone: 202-225-6631
@@ -12873,7 +12874,7 @@
     district: 5
     party: Democrat
     url: https://meeks.house.gov
-    rss_url: http://meeks.house.gov/rss.xml
+    rss_url: https://meeks.house.gov/rss.xml
     address: 2310 Rayburn House Office Building Washington DC 20515-3205
     office: 2310 Rayburn House Office Building
     phone: 202-225-3461
@@ -13700,7 +13701,7 @@
     district: 31
     party: Democrat
     url: https://napolitano.house.gov
-    rss_url: http://napolitano.house.gov/rss.xml
+    rss_url: https://napolitano.house.gov/rss.xml
     address: 1610 Longworth House Office Building Washington DC 20515-0531
     office: 1610 Longworth House Office Building
     phone: 202-225-5256
@@ -14048,7 +14049,7 @@
     district: 0
     party: Democrat
     url: https://norton.house.gov
-    rss_url: http://norton.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://norton.house.gov/rss.xml
     address: 2136 Rayburn House Office Building Washington DC 20515-5101
     office: 2136 Rayburn House Office Building
     phone: 202-225-8050
@@ -14234,7 +14235,7 @@
     district: 6
     party: Democrat
     url: https://pallone.house.gov
-    rss_url: http://pallone.house.gov/rss.xml
+    rss_url: https://pallone.house.gov/rss.xml
     address: 2107 Rayburn House Office Building Washington DC 20515-3006
     office: 2107 Rayburn House Office Building
     phone: 202-225-4671
@@ -14665,7 +14666,7 @@
     district: 11
     party: Democrat
     url: https://pelosi.house.gov
-    rss_url: http://pelosi.house.gov/atom.xml
+    rss_url: https://pelosi.house.gov/rss.xml
     address: 1236 Longworth House Office Building Washington DC 20515-0511
     office: 1236 Longworth House Office Building
     phone: 202-225-4965
@@ -14981,7 +14982,7 @@
     district: 8
     party: Republican
     url: https://posey.house.gov
-    rss_url: http://posey.house.gov/news/rss.aspx?documenttypeid=1487
+    rss_url: https://posey.house.gov/news/rss.aspx
     address: 2150 Rayburn House Office Building Washington DC 20515-0908
     office: 2150 Rayburn House Office Building
     phone: 202-225-3671
@@ -15095,7 +15096,7 @@
     district: 5
     party: Democrat
     url: https://quigley.house.gov
-    rss_url: http://quigley.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://quigley.house.gov/rss.xml
     address: 2083 Rayburn House Office Building Washington DC 20515-1305
     office: 2083 Rayburn House Office Building
     phone: 202-225-4061
@@ -15633,7 +15634,7 @@
     district: 2
     party: Democrat
     url: https://ruppersberger.house.gov
-    rss_url: http://dutch.house.gov/atom.xml
+    rss_url: https://ruppersberger.house.gov/rss.xml
     address: 2206 Rayburn House Office Building Washington DC 20515-2002
     office: 2206 Rayburn House Office Building
     phone: 202-225-3061
@@ -15754,7 +15755,7 @@
     district: 0
     party: Democrat
     url: https://sablan.house.gov
-    rss_url: http://sablan.house.gov/rss.xml
+    rss_url: https://sablan.house.gov/rss.xml
     address: 2267 Rayburn House Office Building Washington DC 20515-5201
     office: 2267 Rayburn House Office Building
     phone: 202-225-2646
@@ -15876,7 +15877,7 @@
     district: 3
     party: Democrat
     url: https://sarbanes.house.gov
-    rss_url: http://sarbanes.house.gov/rss_news.asp
+    rss_url: https://sarbanes.house.gov/rss.xml
     address: 2370 Rayburn House Office Building Washington DC 20515-2003
     office: 2370 Rayburn House Office Building
     phone: 202-225-4016
@@ -16025,7 +16026,7 @@
     district: 1
     party: Republican
     url: https://scalise.house.gov
-    rss_url: http://scalise.house.gov/rss.xml
+    rss_url: https://scalise.house.gov/rss.xml
     address: 2049 Rayburn House Office Building Washington DC 20515-1801
     office: 2049 Rayburn House Office Building
     phone: 202-225-3015
@@ -16174,7 +16175,7 @@
     district: 9
     party: Democrat
     url: https://schakowsky.house.gov
-    rss_url: http://schakowsky.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://schakowsky.house.gov/rss.xml
     address: 2408 Rayburn House Office Building Washington DC 20515-1309
     office: 2408 Rayburn House Office Building
     phone: 202-225-2111
@@ -16682,7 +16683,7 @@
     district: 8
     party: Republican
     url: https://austinscott.house.gov
-    rss_url: http://austinscott.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://austinscott.house.gov/?a=RSS.Feed
     address: 2185 Rayburn House Office Building Washington DC 20515-1008
     office: 2185 Rayburn House Office Building
     phone: 202-225-6531
@@ -16984,7 +16985,7 @@
     district: 3
     party: Democrat
     url: https://bobbyscott.house.gov
-    rss_url: http://www.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://bobbyscott.house.gov/rss.xml
     address: 2328 Rayburn House Office Building Washington DC 20515-4603
     office: 2328 Rayburn House Office Building
     phone: 202-225-8351
@@ -17184,7 +17185,7 @@
     district: 7
     party: Democrat
     url: https://sewell.house.gov
-    rss_url: http://sewell.house.gov/rss.xml
+    rss_url: https://sewell.house.gov/?a=RSS.Feed
     address: 1035 Longworth House Office Building Washington DC 20515-0107
     office: 1035 Longworth House Office Building
     phone: 202-225-2665
@@ -17338,7 +17339,7 @@
     district: 32
     party: Democrat
     url: https://sherman.house.gov
-    rss_url: http://bradsherman.house.gov/press-releases-and-columns/rss.shtml
+    rss_url: https://sherman.house.gov/rss.xml
     address: 2365 Rayburn House Office Building Washington DC 20515-0532
     office: 2365 Rayburn House Office Building
     phone: 202-225-5911
@@ -17640,7 +17641,7 @@
     district: 9
     party: Democrat
     url: https://adamsmith.house.gov
-    rss_url: http://www.house.gov/news/rss.aspx
+    rss_url: https://adamsmith.house.gov/rss.xml
     address: 2264 Rayburn House Office Building Washington DC 20515-4709
     office: 2264 Rayburn House Office Building
     phone: 202-225-8901
@@ -17761,7 +17762,7 @@
     district: 3
     party: Republican
     url: https://adriansmith.house.gov
-    rss_url: http://adriansmith.house.gov/rss.xml
+    rss_url: https://adriansmith.house.gov/rss.xml
     address: 502 Cannon House Office Building Washington DC 20515-2703
     office: 502 Cannon House Office Building
     phone: 202-225-6435
@@ -18100,7 +18101,7 @@
     district: 38
     party: Democrat
     url: https://lindasanchez.house.gov
-    rss_url: http://lindasanchez.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://lindasanchez.house.gov/rss.xml
     address: 2428 Rayburn House Office Building Washington DC 20515-0538
     office: 2428 Rayburn House Office Building
     phone: 202-225-6676
@@ -18269,7 +18270,7 @@
     district: 2
     party: Democrat
     url: https://benniethompson.house.gov
-    rss_url: http://benniethompson.house.gov/index.php?format=feed&amp;type=rss
+    rss_url: https://benniethompson.house.gov/rss.xml
     address: 2466 Rayburn House Office Building Washington DC 20515-2402
     office: 2466 Rayburn House Office Building
     phone: 202-225-5876
@@ -18417,7 +18418,7 @@
     district: 4
     party: Democrat
     url: https://mikethompson.house.gov
-    rss_url: http://mikethompson.house.gov/news/rss.aspx
+    rss_url: https://mikethompson.house.gov/rss.xml
     address: 268 Cannon House Office Building Washington DC 20515-0504
     office: 268 Cannon House Office Building
     phone: 202-225-3311
@@ -18531,7 +18532,7 @@
     district: 15
     party: Republican
     url: https://thompson.house.gov
-    rss_url: http://thompson.house.gov/rss.xml
+    rss_url: https://thompson.house.gov/rss.xml
     address: 400 Cannon House Office Building Washington DC 20515-3815
     office: 400 Cannon House Office Building
     phone: 202-225-5121
@@ -19171,6 +19172,7 @@
     address: 2302 Rayburn House Office Building Washington DC 20515-3207
     office: 2302 Rayburn House Office Building
     phone: 202-225-2361
+    rss_url: https://velazquez.house.gov/rss.xml
 - id:
     bioguide: W000798
     thomas: '01855'
@@ -19280,7 +19282,7 @@
     district: 5
     party: Republican
     url: https://walberg.house.gov
-    rss_url: http://walberg.house.gov/news/rss.aspx
+    rss_url: https://walberg.house.gov/rss.xml
     address: 2266 Rayburn House Office Building Washington DC 20515-2205
     office: 2266 Rayburn House Office Building
     phone: 202-225-6276
@@ -19578,7 +19580,7 @@
     district: 43
     party: Democrat
     url: https://waters.house.gov
-    rss_url: http://waters.house.gov/news/rss.aspx
+    rss_url: https://waters.house.gov/rss.xml
     address: 2221 Rayburn House Office Building Washington DC 20515-0543
     office: 2221 Rayburn House Office Building
     phone: 202-225-2201
@@ -19685,7 +19687,7 @@
     district: 11
     party: Republican
     url: https://webster.house.gov
-    rss_url: http://webster.house.gov/news/rss.aspx
+    rss_url: https://webster.house.gov/?a=RSS.Feed
     address: 2184 Rayburn House Office Building Washington DC 20515-0911
     office: 2184 Rayburn House Office Building
     phone: 202-225-1002
@@ -19951,7 +19953,7 @@
     district: 2
     party: Republican
     url: https://joewilson.house.gov
-    rss_url: http://joewilson.house.gov/news/rss.aspx
+    rss_url: https://joewilson.house.gov/rss.xml
     address: 1436 Longworth House Office Building Washington DC 20515-4002
     office: 1436 Longworth House Office Building
     phone: 202-225-2452
@@ -20620,7 +20622,7 @@
     district: 2
     party: Republican
     url: https://amodei.house.gov
-    rss_url: http://amodei.house.gov/common/rss//?rss=49
+    rss_url: https://amodei.house.gov/rss.xml
     address: 104 Cannon House Office Building Washington DC 20515-2802
     office: 104 Cannon House Office Building
     phone: 202-225-6155
@@ -20726,7 +20728,7 @@
     district: 1
     party: Democrat
     url: https://bonamici.house.gov
-    rss_url: http://bonamici.house.gov/rss.xml
+    rss_url: https://bonamici.house.gov/rss.xml
     address: 2231 Rayburn House Office Building Washington DC 20515-3701
     office: 2231 Rayburn House Office Building
     phone: 202-225-0855
@@ -21128,7 +21130,7 @@
     district: 11
     party: Democrat
     url: https://foster.house.gov
-    rss_url: http://foster.house.gov/rss.xml
+    rss_url: https://foster.house.gov/rss.xml
     address: 2366 Rayburn House Office Building Washington DC 20515-1311
     office: 2366 Rayburn House Office Building
     phone: 202-225-3515
@@ -21469,7 +21471,7 @@
     district: 1
     party: Republican
     url: https://lamalfa.house.gov
-    rss_url: http://lamalfa.house.gov/rss.xml
+    rss_url: https://lamalfa.house.gov/rss.xml
     address: 408 Cannon House Office Building Washington DC 20515-0501
     office: 408 Cannon House Office Building
     phone: 202-225-3076
@@ -21746,6 +21748,7 @@
     address: 174 Cannon House Office Building Washington DC 20515-0514
     office: 174 Cannon House Office Building
     phone: 202-225-5065
+    rss_url: https://swalwell.house.gov/rss.xml
 - id:
     govtrack: 412516
     bioguide: B001285
@@ -21837,7 +21840,7 @@
     district: 26
     party: Democrat
     url: https://juliabrownley.house.gov
-    rss_url: http://juliabrownley.house.gov/rss.xml
+    rss_url: https://juliabrownley.house.gov/feed/
     address: 2262 Rayburn House Office Building Washington DC 20515-0526
     office: 2262 Rayburn House Office Building
     phone: 202-225-5811
@@ -22024,7 +22027,7 @@
     district: 25
     party: Democrat
     url: https://ruiz.house.gov
-    rss_url: http://ruiz.house.gov/rss.xml
+    rss_url: https://ruiz.house.gov/rss.xml
     address: 2342 Rayburn House Office Building Washington DC 20515-0525
     office: 2342 Rayburn House Office Building
     phone: 202-225-5330
@@ -22306,7 +22309,7 @@
     district: 50
     party: Democrat
     url: https://scottpeters.house.gov
-    rss_url: http://scottpeters.house.gov/rss.xml
+    rss_url: https://scottpeters.house.gov/?a=RSS.Feed
     address: 1201 Longworth House Office Building Washington DC 20515-0550
     office: 1201 Longworth House Office Building
     phone: 202-225-0508
@@ -22773,7 +22776,7 @@
     district: 8
     party: Democrat
     url: https://dankildee.house.gov
-    rss_url: http://dankildee.house.gov/rss.xml
+    rss_url: https://dankildee.house.gov/rss.xml
     address: 200 Cannon House Office Building Washington DC 20515-2208
     office: 200 Cannon House Office Building
     phone: 202-225-3611
@@ -22869,7 +22872,7 @@
     district: 2
     party: Republican
     url: https://wagner.house.gov
-    rss_url: http://wagner.house.gov/rss.xml
+    rss_url: https://wagner.house.gov/rss.xml
     address: 2350 Rayburn House Office Building Washington DC 20515-2502
     office: 2350 Rayburn House Office Building
     phone: 202-225-1621
@@ -23034,7 +23037,7 @@
     district: 9
     party: Republican
     url: https://hudson.house.gov
-    rss_url: http://hudson.house.gov/rss.xml
+    rss_url: https://hudson.house.gov/rss.xml
     address: 2112 Rayburn House Office Building Washington DC 20515-3309
     office: 2112 Rayburn House Office Building
     phone: 202-225-3715
@@ -23352,7 +23355,7 @@
     district: 6
     party: Democrat
     url: https://meng.house.gov
-    rss_url: http://meng.house.gov/rss.xml
+    rss_url: https://meng.house.gov/rss.xml
     address: 2209 Rayburn House Office Building Washington DC 20515-3206
     office: 2209 Rayburn House Office Building
     phone: 202-225-2601
@@ -23456,7 +23459,7 @@
     district: 8
     party: Democrat
     url: https://jeffries.house.gov
-    rss_url: http://jeffries.house.gov/rss.xml
+    rss_url: https://jeffries.house.gov/feed/
     address: 2433 Rayburn House Office Building Washington DC 20515-3208
     office: 2433 Rayburn House Office Building
     phone: 202-225-5936
@@ -23638,7 +23641,7 @@
     district: 3
     party: Democrat
     url: https://beatty.house.gov
-    rss_url: http://beatty.house.gov/rss.xml
+    rss_url: https://beatty.house.gov/rss.xml
     address: 2079 Rayburn House Office Building Washington DC 20515-3503
     office: 2079 Rayburn House Office Building
     phone: 202-225-4324
@@ -24353,7 +24356,7 @@
     district: 25
     party: Republican
     url: https://williams.house.gov
-    rss_url: http://williams.house.gov/rss.xml
+    rss_url: https://williams.house.gov/rss.xml
     address: 2336 Rayburn House Office Building Washington DC 20515-4325
     office: 2336 Rayburn House Office Building
     phone: 202-225-9896
@@ -24447,7 +24450,7 @@
     district: 33
     party: Democrat
     url: https://veasey.house.gov
-    rss_url: http://veasey.house.gov/rss.xml
+    rss_url: https://veasey.house.gov/rss.xml
     address: 2348 Rayburn House Office Building Washington DC 20515-4333
     office: 2348 Rayburn House Office Building
     phone: 202-225-9897
@@ -24684,7 +24687,7 @@
     district: 2
     party: Democrat
     url: https://pocan.house.gov
-    rss_url: http://pocan.house.gov/rss.xml
+    rss_url: https://pocan.house.gov/rss.xml
     address: 1026 Longworth House Office Building Washington DC 20515-4902
     office: 1026 Longworth House Office Building
     phone: 202-225-2906
@@ -24780,7 +24783,7 @@
     district: 2
     party: Democrat
     url: https://robinkelly.house.gov
-    rss_url: http://robinkelly.house.gov/rss.xml
+    rss_url: https://robinkelly.house.gov/rss.xml
     address: 2329 Rayburn House Office Building Washington DC 20515-1302
     office: 2329 Rayburn House Office Building
     phone: 202-225-0773
@@ -25131,6 +25134,7 @@
     address: 2427 Rayburn House Office Building Washington DC 20515-3001
     office: 2427 Rayburn House Office Building
     phone: 202-225-6501
+    rss_url: https://norcross.house.gov/?a=RSS.Feed
 - id:
     bioguide: A000370
     thomas: '02201'
@@ -25220,6 +25224,7 @@
     address: 2436 Rayburn House Office Building Washington DC 20515-3312
     office: 2436 Rayburn House Office Building
     phone: 202-225-1510
+    rss_url: https://adams.house.gov/rss.xml
 - id:
     bioguide: P000609
     fec:
@@ -25308,6 +25313,7 @@
     address: 170 Cannon House Office Building Washington DC 20515-0106
     office: 170 Cannon House Office Building
     phone: 202-225-4921
+    rss_url: https://palmer.house.gov/rss.xml
 - id:
     bioguide: H001072
     fec:
@@ -25457,6 +25463,7 @@
     address: 202 Cannon House Office Building Washington DC 20515-0404
     office: 202 Cannon House Office Building
     phone: 202-225-3772
+    rss_url: https://westerman.house.gov/rss.xml
 - id:
     bioguide: G000574
     fec:
@@ -25605,6 +25612,7 @@
     address: 503 Cannon House Office Building Washington DC 20515-0510
     office: 503 Cannon House Office Building
     phone: 202-225-2095
+    rss_url: https://desaulnier.house.gov/rss.xml
 - id:
     bioguide: A000371
     fec:
@@ -25763,6 +25771,7 @@
     address: 2454 Rayburn House Office Building Washington DC 20515-0536
     office: 2454 Rayburn House Office Building
     phone: 202-225-3976
+    rss_url: https://lieu.house.gov/rss.xml
 - id:
     bioguide: T000474
     fec:
@@ -26293,6 +26302,7 @@
     address: 1126 Longworth House Office Building Washington DC 20515-2106
     office: 1126 Longworth House Office Building
     phone: 202-225-8020
+    rss_url: https://moulton.house.gov/rss.xml
 - id:
     bioguide: M001194
     fec:
@@ -26369,6 +26379,7 @@
     address: 246 Cannon House Office Building Washington DC 20515-2202
     office: 246 Cannon House Office Building
     phone: 202-225-3561
+    rss_url: https://moolenaar.house.gov/rss.xml
 - id:
     bioguide: D000624
     fec:
@@ -26835,6 +26846,7 @@
     address: 1502 Longworth House Office Building Washington DC 20515-3802
     office: 1502 Longworth House Office Building
     phone: 202-225-6111
+    rss_url: https://boyle.house.gov/rss.xml
 - id:
     bioguide: B001291
     fec:
@@ -27137,6 +27149,7 @@
     address: 504 Cannon House Office Building Washington DC 20515-4704
     office: 504 Cannon House Office Building
     phone: 202-225-5816
+    rss_url: https://newhouse.house.gov/rss.xml
 - id:
     bioguide: G000576
     fec:
@@ -28172,7 +28185,7 @@
     district: 10
     party: Democrat
     url: https://schneider.house.gov
-    rss_url: http://schneider.house.gov/rss.xml
+    rss_url: https://schneider.house.gov/rss.xml
     address: 300 Cannon House Office Building Washington DC 20515-1310
     office: 300 Cannon House Office Building
     phone: 202-225-4835
@@ -28238,6 +28251,7 @@
     address: 252 Cannon House Office Building Washington DC 20515-0305
     office: 252 Cannon House Office Building
     phone: 202-225-2635
+    rss_url: https://biggs.house.gov/rss.xml
 - id:
     bioguide: K000389
     govtrack: 412684
@@ -28300,6 +28314,7 @@
     address: 306 Cannon House Office Building Washington DC 20515-0517
     office: 306 Cannon House Office Building
     phone: 202-225-2631
+    rss_url: https://khanna.house.gov/rss.xml
 - id:
     bioguide: P000613
     govtrack: 412685
@@ -28362,6 +28377,7 @@
     address: 304 Cannon House Office Building Washington DC 20515-0519
     office: 304 Cannon House Office Building
     phone: 202-225-2861
+    rss_url: https://panetta.house.gov/rss.xml
 - id:
     bioguide: C001112
     govtrack: 412686
@@ -28675,6 +28691,7 @@
     address: 2021 Rayburn House Office Building Washington DC 20515-0901
     office: 2021 Rayburn House Office Building
     phone: 202-225-4136
+    rss_url: https://gaetz.house.gov/rss.xml
 - id:
     bioguide: D000628
     govtrack: 412691
@@ -28738,6 +28755,7 @@
     address: 466 Cannon House Office Building Washington DC 20515-0902
     office: 466 Cannon House Office Building
     phone: 202-225-5235
+    rss_url: https://dunn.house.gov/?a=RSS.Feed
 - id:
     bioguide: R000609
     govtrack: 412692
@@ -28801,6 +28819,7 @@
     address: 1711 Longworth House Office Building Washington DC 20515-0905
     office: 1711 Longworth House Office Building
     phone: 202-225-2501
+    rss_url: https://rutherford.house.gov/rss.xml
 - id:
     bioguide: S001200
     govtrack: 412695
@@ -28863,6 +28882,7 @@
     address: 2353 Rayburn House Office Building Washington DC 20515-0909
     office: 2353 Rayburn House Office Building
     phone: 202-225-9889
+    rss_url: https://soto.house.gov/rss.xml
 - id:
     bioguide: M001199
     govtrack: 412698
@@ -29052,6 +29072,7 @@
     address: 2367 Rayburn House Office Building Washington DC 20515-1308
     office: 2367 Rayburn House Office Building
     phone: 202-225-3711
+    rss_url: https://krishnamoorthi.house.gov/rss.xml
 - id:
     bioguide: B001299
     govtrack: 412702
@@ -29232,6 +29253,7 @@
     address: 572 Cannon House Office Building Washington DC 20515-1803
     office: 572 Cannon House Office Building
     phone: 202-225-2031
+    rss_url: https://clayhiggins.house.gov/feed/
 - id:
     bioguide: J000299
     govtrack: 412706
@@ -29724,6 +29746,7 @@
     address: 2332 Rayburn House Office Building Washington DC 20515-3213
     office: 2332 Rayburn House Office Building
     phone: 202-225-4365
+    rss_url: https://espaillat.house.gov/rss.xml
 - id:
     bioguide: F000466
     govtrack: 412721
@@ -29849,6 +29872,7 @@
     address: 302 Cannon House Office Building Washington DC 20515-3811
     office: 302 Cannon House Office Building
     phone: 202-225-2411
+    rss_url: https://smucker.house.gov/rss.xml
 - id:
     bioguide: G000582
     govtrack: 412723
@@ -29898,6 +29922,7 @@
     address: 2338 Rayburn House Office Building Washington DC 20515-5401
     office: 2338 Rayburn House Office Building
     phone: 202-225-2615
+    rss_url: https://gonzalez-colon.house.gov/rss.xml
 - id:
     bioguide: K000392
     govtrack: 412724
@@ -29960,6 +29985,7 @@
     address: 560 Cannon House Office Building Washington DC 20515-4208
     office: 560 Cannon House Office Building
     phone: 202-225-4714
+    rss_url: https://kustoff.house.gov/rss.xml
 - id:
     bioguide: G000581
     govtrack: 412725
@@ -30022,6 +30048,7 @@
     address: 154 Cannon House Office Building Washington DC 20515-4334
     office: 154 Cannon House Office Building
     phone: 202-225-2531
+    rss_url: https://gonzalez.house.gov/rss.xml
 - id:
     bioguide: A000375
     govtrack: 412726
@@ -30582,6 +30609,7 @@
     address: 1214 Longworth House Office Building Washington DC 20515-0308
     office: 1214 Longworth House Office Building
     phone: 202-225-4576
+    rss_url: https://lesko.house.gov/?a=RSS.Feed
 - id:
     bioguide: C001115
     fec:
@@ -30825,6 +30853,7 @@
     address: 570 Cannon House Office Building Washington DC 20515-3225
     office: 570 Cannon House Office Building
     phone: 202-225-3615
+    rss_url: https://morelle.house.gov/rss.xml
 - id:
     bioguide: S001205
     fec:
@@ -30947,6 +30976,7 @@
     address: 1027 Longworth House Office Building Washington DC 20515-3807
     office: 1027 Longworth House Office Building
     phone: 202-225-6411
+    rss_url: https://wild.house.gov/rss.xml
 - id:
     bioguide: C001055
     fec:
@@ -31077,7 +31107,7 @@
     district: 4
     party: Democrat
     url: https://horsford.house.gov
-    rss_url: http://horsford.house.gov/rss.xml
+    rss_url: https://horsford.house.gov/rss.xml
     address: 406 Cannon House Office Building Washington DC 20515-2804
     office: 406 Cannon House Office Building
     phone: 202-225-9894
@@ -31181,6 +31211,7 @@
     address: 209 Cannon House Office Building Washington DC 20515-0509
     office: 209 Cannon House Office Building
     phone: 202-225-4540
+    rss_url: https://harder.house.gov/rss.xml
 - id:
     bioguide: P000618
     fec:
@@ -31330,6 +31361,7 @@
     address: 2400 Rayburn House Office Building Washington DC 20515-0602
     office: 2400 Rayburn House Office Building
     phone: 202-225-2161
+    rss_url: https://neguse.house.gov/rss.xml
 - id:
     bioguide: C001121
     fec:
@@ -31380,6 +31412,7 @@
     address: 1323 Longworth House Office Building Washington DC 20515-0606
     office: 1323 Longworth House Office Building
     phone: 202-225-7882
+    rss_url: https://crow.house.gov/rss.xml
 - id:
     bioguide: H001081
     fec:
@@ -31683,6 +31716,7 @@
     address: 1519 Longworth House Office Building Washington DC 20515-1304
     office: 1519 Longworth House Office Building
     phone: 202-225-8203
+    rss_url: https://chuygarcia.house.gov/rss.xml
 - id:
     bioguide: C001117
     fec:
@@ -31782,6 +31816,7 @@
     address: 1410 Longworth House Office Building Washington DC 20515-1314
     office: 1410 Longworth House Office Building
     phone: 202-225-2976
+    rss_url: https://underwood.house.gov/rss.xml
 - id:
     bioguide: B001307
     fec:
@@ -31883,6 +31918,7 @@
     address: 404 Cannon House Office Building Washington DC 20515-1406
     office: 404 Cannon House Office Building
     phone: 202-225-3021
+    rss_url: https://pence.house.gov/rss.xml
 - id:
     bioguide: D000629
     fec:
@@ -31933,6 +31969,7 @@
     address: 2435 Rayburn House Office Building Washington DC 20515-1603
     office: 2435 Rayburn House Office Building
     phone: 202-225-2865
+    rss_url: https://davids.house.gov/rss.xml
 - id:
     bioguide: T000482
     fec:
@@ -32134,6 +32171,7 @@
     address: 2245 Rayburn House Office Building Washington DC 20515-2207
     office: 2245 Rayburn House Office Building
     phone: 202-225-4872
+    rss_url: https://slotkin.house.gov/rss.xml
 - id:
     bioguide: S001215
     fec:
@@ -32185,6 +32223,7 @@
     address: 2411 Rayburn House Office Building Washington DC 20515-2211
     office: 2411 Rayburn House Office Building
     phone: 202-225-8171
+    rss_url: https://stevens.house.gov/rss.xml
 - id:
     bioguide: T000481
     fec:
@@ -32235,6 +32274,7 @@
     address: 2438 Rayburn House Office Building Washington DC 20515-2212
     office: 2438 Rayburn House Office Building
     phone: 202-225-5126
+    rss_url: https://d12t4t5x3vyizu.cloudfront.net/tlaib.house.gov/uploads/2023/02/TLAIB_009_xml.pdf
 - id:
     bioguide: C001119
     fec:
@@ -32285,6 +32325,7 @@
     address: 2442 Rayburn House Office Building Washington DC 20515-2302
     office: 2442 Rayburn House Office Building
     phone: 202-225-2271
+    rss_url: https://craig.house.gov/rss.xml
 - id:
     bioguide: P000616
     fec:
@@ -32385,6 +32426,7 @@
     address: 1730 Longworth House Office Building Washington DC 20515-2305
     office: 1730 Longworth House Office Building
     phone: 202-225-4755
+    rss_url: https://omar.house.gov/rss.xml
 - id:
     bioguide: S001212
     fec:
@@ -32435,6 +32477,7 @@
     address: 145 Cannon House Office Building Washington DC 20515-2308
     office: 145 Cannon House Office Building
     phone: 202-225-6211
+    rss_url: https://stauber.house.gov/rss.xml
 - id:
     bioguide: G000591
     fec:
@@ -32484,6 +32527,7 @@
     address: 450 Cannon House Office Building Washington DC 20515-2403
     office: 450 Cannon House Office Building
     phone: 202-225-5031
+    rss_url: https://guest.house.gov/rss.xml
 - id:
     bioguide: A000377
     fec:
@@ -32534,6 +32578,7 @@
     address: 2235 Rayburn House Office Building Washington DC 20515-3400
     office: 2235 Rayburn House Office Building
     phone: 202-225-2611
+    rss_url: https://armstrong.house.gov/rss.xml
 - id:
     bioguide: P000614
     fec:
@@ -32584,6 +32629,7 @@
     address: 452 Cannon House Office Building Washington DC 20515-2901
     office: 452 Cannon House Office Building
     phone: 202-225-5456
+    rss_url: https://pappas.house.gov/rss.xml
 - id:
     bioguide: V000133
     fec:
@@ -32691,6 +32737,7 @@
     address: 2444 Rayburn House Office Building Washington DC 20515-3003
     office: 2444 Rayburn House Office Building
     phone: 202-225-4765
+    rss_url: https://kim.house.gov/rss.xml
 - id:
     bioguide: S001207
     fec:
@@ -32741,6 +32788,7 @@
     address: 1427 Longworth House Office Building Washington DC 20515-3011
     office: 1427 Longworth House Office Building
     phone: 202-225-5034
+    rss_url: https://sherrill.house.gov/rss.xml
 - id:
     bioguide: L000590
     fec:
@@ -32791,6 +32839,7 @@
     address: 365 Cannon House Office Building Washington DC 20515-2803
     office: 365 Cannon House Office Building
     phone: 202-225-3252
+    rss_url: https://susielee.house.gov/rss.xml
 - id:
     bioguide: O000172
     fec:
@@ -32841,6 +32890,7 @@
     address: 250 Cannon House Office Building Washington DC 20515-3214
     office: 250 Cannon House Office Building
     phone: 202-225-3965
+    rss_url: https://ocasio-cortez.house.gov/rss.xml
 - id:
     bioguide: D000631
     fec:
@@ -32991,6 +33041,7 @@
     address: 350 Cannon House Office Building Washington DC 20515-3809
     office: 350 Cannon House Office Building
     phone: 202-225-6511
+    rss_url: https://meuser.house.gov/rss.xml
 - id:
     bioguide: J000302
     fec:
@@ -33041,6 +33092,7 @@
     address: 152 Cannon House Office Building Washington DC 20515-3813
     office: 152 Cannon House Office Building
     phone: 202-225-2431
+    rss_url: https://johnjoyce.house.gov/rss.xml
 - id:
     bioguide: R000610
     fec:
@@ -33192,6 +33244,7 @@
     address: 1714 Longworth House Office Building Washington DC 20515-4100
     office: 1714 Longworth House Office Building
     phone: 202-225-2801
+    rss_url: https://dustyjohnson.house.gov/rss.xml
 - id:
     bioguide: B001309
     fec:
@@ -33242,6 +33295,7 @@
     address: 1122 Longworth House Office Building Washington DC 20515-4202
     office: 1122 Longworth House Office Building
     phone: 202-225-5435
+    rss_url: https://burchett.house.gov/rss.xml
 - id:
     bioguide: R000612
     fec:
@@ -33293,6 +33347,7 @@
     address: 2238 Rayburn House Office Building Washington DC 20515-4206
     office: 2238 Rayburn House Office Building
     phone: 202-225-4231
+    rss_url: https://johnrose.house.gov/rss.xml
 - id:
     bioguide: G000590
     fec:
@@ -33594,6 +33649,7 @@
     address: 103 Cannon House Office Building Washington DC 20515-4321
     office: 103 Cannon House Office Building
     phone: 202-225-4236
+    rss_url: https://roy.house.gov/rss.xml
 - id:
     bioguide: G000587
     fec:
@@ -33645,6 +33701,7 @@
     address: 2419 Rayburn House Office Building Washington DC 20515-4329
     office: 2419 Rayburn House Office Building
     phone: 202-225-1688
+    rss_url: https://sylviagarcia.house.gov/rss.xml
 - id:
     bioguide: A000376
     fec:
@@ -33695,6 +33752,7 @@
     address: 348 Cannon House Office Building Washington DC 20515-4332
     office: 348 Cannon House Office Building
     phone: 202-225-2231
+    rss_url: https://allred.house.gov/rss.xml
 - id:
     bioguide: C001118
     fec:
@@ -33896,6 +33954,7 @@
     address: 1110 Longworth House Office Building Washington DC 20515-4708
     office: 1110 Longworth House Office Building
     phone: 202-225-7761
+    rss_url: https://schrier.house.gov/rss.xml
 - id:
     bioguide: S001213
     fec:
@@ -33946,6 +34005,7 @@
     address: 1526 Longworth House Office Building Washington DC 20515-4901
     office: 1526 Longworth House Office Building
     phone: 202-225-3031
+    rss_url: https://steil.house.gov/rss.xml
 - id:
     bioguide: M001205
     fec:
@@ -33997,6 +34057,7 @@
     address: 465 Cannon House Office Building Washington DC 20515-4801
     office: 465 Cannon House Office Building
     phone: 202-225-3452
+    rss_url: https://miller.house.gov/rss.xml
 - id:
     bioguide: S001217
     lis: S404
@@ -34182,6 +34243,7 @@
     address: 1710 Longworth House Office Building Washington DC 20515-1902
     office: 1710 Longworth House Office Building
     phone: 202-225-6306
+    rss_url: https://golden.house.gov/rss.xml
 - id:
     bioguide: B001311
     fec:
@@ -34232,6 +34294,7 @@
     address: 2459 Rayburn House Office Building Washington DC 20515-3308
     office: 2459 Rayburn House Office Building
     phone: 202-225-1976
+    rss_url: https://danbishop.house.gov/rss.xml
 - id:
     bioguide: M001210
     fec:
@@ -34284,6 +34347,7 @@
     address: 407 Cannon House Office Building Washington DC 20515-3303
     office: 407 Cannon House Office Building
     phone: 202-225-3415
+    rss_url: https://murphy.house.gov/rss.xml
 - id:
     bioguide: M000687
     thomas: '00798'
@@ -34365,6 +34429,7 @@
     address: 2263 Rayburn House Office Building Washington DC 20515-2007
     office: 2263 Rayburn House Office Building
     phone: 202-225-4741
+    rss_url: https://mfume.house.gov/rss.xml
 - id:
     bioguide: T000165
     fec:
@@ -34412,6 +34477,7 @@
     address: 451 Cannon House Office Building Washington DC 20515-4907
     office: 451 Cannon House Office Building
     phone: 202-225-3365
+    rss_url: https://tiffany.house.gov/rss.xml
 - id:
     bioguide: G000061
     fec:
@@ -34716,7 +34782,7 @@
     district: 48
     party: Republican
     url: https://issa.house.gov
-    rss_url: http://issa.house.gov/feed/
+    rss_url: https://issa.house.gov/rss.xml
     address: 2108 Rayburn House Office Building Washington DC 20515-0548
     office: 2108 Rayburn House Office Building
     phone: 202-225-5672
@@ -34859,7 +34925,7 @@
     district: 17
     party: Republican
     url: https://sessions.house.gov
-    rss_url: http://sessions.house.gov/?a=rss.feed
+    rss_url: https://sessions.house.gov/?a=RSS.Feed
     address: 2204 Rayburn House Office Building Washington DC 20515-4317
     office: 2204 Rayburn House Office Building
     phone: 202-225-6105
@@ -35084,6 +35150,7 @@
     address: 1330 Longworth House Office Building Washington DC 20515-0101
     office: 1330 Longworth House Office Building
     phone: 202-225-4931
+    rss_url: https://carl.house.gov/rss.xml
 - id:
     bioguide: M001212
     fec:
@@ -35122,6 +35189,7 @@
     address: 1504 Longworth House Office Building Washington DC 20515-0102
     office: 1504 Longworth House Office Building
     phone: 202-225-2901
+    rss_url: https://barrymoore.house.gov/rss.xml
 - id:
     bioguide: O000019
     fec:
@@ -35161,6 +35229,7 @@
     address: 1029 Longworth House Office Building Washington DC 20515-0523
     office: 1029 Longworth House Office Building
     phone: 202-225-5861
+    rss_url: https://obernolte.house.gov/rss.xml
 - id:
     bioguide: K000397
     fec:
@@ -35200,6 +35269,7 @@
     address: 1306 Longworth House Office Building Washington DC 20515-0540
     office: 1306 Longworth House Office Building
     phone: 202-225-4111
+    rss_url: https://youngkim.house.gov/feed/
 - id:
     bioguide: S001135
     fec:
@@ -35238,6 +35308,7 @@
     address: 1127 Longworth House Office Building Washington DC 20515-0545
     office: 1127 Longworth House Office Building
     phone: 202-225-2415
+    rss_url: https://steel.house.gov/rss.xml
 - id:
     bioguide: J000305
     fec:
@@ -35314,6 +35385,7 @@
     address: 1713 Longworth House Office Building Washington DC 20515-0603
     office: 1713 Longworth House Office Building
     phone: 202-225-4761
+    rss_url: https://boebert.house.gov/rss.xml
 - id:
     bioguide: C001039
     fec:
@@ -35508,6 +35580,7 @@
     address: 2162 Rayburn House Office Building Washington DC 20515-0927
     office: 2162 Rayburn House Office Building
     phone: 202-225-3931
+    rss_url: https://salazar.house.gov/rss.xml
 - id:
     bioguide: W000788
     fec:
@@ -35664,6 +35737,7 @@
     address: 1717 Longworth House Office Building Washington DC 20515-1502
     office: 1717 Longworth House Office Building
     phone: 202-225-2911
+    rss_url: https://hinson.house.gov/rss.xml
 - id:
     bioguide: M001215
     fec:
@@ -35704,6 +35778,7 @@
     address: 1034 Longworth House Office Building Washington DC 20515-1501
     office: 1034 Longworth House Office Building
     phone: 202-225-6576
+    rss_url: https://millermeeks.house.gov/rss.xml
 - id:
     bioguide: F000446
     fec:
@@ -35744,6 +35819,7 @@
     address: 1440 Longworth House Office Building Washington DC 20515-1504
     office: 1440 Longworth House Office Building
     phone: 202-225-4426
+    rss_url: https://feenstra.house.gov/rss.xml
 - id:
     bioguide: M001211
     fec:
@@ -35782,6 +35858,7 @@
     address: 1740 Longworth House Office Building Washington DC 20515-1315
     office: 1740 Longworth House Office Building
     phone: 202-225-5271
+    rss_url: https://marymiller.house.gov/rss.xml
 - id:
     bioguide: M001214
     fec:
@@ -35820,6 +35897,7 @@
     address: 1607 Longworth House Office Building Washington DC 20515-1401
     office: 1607 Longworth House Office Building
     phone: 202-225-2461
+    rss_url: https://mrvan.house.gov/rss.xml
 - id:
     bioguide: S000929
     fec:
@@ -35858,6 +35936,7 @@
     address: 1609 Longworth House Office Building Washington DC 20515-1405
     office: 1609 Longworth House Office Building
     phone: 202-225-2276
+    rss_url: https://spartz.house.gov/rss.xml
 - id:
     bioguide: M000871
     fec:
@@ -35896,6 +35975,7 @@
     address: 344 Cannon House Office Building Washington DC 20515-1601
     office: 344 Cannon House Office Building
     phone: 202-225-2715
+    rss_url: https://mann.house.gov/rss.xml
 - id:
     bioguide: L000266
     fec:
@@ -35934,6 +36014,7 @@
     address: 2441 Rayburn House Office Building Washington DC 20515-1602
     office: 2441 Rayburn House Office Building
     phone: 202-225-6601
+    rss_url: https://laturner.house.gov/rss.xml
 - id:
     bioguide: A000148
     fec:
@@ -36206,6 +36287,7 @@
     address: 307 Cannon House Office Building Washington DC 20515-3306
     office: 307 Cannon House Office Building
     phone: 202-225-3065
+    rss_url: https://manning.house.gov/rss.xml
 - id:
     bioguide: L000273
     fec:
@@ -36243,6 +36325,7 @@
     address: 1510 Longworth House Office Building Washington DC 20515-3103
     office: 1510 Longworth House Office Building
     phone: 202-225-6190
+    rss_url: https://fernandez.house.gov/rss.xml
 - id:
     bioguide: G000597
     fec:
@@ -36281,6 +36364,7 @@
     address: 2344 Rayburn House Office Building Washington DC 20515-3202
     office: 2344 Rayburn House Office Building
     phone: 202-225-7896
+    rss_url: https://garbarino.house.gov/rss.xml
 - id:
     bioguide: M000317
     fec:
@@ -36318,6 +36402,7 @@
     address: 351 Cannon House Office Building Washington DC 20515-3211
     office: 351 Cannon House Office Building
     phone: 202-225-3371
+    rss_url: https://malliotakis.house.gov/rss.xml
 - id:
     bioguide: T000486
     fec:
@@ -36434,6 +36519,7 @@
     address: 2437 Rayburn House Office Building Washington DC 20515-3605
     office: 2437 Rayburn House Office Building
     phone: 202-225-2132
+    rss_url: https://bice.house.gov/rss.xml
 - id:
     bioguide: B000668
     fec:
@@ -36472,6 +36558,7 @@
     address: 409 Cannon House Office Building Washington DC 20515-3702
     office: 409 Cannon House Office Building
     phone: 202-225-6730
+    rss_url: https://bentz.house.gov/rss.xml
 - id:
     bioguide: M000194
     fec:
@@ -36511,6 +36598,7 @@
     address: 1728 Longworth House Office Building Washington DC 20515-4001
     office: 1728 Longworth House Office Building
     phone: 202-225-3176
+    rss_url: https://mace.house.gov/rss.xml
 - id:
     bioguide: H001086
     fec:
@@ -36548,6 +36636,7 @@
     address: 167 Cannon House Office Building Washington DC 20515-4201
     office: 167 Cannon House Office Building
     phone: 202-225-6356
+    rss_url: https://harshbarger.house.gov/rss.xml
 - id:
     bioguide: F000246
     fec:
@@ -36705,6 +36794,7 @@
     address: 1104 Longworth House Office Building Washington DC 20515-4322
     office: 1104 Longworth House Office Building
     phone: 202-225-5951
+    rss_url: https://nehls.house.gov/rss.xml
 - id:
     bioguide: G000594
     fec:
@@ -36784,6 +36874,7 @@
     address: 1725 Longworth House Office Building Washington DC 20515-4324
     office: 1725 Longworth House Office Building
     phone: 202-225-6605
+    rss_url: https://vanduyne.house.gov/?a=RSS.Feed
 - id:
     bioguide: M001213
     fec:
@@ -36900,6 +36991,7 @@
     address: 461 Cannon House Office Building Washington DC 20515-4605
     office: 461 Cannon House Office Building
     phone: 202-225-4711
+    rss_url: https://good.house.gov/rss.xml
 - id:
     bioguide: S001159
     fec:
@@ -36937,6 +37029,7 @@
     address: 1708 Longworth House Office Building Washington DC 20515-4710
     office: 1708 Longworth House Office Building
     phone: 202-225-9740
+    rss_url: https://strickland.house.gov/feed/
 - id:
     bioguide: F000471
     fec:
@@ -36976,6 +37069,7 @@
     address: 1507 Longworth House Office Building Washington DC 20515-4905
     office: 1507 Longworth House Office Building
     phone: 202-225-5101
+    rss_url: https://fitzgerald.house.gov/rss.xml
 - id:
     bioguide: P000145
     lis: S413
@@ -37204,6 +37298,7 @@
     address: 142 Cannon House Office Building Washington DC 20515-1805
     office: 142 Cannon House Office Building
     phone: 202-225-8490
+    rss_url: https://letlow.house.gov/rss.xml
 - id:
     bioguide: C001125
     fec:
@@ -37242,6 +37337,7 @@
     address: 442 Cannon House Office Building Washington DC 20515-1802
     office: 442 Cannon House Office Building
     phone: 202-225-6636
+    rss_url: https://troycarter.house.gov/rss.xml
 - id:
     bioguide: S001218
     fec:
@@ -37282,6 +37378,7 @@
     address: 1421 Longworth House Office Building Washington DC 20515-3101
     office: 1421 Longworth House Office Building
     phone: 202-225-6316
+    rss_url: https://stansbury.house.gov/rss.xml
 - id:
     bioguide: E000071
     fec:
@@ -37320,6 +37417,7 @@
     address: 1721 Longworth House Office Building Washington DC 20515-4306
     office: 1721 Longworth House Office Building
     phone: 202-225-2002
+    rss_url: https://ellzey.house.gov/?a=RSS.Feed
 - id:
     bioguide: B001313
     fec:
@@ -37357,6 +37455,7 @@
     address: 449 Cannon House Office Building Washington DC 20515-3511
     office: 449 Cannon House Office Building
     phone: 202-225-7032
+    rss_url: https://shontelbrown.house.gov/rss.xml
 - id:
     bioguide: C001126
     fec:
@@ -37393,6 +37492,7 @@
     address: 1433 Longworth House Office Building Washington DC 20515-3515
     office: 1433 Longworth House Office Building
     phone: 202-225-2015
+    rss_url: https://carey.house.gov/feed/
 - id:
     bioguide: C001127
     fec:
@@ -37429,6 +37529,7 @@
     address: 242 Cannon House Office Building Washington DC 20515-0920
     office: 242 Cannon House Office Building
     phone: 202-225-1313
+    rss_url: https://cherfilus-mccormick.house.gov/rss.xml
 - id:
     bioguide: F000474
     fec:
@@ -37466,6 +37567,7 @@
     office: 343 Cannon House Office Building
     phone: 202-225-4806
     url: https://flood.house.gov
+    rss_url: https://flood.house.gov/rss.xml
 - id:
     bioguide: F000475
     fec:
@@ -37504,6 +37606,7 @@
     office: 1605 Longworth House Office Building
     phone: 202-225-2472
     url: https://finstad.house.gov
+    rss_url: https://finstad.house.gov/?a=RSS.Feed
 - id:
     bioguide: P000619
     fec:
@@ -37581,6 +37684,7 @@
     office: 1030 Longworth House Office Building
     phone: 202-225-5614
     url: https://patryan.house.gov
+    rss_url: https://patryan.house.gov/rss.xml
 - id:
     bioguide: Y000067
     fec:
@@ -37672,6 +37776,7 @@
     address: 512 Cannon House Office Building Washington DC 20515-2600
     office: 512 Cannon House Office Building
     phone: 202-225-5628
+    rss_url: https://zinke.house.gov/rss.xml
 - id:
     bioguide: B001319
     lis: S416
@@ -37828,6 +37933,7 @@
     address: 1337 Longworth House Office Building Washington DC 20515-0105
     office: 1337 Longworth House Office Building
     phone: 202-225-4801
+    rss_url: https://strong.house.gov/rss.xml
 - id:
     bioguide: C001132
     fec:
@@ -37884,6 +37990,7 @@
     address: 1429 Longworth House Office Building Washington DC 20515-0306
     office: 1429 Longworth House Office Building
     phone: 202-225-2542
+    rss_url: https://ciscomani.house.gov/rss.xml
 - id:
     bioguide: K000401
     fec:
@@ -37968,6 +38075,7 @@
     address: 1404 Longworth House Office Building Washington DC 20515-0515
     office: 1404 Longworth House Office Building
     phone: 202-225-3531
+    rss_url: https://kevinmullin.house.gov/rss.xml
 - id:
     bioguide: K000400
     fec:
@@ -37997,6 +38105,7 @@
     address: 1419 Longworth House Office Building Washington DC 20515-0537
     office: 1419 Longworth House Office Building
     phone: 202-225-7084
+    rss_url: https://kamlager-dove.house.gov/rss.xml
 - id:
     bioguide: G000598
     fec:
@@ -38025,6 +38134,7 @@
     address: 1305 Longworth House Office Building Washington DC 20515-0542
     office: 1305 Longworth House Office Building
     phone: 202-225-7924
+    rss_url: https://robertgarcia.house.gov/rss.xml
 - id:
     bioguide: P000620
     fec:
@@ -38083,6 +38193,7 @@
     address: 1024 Longworth House Office Building Washington DC 20515-0001
     office: 1024 Longworth House Office Building
     phone: 202-225-5625
+    rss_url: https://caraveo.house.gov/rss.xml
 - id:
     bioguide: B001314
     fec:
@@ -38111,6 +38222,7 @@
     address: 1239 Longworth House Office Building Washington DC 20515-0904
     office: 1239 Longworth House Office Building
     phone: 202-225-0123
+    rss_url: https://bean.house.gov/rss.xml
 - id:
     bioguide: M001216
     fec:
@@ -38138,6 +38250,7 @@
     address: 1237 Longworth House Office Building Washington DC 20515-0907
     office: 1237 Longworth House Office Building
     phone: 202-225-4035
+    rss_url: https://mills.house.gov/rss.xml
 - id:
     bioguide: F000476
     fec:
@@ -38225,6 +38338,7 @@
     address: 1118 Longworth House Office Building Washington DC 20515-0915
     office: 1118 Longworth House Office Building
     phone: 202-225-5626
+    rss_url: https://laurellee.house.gov/rss.xml
 - id:
     bioguide: M001217
     fec:
@@ -38281,6 +38395,7 @@
     address: 1213 Longworth House Office Building Washington DC 20515-1006
     office: 1213 Longworth House Office Building
     phone: 202-225-4272
+    rss_url: https://mccormick.house.gov/rss.xml
 - id:
     bioguide: C001129
     fec:
@@ -38310,6 +38425,7 @@
     address: 1223 Longworth House Office Building Washington DC 20515-1010
     office: 1223 Longworth House Office Building
     phone: 202-225-4101
+    rss_url: https://collins.house.gov/rss.xml
 - id:
     bioguide: M001219
     fec:
@@ -38338,6 +38454,7 @@
     address: 1628 Longworth House Office Building Washington DC 20515-5301
     office: 1628 Longworth House Office Building
     phone: 202-225-1188
+    rss_url: https://moylan.house.gov/rss.xml
 - id:
     bioguide: T000487
     fec:
@@ -38366,6 +38483,7 @@
     address: 1005 Longworth House Office Building Washington DC 20515-1102
     office: 1005 Longworth House Office Building
     phone: 202-225-4906
+    rss_url: https://tokuda.house.gov/rss.xml
 - id:
     bioguide: N000193
     fec:
@@ -38395,6 +38513,7 @@
     address: 1232 Longworth House Office Building Washington DC 20515-1503
     office: 1232 Longworth House Office Building
     phone: 202-225-5476
+    rss_url: https://nunn.house.gov/feed/
 - id:
     bioguide: J000309
     fec:
@@ -38423,6 +38542,7 @@
     address: 1641 Longworth House Office Building Washington DC 20515-1301
     office: 1641 Longworth House Office Building
     phone: 202-225-4372
+    rss_url: https://jonathanjackson.house.gov/rss.xml
 - id:
     bioguide: R000617
     fec:
@@ -38452,6 +38572,7 @@
     address: 1523 Longworth House Office Building Washington DC 20515-1303
     office: 1523 Longworth House Office Building
     phone: 202-225-5701
+    rss_url: https://ramirez.house.gov/rss.xml
 - id:
     bioguide: B001315
     fec:
@@ -38507,6 +38628,7 @@
     address: 1205 Longworth House Office Building Washington DC 20515-1317
     office: 1205 Longworth House Office Building
     phone: 202-225-5905
+    rss_url: https://sorensen.house.gov/rss.xml
 - id:
     bioguide: H001093
     fec:
@@ -38536,6 +38658,7 @@
     address: 1632 Longworth House Office Building Washington DC 20515-1409
     office: 1632 Longworth House Office Building
     phone: 202-225-5315
+    rss_url: https://houchin.house.gov/rss.xml
 - id:
     bioguide: M001220
     fec:
@@ -38592,6 +38715,7 @@
     address: 1529 Longworth House Office Building Washington DC 20515-2004
     office: 1529 Longworth House Office Building
     phone: 202-225-8699
+    rss_url: https://ivey.house.gov/rss.xml
 - id:
     bioguide: S001221
     fec:
@@ -38620,6 +38744,7 @@
     address: 1317 Longworth House Office Building Washington DC 20515-2203
     office: 1317 Longworth House Office Building
     phone: 202-225-3831
+    rss_url: https://scholten.house.gov/rss.xml
 - id:
     bioguide: J000307
     fec:
@@ -38735,6 +38860,7 @@
     address: 1108 Longworth House Office Building Washington DC 20515-2507
     office: 1108 Longworth House Office Building
     phone: 202-225-6536
+    rss_url: https://burlison.house.gov/rss.xml
 - id:
     bioguide: E000235
     fec:
@@ -38790,6 +38916,7 @@
     address: 1123 Longworth House Office Building Washington DC 20515-3301
     office: 1123 Longworth House Office Building
     phone: 202-225-3101
+    rss_url: https://dondavis.house.gov/rss.xml
 - id:
     bioguide: F000477
     fec:
@@ -38847,6 +38974,7 @@
     address: 1505 Longworth House Office Building Washington DC 20515-3311
     office: 1505 Longworth House Office Building
     phone: 202-225-6401
+    rss_url: https://edwards.house.gov/rss.xml
 - id:
     bioguide: N000194
     fec:
@@ -38904,6 +39032,7 @@
     address: 1318 Longworth House Office Building Washington DC 20515-0001
     office: 1318 Longworth House Office Building
     phone: 202-225-5634
+    rss_url: https://jeffjackson.house.gov/rss.xml
 - id:
     bioguide: K000398
     fec:
@@ -38934,6 +39063,7 @@
     address: 251 Cannon House Office Building Washington DC 20515-3007
     office: 251 Cannon House Office Building
     phone: 202-225-5361
+    rss_url: https://kean.house.gov/rss.xml
 - id:
     bioguide: M001226
     fec:
@@ -38963,6 +39093,7 @@
     address: 1007 Longworth House Office Building Washington DC 20515-3008
     office: 1007 Longworth House Office Building
     phone: 202-225-7919
+    rss_url: https://menendez.house.gov/rss.xml
 - id:
     bioguide: V000136
     fec:
@@ -38990,6 +39121,7 @@
     address: 1517 Longworth House Office Building Washington DC 20515-3102
     office: 1517 Longworth House Office Building
     phone: 202-225-2365
+    rss_url: https://vasquez.house.gov/rss.xml
 - id:
     bioguide: L000598
     fec:
@@ -39018,6 +39150,7 @@
     address: 1530 Longworth House Office Building Washington DC 20515-3201
     office: 1530 Longworth House Office Building
     phone: 202-225-3826
+    rss_url: https://lalota.house.gov/rss.xml
 - id:
     bioguide: D000632
     fec:
@@ -39047,6 +39180,7 @@
     address: 1508 Longworth House Office Building Washington DC 20515-3204
     office: 1508 Longworth House Office Building
     phone: 202-225-5516
+    rss_url: https://desposito.house.gov/rss.xml
 - id:
     bioguide: G000599
     fec:
@@ -39076,6 +39210,7 @@
     address: 245 Cannon House Office Building Washington DC 20515-3210
     office: 245 Cannon House Office Building
     phone: 202-225-7944
+    rss_url: https://goldman.house.gov/rss.xml
 - id:
     bioguide: L000599
     fec:
@@ -39191,6 +39326,7 @@
     address: 1630 Longworth House Office Building Washington DC 20515-3223
     office: 1630 Longworth House Office Building
     phone: 202-225-3161
+    rss_url: https://langworthy.house.gov/rss.xml
 - id:
     bioguide: L000601
     fec:
@@ -39361,6 +39497,7 @@
     address: 1722 Longworth House Office Building Washington DC 20515-3705
     office: 1722 Longworth House Office Building
     phone: 202-225-5711
+    rss_url: https://chavez-deremer.house.gov/rss.xml
 - id:
     bioguide: S001226
     fec:
@@ -39390,6 +39527,7 @@
     address: 109 Cannon House Office Building Washington DC 20515-0001
     office: 109 Cannon House Office Building
     phone: 202-225-5643
+    rss_url: https://salinas.house.gov/rss.xml
 - id:
     bioguide: L000602
     fec:
@@ -39448,6 +39586,7 @@
     address: 1222 Longworth House Office Building Washington DC 20515-3817
     office: 1222 Longworth House Office Building
     phone: 202-225-2301
+    rss_url: https://deluzio.house.gov/rss.xml
 - id:
     bioguide: M001223
     fec:
@@ -39476,6 +39615,7 @@
     address: 1218 Longworth House Office Building Washington DC 20515-3902
     office: 1218 Longworth House Office Building
     phone: 202-225-2735
+    rss_url: https://magaziner.house.gov/rss.xml
 - id:
     bioguide: F000478
     fec:
@@ -39534,6 +39674,7 @@
     address: 151 Cannon House Office Building Washington DC 20515-4205
     office: 151 Cannon House Office Building
     phone: 202-225-4311
+    rss_url: https://ogles.house.gov/rss.xml
 - id:
     bioguide: M001224
     fec:
@@ -39593,6 +39734,7 @@
     address: 1113 Longworth House Office Building Washington DC 20515-4303
     office: 1113 Longworth House Office Building
     phone: 202-225-4201
+    rss_url: https://keithself.house.gov/rss.xml
 - id:
     bioguide: L000603
     fec:
@@ -39621,6 +39763,7 @@
     address: 1320 Longworth House Office Building Washington DC 20515-4308
     office: 1320 Longworth House Office Building
     phone: 202-225-4901
+    rss_url: https://luttrell.house.gov/rss.xml
 - id:
     bioguide: D000594
     fec:
@@ -39677,6 +39820,7 @@
     address: 1616 Longworth House Office Building Washington DC 20515-4330
     office: 1616 Longworth House Office Building
     phone: 202-225-8885
+    rss_url: https://crockett.house.gov/rss.xml
 - id:
     bioguide: C001131
     fec:
@@ -39706,6 +39850,7 @@
     address: 1339 Longworth House Office Building Washington DC 20515-4335
     office: 1339 Longworth House Office Building
     phone: 202-225-5645
+    rss_url: https://casar.house.gov/rss.xml
 - id:
     bioguide: H001095
     fec:
@@ -39735,6 +39880,7 @@
     address: 1520 Longworth House Office Building Washington DC 20515-0001
     office: 1520 Longworth House Office Building
     phone: 202-225-5646
+    rss_url: https://hunt.house.gov/rss.xml
 - id:
     bioguide: K000399
     fec:
@@ -39852,6 +39998,7 @@
     address: 1513 Longworth House Office Building Washington DC 20515-4903
     office: 1513 Longworth House Office Building
     phone: 202-225-5506
+    rss_url: https://vanorden.house.gov/rss.xml
 - id:
     bioguide: H001096
     fec:
@@ -39882,6 +40029,7 @@
     address: 1531 Longworth House Office Building Washington DC 20515-5000
     office: 1531 Longworth House Office Building
     phone: 202-225-2311
+    rss_url: https://hageman.house.gov/rss.xml
 - id:
     bioguide: R000618
     lis: S423
@@ -39944,6 +40092,7 @@
     office: 2417 Rayburn House Office Building
     phone: 202-225-6365
     url: https://mcclellan.house.gov
+    rss_url: https://mcclellan.house.gov/rss.xml
 - id:
     bioguide: B001320
     lis: S424
@@ -40000,6 +40149,7 @@
     office: 2233 Rayburn House Office Building
     phone: 202-225-4911
     url: https://amo.house.gov
+    rss_url: https://amo.house.gov/rss.xml
 - id:
     bioguide: M001228
     fec:
@@ -40091,6 +40241,7 @@
     office: 1117 Longworth House Office Building
     phone: 202-225-3335
     url: https://suozzi.house.gov
+    rss_url: https://suozzi.house.gov/rss.xml
 - id:
     bioguide: K000402
     govtrack: 456957
@@ -40146,6 +40297,7 @@
     office: 2468 Rayburn House Office Building
     phone: 202-225-2915
     url: https://fong.house.gov
+    rss_url: https://fong.house.gov/rss.xml
 - id:
     bioguide: R000619
     fec:
@@ -40172,6 +40324,7 @@
     office: 2082 Rayburn House Office Building
     phone: 202-225-5705
     url: https://rulli.house.gov
+    rss_url: https://rulli.house.gov/rss.xml
 - id:
     bioguide: L000604
     fec:
@@ -40197,3 +40350,4 @@
     office: 2455 Rayburn House Office Building
     phone: 202-225-4676
     url: https://lopez.house.gov
+    rss_url: https://lopez.house.gov/rss.xml

--- a/scripts/house_websites.py
+++ b/scripts/house_websites.py
@@ -11,7 +11,7 @@ import lxml.html, io, urllib.request, urllib.error, urllib.parse
 import re
 import utils
 from utils import load_data, save_data, states as state_names
-
+from feedfinder2 import find_feeds
 
 def run():
 
@@ -75,6 +75,7 @@ def run():
 
       url = cells[1].cssselect("a")[0].get("href")
       original_url = url
+      print(url)
 
       # The House uses subdomains now, and occasionally the directory
       # uses URLs with some trailing redirected-to page, like /home.
@@ -91,12 +92,18 @@ def run():
       # kill everything after the domain
       url = re.sub(".gov/.*$", ".gov", url)
 
+      # find rss feed
+      feeds = find_feeds(url)
+
       if state == "AQ":
         state = "AS"
       full_district = "%s%02d" % (state, int(district))
       if full_district in by_district:
         print("[%s] %s %s" % (full_district, url, "" if url == original_url.rstrip("/") else (" <= " + original_url)))
         by_district[full_district]['terms'][-1]['url'] = url
+        if len(feeds) > 0:
+          rss_url = feeds[0]
+          by_district[full_district]['terms'][-1]['rss_url'] = rss_url
       else:
         print("[%s] No current legislator" % full_district)
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,3 +8,4 @@ pyflakes
 pytz
 tweepy
 sparqlwrapper
+feedfinder2


### PR DESCRIPTION
I added to `house_websites.py` a check for an RSS/Atom feed which would be added to the latest term in `current-legislators.yaml`. That check is done using the feedfinder2 library, which I added to the requirements. It definitely slows down the performance of `house_websites.py` so let me know if you think that's an issue.