### PR TITLE
Fix incorrect CSPAN IDs

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -19760,7 +19760,7 @@
     govtrack: 412516
     bioguide: B001285
     thomas: '02106'
-    cspan: 79783
+    cspan: 67561
     votesmart: 59904
     wikipedia: Julia Brownley
     fec:
@@ -19867,7 +19867,7 @@
     govtrack: 412519
     bioguide: R000599
     thomas: '02109'
-    cspan: 79727
+    cspan: 67721
     votesmart: 136407
     wikipedia: Raul Ruiz (politician)
     fec:
@@ -29187,7 +29187,7 @@
     govtrack: 412559
     bioguide: H001066
     thomas: '02147'
-    cspan: 79614
+    cspan: 67777
     votesmart: 44064
     wikipedia: Steven Horsford
     fec:


### PR DESCRIPTION
Fixes #845. Verified that the CSPAN IDs for the five legislators were incorrect and replaced them with the correct ones.