### PR TITLE
Removing Sylvester Turner, who died, from current legislators

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -41231,31 +41231,6 @@
     phone: 202-225-5071
     url: https://craiggoldman.house.gov
 - id:
-    bioguide: T000489
-    fec:
-    - H4TX18237
-    govtrack: 457022
-    wikipedia: Sylvester Turner
-    wikidata: Q16751186
-  name:
-    first: Sylvester
-    last: Turner
-    official_full: Sylvester Turner
-  bio:
-    gender: M
-    birthday: '1954-09-27'
-  terms:
-  - type: rep
-    start: '2025-01-03'
-    end: '2027-01-03'
-    state: TX
-    district: 18
-    party: Democrat
-    address: 1318 Longworth House Office Building Washington DC 20515-4318
-    office: 1318 Longworth House Office Building
-    phone: 202-225-3816
-    url: https://sylvesterturner.house.gov
-- id:
     bioguide: G000603
     fec:
     - H4TX26149

--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -4579,13 +4579,6 @@
     facebook: '61571449239416'
     instagram: repcraiggoldman
 - id:
-    bioguide: T000489
-    govtrack: 457022
-  social:
-    twitter: RepSTurner
-    facebook: repsturner
-    instagram: RepSTurner
-- id:
     bioguide: G000603
     govtrack: 457023
   social:


### PR DESCRIPTION
Removed from current legislators and social media files, added to historical legislators.