### PR TITLE
Update Opensecrets ID for Kean

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -38754,7 +38754,7 @@
     fec:
     - H0NJ07261
     govtrack: 456917
-    opensecrets: N00019149
+    opensecrets: N00027502
     wikidata: Q7791445
     wikipedia: Thomas Kean Jr.
     ballotpedia: Thomas Kean Jr.


### PR DESCRIPTION
Seems to be wrong? I see this 

https://www.opensecrets.org/members-of-congress/thomas-h-kean-jr/summary?cid=N00027502&cycle=2022