### PR TITLE
Adding opensecrets ids

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -39273,6 +39273,7 @@
 - id:
     bioguide: K000402
     govtrack: 456957
+    opensecrets: N00054366
     wikipedia: Tim Kennedy (politician)
     wikidata: Q7807373
     votesmart: 91670
@@ -39314,6 +39315,7 @@
     fec:
     - H4CA20181
     govtrack: 456958
+    opensecrets: N00054216
     wikipedia: Vince Fong
     wikidata: Q27916201
     ballotpedia: Vince Fong
@@ -39352,6 +39354,7 @@
     fec:
     - H4OH06165
     govtrack: 456959
+    opensecrets: N00054190
     wikipedia: Michael Rulli
     wikidata: Q63170062
     votesmart: 179016
@@ -39391,6 +39394,7 @@
     fec:
     - H4NJ10176
     govtrack: 456962
+    opensecrets: N00055172
     wikipedia: LaMonica McIver
     wikidata: Q130323710
     votesmart: 186801
@@ -39430,6 +39434,7 @@
     fec:
     - H4WI08119
     govtrack: 456963
+    opensecrets: N00055013
     wikipedia: Tony Wied
     wikidata: Q131033476
     ballotpedia: Tony Wied
@@ -39466,6 +39471,7 @@
     bioguide: F000110
     thomas: '00379'
     govtrack: 404067
+    opensecrets: N00005398
     wikipedia: Cleo Fields
     house_history: 13112
     icpsr: 29354
@@ -39629,6 +39635,7 @@
     fec:
     - S4MD00327
     govtrack: 456965
+    opensecrets: N00053033
     wikipedia: Angela Alsobrooks
     wikidata: Q58755148
   name:
@@ -39658,6 +39665,7 @@
     fec:
     - S4MT00183
     govtrack: 456966
+    opensecrets: N00053174
     wikipedia: Tim Sheehy (American politician)
     wikidata: Q124433916
   name:
@@ -39686,6 +39694,7 @@
     fec:
     - S4OH00192
     govtrack: 456967
+    opensecrets: N00048437
     wikipedia: Bernie Moreno
     wikidata: Q124858476
   name:
@@ -39713,6 +39722,7 @@
     fec:
     - S2PA00661
     govtrack: 456968
+    opensecrets: N00050244
     wikipedia: Dave McCormick
     wikidata: Q5234544
   name:
@@ -39741,6 +39751,7 @@
     fec:
     - H2AK01083
     govtrack: 456970
+    opensecrets: N00049408
     wikipedia: Nick Begich III
     wikidata: Q113676482
   name:
@@ -39768,6 +39779,7 @@
     fec:
     - H4AL02170
     govtrack: 456971
+    opensecrets: N00053909
     wikipedia: Shomari Figures
     wikidata: Q129431158
   name:
@@ -39794,6 +39806,7 @@
     fec:
     - H4AZ03109
     govtrack: 456972
+    opensecrets: N00052497
     wikipedia: Yassamin Ansari
     wikidata: Q122226202
   name:
@@ -39819,6 +39832,7 @@
     fec:
     - H4AZ08108
     govtrack: 456973
+    opensecrets: N00053795
     wikipedia: Abraham Hamadeh
     wikidata: Q124307977
   name:
@@ -39845,6 +39859,7 @@
     fec:
     - H4CA12154
     govtrack: 456974
+    opensecrets: N00052195
     wikipedia: Lateefah Simon
     wikidata: Q6495426
   name:
@@ -39871,6 +39886,7 @@
     fec:
     - H2CA13115
     govtrack: 456975
+    opensecrets: N00050061
     wikipedia: Adam Gray
     wikidata: Q3000097
   name:
@@ -39897,6 +39913,7 @@
     fec:
     - H4CA16197
     govtrack: 456976
+    opensecrets: N00054265
     wikipedia: Sam Liccardo
     wikidata: Q16731481
   name:
@@ -39923,6 +39940,7 @@
     fec:
     - H4CA27111
     govtrack: 456977
+    opensecrets: N00052205
     wikipedia: George T. Whitesides
     wikidata: Q3511804
   name:
@@ -39949,6 +39967,7 @@
     fec:
     - H4CA29141
     govtrack: 456978
+    opensecrets: N00054215
     wikipedia: Luz Rivas
     wikidata: Q54861699
   name:
@@ -39975,6 +39994,7 @@
     fec:
     - H4CA30149
     govtrack: 456979
+    opensecrets: N00052209
     wikipedia: Laura Friedman
     wikidata: Q6498920
   name:
@@ -40001,6 +40021,7 @@
     fec:
     - H4CA45170
     govtrack: 456980
+    opensecrets: N00053582
     wikipedia: Derek Tran
     wikidata: Q131339671
   name:
@@ -40027,6 +40048,7 @@
     fec:
     - H4CA47085
     govtrack: 456981
+    opensecrets: N00040866
     wikipedia: Dave Min
     wikidata: Q31213321
   name:
@@ -40053,6 +40075,7 @@
     fec:
     - H4CO03357
     govtrack: 456982
+    opensecrets: N00053367
     wikipedia: Jeff Hurd (politician)
     wikidata: Q131101500
   name:
@@ -40079,6 +40102,7 @@
     fec:
     - H6CO05142
     govtrack: 456983
+    opensecrets: N00028132
     wikipedia: Jeff Crank
     wikidata: Q27663361
   name:
@@ -40105,6 +40129,7 @@
     fec:
     - H4CO08034
     govtrack: 456984
+    opensecrets: N00053312
     wikipedia: Gabe Evans
     wikidata: Q115458993
   name:
@@ -40130,6 +40155,7 @@
     fec:
     - H4DE00045
     govtrack: 456985
+    opensecrets: N00053312
     wikipedia: Sarah McBride
     wikidata: Q17011236
   name:
@@ -40156,6 +40182,7 @@
     fec:
     - H4FL08168
     govtrack: 456986
+    opensecrets: N00033076
     wikipedia: Mike Haridopolos
     wikidata: Q6847137
   name:
@@ -40182,6 +40209,7 @@
     fec:
     - H4GA03126
     govtrack: 456987
+    opensecrets: N00055118
     wikipedia: Brian Jack
     wikidata: Q86493775
   name:
@@ -40208,6 +40236,7 @@
     fec:
     - H4IN06185
     govtrack: 456988
+    opensecrets: N00054651
     wikipedia: Jefferson Shreve
     wikidata: Q130979817
   name:
@@ -40234,6 +40263,7 @@
     fec:
     - H4IN08249
     govtrack: 456989
+    opensecrets: N00054523
     wikipedia: Mark Messmer
     wikidata: Q6768869
   name:
@@ -40259,6 +40289,7 @@
     fec:
     - H4KS02164
     govtrack: 456990
+    opensecrets: N00055179
     wikipedia: Derek Schmidt
     wikidata: Q5262335
   name:
@@ -40285,6 +40316,7 @@
     fec:
     - H4MD02232
     govtrack: 456991
+    opensecrets: N00054814
     wikipedia: Johnny Olszewski
     wikidata: Q6217866
   name:
@@ -40312,6 +40344,7 @@
     fec:
     - H4MD03156
     govtrack: 456992
+    opensecrets: N00053710
     wikipedia: Sarah Elfreth
     wikidata: Q61970401
   name:
@@ -40364,6 +40397,7 @@
     fec:
     - H2MI07123
     govtrack: 456994
+    opensecrets: N00049596
     wikipedia: Tom Barrett (Michigan politician)
     wikidata: Q18684588
   name:
@@ -40390,6 +40424,7 @@
     fec:
     - H4MI08218
     govtrack: 456995
+    opensecrets: N00054163
     wikipedia: Kristen McDonald Rivet
     wikidata: Q115227000
   name:
@@ -40416,6 +40451,7 @@
     fec:
     - H4MN03118
     govtrack: 456996
+    opensecrets: N00053930
     wikipedia: Kelly Morrison
     wikidata: Q58416636
   name:
@@ -40442,6 +40478,7 @@
     fec:
     - H4MO01134
     govtrack: 456997
+    opensecrets: N00053042
     wikipedia: Wesley Bell
     wikidata: Q23806350
   name:
@@ -40468,6 +40505,7 @@
     fec:
     - H8MO09146
     govtrack: 456998
+    opensecrets: N00030025
     wikipedia: Bob Onder
     wikidata: Q27064117
   name:
@@ -40521,6 +40559,7 @@
     fec:
     - H4MT02098
     govtrack: 457000
+    opensecrets: N00041283
     wikipedia: Troy Downing
     wikidata: Q103158011
   name:
@@ -40547,6 +40586,7 @@
     fec:
     - H4NC06177
     govtrack: 457001
+    opensecrets: N00054055
     wikipedia: Addison McDowell
     wikidata: Q130979819
   name:
@@ -40573,6 +40613,7 @@
     fec:
     - H6NC09200
     govtrack: 457002
+    opensecrets: N00035491
     wikipedia: Mark Harris (North Carolina politician)
     wikidata: Q55622212
   name:
@@ -40599,6 +40640,7 @@
     fec:
     - H2NC13243
     govtrack: 457003
+    opensecrets: N00050144
     wikipedia: Pat Harrigan
     wikidata: Q131179069
   name:
@@ -40624,6 +40666,7 @@
     fec:
     - H4NC13116
     govtrack: 457004
+    opensecrets: N00053743
     wikipedia: Brad Knott
     wikidata: Q130979816
   name:
@@ -40649,6 +40692,7 @@
     fec:
     - H4NC14015
     govtrack: 457005
+    opensecrets: N00053948
     wikipedia: Tim Moore (North Carolina politician)
     wikidata: Q7804002
   name:
@@ -40675,6 +40719,7 @@
     fec:
     - H4ND00061
     govtrack: 457006
+    opensecrets: N00054800
     wikipedia: Julie Fedorchak
     wikidata: Q37824664
   name:
@@ -40701,6 +40746,7 @@
     fec:
     - H4NH02399
     govtrack: 457007
+    opensecrets: N00055218
     wikipedia: Maggie Goodlander
     wikidata: Q126718734
   name:
@@ -40727,6 +40773,7 @@
     fec:
     - H4NJ03080
     govtrack: 457008
+    opensecrets: N00026951
     wikipedia: Herb Conaway
     wikidata: Q14596151
   name:
@@ -40754,6 +40801,7 @@
     fec:
     - H4NJ09194
     govtrack: 457009
+    opensecrets: N00055613
     wikipedia: Nellie Pou
     wikidata: Q6990132
   name:
@@ -40780,6 +40828,7 @@
     fec:
     - H4NY04158
     govtrack: 457010
+    opensecrets: N00050425
     wikipedia: Laura Gillen
     wikidata: Q131105202
   name:
@@ -40806,6 +40855,7 @@
     fec:
     - H4NY16087
     govtrack: 457011
+    opensecrets: N00054136
     wikipedia: George Latimer (New York politician)
     wikidata: Q5544169
   name:
@@ -40832,6 +40882,7 @@
     fec:
     - H8NY22177
     govtrack: 457012
+    opensecrets: N00049916
     wikipedia: Josh Riley
     wikidata: Q113988129
   name:
@@ -40858,6 +40909,7 @@
     fec:
     - H4NY22085
     govtrack: 457013
+    opensecrets: N00053112
     wikipedia: John Mannion (American politician)
     wikidata: Q106089566
   name:
@@ -40884,6 +40936,7 @@
     fec:
     - H4OH02248
     govtrack: 457014
+    opensecrets: N00054098
     wikipedia: David Taylor (Ohio politician)
     wikidata: Q131123679
   name:
@@ -40910,6 +40963,7 @@
     fec:
     - H4OR03192
     govtrack: 457015
+    opensecrets: N00054144
     wikipedia: Maxine Dexter
     wikidata: Q96777172
   name:
@@ -40936,6 +40990,7 @@
     fec:
     - H4OR05304
     govtrack: 457016
+    opensecrets: N00052777
     wikipedia: Janelle Bynum
     wikidata: Q28507879
   name:
@@ -40962,6 +41017,7 @@
     fec:
     - H8PA15195
     govtrack: 457017
+    opensecrets: N00041866
     wikipedia: Ryan Mackenzie
     wikidata: Q7384273
   name:
@@ -40988,6 +41044,7 @@
     fec:
     - H4PA08124
     govtrack: 457018
+    opensecrets: N00053588
     wikipedia: Rob Bresnahan
     wikidata: Q130963821
   name:
@@ -41015,6 +41072,7 @@
     fec:
     - H4PR01010
     govtrack: 457019
+    opensecrets: N00052286
     wikipedia: Pablo Hernández Rivera
     wikidata: Q130997176
   name:
@@ -41040,6 +41098,7 @@
     fec:
     - H4SC01313
     govtrack: 457020
+    opensecrets: N00054222
     wikipedia: Sheri Biggs
     wikidata: Q130979821
   name:
@@ -41066,6 +41125,7 @@
     fec:
     - H4TX12065
     govtrack: 457021
+    opensecrets: N00053861
     wikipedia: Craig Goldman
     wikidata: Q16199453
   name:
@@ -41092,6 +41152,7 @@
     fec:
     - H4TX26149
     govtrack: 457023
+    opensecrets: N00054402
     wikipedia: Brandon Gill
     wikidata: Q124753679
   name:
@@ -41118,6 +41179,7 @@
     fec:
     - H4TX32089
     govtrack: 457024
+    opensecrets: N00052806
     wikipedia: Julie Johnson (politician)
     wikidata: Q64753063
   name:
@@ -41144,6 +41206,7 @@
     fec:
     - H4UT03260
     govtrack: 457025
+    opensecrets: N00043086
     wikipedia: Mike Kennedy (politician)
     wikidata: Q16730723
   name:
@@ -41170,6 +41233,7 @@
     fec:
     - H4VA05071
     govtrack: 457026
+    opensecrets: N00045930
     wikipedia: John McGuire (Virginia politician)
     wikidata: Q47545631
   name:
@@ -41197,6 +41261,7 @@
     fec:
     - H4VA07234
     govtrack: 457027
+    opensecrets: N00054112
     wikipedia: Eugene Vindman
     wikidata: Q112610369
   name:
@@ -41223,6 +41288,7 @@
     fec:
     - H4VA10279
     govtrack: 457028
+    opensecrets: N00054085
     wikipedia: Suhas Subramanyam
     wikidata: Q83250082
   name:
@@ -41248,6 +41314,7 @@
     fec:
     - H4WA05234
     govtrack: 457029
+    opensecrets: N00033716
     wikipedia: Michael Baumgartner
     wikidata: Q6828508
   name:
@@ -41274,6 +41341,7 @@
     fec:
     - H4WA06117
     govtrack: 457030
+    opensecrets: N00054078
     wikipedia: Emily Randall
     wikidata: Q60473885
   name:
@@ -41300,6 +41368,7 @@
     fec:
     - H4WV02205
     govtrack: 457031
+    opensecrets: N00051965
     wikipedia: Riley Moore
     wikidata: Q93769958
   name:
@@ -41327,6 +41396,7 @@
     fec:
     - S4WV00332
     govtrack: 456969
+    opensecrets: N00053062
     wikipedia: Jim Justice
     wikidata: Q20684288
   name:

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -40371,6 +40371,7 @@
     fec:
     - H4MD06340
     govtrack: 456993
+    opensecrets: N00053899
     wikipedia: April McClain-Delaney
     wikidata: Q125935301
   name:


### PR DESCRIPTION
Added the opensecret ids to records that had none (76 cases), except where opensecrets has apparently not yet assigned an id (5 cases). The latter are are for one Delegate, two appointed Senators, and two who were the winners of special elections in 2025.