### PR TITLE
Add pictorial ids, script for 118th Congress

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following fields are available in `legislators-current.yaml` and `legislator
 	* maplight : The numeric ID for this legislator on maplight.org (stored as an integer).
 	* house_history: The numeric ID for this legislator on http://history.house.gov/People/Search/. The ID is present only for members who have served in the U.S. House.
 	* bioguide_previous: When bioguide.congress.gov mistakenly listed a legislator under multiple IDs, this field is a *list* of alternative IDs. (This often ocurred for women who changed their name.) The IDs in this list probably were removed from bioguide.congress.gov but might still be in use in the wild.
+	* pictorial: The numeric ID for this legislator on https://pictorial.gpo.gov/member-search/ (stored as an integer).
 
 * name
 	* first: The legislator's _recognizable_ first name. Many people go by a different name than their legal first name, often their legal middle name, and our approach is to ensure that our first + last name fields combine to a recognizable name of the legislator. Normally we'll follow the name as it appears on House.gov or Senate.gov (and bioguide.congress.gov), which follows the legislator's own preference for how they want to be named in official places. However, in some cases the legislator goes by a first name that is merely a common short or informal form of their legal first name (e.g. Chris vs Christopher), and while they may prefer the informal name, we may use their longer legal first name because they would be recognizable by their legal name. If they sign official documents (e.g. letters to agencies, FEC filings) using their longer legal first name, we would use their legal first name and put their preferred shorter name in the `nickname` field. When legislators go by a first initial and middle name, we set the `first` name field to the initial (one character plus a period).
@@ -483,6 +484,10 @@ The following script takes one required command line argument
 * `icpsr_ids.py`: Updates ICPSR ID's for all members of the House and Senate in a given congress, based on roll call vote data files stored by Voteview.com. The script takes one command line argument:
 --congress=congress_number
 where congress_number is the number of the Congress to be updated. As of July, 2013, the permanent URL for future roll call data is unclear, and as such, the script may need to be modified when it is run for the 114th congress.
+
+* `pictorial_ids.py`: Updates [Pictorial](https://pictorial.gpo.gov/member-search/) ID's for all members of the House and Senate in a given congress, using on [Pictorial's API](https://pictorialapi.gpo.gov/api/). The script takes one command line argument:
+--congress=congress_number
+where congress_number is the number of the Congress to be updated.
 
 The following script is run to create alternately formatted data files for the `gh-pages` branch. It takes no command-line arguments.
 

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40181,6 +40181,7 @@
     wikipedia: Gabe Amo
     wikidata: Q118901875
     ballotpedia: Gabe Amo
+    pictorial: 13239
   name:
     first: Gabe
     last: Amo
@@ -40208,6 +40209,7 @@
     wikipedia: Celeste Maloy
     wikidata: Q119578731
     ballotpedia: Celeste Maloy
+    pictorial: 13297
   name:
     first: Celeste
     last: Maloy

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -16,6 +16,7 @@
     icpsr: 29389
     wikidata: Q381880
     google_entity_id: kg:/m/034s80
+    pictorial: 13413
   name:
     first: Sherrod
     last: Brown
@@ -125,6 +126,7 @@
     icpsr: 39310
     wikidata: Q22250
     google_entity_id: kg:/m/01x68t
+    pictorial: 13398
   name:
     first: Maria
     last: Cantwell
@@ -203,6 +205,7 @@
     maplight: 182
     wikidata: Q723295
     google_entity_id: kg:/m/025k3k
+    pictorial: 13396
   name:
     first: Benjamin
     middle: L.
@@ -330,6 +333,7 @@
     maplight: 545
     wikidata: Q457432
     google_entity_id: kg:/m/01xw7t
+    pictorial: 13397
   name:
     first: Thomas
     middle: Richard
@@ -431,6 +435,7 @@
     icpsr: 40703
     wikidata: Q887841
     google_entity_id: kg:/m/047ymw
+    pictorial: 13400
   name:
     first: Robert
     middle: P.
@@ -498,6 +503,7 @@
     icpsr: 40700
     wikidata: Q22237
     google_entity_id: kg:/m/05fbpt
+    pictorial: 13431
   name:
     first: Amy
     middle: Jean
@@ -574,6 +580,7 @@
     icpsr: 29373
     wikidata: Q888132
     google_entity_id: kg:/m/033d3p
+    pictorial: 13358
   name:
     first: Robert
     last: Menendez
@@ -694,6 +701,7 @@
     house_history: 21173
     wikidata: Q359442
     google_entity_id: kg:/m/01_gbv
+    pictorial: 13382
   name:
     first: Bernard
     last: Sanders
@@ -825,6 +833,7 @@
     house_history: 22090
     wikidata: Q241092
     google_entity_id: kg:/m/01xh64
+    pictorial: 13388
   name:
     first: Debbie
     middle: Ann
@@ -920,6 +929,7 @@
     icpsr: 40702
     wikidata: Q529351
     google_entity_id: kg:/m/066cdp
+    pictorial: 13371
   name:
     first: Jon
     last: Tester
@@ -983,6 +993,7 @@
     icpsr: 40704
     wikidata: Q652066
     google_entity_id: kg:/m/07qw94
+    pictorial: 13372
   name:
     first: Sheldon
     last: Whitehouse
@@ -1046,6 +1057,7 @@
     icpsr: 40707
     wikidata: Q720521
     google_entity_id: kg:/m/02rsm32
+    pictorial: 13410
   name:
     first: John
     middle: A.
@@ -1125,6 +1137,7 @@
     house_history: 23734
     wikidata: Q390491
     google_entity_id: kg:/m/025xxb
+    pictorial: 13373
   name:
     first: Roger
     middle: F.
@@ -1234,6 +1247,7 @@
     icpsr: 49703
     wikidata: Q22279
     google_entity_id: kg:/m/020y8m
+    pictorial: 13395
   name:
     first: Susan
     middle: M.
@@ -1313,6 +1327,7 @@
     icpsr: 40305
     wikidata: Q719568
     google_entity_id: kg:/m/01xcqs
+    pictorial: 13403
   name:
     first: John
     last: Cornyn
@@ -1573,6 +1588,7 @@
     icpsr: 29566
     wikidata: Q22212
     google_entity_id: kg:/m/01_pdg
+    pictorial: 13440
   name:
     first: Lindsey
     middle: O.
@@ -1670,6 +1686,7 @@
     maplight: 593
     wikidata: Q355522
     google_entity_id: kg:/m/01z6ls
+    pictorial: 13357
   name:
     first: Mitch
     last: McConnell
@@ -1800,6 +1817,7 @@
     icpsr: 40908
     wikidata: Q1368405
     google_entity_id: kg:/m/026k60f
+    pictorial: 13359
   name:
     first: Jeff
     last: Merkley
@@ -1867,6 +1885,7 @@
     icpsr: 29142
     wikidata: Q528979
     google_entity_id: kg:/m/0202mc
+    pictorial: 13349
   name:
     first: John
     middle: F.
@@ -1965,6 +1984,7 @@
     icpsr: 40902
     wikidata: Q721871
     google_entity_id: kg:/m/06y9p0
+    pictorial: 13383
   name:
     first: James
     middle: E.
@@ -2029,6 +2049,7 @@
     house_history: 22618
     wikidata: Q270316
     google_entity_id: kg:/m/01rrm2
+    pictorial: 13394
   name:
     first: Jeanne
     last: Shaheen
@@ -2095,6 +2116,7 @@
     icpsr: 40909
     wikidata: Q453893
     google_entity_id: kg:/m/024mm1
+    pictorial: 13376
   name:
     first: Mark
     middle: R.
@@ -2167,6 +2189,7 @@
     icpsr: 20735
     wikidata: Q22222
     google_entity_id: kg:/m/0gnfc4
+    pictorial: 13442
   name:
     first: Kirsten
     middle: E.
@@ -2246,6 +2269,7 @@
     icpsr: 40916
     wikidata: Q923242
     google_entity_id: kg:/m/082d3d
+    pictorial: 13405
   name:
     first: Christopher
     middle: Andrew
@@ -2312,6 +2336,7 @@
     icpsr: 40915
     wikidata: Q538868
     google_entity_id: kg:/m/04lc5t
+    pictorial: 13360
   name:
     first: Joe
     last: Manchin
@@ -2388,6 +2413,7 @@
     icpsr: 29701
     wikidata: Q672671
     google_entity_id: kg:/m/024p03
+    pictorial: 12897
   name:
     first: Robert
     last: Aderholt
@@ -2544,6 +2570,7 @@
     icpsr: 29940
     wikidata: Q40628
     google_entity_id: kg:/m/024v02
+    pictorial: 13412
   name:
     first: Tammy
     last: Baldwin
@@ -2655,6 +2682,7 @@
     icpsr: 40910
     wikidata: Q554792
     google_entity_id: kg:/m/05b60qf
+    pictorial: 13409
   name:
     first: Michael
     middle: F.
@@ -2729,6 +2757,7 @@
     icpsr: 20758
     wikidata: Q1555314
     google_entity_id: kg:/m/0dy3z1
+    pictorial: 12993
   name:
     first: Gus
     last: Bilirakis
@@ -2854,6 +2883,7 @@
     wikidata: Q983428
     google_entity_id: kg:/m/02554k
     ballotpedia: Sanford Bishop Jr.
+    pictorial: 13011
   name:
     first: Sanford
     middle: D.
@@ -3023,6 +3053,7 @@
     wikidata: Q458971
     google_entity_id: kg:/m/01fnkt
     lis: S396
+    pictorial: 13419
   name:
     first: Marsha
     middle: W.
@@ -3138,6 +3169,7 @@
     icpsr: 29588
     wikidata: Q748066
     google_entity_id: kg:/m/033tw8
+    pictorial: 13217
   name:
     first: Earl
     last: Blumenauer
@@ -3297,6 +3329,7 @@
     icpsr: 41101
     wikidata: Q2023708
     google_entity_id: kg:/m/03tg8m
+    pictorial: 13417
   name:
     first: Richard
     last: Blumenthal
@@ -3364,6 +3397,7 @@
     icpsr: 20101
     wikidata: Q1344707
     google_entity_id: kg:/m/024s3v
+    pictorial: 13420
   name:
     first: John
     last: Boozman
@@ -3463,6 +3497,7 @@
     icpsr: 20709
     wikidata: Q2517229
     google_entity_id: kg:/m/0gtjsp
+    pictorial: 12997
   name:
     first: Vern
     last: Buchanan
@@ -3584,6 +3619,7 @@
     icpsr: 21132
     wikidata: Q944286
     google_entity_id: kg:/m/0dd9k_y
+    pictorial: 13057
   name:
     first: Larry
     last: Bucshon
@@ -3689,6 +3725,7 @@
     icpsr: 20355
     wikidata: Q539521
     google_entity_id: kg:/m/03tq8_
+    pictorial: 13283
   name:
     first: Michael
     middle: C.
@@ -3825,6 +3862,7 @@
     wikidata: Q538978
     google_entity_id: kg:/m/024xl1
     ballotpedia: Ken Calvert
+    pictorial: 12955
   name:
     first: Ken
     middle: S.
@@ -4109,6 +4147,7 @@
     icpsr: 20757
     wikidata: Q517649
     google_entity_id: kg:/m/03qcvz1
+    pictorial: 13056
   name:
     first: André
     last: Carson
@@ -4233,6 +4272,7 @@
     icpsr: 20356
     wikidata: Q369814
     google_entity_id: kg:/m/04m7rg
+    pictorial: 13288
   name:
     first: John
     middle: R.
@@ -4453,6 +4493,7 @@
     icpsr: 20708
     wikidata: Q458492
     google_entity_id: kg:/m/0dq1v6
+    pictorial: 12995
   name:
     first: Kathy
     last: Castor
@@ -4574,6 +4615,7 @@
     wikidata: Q460035
     google_entity_id: kg:/m/0krsk2
     ballotpedia: Judy Chu
+    pictorial: 12942
   name:
     first: Judy
     middle: M.
@@ -4689,6 +4731,7 @@
     icpsr: 20733
     wikidata: Q461679
     google_entity_id: kg:/m/06h90t
+    pictorial: 13177
   name:
     first: Yvette
     middle: D.
@@ -4811,6 +4854,7 @@
     wikidata: Q1334654
     google_entity_id: kg:/m/04cbbm
     ballotpedia: Emanuel Cleaver
+    pictorial: 13119
   name:
     first: Emanuel
     last: Cleaver
@@ -4939,6 +4983,7 @@
     icpsr: 39301
     wikidata: Q1289889
     google_entity_id: kg:/m/03c469
+    pictorial: 13246
   name:
     first: James
     middle: E.
@@ -5121,6 +5166,7 @@
     wikidata: Q512330
     google_entity_id: kg:/m/04l8cr
     ballotpedia: Steve Cohen
+    pictorial: 13257
   name:
     first: Steve
     last: Cohen
@@ -5242,6 +5288,7 @@
     icpsr: 20344
     wikidata: Q173839
     google_entity_id: kg:/m/03tqb0
+    pictorial: 13213
   name:
     first: Tom
     last: Cole
@@ -5377,6 +5424,7 @@
     wikidata: Q1514859
     google_entity_id: kg:/m/04f40kn
     ballotpedia: Gerald Connolly
+    pictorial: 13309
   name:
     first: Gerald
     middle: E.
@@ -5492,6 +5540,7 @@
     wikidata: Q675869
     google_entity_id: kg:/m/04chm2
     ballotpedia: Jim Costa
+    pictorial: 12935
   name:
     first: Jim
     last: Costa
@@ -5619,6 +5668,7 @@
     icpsr: 20706
     wikidata: Q434470
     google_entity_id: kg:/m/0700nd
+    pictorial: 12976
   name:
     first: Joe
     last: Courtney
@@ -5742,6 +5792,7 @@
     icpsr: 29345
     wikidata: Q734319
     google_entity_id: kg:/m/021pgp
+    pictorial: 13406
   name:
     first: Michael
     middle: D.
@@ -5838,6 +5889,7 @@
     icpsr: 21106
     wikidata: Q2151554
     google_entity_id: kg:/m/0czb3pp
+    pictorial: 12901
   name:
     first: Eric
     middle: A.
@@ -5946,6 +5998,7 @@
     wikidata: Q539562
     google_entity_id: kg:/m/04clj6
     ballotpedia: Henry Cuellar
+    pictorial: 13285
   name:
     first: Henry
     last: Cuellar
@@ -6073,6 +6126,7 @@
     icpsr: 29717
     wikidata: Q1164657
     google_entity_id: kg:/m/0256k7
+    pictorial: 13039
   name:
     first: Danny
     middle: K.
@@ -6227,6 +6281,7 @@
     icpsr: 29710
     wikidata: Q437159
     google_entity_id: kg:/m/024z95
+    pictorial: 12967
   name:
     first: Diana
     middle: L.
@@ -6381,6 +6436,7 @@
     icpsr: 29109
     wikidata: Q434952
     google_entity_id: kg:/m/024zn0
+    pictorial: 12977
   name:
     first: Rosa
     middle: L.
@@ -6553,6 +6609,7 @@
     wikidata: Q2260839
     google_entity_id: kg:/m/09k4h2_
     ballotpedia: Scott DesJarlais
+    pictorial: 13252
   name:
     first: Scott
     last: DesJarlais
@@ -6659,6 +6716,7 @@
     icpsr: 20316
     wikidata: Q767270
     google_entity_id: kg:/m/02536z
+    pictorial: 13007
   name:
     first: Mario
     last: Diaz-Balart
@@ -6797,6 +6855,7 @@
     wikidata: Q363817
     google_entity_id: kg:/m/03flzn
     ballotpedia: Lloyd Doggett
+    pictorial: 13294
   name:
     first: Lloyd
     middle: A.
@@ -6957,6 +7016,7 @@
     icpsr: 21174
     wikidata: Q1027026
     google_entity_id: kg:/m/0ddgp1k
+    pictorial: 13243
   name:
     first: Jeff
     last: Duncan
@@ -7063,6 +7123,7 @@
     wikidata: Q291193
     google_entity_id: kg:/m/024t6x
     ballotpedia: Anna Eshoo
+    pictorial: 12930
   name:
     first: Anna
     middle: G.
@@ -7229,6 +7290,7 @@
     wikidata: Q521959
     google_entity_id: kg:/m/0ddd54f
     ballotpedia: Charles Fleischmann
+    pictorial: 13251
   name:
     first: Charles
     last: Fleischmann
@@ -7337,6 +7399,7 @@
     icpsr: 20521
     wikidata: Q458453
     google_entity_id: kg:/m/02b5dz
+    pictorial: 13134
   name:
     first: Virginia
     last: Foxx
@@ -7464,6 +7527,7 @@
     wikidata: Q1340268
     google_entity_id: kg:/m/05fvls
     ballotpedia: John Garamendi
+    pictorial: 12922
   name:
     first: John
     last: Garamendi
@@ -7578,6 +7642,7 @@
     icpsr: 21103
     wikidata: Q2059832
     google_entity_id: kg:/m/0czdqz0
+    pictorial: 12914
   name:
     first: Paul
     last: Gosar
@@ -7685,6 +7750,7 @@
     wikidata: Q468807
     google_entity_id: kg:/m/03tndx
     ballotpedia: Kay Granger
+    pictorial: 13269
   name:
     first: Kay
     last: Granger
@@ -7839,6 +7905,7 @@
     maplight: 570
     wikidata: Q529294
     google_entity_id: kg:/m/020ymy
+    pictorial: 13441
   name:
     first: Charles
     middle: E.
@@ -7965,6 +8032,7 @@
     wikidata: Q465638
     google_entity_id: kg:/m/03tnfy
     ballotpedia: Sam Graves
+    pictorial: 13120
   name:
     first: Sam
     middle: B.
@@ -8107,6 +8175,7 @@
     icpsr: 20529
     wikidata: Q749039
     google_entity_id: kg:/m/02kn0_
+    pictorial: 13266
   name:
     first: Al
     last: Green
@@ -8234,6 +8303,7 @@
     icpsr: 21191
     wikidata: Q1684857
     google_entity_id: kg:/m/025vdrq
+    pictorial: 13307
   name:
     first: H.
     middle: Morgan
@@ -8341,6 +8411,7 @@
     icpsr: 20305
     wikidata: Q946606
     google_entity_id: kg:/m/024s1z
+    pictorial: 12912
   name:
     first: Raúl
     middle: M.
@@ -8477,6 +8548,7 @@
     icpsr: 20916
     wikidata: Q910794
     google_entity_id: kg:/m/0411qqt
+    pictorial: 13064
   name:
     first: Brett
     last: Guthrie
@@ -8591,6 +8663,7 @@
     wikidata: Q506639
     google_entity_id: kg:/m/02852wc
     ballotpedia: Andrew Harris
+    pictorial: 13084
   name:
     first: Andy
     last: Harris
@@ -8699,6 +8772,7 @@
     icpsr: 20930
     wikidata: Q565374
     google_entity_id: kg:/m/02qkv0r
+    pictorial: 13428
   name:
     first: Martin
     last: Heinrich
@@ -8767,6 +8841,7 @@
     icpsr: 20907
     wikidata: Q1689111
     google_entity_id: kg:/m/03w9x9v
+    pictorial: 12978
   name:
     first: James
     nickname: Jim
@@ -8885,6 +8960,7 @@
     icpsr: 20713
     wikidata: Q16476
     google_entity_id: kg:/m/0357cd
+    pictorial: 13423
   name:
     first: Mazie
     middle: K.
@@ -8963,6 +9039,7 @@
     icpsr: 41107
     wikidata: Q374762
     google_entity_id: kg:/m/01qb45
+    pictorial: 13422
   name:
     first: John
     last: Hoeven
@@ -9028,6 +9105,7 @@
     maplight: 293
     wikidata: Q516515
     google_entity_id: kg:/m/025k5p
+    pictorial: 13088
   name:
     first: Steny
     middle: H.
@@ -9263,6 +9341,7 @@
     icpsr: 21142
     wikidata: Q862199
     google_entity_id: kg:/m/05b0j1w
+    pictorial: 13097
   name:
     first: Bill
     last: Huizenga
@@ -9369,6 +9448,7 @@
     icpsr: 20712
     wikidata: Q983537
     google_entity_id: kg:/m/0flgyy
+    pictorial: 13013
   name:
     first: Henry
     middle: C.
@@ -9493,6 +9573,7 @@
     icpsr: 41111
     wikidata: Q970272
     google_entity_id: kg:/m/0cmdpzc
+    pictorial: 13435
   name:
     first: Ron
     last: Johnson
@@ -9558,6 +9639,7 @@
     icpsr: 20738
     wikidata: Q186215
     google_entity_id: kg:/m/04l4x5
+    pictorial: 13198
   name:
     first: Jim
     last: Jordan
@@ -9679,6 +9761,7 @@
     wikidata: Q436537
     google_entity_id: kg:/m/039s3l
     ballotpedia: Marcy Kaptur
+    pictorial: 13203
   name:
     first: Marcy
     last: Kaptur
@@ -9874,6 +9957,7 @@
     wikidata: Q775412
     google_entity_id: kg:/m/09v6g7c
     ballotpedia: Bill Keating
+    pictorial: 13083
   name:
     first: William
     last: Keating
@@ -9981,6 +10065,7 @@
     icpsr: 21167
     wikidata: Q1431761
     google_entity_id: kg:/m/0ds6wcw
+    pictorial: 13236
   name:
     first: Mike
     last: Kelly
@@ -10087,6 +10172,7 @@
     icpsr: 20704
     wikidata: Q371106
     google_entity_id: kg:/m/0fsgdd
+    pictorial: 12971
   name:
     first: Doug
     last: Lamborn
@@ -10210,6 +10296,7 @@
     lis: S378
     wikidata: Q45940
     google_entity_id: kg:/m/0dgrrx6
+    pictorial: 13356
   name:
     first: James
     last: Lankford
@@ -10293,6 +10380,7 @@
     wikidata: Q503529
     google_entity_id: kg:/m/025953
     ballotpedia: Rick Larsen
+    pictorial: 13313
   name:
     first: Rick
     last: Larsen
@@ -10434,6 +10522,7 @@
     icpsr: 29908
     wikidata: Q357832
     google_entity_id: kg:/m/024zl9
+    pictorial: 12975
   name:
     first: John
     middle: B.
@@ -10582,6 +10671,7 @@
     icpsr: 20755
     wikidata: Q888061
     google_entity_id: kg:/m/02z6_j1
+    pictorial: 13199
   name:
     first: Robert
     middle: E.
@@ -10707,6 +10797,7 @@
     wikidata: Q289317
     google_entity_id: kg:/m/024sjy
     ballotpedia: Barbara Lee (California)
+    pictorial: 12926
   name:
     first: Barbara
     last: Lee
@@ -10860,6 +10951,7 @@
     icpsr: 41110
     wikidata: Q627098
     google_entity_id: kg:/m/09v5q9x
+    pictorial: 13353
   name:
     first: Mike
     last: Lee
@@ -10923,6 +11015,7 @@
     icpsr: 29504
     wikidata: Q218217
     google_entity_id: kg:/m/024t94
+    pictorial: 12932
   name:
     first: Zoe
     last: Lofgren
@@ -11082,6 +11175,7 @@
     icpsr: 29393
     wikidata: Q246049
     google_entity_id: kg:/m/033tnk
+    pictorial: 13212
   name:
     first: Frank
     middle: D.
@@ -11248,6 +11342,7 @@
     wikidata: Q522181
     google_entity_id: kg:/m/04ycpq1
     ballotpedia: Blaine Luetkemeyer
+    pictorial: 13117
   name:
     first: Blaine
     last: Luetkemeyer
@@ -11475,6 +11570,7 @@
     icpsr: 20119
     wikidata: Q2344921
     google_entity_id: kg:/m/028vsz
+    pictorial: 13082
   name:
     first: Stephen
     middle: F.
@@ -11619,6 +11715,7 @@
     maplight: 351
     wikidata: Q1282411
     google_entity_id: kg:/m/028vr4
+    pictorial: 13363
   name:
     first: Edward
     middle: J.
@@ -11818,6 +11915,7 @@
     wikidata: Q399561
     google_entity_id: kg:/m/059hdf
     ballotpedia: Doris Matsui
+    pictorial: 12921
   name:
     first: Doris
     middle: O.
@@ -11949,6 +12047,7 @@
     icpsr: 20530
     wikidata: Q539509
     google_entity_id: kg:/m/0492cz
+    pictorial: 13267
   name:
     first: Michael
     middle: T.
@@ -12072,6 +12171,7 @@
     wikidata: Q535887
     google_entity_id: kg:/m/01r6jp
     ballotpedia: Tom McClintock
+    pictorial: 12919
   name:
     first: Tom
     last: McClintock
@@ -12186,6 +12286,7 @@
     icpsr: 20122
     wikidata: Q434893
     google_entity_id: kg:/m/0249hy
+    pictorial: 13110
   name:
     first: Betty
     middle: Louise
@@ -12328,6 +12429,7 @@
     wikidata: Q1337459
     google_entity_id: kg:/m/028vn7
     ballotpedia: Jim McGovern (Massachusetts)
+    pictorial: 13076
   name:
     first: James
     middle: P.
@@ -12483,6 +12585,7 @@
     icpsr: 20522
     wikidata: Q2057809
     google_entity_id: kg:/m/02b4rz
+    pictorial: 13139
   name:
     first: Patrick
     middle: T.
@@ -12611,6 +12714,7 @@
     icpsr: 20535
     wikidata: Q293343
     google_entity_id: kg:/m/03dlf3
+    pictorial: 13316
   name:
     first: Cathy
     middle: Anne
@@ -12739,6 +12843,7 @@
     wikidata: Q1545391
     google_entity_id: kg:/m/024_3b
     ballotpedia: Gregory Meeks
+    pictorial: 13173
   name:
     first: Gregory
     middle: W.
@@ -12893,6 +12998,7 @@
     icpsr: 20537
     wikidata: Q461698
     google_entity_id: kg:/m/04cvds
+    pictorial: 13325
   name:
     first: Gwen
     last: Moore
@@ -13022,6 +13128,7 @@
     icpsr: 29722
     wikidata: Q1365787
     google_entity_id: kg:/m/024s8t
+    pictorial: 13347
   name:
     first: Jerry
     last: Moran
@@ -13134,6 +13241,7 @@
     icpsr: 40300
     wikidata: Q22360
     google_entity_id: kg:/m/0202kt
+    pictorial: 13345
   name:
     first: Lisa
     middle: A.
@@ -13220,6 +13328,7 @@
     icpsr: 20707
     wikidata: Q1077594
     google_entity_id: kg:/m/0cy_dh
+    pictorial: 13344
   name:
     first: Christopher
     middle: S.
@@ -13299,6 +13408,7 @@
     icpsr: 49308
     wikidata: Q258825
     google_entity_id: kg:/m/018qx5
+    pictorial: 13346
   name:
     first: Patty
     last: Murray
@@ -13400,6 +13510,7 @@
     wikidata: Q505598
     google_entity_id: kg:/m/03tk11
     ballotpedia: Jerrold Nadler
+    pictorial: 13180
   name:
     first: Jerrold
     middle: L.
@@ -13572,6 +13683,7 @@
     wikidata: Q469139
     google_entity_id: kg:/m/024v0s
     ballotpedia: Grace Napolitano
+    pictorial: 12945
   name:
     first: Grace
     middle: F.
@@ -13720,6 +13832,7 @@
     wikidata: Q1464697
     google_entity_id: kg:/m/028vm4
     ballotpedia: Richard Neal
+    pictorial: 13075
   name:
     first: Richard
     middle: E.
@@ -13896,6 +14009,7 @@
     maplight: 390
     wikidata: Q461649
     google_entity_id: kg:/m/01s_vp
+    pictorial: 12980
   name:
     first: Eleanor
     middle: Holmes
@@ -14069,6 +14183,7 @@
     wikidata: Q965289
     google_entity_id: kg:/m/0g6t5w
     ballotpedia: Frank Pallone
+    pictorial: 13155
   name:
     first: Frank
     middle: J.
@@ -14254,6 +14369,7 @@
     icpsr: 41104
     wikidata: Q463557
     google_entity_id: kg:/m/05pdb7q
+    pictorial: 13350
   name:
     first: Rand
     last: Paul
@@ -14322,6 +14438,7 @@
     maplight: 408
     wikidata: Q170581
     google_entity_id: kg:/m/012v1t
+    pictorial: 12925
   name:
     first: Nancy
     last: Pelosi
@@ -14535,6 +14652,7 @@
     lis: S380
     wikidata: Q1494930
     google_entity_id: kg:/m/02x0lnt
+    pictorial: 13351
   name:
     first: Gary
     middle: C.
@@ -14618,6 +14736,7 @@
     icpsr: 20920
     wikidata: Q457243
     google_entity_id: kg:/m/05gflq
+    pictorial: 13092
   name:
     first: Chellie
     last: Pingree
@@ -14732,6 +14851,7 @@
     icpsr: 20909
     wikidata: Q862373
     google_entity_id: kg:/m/0281vxy
+    pictorial: 12989
   name:
     first: Bill
     last: Posey
@@ -14846,6 +14966,7 @@
     icpsr: 20954
     wikidata: Q465767
     google_entity_id: kg:/m/0fccwh
+    pictorial: 13037
   name:
     first: Mike
     last: Quigley
@@ -14960,6 +15081,7 @@
     maplight: 434
     wikidata: Q547153
     google_entity_id: kg:/m/025jnx
+    pictorial: 13067
   name:
     first: Harold
     last: Rogers
@@ -15162,6 +15284,7 @@
     icpsr: 20301
     wikidata: Q693238
     google_entity_id: kg:/m/024n_s
+    pictorial: 12896
   name:
     first: Mike
     last: Rogers
@@ -15297,6 +15420,7 @@
     icpsr: 41102
     wikidata: Q324546
     google_entity_id: kg:/m/0dpr5f
+    pictorial: 13379
   name:
     first: Marco
     last: Rubio
@@ -15362,6 +15486,7 @@
     wikidata: Q981559
     google_entity_id: kg:/m/025k36
     ballotpedia: Dutch Ruppersberger
+    pictorial: 13085
   name:
     first: C.
     middle: A. Dutch
@@ -15496,6 +15621,7 @@
     house_history: 22610
     wikidata: Q3116336
     google_entity_id: kg:/m/04ycmvy
+    pictorial: 13123
   name:
     first: Gregorio
     last: Sablan
@@ -15619,6 +15745,7 @@
     wikidata: Q984509
     google_entity_id: kg:/m/08_r8n
     ballotpedia: John Sarbanes
+    pictorial: 13086
   name:
     first: John
     middle: P.
@@ -15744,6 +15871,7 @@
     house_history: 22608
     wikidata: Q1857141
     google_entity_id: kg:/m/0br34c
+    pictorial: 13069
   name:
     first: Steve
     middle: Joseph
@@ -15890,6 +16018,7 @@
     house_history: 22550
     wikidata: Q440885
     google_entity_id: kg:/m/0256nw
+    pictorial: 13041
   name:
     first: Janice
     middle: D.
@@ -16039,6 +16168,7 @@
     house_history: 22560
     wikidata: Q350843
     google_entity_id: kg:/m/024tls
+    pictorial: 12944
   name:
     first: Adam
     middle: B.
@@ -16183,6 +16313,7 @@
     house_history: 21322
     wikidata: Q380900
     google_entity_id: kg:/m/01w74d
+    pictorial: 13392
   name:
     first: Charles
     middle: E.
@@ -16336,6 +16467,7 @@
     house_history: 22621
     wikidata: Q1176561
     google_entity_id: kg:/m/03wbpxj
+    pictorial: 12906
   name:
     first: David
     last: Schweikert
@@ -16441,6 +16573,7 @@
     house_history: 22631
     wikidata: Q781167
     google_entity_id: kg:/m/076zn3y
+    pictorial: 13017
   name:
     first: Austin
     last: Scott
@@ -16547,6 +16680,7 @@
     house_history: 22574
     wikidata: Q132071
     google_entity_id: kg:/m/0255r4
+    pictorial: 13022
   name:
     first: David
     last: Scott
@@ -16682,6 +16816,7 @@
     house_history: 21368
     wikidata: Q888668
     google_entity_id: kg:/m/03twgl
+    pictorial: 13302
   name:
     first: Robert
     middle: C.
@@ -16851,6 +16986,7 @@
     house_history: 22623
     wikidata: Q561315
     google_entity_id: kg:/m/0c407g6
+    pictorial: 13390
   name:
     first: Tim
     last: Scott
@@ -16942,6 +17078,7 @@
     house_history: 22624
     wikidata: Q461621
     google_entity_id: kg:/m/05pbszt
+    pictorial: 12900
   name:
     first: Terri
     last: Sewell
@@ -17049,6 +17186,7 @@
     wikidata: Q672919
     google_entity_id: kg:/m/024tkr
     ballotpedia: Brad Sherman
+    pictorial: 12946
   name:
     first: Brad
     middle: J.
@@ -17203,6 +17341,7 @@
     house_history: 22556
     wikidata: Q549521
     google_entity_id: kg:/m/0255tn
+    pictorial: 13032
   name:
     first: Michael
     middle: K.
@@ -17352,6 +17491,7 @@
     house_history: 21774
     wikidata: Q350916
     google_entity_id: kg:/m/024zj_
+    pictorial: 13320
   name:
     first: Adam
     last: Smith
@@ -17505,6 +17645,7 @@
     house_history: 22600
     wikidata: Q373443
     google_entity_id: kg:/m/0c505n
+    pictorial: 13147
   name:
     first: Adrian
     last: Smith
@@ -17626,6 +17767,7 @@
     wikidata: Q981167
     google_entity_id: kg:/m/033f4d
     ballotpedia: Chris Smith (New Jersey)
+    pictorial: 13153
   name:
     first: Christopher
     middle: H.
@@ -17829,6 +17971,7 @@
     wikidata: Q291143
     google_entity_id: kg:/m/024xc7
     ballotpedia: Linda Sánchez
+    pictorial: 12952
   name:
     first: Linda
     middle: T.
@@ -17968,6 +18111,7 @@
     wikidata: Q817877
     google_entity_id: kg:/m/033tc5
     ballotpedia: Bennie Thompson
+    pictorial: 13125
   name:
     first: Bennie
     middle: G.
@@ -18134,6 +18278,7 @@
     wikidata: Q1323196
     google_entity_id: kg:/m/024sdl
     ballotpedia: Mike Thompson (California)
+    pictorial: 12918
   name:
     first: Mike
     middle: Michael
@@ -18282,6 +18427,7 @@
     wikidata: Q1531120
     google_entity_id: kg:/m/0409b0_
     ballotpedia: Glenn Thompson (Pennsylvania)
+    pictorial: 13235
   name:
     first: Glenn
     last: Thompson
@@ -18398,6 +18544,7 @@
     house_history: 22937
     wikidata: Q462981
     google_entity_id: kg:/m/03ybyn
+    pictorial: 13370
   name:
     first: John
     last: Thune
@@ -18504,6 +18651,7 @@
     wikidata: Q1373548
     google_entity_id: kg:/m/0gzy4c
     ballotpedia: Paul Tonko
+    pictorial: 13188
   name:
     first: Paul
     last: Tonko
@@ -18619,6 +18767,7 @@
     house_history: 23206
     wikidata: Q505722
     google_entity_id: kg:/m/03440l
+    pictorial: 13204
   name:
     first: Michael
     middle: R.
@@ -18757,6 +18906,7 @@
     google_entity_id: kg:/m/025kb5
     lis: S390
     ballotpedia: Chris Van Hollen
+    pictorial: 13367
   name:
     first: Chris
     last: Van Hollen
@@ -18872,6 +19022,7 @@
     wikidata: Q434890
     google_entity_id: kg:/m/03sjbt
     ballotpedia: Nydia Velazquez
+    pictorial: 13175
   name:
     first: Nydia
     middle: M.
@@ -19032,6 +19183,7 @@
     house_history: 24179
     wikidata: Q978618
     google_entity_id: kg:/m/0d7n3m
+    pictorial: 13098
   name:
     first: Tim
     last: Walberg
@@ -19145,6 +19297,7 @@
     house_history: 24177
     wikidata: Q50104
     google_entity_id: kg:/m/04cmyw
+    pictorial: 13006
   name:
     first: Debbie
     last: Wasserman Schultz
@@ -19272,6 +19425,7 @@
     house_history: 23438
     wikidata: Q461727
     google_entity_id: kg:/m/024tyk
+    pictorial: 12957
   name:
     first: Maxine
     last: Waters
@@ -19444,6 +19598,7 @@
     house_history: 24192
     wikidata: Q1163099
     google_entity_id: kg:/m/03cg47l
+    pictorial: 12992
   name:
     first: Daniel
     last: Webster
@@ -19552,6 +19707,7 @@
     house_history: 24183
     wikidata: Q1112656
     google_entity_id: kg:/m/0db4gl
+    pictorial: 13355
   name:
     first: Peter
     last: Welch
@@ -19674,6 +19830,7 @@
     house_history: 24173
     wikidata: Q928855
     google_entity_id: kg:/m/03tll0
+    pictorial: 13242
   name:
     first: Joe
     middle: G.
@@ -19816,6 +19973,7 @@
     house_history: 24196
     wikidata: Q461504
     google_entity_id: kg:/m/03cg3tv
+    pictorial: 13005
   name:
     first: Frederica
     last: Wilson
@@ -19923,6 +20081,7 @@
     house_history: 24189
     wikidata: Q541251
     google_entity_id: kg:/m/03cx7ld
+    pictorial: 13300
   name:
     first: Robert
     middle: J.
@@ -20045,6 +20204,7 @@
     house_history: 24197
     wikidata: Q1029527
     google_entity_id: kg:/m/0cmcvkz
+    pictorial: 12903
   name:
     first: Steve
     last: Womack
@@ -20153,6 +20313,7 @@
     house_history: 24150
     wikidata: Q529344
     google_entity_id: kg:/m/0178p9
+    pictorial: 13375
   name:
     first: Ron
     last: Wyden
@@ -20288,6 +20449,7 @@
     wikidata: Q25483
     google_entity_id: kg:/m/0ds030m
     lis: S391
+    pictorial: 13374
   name:
     first: Todd
     middle: C.
@@ -20377,6 +20539,7 @@
     icpsr: 21196
     wikidata: Q23944
     google_entity_id: kg:/m/03bzdkn
+    pictorial: 13166
   name:
     first: Mark
     middle: E.
@@ -20485,6 +20648,7 @@
     icpsr: 21198
     wikidata: Q45946
     google_entity_id: kg:/m/02q453x
+    pictorial: 13215
   name:
     first: Suzanne
     last: Bonamici
@@ -20591,6 +20755,7 @@
     house_history: 15032387032
     wikidata: Q2091892
     google_entity_id: kg:/m/05p0dnk
+    pictorial: 13312
   name:
     first: Suzan
     middle: K.
@@ -20696,6 +20861,7 @@
     icpsr: 31102
     wikidata: Q2426031
     google_entity_id: kg:/m/0h_cb6v
+    pictorial: 13066
   name:
     first: Thomas
     last: Massie
@@ -20802,6 +20968,7 @@
     icpsr: 41112
     wikidata: Q1827902
     google_entity_id: kg:/m/0dd109
+    pictorial: 13380
   name:
     first: Brian
     middle: Emanuel
@@ -20884,6 +21051,7 @@
     icpsr: 20749
     wikidata: Q2903389
     google_entity_id: kg:/m/02rq8nc
+    pictorial: 13043
   name:
     first: Bill
     last: Foster
@@ -20993,6 +21161,7 @@
     house_history: 23215
     wikidata: Q524440
     google_entity_id: kg:/m/07hwl2
+    pictorial: 13165
   name:
     first: Dina
     last: Titus
@@ -21094,6 +21263,7 @@
     lis: S374
     wikidata: Q3090307
     google_entity_id: kg:/m/02g3ds
+    pictorial: 13407
   name:
     first: Tom
     last: Cotton
@@ -21156,6 +21326,7 @@
     house_history: 15032387755
     wikidata: Q1556541
     google_entity_id: kg:/m/03qnndb
+    pictorial: 13387
   name:
     first: Kyrsten
     last: Sinema
@@ -21239,6 +21410,7 @@
     icpsr: 21302
     wikidata: Q1703840
     google_entity_id: kg:/m/0288tnx
+    pictorial: 12915
   name:
     first: Doug
     last: LaMalfa
@@ -21333,6 +21505,7 @@
     icpsr: 21303
     wikidata: Q3276717
     google_entity_id: kg:/m/0ksfyx
+    pictorial: 12916
   name:
     first: Jared
     last: Huffman
@@ -21427,6 +21600,7 @@
     icpsr: 21304
     wikidata: Q3389105
     google_entity_id: kg:/m/0dgqnts
+    pictorial: 12920
   name:
     first: Ami
     last: Bera
@@ -21521,6 +21695,7 @@
     icpsr: 21306
     wikidata: Q3466996
     google_entity_id: kg:/m/0ncq55g
+    pictorial: 12928
   name:
     first: Eric
     last: Swalwell
@@ -21607,6 +21782,7 @@
     house_history: 15032386871
     wikidata: Q3577073
     google_entity_id: kg:/m/027z42z
+    pictorial: 12940
   name:
     first: Julia
     last: Brownley
@@ -21701,6 +21877,7 @@
     icpsr: 21309
     wikidata: Q3620422
     google_entity_id: kg:/m/0cgzsw
+    pictorial: 12943
   name:
     first: Tony
     last: Cárdenas
@@ -21795,6 +21972,7 @@
     icpsr: 21311
     wikidata: Q3701994
     google_entity_id: kg:/m/02p8pz0
+    pictorial: 12939
   name:
     first: Raul
     last: Ruiz
@@ -21888,6 +22066,7 @@
     icpsr: 21312
     wikidata: Q399593
     google_entity_id: kg:/m/0k3lj_y
+    pictorial: 12953
   name:
     first: Mark
     last: Takano
@@ -21981,6 +22160,7 @@
     icpsr: 21314
     wikidata: Q3791701
     google_entity_id: kg:/m/076bp4
+    pictorial: 12966
   name:
     first: Juan
     last: Vargas
@@ -22075,6 +22255,7 @@
     icpsr: 21315
     wikidata: Q3791514
     google_entity_id: kg:/m/02rymxd
+    pictorial: 12964
   name:
     first: Scott
     last: Peters
@@ -22172,6 +22353,7 @@
     house_history: 15032387115
     wikidata: Q3182451
     google_entity_id: kg:/m/0gjdw8_
+    pictorial: 13003
   name:
     first: Lois
     last: Frankel
@@ -22269,6 +22451,7 @@
     wikidata: Q3036410
     google_entity_id: kg:/m/09vqjr
     lis: S386
+    pictorial: 13439
   name:
     first: Tammy
     last: Duckworth
@@ -22340,6 +22523,7 @@
     icpsr: 21333
     wikidata: Q3828645
     google_entity_id: kg:/m/0ddc6r6
+    pictorial: 13068
   name:
     first: Garland
     last: Barr
@@ -22434,6 +22618,7 @@
     house_history: 15032390639
     wikidata: Q434706
     google_entity_id: kg:/m/01qh39
+    pictorial: 13378
   name:
     first: Elizabeth
     last: Warren
@@ -22489,6 +22674,7 @@
     icpsr: 41300
     wikidata: Q544464
     google_entity_id: kg:/m/02hfx0
+    pictorial: 13432
   name:
     first: Angus
     middle: S.
@@ -22543,6 +22729,7 @@
     icpsr: 21372
     wikidata: Q3880272
     google_entity_id: kg:/m/0n4c3yt
+    pictorial: 13101
   name:
     first: Daniel
     last: Kildee
@@ -22641,6 +22828,7 @@
     house_history: 15032387908
     wikidata: Q3917251
     google_entity_id: kg:/m/07q9w8
+    pictorial: 13116
   name:
     first: Ann
     last: Wagner
@@ -22735,6 +22923,7 @@
     lis: S375
     wikidata: Q3200900
     google_entity_id: kg:/m/03qlc5t
+    pictorial: 13401
   name:
     first: Steve
     last: Daines
@@ -22799,6 +22988,7 @@
     icpsr: 21346
     wikidata: Q3956999
     google_entity_id: kg:/m/0nbwfxs
+    pictorial: 13138
   name:
     first: Richard
     last: Hudson
@@ -22901,6 +23091,7 @@
     wikidata: Q3957020
     google_entity_id: kg:/m/02rhrnw
     lis: S398
+    pictorial: 13408
   name:
     first: Kevin
     last: Cramer
@@ -22976,6 +23167,7 @@
     house_history: 15032390640
     wikidata: Q2580649
     google_entity_id: kg:/m/0c4cp0
+    pictorial: 13438
   name:
     first: Deb
     last: Fischer
@@ -23027,6 +23219,7 @@
     house_history: 15032387341
     wikidata: Q3917208
     google_entity_id: kg:/m/064p47_
+    pictorial: 13149
   name:
     first: Ann
     last: Kuster
@@ -23123,6 +23316,7 @@
     house_history: 15032387500
     wikidata: Q5591303
     google_entity_id: kg:/m/04ld76x
+    pictorial: 13174
   name:
     first: Grace
     last: Meng
@@ -23216,6 +23410,7 @@
     icpsr: 21343
     wikidata: Q5640425
     google_entity_id: kg:/m/025_74m
+    pictorial: 13176
   name:
     first: Hakeem
     last: Jeffries
@@ -23320,6 +23515,7 @@
     icpsr: 21351
     wikidata: Q892413
     google_entity_id: kg:/m/0j63b7n
+    pictorial: 13196
   name:
     first: Brad
     last: Wenstrup
@@ -23409,6 +23605,7 @@
     house_history: 15032386867
     wikidata: Q976417
     google_entity_id: kg:/m/03lcwb
+    pictorial: 13197
   name:
     first: Joyce
     last: Beatty
@@ -23502,6 +23699,7 @@
     icpsr: 21353
     wikidata: Q976778
     google_entity_id: kg:/m/0ktwnp_
+    pictorial: 13208
   name:
     first: David
     last: Joyce
@@ -23598,6 +23796,7 @@
     icpsr: 21355
     wikidata: Q3448772
     google_entity_id: kg:/m/0lq78pn
+    pictorial: 13425
   name:
     first: Markwayne
     last: Mullin
@@ -23693,6 +23892,7 @@
     icpsr: 21356
     wikidata: Q7437040
     google_entity_id: kg:/m/04mwt6y
+    pictorial: 13230
   name:
     first: Scott
     last: Perry
@@ -23787,6 +23987,7 @@
     icpsr: 21358
     wikidata: Q4111531
     google_entity_id: kg:/m/0j_6b9d
+    pictorial: 13228
   name:
     first: Matthew
     middle: A.
@@ -23884,6 +24085,7 @@
     icpsr: 41304
     wikidata: Q2036942
     google_entity_id: kg:/m/07j6ty
+    pictorial: 13402
   name:
     first: Ted
     last: Cruz
@@ -23932,6 +24134,7 @@
     icpsr: 21360
     wikidata: Q4014569
     google_entity_id: kg:/m/0km63t0
+    pictorial: 13271
   name:
     first: Randy
     last: Weber
@@ -24028,6 +24231,7 @@
     icpsr: 21362
     wikidata: Q1167934
     google_entity_id: kg:/m/0bmclg
+    pictorial: 13277
   name:
     first: Joaquin
     last: Castro
@@ -24123,6 +24327,7 @@
     icpsr: 21364
     wikidata: Q4014560
     google_entity_id: kg:/m/08rszb
+    pictorial: 13282
   name:
     first: Roger
     last: Williams
@@ -24217,6 +24422,7 @@
     icpsr: 21365
     wikidata: Q4068811
     google_entity_id: kg:/m/0kmnfw5
+    pictorial: 13290
   name:
     first: Marc
     last: Veasey
@@ -24312,6 +24518,7 @@
     icpsr: 41305
     wikidata: Q359888
     google_entity_id: kg:/m/053f8h
+    pictorial: 13434
   name:
     first: Timothy
     nickname: Tim
@@ -24363,6 +24570,7 @@
     icpsr: 21368
     wikidata: Q4068828
     google_entity_id: kg:/m/03w9yd6
+    pictorial: 13317
   name:
     first: Derek
     last: Kilmer
@@ -24454,6 +24662,7 @@
     icpsr: 21370
     wikidata: Q1900355
     google_entity_id: kg:/m/0gyhpz
+    pictorial: 13323
   name:
     first: Mark
     last: Pocan
@@ -24549,6 +24758,7 @@
     maplight: 2045
     wikidata: Q3437091
     google_entity_id: kg:/m/0g8l32
+    pictorial: 13034
   name:
     first: Robin
     middle: L.
@@ -24644,6 +24854,7 @@
     icpsr: 21373
     wikidata: Q6163589
     google_entity_id: kg:/m/0g9yj_2
+    pictorial: 13122
   name:
     first: Jason
     middle: T.
@@ -24740,6 +24951,7 @@
     wikidata: Q1135767
     google_entity_id: kg:/m/06p430
     icpsr: 41308
+    pictorial: 13421
   name:
     first: Cory
     middle: Anthony
@@ -24806,6 +25018,7 @@
     wikidata: Q6376330
     google_entity_id: kg:/m/0fpjc8b
     icpsr: 21375
+    pictorial: 13079
   name:
     first: Katherine
     middle: M.
@@ -24903,6 +25116,7 @@
     google_entity_id: kg:/m/09g8b1_
     votesmart: 116277
     icpsr: 21536
+    pictorial: 13150
   name:
     first: Donald
     middle: W.
@@ -24992,6 +25206,7 @@
     google_entity_id: kg:/m/02b45d
     votesmart: 5935
     icpsr: 21545
+    pictorial: 13141
   name:
     first: Alma
     middle: S.
@@ -25080,6 +25295,7 @@
     cspan: 76094
     icpsr: 21500
     ballotpedia: Gary Palmer
+    pictorial: 12899
   name:
     first: Gary
     middle: J.
@@ -25168,6 +25384,7 @@
     cspan: 9265172
     icpsr: 21503
     ballotpedia: French Hill
+    pictorial: 12902
   name:
     first: J.
     middle: French
@@ -25244,6 +25461,7 @@
     cspan: 76097
     icpsr: 21563
     ballotpedia: Bruce Westerman
+    pictorial: 12904
   name:
     first: Bruce
     last: Westerman
@@ -25317,6 +25535,7 @@
     icpsr: 21502
     votesmart: 123732
     ballotpedia: Ruben Gallego
+    pictorial: 12908
   name:
     first: Ruben
     last: Gallego
@@ -25390,6 +25609,7 @@
     icpsr: 21504
     votesmart: 69477
     ballotpedia: Mark DeSaulnier
+    pictorial: 12924
   name:
     first: Mark
     last: DeSaulnier
@@ -25465,6 +25685,7 @@
     cspan: 79994
     icpsr: 21506
     ballotpedia: Pete Aguilar
+    pictorial: 12947
   name:
     first: Pete
     last: Aguilar
@@ -25548,6 +25769,7 @@
     icpsr: 21507
     votesmart: 1516
     ballotpedia: Ted Lieu
+    pictorial: 12950
   name:
     first: Ted
     last: Lieu
@@ -25624,6 +25846,7 @@
     icpsr: 21508
     votesmart: 71284
     ballotpedia: Norma Torres
+    pictorial: 12949
   name:
     first: Norma
     middle: J.
@@ -25700,6 +25923,7 @@
     cspan: 76158
     icpsr: 21513
     ballotpedia: Earl "Buddy" Carter
+    pictorial: 13010
   name:
     first: Earl
     middle: L.
@@ -25777,6 +26001,7 @@
     cspan: 76165
     icpsr: 21515
     ballotpedia: Barry Loudermilk
+    pictorial: 13020
   name:
     first: Barry
     last: Loudermilk
@@ -25852,6 +26077,7 @@
     cspan: 62545
     icpsr: 21516
     ballotpedia: Rick Allen
+    pictorial: 13021
   name:
     first: Rick
     middle: W.
@@ -25928,6 +26154,7 @@
     icpsr: 21519
     votesmart: 6302
     ballotpedia: Mike Bost
+    pictorial: 13044
   name:
     first: Mike
     last: Bost
@@ -26003,6 +26230,7 @@
     cspan: 9274609
     icpsr: 21523
     ballotpedia: Garret Graves
+    pictorial: 13074
   name:
     first: Garret
     last: Graves
@@ -26078,6 +26306,7 @@
     ballotpedia: Seth Moulton
     cspan: 78453
     icpsr: 21525
+    pictorial: 13080
   name:
     first: Seth
     last: Moulton
@@ -26153,6 +26382,7 @@
     cspan: 76660
     icpsr: 21526
     ballotpedia: John Moolenaar
+    pictorial: 13095
   name:
     first: John
     middle: R.
@@ -26230,6 +26460,7 @@
     cspan: 20818
     icpsr: 21529
     ballotpedia: Debbie Dingell
+    pictorial: 13099
   name:
     first: Debbie
     last: Dingell
@@ -26305,6 +26536,7 @@
     cspan: 75567
     icpsr: 21531
     ballotpedia: Tom Emmer
+    pictorial: 13112
   name:
     first: Tom
     last: Emmer
@@ -26384,6 +26616,7 @@
     cspan: 79710
     icpsr: 21544
     ballotpedia: David Rouzer
+    pictorial: 13136
   name:
     first: David
     last: Rouzer
@@ -26459,6 +26692,7 @@
     votesmart: 24799
     cspan: 79091
     icpsr: 21538
+    pictorial: 13161
   name:
     first: Bonnie
     last: Watson Coleman
@@ -26535,6 +26769,7 @@
     cspan: 76364
     icpsr: 21541
     ballotpedia: Elise Stefanik
+    pictorial: 13189
   name:
     first: Elise
     middle: M.
@@ -26619,6 +26854,7 @@
     cspan: 76428
     icpsr: 21548
     ballotpedia: Brendan Boyle
+    pictorial: 13222
   name:
     first: Brendan
     middle: F.
@@ -26695,6 +26931,7 @@
     cspan: 44883
     icpsr: 21551
     ballotpedia: Brian Babin
+    pictorial: 13293
   name:
     first: Brian
     last: Babin
@@ -26770,6 +27007,7 @@
     cspan: 21141
     icpsr: 21554
     ballotpedia: Don Beyer
+    pictorial: 13306
   name:
     first: Donald
     middle: S.
@@ -26846,6 +27084,7 @@
     google_entity_id: kg:/m/012844_c
     cspan: 79090
     votesmart: 155929
+    pictorial: 13310
   name:
     first: Stacey
     middle: E.
@@ -26922,6 +27161,7 @@
     cspan: 78315
     icpsr: 21556
     ballotpedia: Dan Newhouse
+    pictorial: 13315
   name:
     first: Dan
     last: Newhouse
@@ -26997,6 +27237,7 @@
     cspan: 77282
     icpsr: 21559
     ballotpedia: Glenn Grothman
+    pictorial: 13327
   name:
     first: Glenn
     last: Grothman
@@ -27072,6 +27313,7 @@
     icpsr: 21557
     votesmart: 145943
     ballotpedia: Alexander Mooney
+    pictorial: 13331
   name:
     first: Alexander
     middle: X.
@@ -27148,6 +27390,7 @@
     cspan: 5188
     votesmart: 128380
     ballotpedia: Amata Radewagen
+    pictorial: 12905
   name:
     first: Aumua Amata
     last: Radewagen
@@ -27225,6 +27468,7 @@
     cspan: 1023262
     icpsr: 41500
     ballotpedia: Daniel S. Sullivan
+    pictorial: 13368
   name:
     first: Dan
     last: Sullivan
@@ -27274,6 +27518,7 @@
     cspan: 75342
     icpsr: 41502
     ballotpedia: Joni Ernst
+    pictorial: 13437
   name:
     first: Joni
     last: Ernst
@@ -27334,6 +27579,7 @@
     cspan: 77055
     icpsr: 41504
     ballotpedia: Thom Tillis (North Carolina)
+    pictorial: 13369
   name:
     first: Thom
     last: Tillis
@@ -27382,6 +27628,7 @@
     cspan: 78317
     icpsr: 41505
     ballotpedia: Mike Rounds
+    pictorial: 13384
   name:
     first: Mike
     last: Rounds
@@ -27429,6 +27676,7 @@
     google_entity_id: kg:/m/013b9qgh
     cspan: 97322
     icpsr: 21561
+    pictorial: 13124
   name:
     first: Trent
     last: Kelly
@@ -27504,6 +27752,7 @@
     google_entity_id: kg:/m/0gg7rcy
     cspan: 70020
     icpsr: 21562
+    pictorial: 13048
   name:
     first: Darin
     last: LaHood
@@ -27578,6 +27827,7 @@
     google_entity_id: kg:/g/11cmmch3q8
     cspan: 102555
     icpsr: 21564
+    pictorial: 13202
   name:
     first: Warren
     last: Davidson
@@ -27649,6 +27899,7 @@
     votesmart: 35169
     maplight: 2166
     icpsr: 21565
+    pictorial: 13063
   name:
     first: James
     last: Comer
@@ -27727,6 +27978,7 @@
     votesmart: 9128
     maplight: 2167
     icpsr: 21566
+    pictorial: 13223
   name:
     first: Dwight
     last: Evans
@@ -27806,6 +28058,7 @@
     google_entity_id: kg:/m/0fl2sv
     cspan: 1011723
     icpsr: 41703
+    pictorial: 13429
   name:
     first: John
     middle: Neely
@@ -27854,6 +28107,7 @@
     maplight: 2192
     cspan: 67481
     icpsr: 41702
+    pictorial: 13426
   name:
     first: Margaret
     middle: Wood
@@ -27903,6 +28157,7 @@
     maplight: 2193
     cspan: 105698
     icpsr: 41700
+    pictorial: 13404
   name:
     first: Catherine
     last: Cortez Masto
@@ -27954,6 +28209,7 @@
     icpsr: 21326
     wikidata: Q2923426
     google_entity_id: kg:/m/0j63zyv
+    pictorial: 13042
   name:
     first: Bradley
     last: Schneider
@@ -28035,6 +28291,7 @@
     cspan: 105145
     icpsr: 21705
     ballotpedia: Andy Biggs
+    pictorial: 12910
   name:
     first: Andy
     last: Biggs
@@ -28097,6 +28354,7 @@
     cspan: 31129
     icpsr: 21728
     ballotpedia: Ro Khanna
+    pictorial: 12931
   name:
     first: Ro
     last: Khanna
@@ -28159,6 +28417,7 @@
     cspan: 104727
     icpsr: 21740
     ballotpedia: Jimmy Panetta
+    pictorial: 12933
   name:
     first: Jimmy
     last: Panetta
@@ -28221,6 +28480,7 @@
     cspan: 104728
     icpsr: 21709
     ballotpedia: Salud Carbajal
+    pictorial: 12938
   name:
     first: Salud
     middle: O.
@@ -28284,6 +28544,7 @@
     cspan: 104730
     icpsr: 21703
     ballotpedia: Nanette Barragán
+    pictorial: 12958
   name:
     first: Nanette
     middle: Diaz
@@ -28347,6 +28608,7 @@
     cspan: 46310
     icpsr: 21711
     ballotpedia: Lou Correa
+    pictorial: 12960
   name:
     first: J.
     middle: Luis
@@ -28410,6 +28672,7 @@
     cspan: 104772
     icpsr: 21706
     ballotpedia: Lisa Blunt Rochester
+    pictorial: 12981
   name:
     first: Lisa
     last: Blunt Rochester
@@ -28472,6 +28735,7 @@
     cspan: 104528
     icpsr: 21719
     ballotpedia: Matt Gaetz
+    pictorial: 12982
   name:
     first: Matt
     last: Gaetz
@@ -28534,6 +28798,7 @@
     cspan: 104529
     icpsr: 21714
     ballotpedia: Neal Dunn
+    pictorial: 12983
   name:
     first: Neal
     middle: P.
@@ -28597,6 +28862,7 @@
     cspan: 104531
     icpsr: 21744
     ballotpedia: John Rutherford (Florida)
+    pictorial: 12986
   name:
     first: John
     middle: H.
@@ -28660,6 +28926,7 @@
     cspan: 104534
     icpsr: 21746
     ballotpedia: Darren Soto
+    pictorial: 12990
   name:
     first: Darren
     last: Soto
@@ -28722,6 +28989,7 @@
     ballotpedia: Brian Mast
     cspan: 104540
     icpsr: 21735
+    pictorial: 13002
   name:
     first: Brian
     middle: J.
@@ -28785,6 +29053,7 @@
     cspan: 104731
     icpsr: 21717
     ballotpedia: Drew Ferguson
+    pictorial: 13012
   name:
     first: A.
     middle: Drew
@@ -28849,6 +29118,7 @@
     cspan: 103408
     icpsr: 21730
     ballotpedia: Raja Krishnamoorthi
+    pictorial: 13040
   name:
     first: Raja
     last: Krishnamoorthi
@@ -28911,6 +29181,7 @@
     ballotpedia: Jim Banks
     cspan: 89806
     icpsr: 21702
+    pictorial: 13052
   name:
     first: Jim
     last: Banks
@@ -29029,6 +29300,7 @@
     cspan: 106094
     icpsr: 21724
     ballotpedia: Clay Higgins
+    pictorial: 13071
   name:
     first: Clay
     last: Higgins
@@ -29091,6 +29363,7 @@
     cspan: 106095
     icpsr: 21727
     ballotpedia: Mike Johnson (Louisiana)
+    pictorial: 13072
   name:
     first: Mike
     last: Johnson
@@ -29162,6 +29435,7 @@
     cspan: 12924
     icpsr: 21741
     ballotpedia: Jamie Raskin
+    pictorial: 13091
   name:
     first: Jamie
     last: Raskin
@@ -29224,6 +29498,7 @@
     cspan: 1020529
     icpsr: 21704
     ballotpedia: Jack Bergman
+    pictorial: 13094
   name:
     first: Jack
     last: Bergman
@@ -29287,6 +29562,7 @@
     cspan: 103513
     icpsr: 21708
     ballotpedia: Ted Budd
+    pictorial: 13415
   name:
     first: Ted
     last: Budd
@@ -29351,6 +29627,7 @@
     cspan: 103442
     icpsr: 21701
     ballotpedia: Don Bacon
+    pictorial: 13146
   name:
     first: Don
     last: Bacon
@@ -29413,6 +29690,7 @@
     cspan: 9275683
     icpsr: 21723
     ballotpedia: Josh Gottheimer
+    pictorial: 13154
   name:
     first: Josh
     last: Gottheimer
@@ -29476,6 +29754,7 @@
     google_entity_id: kg:/g/11cntnvwkg
     cspan: 104738
     icpsr: 21743
+    pictorial: 13386
   name:
     first: Jacky
     last: Rosen
@@ -29520,6 +29799,7 @@
     cspan: 68413
     icpsr: 21715
     ballotpedia: Adriano Espaillat
+    pictorial: 13181
   name:
     first: Adriano
     last: Espaillat
@@ -29583,6 +29863,7 @@
     cspan: 103537
     icpsr: 21718
     ballotpedia: Brian Fitzpatrick
+    pictorial: 13221
   name:
     first: Brian
     middle: K.
@@ -29646,6 +29927,7 @@
     cspan: 103540
     icpsr: 21745
     ballotpedia: Lloyd Smucker
+    pictorial: 13231
   name:
     first: Lloyd
     last: Smucker
@@ -29705,6 +29987,7 @@
     maplight: 2235
     google_entity_id: kg:/m/027s3vf
     cspan: 67353
+    pictorial: 13238
   name:
     first: Jenniffer
     last: González-Colón
@@ -29757,6 +30040,7 @@
     cspan: 28903
     icpsr: 21731
     ballotpedia: David Kustoff
+    pictorial: 13256
   name:
     first: David
     last: Kustoff
@@ -29819,6 +30103,7 @@
     cspan: 103568
     icpsr: 21722
     ballotpedia: Vicente Gonzalez Jr.
+    pictorial: 13291
   name:
     first: Vicente
     last: Gonzalez
@@ -29881,6 +30166,7 @@
     cspan: 1016482
     icpsr: 21700
     ballotpedia: Jodey Arrington
+    pictorial: 13276
   name:
     first: Jodey
     middle: C.
@@ -29944,6 +30230,7 @@
     cspan: 9267128
     icpsr: 21726
     ballotpedia: Pramila Jayapal
+    pictorial: 13318
   name:
     first: Pramila
     last: Jayapal
@@ -30007,6 +30294,7 @@
     google_entity_id: kg:/m/0gfgsrm
     opensecrets: N00040712
     icpsr: 21750
+    pictorial: 13062
   name:
     first: Ron
     last: Estes
@@ -30071,6 +30359,7 @@
     house_history: 15032448994
     maplight: 2248
     icpsr: 21753
+    pictorial: 13245
   name:
     first: Ralph
     last: Norman
@@ -30135,6 +30424,7 @@
     house_history: 15032449022
     maplight: 2250
     icpsr: 21754
+    pictorial: 12948
   name:
     first: Jimmy
     last: Gomez
@@ -30196,6 +30486,7 @@
     google_entity_id: kg:/m/0bmdhtb
     maplight: 2251
     icpsr: 21755
+    pictorial: 13298
   name:
     first: John
     middle: R.
@@ -30260,6 +30551,7 @@
     google_entity_id: kg:/m/0127xvy3
     maplight: 2253
     opensecrets: N00042353
+    pictorial: 13389
   name:
     first: Tina
     middle: Flint
@@ -30321,6 +30613,7 @@
     icpsr: 41707
     google_entity_id: kg:/m/03wc2px
     opensecrets: N00043298
+    pictorial: 13424
   name:
     first: Cindy
     last: Hyde-Smith
@@ -30379,6 +30672,7 @@
     google_entity_id: kg:/m/0zwmkgq
     votesmart: 106483
     icpsr: 21757
+    pictorial: 12913
   name:
     first: Debbie
     last: Lesko
@@ -30440,6 +30734,7 @@
     votesmart: 177350
     icpsr: 21758
     google_entity_id: kg:/g/11f6y3n6vk
+    pictorial: 13284
   name:
     first: Michael
     last: Cloud
@@ -30500,6 +30795,7 @@
     google_entity_id: kg:/m/09ry4tm
     votesmart: 102781
     icpsr: 21759
+    pictorial: 13206
   name:
     first: Troy
     last: Balderson
@@ -30560,6 +30856,7 @@
     votesmart: 180004
     icpsr: 21760
     google_entity_id: kg:/g/11gzqw48lf
+    pictorial: 13210
   name:
     first: Kevin
     middle: R.
@@ -30621,6 +30918,7 @@
     google_entity_id: kg:/m/03d820m
     votesmart: 4362
     icpsr: 21761
+    pictorial: 13193
   name:
     first: Joseph
     middle: D.
@@ -30682,6 +30980,7 @@
     votesmart: 178890
     icpsr: 21762
     google_entity_id: kg:/g/11gtg87gkn
+    pictorial: 13225
   name:
     first: Mary
     middle: Gay
@@ -30743,6 +31042,7 @@
     votesmart: 178895
     icpsr: 21763
     google_entity_id: kg:/g/11gtg86jn6
+    pictorial: 13227
   name:
     first: Susan
     middle: Ellis
@@ -30805,6 +31105,7 @@
     wikidata: Q597613
     google_entity_id: kg:/m/0255s6
     ballotpedia: Ed Case
+    pictorial: 13025
   name:
     first: Ed
     last: Case
@@ -30872,6 +31173,7 @@
     icpsr: 21339
     wikidata: Q3514907
     google_entity_id: kg:/m/03c01w9
+    pictorial: 13168
   name:
     first: Steven
     last: Horsford
@@ -30938,6 +31240,7 @@
     votesmart: 72030
     icpsr: 21968
     ballotpedia: Greg Stanton
+    pictorial: 12909
   name:
     first: Greg
     last: Stanton
@@ -30988,6 +31291,7 @@
     ballotpedia: Josh Harder
     icpsr: 21930
     google_entity_id: kg:/g/11fhwknffg
+    pictorial: 12923
   name:
     first: Josh
     last: Harder
@@ -31038,6 +31342,7 @@
     icpsr: 21954
     ballotpedia: Katie Porter
     google_entity_id: kg:/g/11fkr56zm6
+    pictorial: 12961
   name:
     first: Katie
     last: Porter
@@ -31087,6 +31392,7 @@
     votesmart: 179416
     icpsr: 21939
     google_entity_id: kg:/g/11gfd5mdpc
+    pictorial: 12963
   name:
     first: Mike
     last: Levin
@@ -31137,6 +31443,7 @@
     icpsr: 21948
     ballotpedia: Joe Neguse
     google_entity_id: kg:/g/11gnsnch0m
+    pictorial: 12968
   name:
     first: Joe
     last: Neguse
@@ -31187,6 +31494,7 @@
     icpsr: 21912
     ballotpedia: Jason Crow
     google_entity_id: kg:/g/11gzqdw_wg
+    pictorial: 12972
   name:
     first: Jason
     last: Crow
@@ -31237,6 +31545,7 @@
     icpsr: 21931
     ballotpedia: Jahana Hayes
     google_entity_id: kg:/g/11cn8wstn6
+    pictorial: 12979
   name:
     first: Jahana
     last: Hayes
@@ -31287,6 +31596,7 @@
     google_entity_id: kg:/g/11f50xlkjm
     ballotpedia: Michael Waltz
     votesmart: 182261
+    pictorial: 12987
   name:
     first: Michael
     last: Waltz
@@ -31337,6 +31647,7 @@
     votesmart: 117248
     icpsr: 21971
     ballotpedia: Greg Steube
+    pictorial: 12998
   name:
     first: W.
     middle: Gregory
@@ -31388,6 +31699,7 @@
     votesmart: 178538
     icpsr: 21944
     ballotpedia: Lucy McBath
+    pictorial: 13016
   name:
     first: Lucy
     last: McBath
@@ -31438,6 +31750,7 @@
     votesmart: 33091
     icpsr: 21920
     ballotpedia: Russ Fulcher
+    pictorial: 13031
   name:
     first: Russ
     last: Fulcher
@@ -31488,6 +31801,7 @@
     votesmart: 6261
     icpsr: 21921
     ballotpedia: Jesus Garcia
+    pictorial: 13036
   name:
     first: Jesús
     middle: G.
@@ -31540,6 +31854,7 @@
     google_entity_id: kg:/g/11hc_0775g
     ballotpedia: Sean Casten
     votesmart: 176982
+    pictorial: 13038
   name:
     first: Sean
     last: Casten
@@ -31589,6 +31904,7 @@
     votesmart: 177001
     icpsr: 21979
     google_entity_id: kg:/g/11gfm73_1z
+    pictorial: 13046
   name:
     first: Lauren
     last: Underwood
@@ -31639,6 +31955,7 @@
     icpsr: 21903
     ballotpedia: James Baird
     google_entity_id: kg:/g/11gfd5wndr
+    pictorial: 13053
   name:
     first: James
     middle: R.
@@ -31690,6 +32007,7 @@
     icpsr: 21952
     ballotpedia: Greg Pence
     google_entity_id: kg:/g/11gh5qt6_p
+    pictorial: 13055
   name:
     first: Greg
     last: Pence
@@ -31740,6 +32058,7 @@
     ballotpedia: Sharice Davids
     icpsr: 21914
     google_entity_id: kg:/g/11fgm1fq16
+    pictorial: 13061
   name:
     first: Sharice
     last: Davids
@@ -31790,6 +32109,7 @@
     icpsr: 21977
     ballotpedia: Lori Trahan
     google_entity_id: kg:/g/11gtcg496z
+    pictorial: 13077
   name:
     first: Lori
     last: Trahan
@@ -31840,6 +32160,7 @@
     votesmart: 122700
     icpsr: 21955
     ballotpedia: Ayanna Pressley
+    pictorial: 13081
   name:
     first: Ayanna
     last: Pressley
@@ -31890,6 +32211,7 @@
     icpsr: 21978
     ballotpedia: David Trone
     google_entity_id: kg:/g/11dxnzbmvl
+    pictorial: 13089
   name:
     first: David
     middle: J.
@@ -31941,6 +32263,7 @@
     ballotpedia: Elissa Slotkin
     icpsr: 21965
     google_entity_id: kg:/g/11dfr3z7r1
+    pictorial: 13100
   name:
     first: Elissa
     last: Slotkin
@@ -31991,6 +32314,7 @@
     ballotpedia: Haley Stevens
     icpsr: 21972
     google_entity_id: kg:/g/11fjw095g8
+    pictorial: 13104
   name:
     first: Haley
     middle: M.
@@ -32042,6 +32366,7 @@
     votesmart: 105368
     icpsr: 21975
     ballotpedia: Rashida Tlaib
+    pictorial: 13105
   name:
     first: Rashida
     last: Tlaib
@@ -32092,6 +32417,7 @@
     ballotpedia: Angie Craig
     icpsr: 21910
     google_entity_id: kg:/g/11fjb43ny7
+    pictorial: 13108
   name:
     first: Angie
     last: Craig
@@ -32142,6 +32468,7 @@
     icpsr: 21953
     ballotpedia: Dean Phillips
     google_entity_id: kg:/g/11fg48_c9t
+    pictorial: 13109
   name:
     first: Dean
     last: Phillips
@@ -32192,6 +32519,7 @@
     icpsr: 21950
     ballotpedia: Ilhan Omar
     google_entity_id: kg:/g/11c4wx5dm0
+    pictorial: 13111
   name:
     first: Ilhan
     last: Omar
@@ -32242,6 +32570,7 @@
     icpsr: 21969
     ballotpedia: Pete Stauber
     google_entity_id: kg:/g/11gjy6v3nv
+    pictorial: 13114
   name:
     first: Pete
     last: Stauber
@@ -32291,6 +32620,7 @@
     icpsr: 21927
     google_entity_id: kg:/g/11fjx_n80p
     ballotpedia: Michael Guest
+    pictorial: 13126
   name:
     first: Michael
     last: Guest
@@ -32341,6 +32671,7 @@
     icpsr: 21901
     ballotpedia: Kelly Armstrong
     google_entity_id: kg:/g/11hcszksh3
+    pictorial: 13144
   name:
     first: Kelly
     last: Armstrong
@@ -32391,6 +32722,7 @@
     icpsr: 21951
     votesmart: 42635
     ballotpedia: Chris Pappas
+    pictorial: 13148
   name:
     first: Chris
     last: Pappas
@@ -32441,6 +32773,7 @@
     votesmart: 24685
     icpsr: 21980
     ballotpedia: Jeff Van Drew
+    pictorial: 13151
   name:
     first: Jefferson
     last: Van Drew
@@ -32498,6 +32831,7 @@
     google_entity_id: kg:/g/11f730yxds
     ballotpedia: Andrew Kim (New Jersey)
     votesmart: 179640
+    pictorial: 13152
   name:
     first: Andy
     last: Kim
@@ -32548,6 +32882,7 @@
     ballotpedia: Mikie Sherrill
     icpsr: 21964
     google_entity_id: kg:/g/11f3r4x6x5
+    pictorial: 13160
   name:
     first: Mikie
     last: Sherrill
@@ -32598,6 +32933,7 @@
     icpsr: 21938
     ballotpedia: Susie Lee
     google_entity_id: kg:/g/11gtdntn1_
+    pictorial: 13167
   name:
     first: Susie
     last: Lee
@@ -32648,6 +32984,7 @@
     ballotpedia: Alexandria Ocasio-Cortez
     icpsr: 21949
     google_entity_id: kg:/g/11f6y3nqg6
+    pictorial: 13182
   name:
     first: Alexandria
     last: Ocasio-Cortez
@@ -32698,6 +33035,7 @@
     votesmart: 136484
     icpsr: 21915
     ballotpedia: Madeleine Dean
+    pictorial: 13224
   name:
     first: Madeleine
     last: Dean
@@ -32748,6 +33086,7 @@
     ballotpedia: Chrissy Houlahan
     icpsr: 21934
     google_entity_id: kg:/g/11fghyq4ym
+    pictorial: 13226
   name:
     first: Chrissy
     last: Houlahan
@@ -32798,6 +33137,7 @@
     votesmart: 102438
     icpsr: 21945
     ballotpedia: Dan Meuser
+    pictorial: 13229
   name:
     first: Daniel
     last: Meuser
@@ -32848,6 +33188,7 @@
     google_entity_id: kg:/g/11fgkqqf2l
     ballotpedia: John Joyce (Pennsylvania)
     votesmart: 178911
+    pictorial: 13233
   name:
     first: John
     last: Joyce
@@ -32898,6 +33239,7 @@
     votesmart: 166004
     icpsr: 21956
     ballotpedia: Guy Reschenthaler
+    pictorial: 13234
   name:
     first: Guy
     last: Reschenthaler
@@ -32948,6 +33290,7 @@
     votesmart: 168923
     icpsr: 21974
     ballotpedia: William Timmons
+    pictorial: 13244
   name:
     first: William
     middle: R.
@@ -32999,6 +33342,7 @@
     icpsr: 21935
     ballotpedia: Dusty Johnson
     google_entity_id: kg:/g/11dyzlcnbr
+    pictorial: 13248
   name:
     first: Dusty
     last: Johnson
@@ -33049,6 +33393,7 @@
     votesmart: 24379
     icpsr: 21905
     ballotpedia: Tim Burchett
+    pictorial: 13250
   name:
     first: Tim
     last: Burchett
@@ -33099,6 +33444,7 @@
     icpsr: 21959
     ballotpedia: John Rose (Tennessee)
     google_entity_id: kg:/g/11g8xhg1mz
+    pictorial: 13254
   name:
     first: John
     middle: W.
@@ -33150,6 +33496,7 @@
     votesmart: 139030
     icpsr: 21926
     ballotpedia: Mark Green (Tennessee)
+    pictorial: 13255
   name:
     first: Mark
     middle: E.
@@ -33201,6 +33548,7 @@
     votesmart: 177270
     icpsr: 21911
     ballotpedia: Daniel Crenshaw
+    pictorial: 13259
   name:
     first: Dan
     last: Crenshaw
@@ -33251,6 +33599,7 @@
     votesmart: 177282
     icpsr: 21925
     ballotpedia: Lance Gooden
+    pictorial: 13262
   name:
     first: Lance
     last: Gooden
@@ -33301,6 +33650,7 @@
     ballotpedia: Lizzie Pannill Fletcher
     icpsr: 21919
     google_entity_id: kg:/g/11gzqssv7p
+    pictorial: 13264
   name:
     first: Lizzie
     last: Fletcher
@@ -33351,6 +33701,7 @@
     icpsr: 21917
     ballotpedia: Veronica Escobar
     google_entity_id: kg:/g/11ghdw9g9p
+    pictorial: 13273
   name:
     first: Veronica
     last: Escobar
@@ -33401,6 +33752,7 @@
     icpsr: 21961
     ballotpedia: Chip Roy
     google_entity_id: kg:/g/11fghyq4y1
+    pictorial: 13278
   name:
     first: Chip
     last: Roy
@@ -33451,6 +33803,7 @@
     votesmart: 49734
     icpsr: 21922
     ballotpedia: Sylvia Garcia
+    pictorial: 13286
   name:
     first: Sylvia
     middle: R.
@@ -33501,6 +33854,7 @@
     votesmart: 177357
     icpsr: 21900
     ballotpedia: Colin Allred
+    pictorial: 13289
   name:
     first: Colin
     middle: Z.
@@ -33552,6 +33906,7 @@
     votesmart: 50959
     icpsr: 21908
     ballotpedia: Ben Cline
+    pictorial: 13304
   name:
     first: Ben
     last: Cline
@@ -33602,6 +33957,7 @@
     icpsr: 21966
     ballotpedia: Abigail Spanberger
     google_entity_id: kg:/g/11fgm1ffs7
+    pictorial: 13305
   name:
     first: Abigail
     middle: Davis
@@ -33653,6 +34009,7 @@
     votesmart: 147013
     icpsr: 21983
     ballotpedia: Jennifer Wexton
+    pictorial: 13308
   name:
     first: Jennifer
     last: Wexton
@@ -33703,6 +34060,7 @@
     icpsr: 21962
     ballotpedia: Kim Schrier
     google_entity_id: kg:/g/11fk1mqvq7
+    pictorial: 13319
   name:
     first: Kim
     last: Schrier
@@ -33753,6 +34111,7 @@
     ballotpedia: Bryan Steil
     google_entity_id: kg:/g/11fhnfybnd
     votesmart: 181289
+    pictorial: 13322
   name:
     first: Bryan
     last: Steil
@@ -33803,6 +34162,7 @@
     votesmart: 52123
     icpsr: 21946
     ballotpedia: Carol Miller (West Virginia)
+    pictorial: 13330
   name:
     first: Carol
     middle: D.
@@ -33855,6 +34215,7 @@
     google_entity_id: kg:/m/0btx2g
     votesmart: 124204
     icpsr: 41903
+    pictorial: 13391
   name:
     first: Rick
     last: Scott
@@ -33888,6 +34249,7 @@
     google_entity_id: kg:/g/11f2ckdwty
     votesmart: 148564
     icpsr: 41900
+    pictorial: 13414
   name:
     first: Mike
     last: Braun
@@ -33921,6 +34283,7 @@
     google_entity_id: kg:/g/11bwy_95zy
     votesmart: 169716
     icpsr: 41901
+    pictorial: 13427
   name:
     first: Joshua
     nickname: Josh
@@ -33956,6 +34319,7 @@
     google_entity_id: kg:/m/0271_s
     votesmart: 21942
     icpsr: 41902
+    pictorial: 13385
   name:
     first: Mitt
     last: Romney
@@ -33988,6 +34352,7 @@
     icpsr: 21923
     ballotpedia: Jared Golden
     google_entity_id: kg:/g/11f1224576
+    pictorial: 13093
   name:
     first: Jared
     middle: Forrest
@@ -34038,6 +34403,7 @@
     ballotpedia: Dan Bishop
     icpsr: 21986
     votesmart: 92423
+    pictorial: 13137
   name:
     first: Dan
     last: Bishop
@@ -34089,6 +34455,7 @@
     icpsr: 21987
     google_entity_id: kg:/g/11clyw935r
     votesmart: 166135
+    pictorial: 13132
   name:
     first: Gregory
     middle: Francis
@@ -34143,6 +34510,7 @@
     wikipedia: Kweisi Mfume
     wikidata: Q519504
     google_entity_id: kg:/m/04znp2
+    pictorial: 13090
   name:
     first: Kweisi
     last: Mfume
@@ -34219,6 +34587,7 @@
     wikipedia: Tom Tiffany
     wikidata: Q7817838
     ballotpedia: Tom Tiffany
+    pictorial: 13328
   name:
     first: Thomas
     middle: P.
@@ -34268,6 +34637,7 @@
     ballotpedia: Mike Garcia
     google_entity_id: kg:/g/11j2j3x1pl
     votesmart: 188664
+    pictorial: 12941
   name:
     first: Mike
     last: Garcia
@@ -34316,6 +34686,7 @@
     wikidata: Q357510
     ballotpedia: Mark Kelly
     votesmart: 190594
+    pictorial: 13430
   name:
     first: Mark
     last: Kelly
@@ -34367,6 +34738,7 @@
     icpsr: 20953
     wikidata: Q456064
     google_entity_id: kg:/m/02qvjv3
+    pictorial: 13361
   name:
     first: Cynthia
     middle: M.
@@ -34450,6 +34822,7 @@
     icpsr: 20107
     wikidata: Q1166592
     google_entity_id: kg:/m/01r7wc
+    pictorial: 12962
   name:
     first: Darrell
     last: Issa
@@ -34581,6 +34954,7 @@
     house_history: 21446
     wikidata: Q437852
     google_entity_id: kg:/m/03v39l
+    pictorial: 13274
   name:
     first: Pete
     middle: A.
@@ -34723,6 +35097,7 @@
     icpsr: 21307
     wikidata: Q3528567
     google_entity_id: kg:/m/0g55rlx
+    pictorial: 12936
   name:
     first: David
     last: Valadao
@@ -34804,6 +35179,7 @@
     google_entity_id: kg:/m/04tmr4
     votesmart: 188306
     ballotpedia: Tommy Tuberville
+    pictorial: 13365
   name:
     first: Tommy
     middle: Hawley
@@ -34836,6 +35212,7 @@
     wikipedia: John Hickenlooper
     google_entity_id: kg:/m/04g_1z
     ballotpedia: John Hickenlooper
+    pictorial: 13433
   name:
     first: John
     middle: Wright
@@ -34869,6 +35246,7 @@
     google_entity_id: kg:/g/11c1xp6h9v
     votesmart: 128466
     ballotpedia: Bill Hagerty
+    pictorial: 13411
   name:
     first: Bill
     middle: Francis
@@ -34899,6 +35277,7 @@
     wikidata: Q102277702
     wikipedia: Jerry Carl
     google_entity_id: kg:/g/11j2j1brnb
+    pictorial: 12894
   name:
     first: Jerry
     middle: Lee
@@ -34939,6 +35318,7 @@
     wikipedia: Barry Moore (Alabama politician)
     google_entity_id: kg:/g/11fkw7vjdf
     ballotpedia: Barry Moore (Alabama)
+    pictorial: 12895
   name:
     first: Barry
     last: Moore
@@ -34977,6 +35357,7 @@
     wikipedia: Jay Obernolte
     google_entity_id: kg:/m/02hpvtf
     ballotpedia: Jay Obernolte
+    pictorial: 12937
   name:
     first: Jay
     middle: Phillip
@@ -35016,6 +35397,7 @@
     wikipedia: Young Kim
     google_entity_id: kg:/m/012c98r4
     votesmart: 151787
+    pictorial: 12954
   name:
     first: Young
     middle: Oak
@@ -35054,6 +35436,7 @@
     wikidata: Q6837200
     wikipedia: Michelle Steel
     google_entity_id: kg:/m/028bz6v
+    pictorial: 12959
   name:
     first: Michelle
     middle: Eunjoo
@@ -35092,6 +35475,7 @@
     wikidata: Q50825637
     wikipedia: Sara Jacobs
     google_entity_id: kg:/g/11ghs2x3tm
+    pictorial: 12965
   name:
     first: Sara
     last: Jacobs
@@ -35130,6 +35514,7 @@
     wikipedia: Lauren Boebert
     google_entity_id: kg:/g/11j2v06x6p
     ballotpedia: Lauren Boebert
+    pictorial: 12969
   name:
     first: Lauren
     middle: Opal
@@ -35168,6 +35553,7 @@
     wikidata: Q98523243
     wikipedia: Kat Cammack
     google_entity_id: kg:/g/11fsp_lppx
+    pictorial: 12984
   name:
     first: Katherine
     nickname: Kat
@@ -35206,6 +35592,7 @@
     wikidata: Q101198561
     wikipedia: Scott Franklin (politician)
     google_entity_id: kg:/g/11ft5hszwx
+    pictorial: 12999
   name:
     first: C.
     middle: Scott
@@ -35245,6 +35632,7 @@
     wikipedia: Byron Donalds
     google_entity_id: kg:/g/11c1xk7pbn
     votesmart: 137655
+    pictorial: 13000
   name:
     first: Byron
     middle: Lowell
@@ -35285,6 +35673,7 @@
     google_entity_id: kg:/m/03cc6vt
     votesmart: 81366
     ballotpedia: Carlos Gimenez
+    pictorial: 13009
   name:
     first: Carlos
     middle: A.
@@ -35324,6 +35713,7 @@
     wikipedia: María Elvira Salazar
     google_entity_id: kg:/g/1hb_g7r18
     votesmart: 182300
+    pictorial: 13008
   name:
     first: Maria
     middle: Elvira
@@ -35363,6 +35753,7 @@
     wikipedia: Nikema Williams
     google_entity_id: kg:/g/11fctqx0jy
     ballotpedia: Nikema Williams
+    pictorial: 13014
   name:
     first: Nikema
     middle: Natassha
@@ -35401,6 +35792,7 @@
     wikidata: Q102277679
     wikipedia: Andrew Clyde
     google_entity_id: kg:/g/11j32tm4v4
+    pictorial: 13018
   name:
     first: Andrew
     middle: S.
@@ -35441,6 +35833,7 @@
     google_entity_id: kg:/g/11fscs046n
     ballotpedia: Marjorie Taylor Greene
     votesmart: 189785
+    pictorial: 13023
   name:
     first: Marjorie
     middle: Taylor
@@ -35481,6 +35874,7 @@
     google_entity_id: kg:/g/11fjq_fl2t
     votesmart: 168783
     ballotpedia: Ashley Hinson
+    pictorial: 13028
   name:
     first: Ashley
     last: Hinson
@@ -35520,6 +35914,7 @@
     google_entity_id: kg:/g/11fhm4wv8g
     votesmart: 103294
     ballotpedia: Mariannette Miller-Meeks
+    pictorial: 13027
   name:
     first: Mariannette
     middle: Jane
@@ -35560,6 +35955,7 @@
     google_entity_id: kg:/m/05p06tx
     votesmart: 103301
     ballotpedia: Randy Feenstra
+    pictorial: 13030
   name:
     first: Randy
     middle: L.
@@ -35598,6 +35994,7 @@
     wikidata: Q101204553
     wikipedia: Mary Miller (politician)
     google_entity_id: kg:/g/11fsd5mh_l
+    pictorial: 13047
   name:
     first: Mary
     middle: E.
@@ -35636,6 +36033,7 @@
     wikidata: Q96077897
     wikipedia: Frank J. Mrvan
     google_entity_id: kg:/g/11gtz3tlbh
+    pictorial: 13050
   name:
     first: Frank
     middle: John
@@ -35675,6 +36073,7 @@
     wikipedia: Victoria Spartz
     google_entity_id: kg:/g/11h23hjb94
     votesmart: 178203
+    pictorial: 13054
   name:
     first: Victoria
     last: Spartz
@@ -35712,6 +36111,7 @@
     wikidata: Q48767554
     wikipedia: Tracey Mann
     google_entity_id: kg:/g/11hcbb5b38
+    pictorial: 13059
   name:
     first: Tracey
     middle: Robert
@@ -35750,6 +36150,7 @@
     wikidata: Q16731273
     wikipedia: Jake LaTurner
     google_entity_id: kg:/m/0w32xrn
+    pictorial: 13060
   name:
     first: Jacob
     nickname: Jake
@@ -35788,6 +36189,7 @@
     wikidata: Q101196632
     wikipedia: Jake Auchincloss
     google_entity_id: kg:/g/11f0xw2_p4
+    pictorial: 13078
   name:
     first: Jake
     middle: Daniel
@@ -35827,6 +36229,7 @@
     wikipedia: Lisa McClain
     google_entity_id: kg:/g/11j1xf64qr
     ballotpedia: Lisa McClain
+    pictorial: 13102
   name:
     first: Lisa
     middle: C.
@@ -35866,6 +36269,7 @@
     wikipedia: Michelle Fischbach
     google_entity_id: kg:/m/063_kp4
     ballotpedia: Michelle Fischbach
+    pictorial: 13113
   name:
     first: Michelle
     middle: Louise Helene
@@ -35905,6 +36309,7 @@
     wikipedia: Cori Bush
     google_entity_id: kg:/g/11cntkcbkt
     ballotpedia: Cori Bush
+    pictorial: 13115
   name:
     first: Cori
     last: Bush
@@ -35944,6 +36349,7 @@
     google_entity_id: kg:/m/0j260rd
     votesmart: 120815
     ballotpedia: Matthew Rosendale
+    pictorial: 13129
   name:
     first: Matthew
     middle: Martin
@@ -35984,6 +36390,7 @@
     wikipedia: Deborah Ross (politician)
     google_entity_id: kg:/m/02b3x2
     ballotpedia: Deborah Ross
+    pictorial: 13131
   name:
     first: Deborah
     middle: Koff
@@ -36022,6 +36429,7 @@
     wikidata: Q101136890
     wikipedia: Kathy Manning
     google_entity_id: kg:/g/11dxpjz93v
+    pictorial: 13135
   name:
     first: Kathy
     middle: Ellen
@@ -36060,6 +36468,7 @@
     wikidata: Q96054905
     wikipedia: Teresa Leger Fernandez
     google_entity_id: kg:/g/11h_x7n8f5
+    pictorial: 13164
   name:
     first: Teresa
     last: Leger Fernandez
@@ -36097,6 +36506,7 @@
     wikidata: Q21257859
     wikipedia: Andrew Garbarino
     google_entity_id: kg:/g/11bw8f4j8q
+    pictorial: 13170
   name:
     first: Andrew
     middle: R.
@@ -36135,6 +36545,7 @@
     wikidata: Q7030112
     wikipedia: Nicole Malliotakis
     google_entity_id: kg:/m/0g5817m
+    pictorial: 13179
   name:
     first: Nicole
     last: Malliotakis
@@ -36173,6 +36584,7 @@
     wikipedia: Ritchie Torres
     google_entity_id: kg:/m/0x11h9s
     ballotpedia: Ritchie Torres
+    pictorial: 13183
   name:
     first: Ritchie
     middle: John
@@ -36212,6 +36624,7 @@
     wikipedia: Jamaal Bowman
     google_entity_id: kg:/g/11fsgvc0xx
     ballotpedia: Jamaal Bowman
+    pictorial: 13184
   name:
     first: Jamaal
     last: Bowman
@@ -36250,6 +36663,7 @@
     wikipedia: Stephanie Bice
     google_entity_id: kg:/g/11h2hmkrv8
     ballotpedia: Stephanie Bice
+    pictorial: 13214
   name:
     first: Stephanie
     middle: I.
@@ -36288,6 +36702,7 @@
     wikidata: Q5132536
     wikipedia: Cliff Bentz
     google_entity_id: kg:/m/0gfdsjb
+    pictorial: 13216
   name:
     first: Cliff
     middle: Stewart
@@ -36327,6 +36742,7 @@
     wikipedia: Nancy Mace
     google_entity_id: kg:/m/048nls
     ballotpedia: Nancy Mace
+    pictorial: 13241
   name:
     first: Nancy
     middle: Ruth
@@ -36365,6 +36781,7 @@
     wikidata: Q101197341
     wikipedia: Diana Harshbarger
     google_entity_id: kg:/g/11f67z977k
+    pictorial: 13249
   name:
     first: Diana
     last: Harshbarger
@@ -36402,6 +36819,7 @@
     wikidata: Q16196923
     wikipedia: Pat Fallon
     google_entity_id: kg:/m/0100nvdw
+    pictorial: 13261
   name:
     first: Patrick
     middle: Edward
@@ -36441,6 +36859,7 @@
     wikidata: Q101196462
     wikipedia: August Pfluger
     google_entity_id: kg:/g/11f3szpd4x
+    pictorial: 13268
   name:
     first: August
     middle: Lee
@@ -36481,6 +36900,7 @@
     wikipedia: Ronny Jackson
     google_entity_id: kg:/g/11gfhx0vbg
     ballotpedia: Ronny Jackson
+    pictorial: 13270
   name:
     first: Ronny
     middle: Lynn
@@ -36521,6 +36941,7 @@
     google_entity_id: kg:/g/11c580_xf2
     votesmart: 188334
     ballotpedia: Troy Nehls
+    pictorial: 13279
   name:
     first: Troy
     middle: E.
@@ -36559,6 +36980,7 @@
     wikidata: Q104648170
     google_entity_id: kg:/g/11fs52clcr
     wikipedia: Tony Gonzales
+    pictorial: 13280
   name:
     first: Ernest
     middle: Anthony
@@ -36600,6 +37022,7 @@
     google_entity_id: kg:/m/0k1c6d8
     votesmart: 79150
     ballotpedia: Beth Van Duyne
+    pictorial: 13281
   name:
     first: Beth
     middle: Ann
@@ -36638,6 +37061,7 @@
     wikidata: Q101196971
     wikipedia: Blake Moore
     google_entity_id: kg:/g/11ftchfsgn
+    pictorial: 13296
   name:
     first: Blake
     middle: David
@@ -36677,6 +37101,7 @@
     wikipedia: Burgess Owens
     google_entity_id: kg:/m/0286z2f
     ballotpedia: Burgess Owens
+    pictorial: 13299
   name:
     first: Clarence
     nickname: Burgess
@@ -36715,6 +37140,7 @@
     wikidata: Q103850475
     wikipedia: Bob Good
     google_entity_id: kg:/g/11fsfm06kc
+    pictorial: 13303
   name:
     first: Robert
     middle: G.
@@ -36754,6 +37180,7 @@
     wikidata: Q1898180
     wikipedia: Marilyn Strickland
     google_entity_id: kg:/m/0bhb38l
+    pictorial: 13321
   name:
     first: Marilyn
     last: Strickland
@@ -36792,6 +37219,7 @@
     wikipedia: Scott Fitzgerald (politician)
     google_entity_id: kg:/m/03nvqsc
     votesmart: 3446
+    pictorial: 13326
   name:
     first: Scott
     middle: L.
@@ -36832,6 +37260,7 @@
     wikidata: Q4717593
     ballotpedia: Alex Padilla
     votesmart: 59742
+    pictorial: 13341
   name:
     first: Alejandro
     nickname: Alex
@@ -36892,6 +37321,7 @@
     ballotpedia: Jon Ossoff
     votesmart: 176134
     google_entity_id: kg:/g/11g6njlbw2
+    pictorial: 13342
   name:
     first: Jon
     last: Ossoff
@@ -36924,6 +37354,7 @@
     ballotpedia: Raphael Warnock
     votesmart: 189794
     google_entity_id: kg:/g/11b5lw9q73
+    pictorial: 13377
   name:
     first: Raphael
     middle: Gamaliel
@@ -36972,6 +37403,7 @@
     cspan: 103481
     icpsr: 21749
     ballotpedia: Claudia Tenney
+    pictorial: 13192
   name:
     first: Claudia
     last: Tenney
@@ -37021,6 +37453,7 @@
     ballotpedia: Julia Letlow
     google_entity_id: kg:/g/11qq9ggdyw
     votesmart: 195745
+    pictorial: 13073
   name:
     first: Julia
     last: Letlow
@@ -37058,6 +37491,7 @@
     wikipedia: Troy Carter (politician)
     wikidata: Q7846787
     ballotpedia: Troy Carter
+    pictorial: 13070
   name:
     first: Troy
     middle: Anthony
@@ -37098,6 +37532,7 @@
     ballotpedia: Melanie Ann Stansbury
     votesmart: 180789
     google_entity_id: kg:/g/11f_jwp_yr
+    pictorial: 13162
   name:
     first: Melanie
     middle: Ann
@@ -37137,6 +37572,7 @@
     wikidata: Q105061782
     ballotpedia: Jake Ellzey
     google_entity_id: kg:/g/11f0lw2cdc
+    pictorial: 13263
   name:
     first: Jake
     last: Ellzey
@@ -37173,6 +37609,7 @@
     opensecrets: N00047875
     wikipedia: Shontel Brown
     wikidata: Q107863952
+    pictorial: 13205
   name:
     first: Shontel
     middle: M.
@@ -37210,6 +37647,7 @@
     opensecrets: N00048568
     wikipedia: Mike Carey (politician)
     wikidata: Q108010312
+    pictorial: 13209
   name:
     first: Mike
     last: Carey
@@ -37246,6 +37684,7 @@
     opensecrets: N00043504
     wikipedia: Sheila Cherfilus-McCormick
     wikidata: Q109560948
+    pictorial: 13001
   name:
     first: Sheila
     last: Cherfilus-McCormick
@@ -37284,6 +37723,7 @@
     wikidata: Q6846855
     ballotpedia: Mike Flood
     votesmart: 41983
+    pictorial: 13145
   name:
     first: Mike
     last: Flood
@@ -37321,6 +37761,7 @@
     wikidata: Q111159803
     ballotpedia: Brad Finstad
     votesmart: 38612
+    pictorial: 13107
   name:
     first: Brad
     last: Finstad
@@ -37359,6 +37800,7 @@
     wikidata: Q13562231
     ballotpedia: Mary Peltola
     votesmart: 207620
+    pictorial: 12893
   name:
     first: Mary
     middle: Sattler
@@ -37399,6 +37841,7 @@
     ballotpedia: Pat Ryan (New York)
     google_entity_id: kg:/g/11f892sjry
     votesmart: 180314
+    pictorial: 13186
   name:
     first: Patrick
     last: Ryan
@@ -37436,6 +37879,7 @@
     wikipedia: Rudy Yakym
     wikidata: Q115137719
     ballotpedia: Rudy Yakym
+    pictorial: 13051
   name:
     first: Rudy
     last: Yakym
@@ -37477,6 +37921,7 @@
     wikipedia: Ryan Zinke
     google_entity_id: kg:/m/0gkz1jg
     votesmart: 104073
+    pictorial: 13128
   name:
     first: Ryan
     last: Zinke
@@ -37529,6 +37974,7 @@
     google_entity_id: kg:/g/11rfpf26r8
     ballotpedia: Katie Britt
     votesmart: 201704
+    pictorial: 13393
   name:
     first: Katie
     middle: Elizabeth
@@ -37561,6 +38007,7 @@
     wikipedia: Eric Schmitt
     ballotpedia: Eric Schmitt
     votesmart: 104474
+    pictorial: 13416
   name:
     first: Eric
     middle: Stephen
@@ -37593,6 +38040,7 @@
     wikipedia: J. D. Vance
     google_entity_id: kg:/g/11c6v_wj1r
     ballotpedia: J.D. Vance
+    pictorial: 13348
   name:
     first: J.D. (James)
     middle: (David)
@@ -37625,6 +38073,7 @@
     wikipedia: John Fetterman
     votesmart: 166286
     ballotpedia: John Fetterman
+    pictorial: 13366
   name:
     first: John
     middle: Karl
@@ -37655,6 +38104,7 @@
     wikidata: Q115137374
     wikipedia: Dale Strong
     votesmart: 81485
+    pictorial: 12898
   name:
     first: Dale
     last: Strong
@@ -37683,6 +38133,7 @@
     wikipedia: Eli Crane
     ballotpedia: Eli Crane
     votesmart: 205885
+    pictorial: 12907
   name:
     first: Eli
     last: Crane
@@ -37710,6 +38161,7 @@
     wikidata: Q115220916
     wikipedia: Juan Ciscomani
     votesmart: 106728
+    pictorial: 12911
   name:
     first: Juan
     middle: Guadaloupe
@@ -37740,6 +38192,7 @@
     google_entity_id: kg:/g/11c5qpst__
     votesmart: 169303
     ballotpedia: Kevin Kiley
+    pictorial: 12917
   name:
     first: Kevin
     middle: Patrick
@@ -37768,6 +38221,7 @@
     wikidata: Q115574315
     wikipedia: John Duarte (politician)
     votesmart: 204965
+    pictorial: 12927
   name:
     first: John
     last: Duarte
@@ -37795,6 +38249,7 @@
     wikidata: Q6397046
     wikipedia: Kevin Mullin
     votesmart: 105586
+    pictorial: 12929
   name:
     first: Kevin
     last: Mullin
@@ -37823,6 +38278,7 @@
     wikipedia: Sydney Kamlager-Dove
     ballotpedia: Sydney Kamlager-Dove
     votesmart: 178079
+    pictorial: 12951
   name:
     first: Sydney
     middle: Kai
@@ -37851,6 +38307,7 @@
     wikidata: Q16204904
     wikipedia: Robert Garcia (California politician)
     votesmart: 29749
+    pictorial: 12956
   name:
     first: Robert
     middle: Julio
@@ -37879,6 +38336,7 @@
     wikidata: Q16734469
     wikipedia: Brittany Pettersen
     votesmart: 138744
+    pictorial: 12973
   name:
     first: Brittany
     middle: Louise
@@ -37909,6 +38367,7 @@
     google_entity_id: kg:/g/11h23hqvwm
     ballotpedia: Yadira Caraveo
     votesmart: 181770
+    pictorial: 12974
   name:
     first: Yadira
     middle: D.
@@ -37937,6 +38396,7 @@
     wikidata: Q4661833
     wikipedia: Aaron Bean
     votesmart: 53932
+    pictorial: 12985
   name:
     first: Aaron
     middle: Paul
@@ -37965,6 +38425,7 @@
     wikidata: Q115137377
     wikipedia: Cory Mills
     votesmart: 209085
+    pictorial: 12988
   name:
     first: Cory
     last: Mills
@@ -37993,6 +38454,7 @@
     wikipedia: Maxwell Frost
     google_entity_id: kg:/g/11p01k7h4b
     votesmart: 209096
+    pictorial: 12991
   name:
     first: Maxwell
     middle: Alejandro
@@ -38022,6 +38484,7 @@
     wikipedia: Anna Paulina Luna
     votesmart: 191344
     ballotpedia: Anna Paulina Luna
+    pictorial: 12994
   name:
     first: Anna
     middle: (Paulina)
@@ -38051,6 +38514,7 @@
     wikipedia: Laurel Lee
     google_entity_id: kg:/g/11h3cbjvc3
     votesmart: 186114
+    pictorial: 12996
   name:
     first: Laurel
     middle: Frances
@@ -38079,6 +38543,7 @@
     wikidata: Q16221073
     wikipedia: Jared Moskowitz
     votesmart: 138155
+    pictorial: 13004
   name:
     first: Jared
     middle: Evan
@@ -38107,6 +38572,7 @@
     wikidata: Q115474083
     wikipedia: Rich McCormick
     votesmart: 189765
+    pictorial: 13015
   name:
     first: Rich
     middle: Dean
@@ -38135,6 +38601,7 @@
     wikipedia: Mike Collins (politician)
     votesmart: 151225
     wikidata: Q115806750
+    pictorial: 13019
   name:
     first: Mike
     middle: Allen
@@ -38164,6 +38631,7 @@
     wikidata: Q114108969
     wikipedia: James Moylan
     ballotpedia: James Moylan
+    pictorial: 13024
   name:
     first: James (Jim)
     middle: Camacho
@@ -38192,6 +38660,7 @@
     wikidata: Q13562293
     wikipedia: Jill Tokuda
     votesmart: 68493
+    pictorial: 13026
   name:
     first: Jill
     middle: Naomi
@@ -38221,6 +38690,7 @@
     wikipedia: Zach Nunn
     votesmart: 151170
     ballotpedia: Zach Nunn
+    pictorial: 13029
   name:
     first: Zachary (Zach)
     middle: Martin
@@ -38249,6 +38719,7 @@
     wikidata: Q6273473
     wikipedia: Jonathan Jackson (Illinois politician)
     votesmart: 204284
+    pictorial: 13033
   name:
     first: Jonathan
     middle: Luther
@@ -38278,6 +38749,7 @@
     wikipedia: Delia Ramirez
     google_entity_id: kg:/g/11fgm72s6f
     votesmart: 177128
+    pictorial: 13035
   name:
     first: Delia
     middle: Catalina
@@ -38306,6 +38778,7 @@
     wikidata: Q111342337
     wikipedia: Nikki Budzinski
     votesmart: 204328
+    pictorial: 13045
   name:
     first: Nicole (Nikki)
     middle: Jai
@@ -38334,6 +38807,7 @@
     wikidata: Q115182513
     wikipedia: Eric Sorensen (politician)
     votesmart: 204339
+    pictorial: 13049
   name:
     first: Eric
     last: Sorensen
@@ -38362,6 +38836,7 @@
     wikipedia: Erin Houchin
     google_entity_id: kg:/g/11b81xpwnd
     votesmart: 149614
+    pictorial: 13058
   name:
     first: Erin
     middle: Suzanne
@@ -38390,6 +38865,7 @@
     wikidata: Q16732298
     wikipedia: Morgan McGarvey
     votesmart: 139826
+    pictorial: 13065
   name:
     first: Morgan
     last: McGarvey
@@ -38418,6 +38894,7 @@
     wikipedia: Glenn Ivey
     google_entity_id: kg:/g/11bxfgrf12
     votesmart: 166279
+    pictorial: 13087
   name:
     first: Glenn
     middle: Frederick
@@ -38446,6 +38923,7 @@
     wikidata: Q115137368
     wikipedia: Hillary Scholten
     votesmart: 191584
+    pictorial: 13096
   name:
     first: Hillary
     middle: Jeanne
@@ -38476,6 +38954,7 @@
     google_entity_id: kg:/g/11f7r6ft_j
     ballotpedia: John James (Michigan)
     votesmart: 181062
+    pictorial: 13103
   name:
     first: John
     middle: Edwards
@@ -38505,6 +38984,7 @@
     wikipedia: Shri Thanedar
     ballotpedia: Shri Thanedar
     votesmart: 182346
+    pictorial: 13106
   name:
     first: Shri
     last: Thanedar
@@ -38532,6 +39012,7 @@
     wikidata: Q115137637
     wikipedia: Mark Alford (politician)
     votesmart: 205858
+    pictorial: 13118
   name:
     first: Mark
     middle: Allen
@@ -38561,6 +39042,7 @@
     wikipedia: Eric Burlison
     votesmart: 104635
     ballotpedia: Eric Burlison
+    pictorial: 13121
   name:
     first: Eric
     middle: Wayne
@@ -38589,6 +39071,7 @@
     wikidata: Q115137554
     wikipedia: Mike Ezell
     votesmart: 202526
+    pictorial: 13127
   name:
     first: Mike
     last: Ezell
@@ -38616,6 +39099,7 @@
     wikidata: Q5294403
     wikipedia: Don Davis (North Carolina politician)
     votesmart: 102950
+    pictorial: 13130
   name:
     first: Donald
     middle: Gene
@@ -38644,6 +39128,7 @@
     wikidata: Q16729064
     wikipedia: Valerie Foushee
     votesmart: 93091
+    pictorial: 13133
   name:
     first: Valerie
     middle: Jean
@@ -38673,6 +39158,7 @@
     wikipedia: Chuck Edwards
     google_entity_id: kg:/g/11ghxw1t29
     votesmart: 166600
+    pictorial: 13140
   name:
     first: Charles (Chuck)
     middle: Marion
@@ -38702,6 +39188,7 @@
     wikipedia: Wiley Nickel
     google_entity_id: kg:/g/11h1r27wjx
     votesmart: 178326
+    pictorial: 13142
   name:
     first: Wiley
     last: Nickel
@@ -38730,6 +39217,7 @@
     wikidata: Q17183308
     wikipedia: Jeff Jackson (politician)
     votesmart: 153729
+    pictorial: 13143
   name:
     first: Jeffrey
     middle: Neale
@@ -38759,6 +39247,7 @@
     wikipedia: Thomas Kean Jr.
     ballotpedia: Thomas Kean Jr.
     votesmart: 43250
+    pictorial: 13156
   name:
     first: Thomas
     middle: Howard
@@ -38788,6 +39277,7 @@
     wikidata: Q115137457
     wikipedia: Rob Menendez
     votesmart: 205678
+    pictorial: 13157
   name:
     first: Robert
     middle: Jacobsen
@@ -38817,6 +39307,7 @@
     wikipedia: Gabe Vasquez
     votesmart: 201740
     opensecrets: N00049142
+    pictorial: 13163
   name:
     first: Gabriel (Gabe)
     last: Vasquez
@@ -38844,6 +39335,7 @@
     wikidata: Q115168182
     wikipedia: Nick LaLota
     votesmart: 191957
+    pictorial: 13169
   name:
     first: Nicolas
     middle: Joseph
@@ -38873,6 +39365,7 @@
     wikipedia: Anthony D'Esposito
     ballotpedia: Anthony D'Esposito
     votesmart: 174091
+    pictorial: 13172
   name:
     first: Anthony
     middle: P.
@@ -38902,6 +39395,7 @@
     wikipedia: Dan Goldman (politician)
     google_entity_id: kg:/g/11j0y32d4c
     votesmart: 208627
+    pictorial: 13178
   name:
     first: Dan
     middle: Sachs
@@ -38931,6 +39425,7 @@
     wikipedia: Mike Lawler
     google_entity_id: kg:/g/11qwsdzzd6
     votesmart: 192271
+    pictorial: 13185
   name:
     first: Michael
     middle: Vincent
@@ -38960,6 +39455,7 @@
     wikipedia: Marc Molinaro
     votesmart: 69202
     ballotpedia: Marcus Molinaro
+    pictorial: 13187
   name:
     first: Marcus
     middle: J.
@@ -38988,6 +39484,7 @@
     wikipedia: Brandon Williams (politician)
     votesmart: 206001
     wikidata: Q115805431
+    pictorial: 13190
   name:
     first: Brandon
     middle: McDonald
@@ -39017,6 +39514,7 @@
     wikipedia: Nick Langworthy
     google_entity_id: kg:/g/11g119yyj8
     votesmart: 208663
+    pictorial: 13191
   name:
     first: Nicholas
     middle: A.
@@ -39046,6 +39544,7 @@
     wikipedia: Greg Landsman
     votesmart: 186237
     google_entity_id: kg:/g/11rn585y5q
+    pictorial: 13195
   name:
     first: Greg
     middle: John
@@ -39074,6 +39573,7 @@
     wikidata: Q106522145
     wikipedia: Max Miller (politician)
     votesmart: 206947
+    pictorial: 13201
   name:
     first: Max
     middle: Leonard
@@ -39102,6 +39602,7 @@
     wikidata: Q18637943
     wikipedia: Emilia Sykes
     votesmart: 152164
+    pictorial: 13207
   name:
     first: Emilia
     middle: Strong
@@ -39130,6 +39631,7 @@
     wikidata: Q6288704
     wikipedia: Josh Brecheen
     votesmart: 124973
+    pictorial: 13211
   name:
     first: Josh
     middle: Chad
@@ -39159,6 +39661,7 @@
     wikipedia: Val Hoyle
     votesmart: 116336
     ballotpedia: Val Hoyle
+    pictorial: 13218
   name:
     first: Valerie
     middle: Anne
@@ -39187,6 +39690,7 @@
     wikidata: Q115522128
     wikipedia: Lori Chavez-DeRemer
     votesmart: 202792
+    pictorial: 13219
   name:
     first: Lori
     middle: Michelle
@@ -39216,6 +39720,7 @@
     wikipedia: Andrea Salinas
     google_entity_id: kg:/g/11fyzcn4zd
     votesmart: 178196
+    pictorial: 13220
   name:
     first: Andrea
     middle: Rose
@@ -39246,6 +39751,7 @@
     google_entity_id: kg:/g/11f8p2q8bd
     ballotpedia: Summer Lee
     votesmart: 179240
+    pictorial: 13232
   name:
     first: Summer
     middle: Lynn
@@ -39274,6 +39780,7 @@
     wikidata: Q115181700
     wikipedia: Chris Deluzio
     votesmart: 202954
+    pictorial: 13237
   name:
     first: Chris
     middle: Raphael
@@ -39302,6 +39809,7 @@
     wikidata: Q16222460
     wikipedia: Seth Magaziner
     votesmart: 154457
+    pictorial: 13240
   name:
     first: Seth
     middle: Michael
@@ -39331,6 +39839,7 @@
     wikipedia: Russell Fry (politician)
     google_entity_id: kg:/g/11f0r9q6_r
     votesmart: 157265
+    pictorial: 13247
   name:
     first: Russell
     middle: William
@@ -39360,6 +39869,7 @@
     wikipedia: Andy Ogles
     votesmart: 48673
     ballotpedia: Andy Ogles
+    pictorial: 13253
   name:
     first: Andrew
     last: Ogles
@@ -39389,6 +39899,7 @@
     wikipedia: Nathaniel Moran
     votesmart: 79156
     ballotpedia: Nathaniel Moran
+    pictorial: 13258
   name:
     first: Nathaniel
     middle: Quentin
@@ -39419,6 +39930,7 @@
     votesmart: 97491
     ballotpedia: Keith Self
     google_entity_id: kg:/g/11s0s133nc
+    pictorial: 13260
   name:
     first: Keith
     middle: Alan
@@ -39447,6 +39959,7 @@
     wikidata: Q115137460
     wikipedia: Morgan Luttrell
     votesmart: 200930
+    pictorial: 13265
   name:
     first: Morgan
     middle: Joe
@@ -39475,6 +39988,7 @@
     wikidata: Q115496109
     wikipedia: Monica De La Cruz
     votesmart: 188292
+    pictorial: 13272
   name:
     first: Mónica
     last: De La Cruz
@@ -39503,6 +40017,7 @@
     wikipedia: Jasmine Crockett
     google_entity_id: kg:/g/11j90m9942
     votesmart: 188486
+    pictorial: 13287
   name:
     first: Jasmine
     middle: Felicia
@@ -39532,6 +40047,7 @@
     wikipedia: Greg Casar
     google_entity_id: kg:/g/11fl9pbltx
     votesmart: 161953
+    pictorial: 13292
   name:
     first: Gregorio
     middle: Eduardo
@@ -39561,6 +40077,7 @@
     wikipedia: Wesley Hunt
     votesmart: 188147
     ballotpedia: Wesley Hunt (Texas Congress)
+    pictorial: 13295
   name:
     first: Wesley
     middle: Parish
@@ -39590,6 +40107,7 @@
     wikipedia: Jen Kiggans
     google_entity_id: kg:/g/11gbjlv65q
     votesmart: 186387
+    pictorial: 13301
   name:
     first: Jennifer
     middle: Ann
@@ -39619,6 +40137,7 @@
     wikipedia: Becca Balint
     google_entity_id: kg:/g/11c1pdt17l
     votesmart: 154056
+    pictorial: 13311
   name:
     first: Becca
     middle: A.
@@ -39649,6 +40168,7 @@
     google_entity_id: kg:/g/11rts0yhzk
     ballotpedia: Marie Gluesenkamp Perez
     votesmart: 207307
+    pictorial: 13314
   name:
     first: Marie
     last: Gluesenkamp Perez
@@ -39678,6 +40198,7 @@
     google_entity_id: kg:/g/11j5bmd2d3
     ballotpedia: Derrick Van Orden
     votesmart: 192343
+    pictorial: 13324
   name:
     first: Derrick
     middle: Francis
@@ -39708,6 +40229,7 @@
     google_entity_id: kg:/g/11f77yffzm
     ballotpedia: Harriet Hageman
     votesmart: 182961
+    pictorial: 13332
   name:
     first: Harriet
     middle: Maxine
@@ -39739,6 +40261,7 @@
     votesmart: 57777
     cspan: 61233
     ballotpedia: Pete Ricketts
+    pictorial: 13381
   name:
     first: Pete
     last: Ricketts
@@ -39771,6 +40294,7 @@
     wikidata: Q6178602
     ballotpedia: Jennifer McClellan
     votesmart: 58655
+    pictorial: 11624
   name:
     first: Jennifer
     last: McClellan
@@ -39796,6 +40320,7 @@
     wikipedia: Laphonza Butler
     wikidata: Q121337973
     ballotpedia: Laphonza Butler
+    pictorial: 13436
   name:
     first: Laphonza
     middle: Romanique

--- a/scripts/pictorial_ids.py
+++ b/scripts/pictorial_ids.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+
+import csv
+import json
+import unicodedata
+import utils
+from utils import load_data, mkdir_p, save_data, parse_date
+
+# Update legislators current pictorial ids
+# https://pictorialapi.gpo.gov/index.html
+#
+# options:
+#  --cache: load from cache if present on disk (default: false)
+#  --bioguide: load only one legislator, by their bioguide ID
+#  --congress: do *only* updates for legislators serving in specific congress
+#
+# example:
+#  python pictorial_ids.py --congress=118
+
+
+def run():
+
+    # default to not caching
+    cache = utils.flags().get("cache", False)
+    force = not cache
+
+    only_bioguide = utils.flags().get("bioguide", None)
+    congress = utils.flags().get("congress", None)
+
+    data_files = []
+    print("Loading %s..." % "legislators-current.yaml")
+    legislators = load_data("legislators-current.yaml")
+    data_files.append((legislators, "legislators-current.yaml"))
+    print("Loading %s..." % "legislators-historical.yaml")
+    legislators = load_data("legislators-historical.yaml")
+    data_files.append((legislators, "legislators-historical.yaml"))
+
+    if congress == None:
+        raise Exception("the --congress flag is required")
+    elif int(congress) >= 110:
+        # Pictorial seems to go back to 110th Congress
+        url = f"https://pictorialapi.gpo.gov/api/GuideMember/GetMembers/{congress}"
+        pass
+    else:
+        raise Exception("no data for congress " + congress)
+
+    pictorial_destination = f"pictorial/source/GetMembers/{congress}.json"
+    pictorial_data = json.loads(utils.download(url, pictorial_destination, force))
+
+    # Filter out non-legislators and the vacant placeholders
+    pictorial_members = [
+        member
+        for member in pictorial_data["memberCollection"]
+        if member["memberType"] in ("Senator", "Representative", "Delegate")
+        and member["name"] != "Vacant, Vacant"
+    ]
+
+    error_filename = f"cache/errors/pictorial/mismatch_{congress}.csv"
+    mkdir_p("cache/errors/pictorial")
+    error_log = csv.writer(open(error_filename, "w"))
+    error_log.writerow(
+        [
+            "message",
+            "bioguide_id",
+            "name_first",
+            "name_last",
+        ]
+    )
+    error_count = 0
+
+    print("Running for congress " + congress)
+    for legislators, filename in data_files:
+        for legislator in legislators:
+            # this can't run unless we've already collected a bioguide for this person
+            bioguide = legislator["id"].get("bioguide", None)
+            # if we've limited this to just one bioguide, skip over everyone else
+            if only_bioguide and (bioguide != only_bioguide):
+                continue
+
+            # only run for selected congress
+            latest_term = legislator["terms"][-1]
+            latest_congress = utils.congress_from_legislative_year(
+                utils.legislative_year(parse_date(latest_term["start"]))
+            )
+            if int(congress) != latest_congress:
+                continue
+
+            # skip if we already have it
+            if legislator["id"].get("pictorial"):
+                continue
+            try:
+                pictorial_id = match_pictorial_id(legislator, pictorial_members)
+                legislator["id"]["pictorial"] = pictorial_id
+            except ValueError as e:
+                error_count += 1
+                error_log.writerow(
+                    [
+                        e,
+                        bioguide,
+                        legislator["name"]["first"],
+                        legislator["name"]["last"],
+                    ]
+                )
+
+        save_data(legislators, filename)
+
+    if error_count:
+        print(f"{error_count} error details written to {error_filename}")
+
+
+def to_ascii(s):
+    return unicodedata.normalize("NFKD", s).encode("ASCII", "ignore").decode("ASCII")
+
+
+def reverse_name(name):
+    """
+    Given a name in "Last, First" format, return "First Last"
+    """
+    return " ".join(name.split(", ")[::-1])
+
+
+def match_pictorial_id(legislator, pictorial_members):
+    """
+    Attempt to find the corresponding pictorial id for the given member.
+
+    There are many odd cases -- see tests/test_gpo_member_photos.py for
+    examples.
+    """
+    name = legislator["name"]["official_full"]
+
+    # Map common nicknames (and GPO typos) from legislators to pictorial
+    common_nicknames = {
+        "Nick": "Nicolas",
+        "Daniel": "Dan",
+        "Mike": "Michael",
+        "Michael": "Mike",
+        "Richard": "Rich",
+        "Christopher": "Chris",
+        "JOhn": "John",
+    }
+
+    matches = []
+    for member_pictorial in pictorial_members:
+        # First check whether the name matches
+        name_matches = False
+        legislator_name_last = to_ascii(legislator["name"]["last"].replace(" ", ""))
+        legislator_name_first = to_ascii(legislator["name"]["first"].replace(" ", ""))
+
+        if legislator_name_last == member_pictorial["lastName"]:
+            if legislator_name_first == member_pictorial["firstName"] or (
+                "nickname" in legislator["name"]
+                and legislator["name"]["nickname"] == member_pictorial["firstName"]
+            ):
+                name_matches = True
+            # Sometimes the nickname is encoded in the first name
+            elif member_pictorial["firstName"] in legislator_name_first:
+                name_matches = True
+            # Sometimes the nickname is encoded in the middle name
+            elif (
+                "middle" in legislator["name"]
+                and member_pictorial["firstName"] in legislator["name"]["middle"]
+            ):
+                name_matches = True
+            # Sometimes the nickname is not encoded
+            elif (
+                member_pictorial["firstName"] in common_nicknames
+                and common_nicknames[member_pictorial["firstName"]]
+                == legislator_name_first
+            ):
+                name_matches = True
+
+        # Sometimes matching the official full name is best
+        if legislator["name"]["official_full"] == reverse_name(
+            member_pictorial["name"]
+        ):
+            name_matches = True
+
+        # The GPO has some first and last names swapped, so check those too
+        if not name_matches and legislator_name_first == member_pictorial["lastName"]:
+            if legislator_name_last == member_pictorial["firstName"] or (
+                "nickname" in legislator["name"]
+                and legislator["name"]["nickname"] == member_pictorial["firstName"]
+            ):
+                name_matches = True
+
+        # If the name matches, check the office and state
+        # Note: Assumes we're matching against most recent term
+        if name_matches:
+            most_recent_term = legislator["terms"][-1]
+            mType = "sen" if member_pictorial["memberType"] == "Senator" else "rep"
+            if (
+                most_recent_term["state"] == member_pictorial["stateId"]
+                and most_recent_term["type"] == mType
+            ):
+                matches.append(member_pictorial)
+
+    if len(matches) == 1:
+        return matches[0]["memberId"]
+    else:
+        if len(matches):
+            raise ValueError(f"Multiple pictorial id matches found for {name}")
+        else:
+            raise ValueError(f"No pictorial id match found for {name}")
+
+
+if __name__ == "__main__":
+    run()

--- a/test/test_pictorial_ids.py
+++ b/test/test_pictorial_ids.py
@@ -1,0 +1,757 @@
+#!/usr/bin/env python
+"""
+Unit tests for pictorial_ids.py.
+Run from root `congress-legislators` dir:
+`python test/test_pictorial_ids.py`
+"""
+import sys
+import unittest
+
+sys.path.insert(0, "scripts")
+from pictorial_ids import match_pictorial_id
+
+
+class TestMatchBioguideID(unittest.TestCase):
+    def test_basic(self):
+        members_pictorial = [
+            {
+                "entryId": "13421",
+                "memberId": 13421,
+                "memberType": "Senator",
+                "lastName": "Booker",
+                "firstName": "Cory",
+                "name": "Booker, Cory A.",
+                "partyDescription": "Democrat",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "NJ",
+                "stateDescription": "New Jersey",
+                "memberTypeId": "SR",
+                "district": 0,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_SR_NJ_Booker_Cory.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_SR_NJ_Booker_Cory.jpg",
+                "imageFile": "118_SR_NJ_Booker_Cory.jpg",
+            }
+        ]
+        legislator = {
+            "id": {
+                "bioguide": "B001288",
+                "lis": "S370",
+                "thomas": "02194",
+                "govtrack": 412598,
+                "opensecrets": "N00035267",
+                "votesmart": 76151,
+                "wikipedia": "Cory Booker",
+                "ballotpedia": "Cory Booker",
+                "fec": ["S4NJ00185"],
+                "cspan": 84679,
+                "maplight": 2051,
+                "wikidata": "Q1135767",
+                "google_entity_id": "kg:/m/06p430",
+                "icpsr": 41308,
+            },
+            "name": {
+                "first": "Cory",
+                "middle": "Anthony",
+                "last": "Booker",
+                "official_full": "Cory A. Booker",
+            },
+            "bio": {"birthday": "1969-04-27", "gender": "M"},
+            "leadership_roles": [
+                {
+                    "title": "Senate Democratic Policy & Communications Committee Vice Chair",
+                    "chamber": "senate",
+                    "start": "2023-01-03",
+                }
+            ],
+            "terms": [
+                {
+                    "type": "sen",
+                    "start": "2013-10-31",
+                    "end": "2015-01-03",
+                    "state": "NJ",
+                    "class": 2,
+                    "party": "Democrat",
+                    "state_rank": "junior",
+                    "url": "http://www.booker.senate.gov",
+                    "phone": "202-224-3224",
+                    "address": "141 Hart Senate Office Building Washington DC 20510",
+                    "office": "141 Hart Senate Office Building",
+                    "contact_form": "http://www.booker.senate.gov/?p=contact",
+                },
+                {
+                    "type": "sen",
+                    "start": "2015-01-06",
+                    "end": "2021-01-03",
+                    "state": "NJ",
+                    "class": 2,
+                    "party": "Democrat",
+                    "state_rank": "junior",
+                    "url": "https://www.booker.senate.gov",
+                    "phone": "202-224-3224",
+                    "address": "717 Hart Senate Office Building Washington DC 20510",
+                    "office": "717 Hart Senate Office Building",
+                    "contact_form": "https://www.booker.senate.gov/?p=contact",
+                    "fax": "202-224-8378",
+                },
+                {
+                    "type": "sen",
+                    "start": "2021-01-03",
+                    "end": "2027-01-03",
+                    "state": "NJ",
+                    "class": 2,
+                    "state_rank": "junior",
+                    "party": "Democrat",
+                    "url": "https://www.booker.senate.gov",
+                    "contact_form": "https://www.booker.senate.gov/?p=contact",
+                    "address": "717 Hart Senate Office Building Washington DC 20510",
+                    "office": "717 Hart Senate Office Building",
+                    "phone": "202-224-3224",
+                },
+            ],
+        }
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_hassan(self):
+        """First name is a nickname"""
+        members_pictorial = [
+            {
+                "entryId": "13426",
+                "memberId": 13426,
+                "memberType": "Senator",
+                "lastName": "Hassan",
+                "firstName": "Maggie",
+                "name": "Hassan, Maggie",
+                "partyDescription": "Democrat",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "NH",
+                "stateDescription": "New Hampshire",
+                "memberTypeId": "SR",
+                "district": 0,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_SR_NH_Hassan_Maggie.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_SR_NH_Hassan_Maggie.jpg",
+                "imageFile": "118_SR_NH_Hassan_Maggie.jpg",
+            }
+        ]
+        legislator = {
+            "id": {
+                "bioguide": "H001076",
+                "fec": ["S6NH00091"],
+                "govtrack": 412680,
+                "votesmart": 42552,
+                "wikipedia": "Maggie Hassan",
+                "ballotpedia": "Maggie Hassan",
+                "lis": "S388",
+                "wikidata": "Q24053",
+                "google_entity_id": "kg:/m/03c3zch",
+                "opensecrets": "N00038397",
+                "maplight": 2192,
+                "cspan": 67481,
+                "icpsr": 41702,
+            },
+            "name": {
+                "first": "Margaret",
+                "middle": "Wood",
+                "nickname": "Maggie",
+                "last": "Hassan",
+                "official_full": "Margaret Wood Hassan",
+            },
+            "bio": {"gender": "F", "birthday": "1958-02-27"},
+            "terms": [
+                {
+                    "type": "sen",
+                    "start": "2017-01-03",
+                    "end": "2023-01-03",
+                    "state": "NH",
+                    "class": 3,
+                    "state_rank": "junior",
+                    "party": "Democrat",
+                    "address": "324 Hart Senate Office Building Washington DC 20510",
+                    "office": "324 Hart Senate Office Building",
+                    "phone": "202-224-3324",
+                    "url": "https://www.hassan.senate.gov",
+                    "contact_form": "https://www.hassan.senate.gov/content/contact-senator",
+                },
+                {
+                    "type": "sen",
+                    "start": "2023-01-03",
+                    "end": "2029-01-03",
+                    "state": "NH",
+                    "class": 3,
+                    "state_rank": "junior",
+                    "party": "Democrat",
+                    "url": "https://www.hassan.senate.gov",
+                    "contact_form": "https://www.hassan.senate.gov/content/contact-senator",
+                    "address": "324 Hart Senate Office Building Washington DC 20510",
+                    "office": "324 Hart Senate Office Building",
+                    "phone": "202-224-3324",
+                },
+            ],
+        }
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_hickenlooper(self):
+        """GPO has first and last names swapped :("""
+        members_pictorial = [
+            {
+                "entryId": "13433",
+                "memberId": 13433,
+                "memberType": "Senator",
+                "lastName": "John",
+                "firstName": "Hickenlooper",
+                "name": "John, Hickenlooper",
+                "partyDescription": "Democrat",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "CO",
+                "stateDescription": "Colorado",
+                "memberTypeId": "SR",
+                "district": 0,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_SR_CO_John_Hickenlooper.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_SR_CO_John_Hickenlooper.jpg",
+                "imageFile": "118_SR_CO_John_Hickenlooper.jpg",
+            }
+        ]
+        legislator = {
+            "id": {
+                "bioguide": "H000273",
+                "lis": "S408",
+                "fec": ["S0CO00575"],
+                "opensecrets": "N00044206",
+                "govtrack": 456797,
+                "wikidata": "Q430518",
+                "wikipedia": "John Hickenlooper",
+                "google_entity_id": "kg:/m/04g_1z",
+                "ballotpedia": "John Hickenlooper",
+            },
+            "name": {
+                "first": "John",
+                "middle": "Wright",
+                "last": "Hickenlooper",
+                "official_full": "John W. Hickenlooper",
+            },
+            "bio": {"gender": "M", "birthday": "1952-02-07"},
+            "terms": [
+                {
+                    "type": "sen",
+                    "start": "2021-01-03",
+                    "end": "2027-01-03",
+                    "state": "CO",
+                    "class": 2,
+                    "state_rank": "junior",
+                    "party": "Democrat",
+                    "url": "https://www.hickenlooper.senate.gov",
+                    "contact_form": "https://www.hickenlooper.senate.gov/contact/",
+                    "address": "374 Russell Senate Office Building Washington DC 20510",
+                    "office": "374 Russell Senate Office Building",
+                    "phone": "202-224-5941",
+                }
+            ],
+        }
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_edwards(self):
+        """Chuck Edwards has nickname coded differently"""
+        members_pictorial = [
+            {
+                "entryId": "13140",
+                "memberId": 13140,
+                "memberType": "Representative",
+                "lastName": "Edwards",
+                "firstName": "Chuck",
+                "name": "Edwards, Chuck",
+                "partyDescription": "Republican",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "NC",
+                "stateDescription": "North Carolina",
+                "memberTypeId": "RP",
+                "district": 11,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_NC_11_Edwards_Chuck.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_NC_11_Edwards_Chuck.jpg",
+                "imageFile": "118_RP_NC_11_Edwards_Chuck.jpg",
+            }
+        ]
+        legislator = {
+            "id": {
+                "bioguide": "E000246",
+                "fec": ["H2NC14050"],
+                "govtrack": 456914,
+                "opensecrets": "N00049670",
+                "wikidata": "Q55065043",
+                "wikipedia": "Chuck Edwards",
+                "google_entity_id": "kg:/g/11ghxw1t29",
+                "votesmart": 166600,
+            },
+            "name": {
+                "first": "Charles (Chuck)",
+                "middle": "Marion",
+                "last": "Edwards",
+                "official_full": "Chuck Edwards",
+            },
+            "bio": {"gender": "M", "birthday": "1960-09-13"},
+            "terms": [
+                {
+                    "type": "rep",
+                    "start": "2023-01-03",
+                    "end": "2025-01-03",
+                    "state": "NC",
+                    "district": 11,
+                    "party": "Republican",
+                    "url": "https://edwards.house.gov",
+                    "address": "1505 Longworth House Office Building Washington DC 20515-3311",
+                    "office": "1505 Longworth House Office Building",
+                    "phone": "202-225-6401",
+                }
+            ],
+        }
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_leger_fernandez(self):
+        """Leger Fernandez has no space in GPO"""
+        members_pictorial = [
+            {
+                "entryId": "13164",
+                "memberId": 13164,
+                "memberType": "Representative",
+                "lastName": "LegerFernandez",
+                "firstName": "Teresa",
+                "name": "LegerFernandez, Teresa",
+                "partyDescription": "Democrat",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "NM",
+                "stateDescription": "New Mexico",
+                "memberTypeId": "RP",
+                "district": 3,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_NM_3_LegerFernandez_Teresa.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_NM_3_LegerFernandez_Teresa.jpg",
+                "imageFile": "118_RP_NM_3_LegerFernandez_Teresa.jpg",
+            }
+        ]
+
+        legislator = {
+            "id": {
+                "bioguide": "L000273",
+                "fec": ["H0NM03102"],
+                "opensecrets": "N00044559",
+                "govtrack": 456835,
+                "wikidata": "Q96054905",
+                "wikipedia": "Teresa Leger Fernandez",
+                "google_entity_id": "kg:/g/11h_x7n8f5",
+            },
+            "name": {
+                "first": "Teresa",
+                "last": "Leger Fernandez",
+                "official_full": "Teresa Leger Fernandez",
+            },
+            "bio": {"gender": "F", "birthday": "1959-07-01"},
+            "terms": [
+                {
+                    "type": "rep",
+                    "start": "2021-01-03",
+                    "end": "2023-01-03",
+                    "state": "NM",
+                    "district": 3,
+                    "party": "Democrat",
+                    "address": "1432 Longworth House Office Building Washington DC 20515-3103",
+                    "office": "1432 Longworth House Office Building",
+                    "phone": "202-225-6190",
+                    "url": "https://fernandez.house.gov",
+                },
+                {
+                    "type": "rep",
+                    "start": "2023-01-03",
+                    "end": "2025-01-03",
+                    "state": "NM",
+                    "district": 3,
+                    "party": "Democrat",
+                    "url": "https://fernandez.house.gov",
+                    "address": "1510 Longworth House Office Building Washington DC 20515-3103",
+                    "office": "1510 Longworth House Office Building",
+                    "phone": "202-225-6190",
+                },
+            ],
+        }
+
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_lalota(self):
+        """LaLota is Nick and Nicholas"""
+        members_pictorial = [
+            {
+                "entryId": "13169",
+                "memberId": 13169,
+                "memberType": "Representative",
+                "lastName": "LaLota",
+                "firstName": "Nick",
+                "name": "LaLota, Nick",
+                "partyDescription": "Republican",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "NY",
+                "stateDescription": "New York",
+                "memberTypeId": "RP",
+                "district": 1,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_NY_1_LaLota_Nick.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_NY_1_LaLota_Nick.jpg",
+                "imageFile": "118_RP_NY_1_LaLota_Nick.jpg",
+            }
+        ]
+
+        legislator = {
+            "id": {
+                "bioguide": "L000598",
+                "fec": ["H2NY01190"],
+                "govtrack": 456920,
+                "opensecrets": "N00050419",
+                "wikidata": "Q115168182",
+                "wikipedia": "Nick LaLota",
+                "votesmart": 191957,
+            },
+            "name": {
+                "first": "Nicolas",
+                "middle": "Joseph",
+                "last": "LaLota",
+                "official_full": "Nick LaLota",
+            },
+            "bio": {"gender": "M", "birthday": "1978-06-23"},
+            "terms": [
+                {
+                    "type": "rep",
+                    "start": "2023-01-03",
+                    "end": "2025-01-03",
+                    "state": "NY",
+                    "district": 1,
+                    "party": "Republican",
+                    "url": "https://lalota.house.gov",
+                    "address": "1530 Longworth House Office Building Washington DC 20515-3201",
+                    "office": "1530 Longworth House Office Building",
+                    "phone": "202-225-3826",
+                }
+            ],
+        }
+
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_franklin(self):
+        """Franklin's nickname is middle name"""
+        members_pictorial = [
+            {
+                "entryId": "12999",
+                "memberId": 12999,
+                "memberType": "Representative",
+                "lastName": "Franklin",
+                "firstName": "Scott",
+                "name": "Franklin, Scott",
+                "partyDescription": "Republican",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "FL",
+                "stateDescription": "Florida",
+                "memberTypeId": "RP",
+                "district": 18,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_FL_18_Franklin_C.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_FL_18_Franklin_C.jpg",
+                "imageFile": "118_RP_FL_18_Franklin_C.jpg",
+            }
+        ]
+
+        legislator = {
+            "id": {
+                "bioguide": "F000472",
+                "fec": ["H0FL15104"],
+                "opensecrets": "N00046760",
+                "govtrack": 456807,
+                "wikidata": "Q101198561",
+                "wikipedia": "Scott Franklin (politician)",
+                "google_entity_id": "kg:/g/11ft5hszwx",
+            },
+            "name": {
+                "first": "C.",
+                "middle": "Scott",
+                "last": "Franklin",
+                "official_full": "Scott Franklin",
+            },
+            "bio": {"gender": "M", "birthday": "1964-08-23"},
+            "terms": [
+                {
+                    "type": "rep",
+                    "start": "2021-01-03",
+                    "end": "2023-01-03",
+                    "state": "FL",
+                    "district": 15,
+                    "party": "Republican",
+                    "address": "1517 Longworth House Office Building Washington DC 20515-0915",
+                    "office": "1517 Longworth House Office Building",
+                    "phone": "202-225-1252",
+                    "url": "https://franklin.house.gov",
+                },
+                {
+                    "type": "rep",
+                    "start": "2023-01-03",
+                    "end": "2025-01-03",
+                    "state": "FL",
+                    "district": 18,
+                    "party": "Republican",
+                    "url": "https://franklin.house.gov",
+                    "address": "249 Cannon House Office Building Washington DC 20515-0918",
+                    "office": "249 Cannon House Office Building",
+                    "phone": "202-225-1252",
+                },
+            ],
+        }
+
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_mcmorris_rodgers(self):
+        """Middle/last names encoded differently"""
+        members_pictorial = [
+            {
+                "entryId": "11088",
+                "memberId": 11088,
+                "memberType": "Representative",
+                "lastName": "Rodgers",
+                "firstName": "Cathy",
+                "name": "Rodgers, Cathy McMorris",
+                "partyDescription": "Republican",
+                "congressionalDescription": "116th Congress",
+                "title": "Not Applicable",
+                "stateId": "WA",
+                "stateDescription": "Washington",
+                "memberTypeId": "RP",
+                "district": 5,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/116_rp_wa_5_rodgers_cathy.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/116_rp_wa_5_rodgers_cathy.jpg",
+                "imageFile": "116_rp_wa_5_rodgers_cathy.jpg",
+            }
+        ]
+
+        legislator = {
+            "id": {
+                "bioguide": "M001159",
+                "thomas": "01809",
+                "govtrack": 400659,
+                "opensecrets": "N00026314",
+                "votesmart": 3217,
+                "fec": ["H4WA05077"],
+                "cspan": 1013063,
+                "wikipedia": "Cathy McMorris Rodgers",
+                "house_history": 18790,
+                "ballotpedia": "Cathy McMorris Rodgers",
+                "maplight": 664,
+                "icpsr": 20535,
+                "wikidata": "Q293343",
+                "google_entity_id": "kg:/m/03dlf3",
+            },
+            "name": {
+                "first": "Cathy",
+                "middle": "Anne",
+                "last": "McMorris Rodgers",
+                "official_full": "Cathy McMorris Rodgers",
+            },
+            "bio": {"birthday": "1969-05-22", "gender": "F"},
+            "terms": [
+                {
+                    "type": "rep",
+                    "start": "2005-01-04",
+                    "end": "2007-01-03",
+                    "state": "WA",
+                    "district": 5,
+                    "party": "Republican",
+                },
+                {
+                    "type": "rep",
+                    "start": "2007-01-04",
+                    "end": "2009-01-03",
+                    "state": "WA",
+                    "district": 5,
+                    "party": "Republican",
+                    "url": "http://mcmorris.house.gov",
+                },
+                {
+                    "type": "rep",
+                    "start": "2009-01-06",
+                    "end": "2011-01-03",
+                    "state": "WA",
+                    "district": 5,
+                    "party": "Republican",
+                    "url": "http://mcmorris.house.gov",
+                },
+                {
+                    "type": "rep",
+                    "start": "2011-01-05",
+                    "end": "2013-01-03",
+                    "state": "WA",
+                    "district": 5,
+                    "party": "Republican",
+                    "url": "http://mcmorris.house.gov",
+                    "address": "2421 Rayburn HOB; Washington DC 20515-4705",
+                    "phone": "202-225-2006",
+                    "fax": "202-225-3392",
+                    "contact_form": "https://mcmorrisforms.house.gov/write-to-cathy1",
+                    "office": "2421 Rayburn House Office Building",
+                },
+                {
+                    "type": "rep",
+                    "start": "2013-01-03",
+                    "end": "2015-01-03",
+                    "state": "WA",
+                    "party": "Republican",
+                    "district": 5,
+                    "url": "http://mcmorris.house.gov",
+                    "address": "203 Cannon HOB; Washington DC 20515-4705",
+                    "phone": "202-225-2006",
+                    "fax": "202-225-3392",
+                    "contact_form": "https://mcmorrisforms.house.gov/write-to-cathy1",
+                    "office": "203 Cannon House Office Building",
+                    "rss_url": "http://mcmorris.house.gov/common/rss/?rss=96",
+                },
+                {
+                    "type": "rep",
+                    "start": "2015-01-06",
+                    "end": "2017-01-03",
+                    "state": "WA",
+                    "party": "Republican",
+                    "district": 5,
+                    "url": "http://mcmorris.house.gov",
+                    "address": "203 Cannon HOB; Washington DC 20515-4705",
+                    "phone": "202-225-2006",
+                    "fax": "202-225-3392",
+                    "contact_form": "https://mcmorrisforms.house.gov/write-to-cathy1",
+                    "office": "203 Cannon House Office Building",
+                    "rss_url": "http://mcmorris.house.gov/common/rss/?rss=96",
+                },
+                {
+                    "type": "rep",
+                    "start": "2017-01-03",
+                    "end": "2019-01-03",
+                    "state": "WA",
+                    "district": 5,
+                    "party": "Republican",
+                    "phone": "202-225-2006",
+                    "url": "https://mcmorris.house.gov",
+                    "rss_url": "http://mcmorris.house.gov/common/rss/?rss=96",
+                    "address": "1314 Longworth House Office Building; Washington DC 20515-4705",
+                    "office": "1314 Longworth House Office Building",
+                    "fax": "202-225-3392",
+                },
+                {
+                    "type": "rep",
+                    "start": "2019-01-03",
+                    "end": "2021-01-03",
+                    "state": "WA",
+                    "district": 5,
+                    "party": "Republican",
+                    "phone": "202-225-2006",
+                    "address": "1035 Longworth House Office Building Washington DC 20515-4705",
+                    "office": "1035 Longworth House Office Building",
+                    "url": "https://mcmorris.house.gov",
+                    "rss_url": "http://mcmorris.house.gov/common/rss/?rss=96",
+                },
+                {
+                    "type": "rep",
+                    "start": "2021-01-03",
+                    "end": "2023-01-03",
+                    "state": "WA",
+                    "district": 5,
+                    "party": "Republican",
+                    "url": "https://mcmorris.house.gov",
+                    "rss_url": "http://mcmorris.house.gov/common/rss/?rss=96",
+                    "address": "1035 Longworth House Office Building Washington DC 20515-4705",
+                    "office": "1035 Longworth House Office Building",
+                    "phone": "202-225-2006",
+                },
+            ],
+        }
+
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+    def test_de_la_cruz(self):
+        """Accent"""
+        members_pictorial = [
+            {
+                "entryId": "13272",
+                "memberId": 13272,
+                "memberType": "Representative",
+                "lastName": "DeLaCruz",
+                "firstName": "Monica",
+                "name": "DeLaCruz, Monica",
+                "partyDescription": "Republican",
+                "congressionalDescription": "118th Congress",
+                "title": "Not Applicable",
+                "stateId": "TX",
+                "stateDescription": "Texas",
+                "memberTypeId": "RP",
+                "district": 15,
+                "thumbNailImageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_TX_15_DeLaCruz_Monica.jpg",
+                "imageUrl": "https://memberguide.gpo.gov/pictorialimages/118_RP_TX_15_DeLaCruz_Monica.jpg",
+                "imageFile": "118_RP_TX_15_DeLaCruz_Monica.jpg",
+            }
+        ]
+
+        legislator = {
+            "id": {
+                "bioguide": "D000594",
+                "fec": ["H0TX15124"],
+                "govtrack": 456943,
+                "opensecrets": "N00045793",
+                "wikidata": "Q115496109",
+                "wikipedia": "Monica De La Cruz",
+                "votesmart": 188292,
+            },
+            "name": {
+                "first": "Mónica",
+                "last": "De La Cruz",
+                "official_full": "Monica De La Cruz",
+            },
+            "bio": {"gender": "F", "birthday": "1974-11-11"},
+            "terms": [
+                {
+                    "type": "rep",
+                    "start": "2023-01-03",
+                    "end": "2025-01-03",
+                    "state": "TX",
+                    "district": 15,
+                    "party": "Republican",
+                    "url": "https://delacruz.house.gov",
+                    "address": "1415 Longworth House Office Building Washington DC 20515-4315",
+                    "office": "1415 Longworth House Office Building",
+                    "phone": "202-225-9901",
+                }
+            ],
+        }
+
+        self.assertTrue(
+            match_pictorial_id(legislator, members_pictorial)
+            == members_pictorial[0]["memberId"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/validate.py
+++ b/test/validate.py
@@ -55,6 +55,7 @@ id_types = {
   "house_history_alternate": int,
   "wikidata": str,
   "google_entity_id": str,
+  "pictorial": int,
 
   # deprecated/to be removed
   "thomas": str,


### PR DESCRIPTION
Adds ids mapping to GPO's Pictorial Member Guide
pictorialapi.gpo.gov

This PR includes ids for all members of 118th Congress. It may also work for historical files -- at least going back to 110 -- but I have not included that work here, as it requires manual fixes and I imagine most interest is in current membership.

Closes #942