### PR TITLE
Update FEC IDs for current legislators

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -41156,7 +41156,8 @@
 - id:
     bioguide: M001239
     fec:
-    - H4VA05071
+    - H2VA07196
+    - H0VA07133
     govtrack: 457026
     opensecrets: N00045930
     wikipedia: John McGuire (Virginia politician)


### PR DESCRIPTION
Added missing fec ids for current legislators, as well as added new fec ids for members who switched positions and got a new id. 