### PR TITLE
Add new Trump/Vance roles and correct Vance's name info

### DIFF
--- a/executive.yaml
+++ b/executive.yaml
@@ -1611,6 +1611,11 @@
     end: '2021-01-20'
     party: Republican
     how: election
+  - type: prez
+    start: '2025-01-20'
+    end: '2029-01-20'
+    party: Republican
+    how: election
 - id:
     bioguide: H001075
     fec:
@@ -1639,4 +1644,31 @@
     start: '2021-01-20'
     end: '2025-01-20'
     party: Democrat
+    how: election
+- id:
+    bioguide: V000137
+    lis: S421
+    fec:
+    - S2OH00436
+    govtrack: 456876
+    opensecrets: N00048832
+    wikidata: Q28935729
+    wikipedia: JD Vance
+    google_entity_id: kg:/g/11c6v_wj1r
+    ballotpedia: J.D. Vance
+    pictorial: 13348
+    votesmart: 201794
+  name:
+    first: James David
+    nickname: J.D.
+    last: Vance
+    official_full: J.D. Vance
+  bio:
+    gender: M
+    birthday: '1984-08-02'
+  terms:
+  - type: viceprez
+    start: '2025-01-20'
+    end: '2029-01-20'
+    party: Republican
     how: election


### PR DESCRIPTION
As in the past, former legislators who serve as president or vice president get a duplicate entry in executive.yaml but only with their executive branch roles, so Vance is duplicated from legislators-historical.yaml.