### PR TITLE
Fix Rep. Luna's last name, not "Paulina Luna"

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -38269,8 +38269,8 @@
     pictorial: 12994
   name:
     first: Anna
-    middle: (Paulina)
-    last: Paulina Luna
+    middle: Paulina
+    last: Luna
     official_full: Anna Paulina Luna
   bio:
     gender: F


### PR DESCRIPTION
Her last name is simply Luna. It was incorrectly combined with her middle name, with it repeated in the middle name field, originally, in 1b0c1c92.

Reported by a GovTrack user.