### PR TITLE
Carol Miller Fax

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -8625,7 +8625,7 @@
     zip: '25704'
     latitude: 38.4015978
     longitude: -82.4922192
-    fax: 771-200-5704
+    fax: 771-200-5618
     phone: 304-522-2201
   - id: M001205-beckley
     address: 3049 Robert C. Byrd Drive


### PR DESCRIPTION
```
Good afternoon!

Your software has a wrong fax number for our office. The correct fax line number for Representative Carol Miller is (771) 200-5618.

Best,

Nicolas Gray
Director of Constituent Services, Rep. Carol D. Miller 2699 Park Avenue, Suite 220, Huntington, WV 25704
(304) 522-2201 – Office | 771-200-5618 – Fax
```