### PR TITLE
Narrow bare excepts in retire and house_history scripts

### DIFF
--- a/scripts/house_history.py
+++ b/scripts/house_history.py
@@ -59,7 +59,7 @@ def get_bioguide_for_house_history_id(id):
         try:
             bioguide_link = dom.cssselect("a.view-in-bioguide")[0].get('href')
             return bioguide_link.split('=')[1]
-        except:
+        except IndexError:
             return None
     else:
         return None

--- a/scripts/retire.py
+++ b/scripts/retire.py
@@ -18,7 +18,7 @@ def run():
 
 	try:
 		utils.parse_date(sys.argv[2])
-	except:
+	except ValueError:
 		print("Invalid date: ", sys.argv[2])
 		sys.exit()
 


### PR DESCRIPTION
`retire.py`'s date check is really catching the `ValueError` from `strptime`, and the bioguide lookup in `house_history.py` is catching the `IndexError` for the no-results case. Saying so explicitly stops a typo'd attribute or a Ctrl+C from getting silently turned into "invalid date" or `None`.