### PR TITLE
Fixed incorrect phone number

### DIFF
--- a/committees-current.yaml
+++ b/committees-current.yaml
@@ -1413,4 +1413,4 @@
   house_committee_id: ZT
   name: House Task Force on the Attempted Assassination of Donald J. Trump
   address: 4440 OHOB; Washington, DC 20515
-  phone: (202) (771) 245-4408
+  phone: (771) 245-4408


### PR DESCRIPTION
House Task Force on the Attempted Assassination of Donald J. Trump - phone number had two area codes. https://clerk.house.gov/member_info/TTD-118.pdf shows the (771) area code is the correct one.

Fixes #958.

That Task Force, along with the House Select Subcommittee on the Coronavirus Pandemic and House Select Subcommittee on the Weaponization of the Federal Government, appear in committees-current but appear to have ended. They should be moved to committees-historical. Will open a new issue for that.