### PR TITLE
Corrections to overlapping historical congressional term dates; adding additional local districts and geocoding for CI pass

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -41240,4 +41240,5 @@
     address: 1427 Longworth House Office Building Washington DC 20515-3011
     office: 1427 Longworth House Office Building
     phone: 202-225-5034
+    fax: 202-225-3186
     url: https://mejia.house.gov

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -41188,6 +41188,7 @@
     address: G12 Dirksen Senate Office Building Washington DC 20510
     office: G12 Dirksen Senate Office Building
     phone: 202-224-4721
+    fax: 202-228-0380
 - id:
     bioguide: F000485
     fec:

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -14716,3 +14716,16 @@
     phone: 706-226-5320
     latitude: 34.7698021
     longitude: -84.9702228
+- id:
+    bioguide: M001246
+    govtrack: 457042
+  offices:
+  - id: M001246-livingston
+    address: 357 S. Livingston Avenue
+    suite: Suite 201
+    city: Livingston
+    state: NJ
+    zip: '07039'
+    phone: 973-526-5668
+    latitude: 40.7824091
+    longitude: -74.3146206

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -14704,3 +14704,15 @@
     fax: 405-604-0917
     latitude: 35.5359239
     longitude: -97.5858215
+- id:
+    bioguide: F000485
+    govtrack: 457041
+  offices:
+  - id: F000485-dalton
+    address: P.O. Box 829
+    city: Dalton
+    state: GA
+    zip: '30722'
+    phone: 706-226-5320
+    latitude: 34.7698021
+    longitude: -84.9702228

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -14690,3 +14690,17 @@
     state: TX
     zip: '77002'
     phone: 713-655-0050
+- id:
+    bioguide: A000383
+    govtrack: 457040
+  offices:
+  - id: A000383-oklahoma_city
+    address: 3817 NW Expressway
+    suite: '#780'
+    city: Oklahoma City
+    state: OK
+    zip: '73112'
+    phone: 405-246-0025
+    fax: 405-604-0917
+    latitude: 35.5359239
+    longitude: -97.5858215

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -1619,7 +1619,7 @@
   - id: C000880-coeur_d__alene
     address: 610 Hubbard Ave
     suite: Suite 209
-    city: Coeur d' Alene
+    city: Coeur d'Alene
     state: ID
     zip: '83814'
     fax: 208-664-0889

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -14628,6 +14628,8 @@
     state: VA
     zip: '22030'
     phone: 703-256-3071
+    latitude: 38.8492741
+    longitude: -77.3142244
 - id:
     bioguide: G000606
     govtrack: 457037
@@ -14640,6 +14642,8 @@
     zip: '85714'
     fax: 520-622-0198
     phone: 520-622-6788
+    latitude: 32.160536
+    longitude: -110.9694903
 - id:
     bioguide: V000139
     govtrack: 457038
@@ -14652,6 +14656,8 @@
     zip: '37040'
     hours: By appointment only
     phone: 931-266-4483
+    latitude: 36.5285985
+    longitude: -87.3594237
   - id: V000139-franklin
     address: 305 Public Square
     suite: Suite 212
@@ -14660,6 +14666,8 @@
     zip: '37064'
     hours: By appointment only
     phone: 629-223-6050
+    latitude: 35.9247753
+    longitude: -86.86896159999999
   - id: V000139-nashville
     address: 801 Broadway
     suite: Suite C 507
@@ -14667,6 +14675,8 @@
     state: TN
     zip: '37203'
     phone: 629-999-4950
+    latitude: 36.15826
+    longitude: -86.7825982
 - id:
     bioguide: M001245
     govtrack: 457039
@@ -14677,12 +14687,16 @@
     state: TX
     zip: '77090'
     phone: 281-891-4899
+    latitude: 29.9944134
+    longitude: -95.4261625
   - id: M001245-houston-1
     address: 2020 Solo Street
     city: Houston
     state: TX
     zip: '77020'
     phone: 713-227-7740
+    latitude: 29.7794665
+    longitude: -95.3203801
   - id: M001245-houston-2
     address: 1919 Smith Street
     suite: Suite 1180
@@ -14690,6 +14704,8 @@
     state: TX
     zip: '77002'
     phone: 713-655-0050
+    latitude: 29.7518958
+    longitude: -95.3736327
 - id:
     bioguide: A000383
     govtrack: 457040


### PR DESCRIPTION
This pull request includes 364 corrections to historical congressional term dates sourced from the U.S. Congress Biographical Directory and House History resources. All of these were identified by looking for overlapping dates in service. Each overlap was flagged and then checked against official sources to determine the actual term start and/or end.

Additionally, three local district offices' entries were added to pass the CI check. Geocoding was updated as well for recent district office additions.

Corrected the following term dates:
| Bioguide | Name | Justification |
| -------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| B000546 | Theodorick Bland | Bland served until his death on June 1, 1790. |
| W000216 | Anthony Wayne | Wayne's seat was declared vacant on March 21, 1792. |
| S000471 | Thomson Joseph Skinner | Skinner filled Theodore Sedgwick's vacancy and served from January 27, 1797. |
| E000147 | Oliver Ellsworth | Ellsworth resigned on March 8, 1796. |
| E000091 | Joseph Eggleston | Eggleston filled William B. Giles's vacancy and served from December 3, 1798. |
| W000637 | Richard Winn | Winn filled Thomas Sumter's vacancy and served from January 24, 1803. |
| C000526 | George Clinton | Clinton filled Samuel L. Mitchill's vacancy and served from February 14, 1805. |
| B000467 | Thomas Bines | Bines filled Jacob Hufty's vacancy and served from October 11, 1814. |
| H000487 | Samuel Henderson | Henderson filled Jonathan Roberts's vacancy and served from October 11, 1814. |
| E000083 | Weldon Nathaniel Edwards | Edwards filled Nathaniel Macon's vacancy and served from February 7, 1816. |
| P000250 | George Peter | Peter filled Alexander C. Hanson's vacancy and served from October 7, 1816. |
| H000761 | Charles Hooks | Hooks filled William R. King's vacancy and served from December 2, 1816. |
| H000176 | Alexander Contee Hanson | George Peter filled Hanson's vacancy and served from October 7, 1816. |
| W000061 | John Williams Walker | Walker served from December 14, 1819, until resigning on December 12, 1822. |
| B000577 | Elijah Boardman | Boardman served from March 4, 1821, until his death on August 18, 1823. |
| R000378 | Daniel Rodney | Daniel Rodney filled Caesar Rodney's vacancy and served from October 1, 1822. |
| K000079 | William Kelly | Kelly filled Walker's vacancy and served from December 12, 1822. |
| E000070 | Henry Waggaman Edwards | Edwards's appointed service began October 8, 1823. |
| B000181 | Daniel Laurens Barringer | Barringer filled Willie P. Mangum's vacancy and served from December 4, 1826. |
| P000322 | Israel Pickens | Pickens served from February 17, 1826, to November 27, 1826. |
| M000519 | John McKinley | McKinley filled Henry Chambers's vacancy and served from November 27, 1826. |
| C000284 | Henry H. Chambers | Chambers served until his death on January 24, 1826. |
| S000594 | Nathan Smith | Smith served from March 4, 1833, until his death on December 6, 1835. |
| N000108 | John Milton Niles | Niles's appointed service began December 14, 1835. |
| F000425 | William Savin Fulton | Fulton served from September 18, 1836, until his death on August 15, 1844. |
| M000519 | John McKinley | Bioguide JSON records McKinley's later Senate position in the term beginning March 4, 1837, ending with his resignation before qualifying on April 22, 1837. |
| C000481 | Clement Comer Clay | Clay filled John McKinley's vacancy and served from June 19, 1837, until resigning on November 15, 1841. |
| B000428 | Thaddeus Betts | Betts served from March 4, 1839, until his death on April 7, 1840. |
| H000997 | Jabez Williams Huntington | Huntington served from May 4, 1840, until his death on November 2, 1847. |
| B000030 | Arthur Pendleton Bagby | Bagby filled Clement C. Clay's vacancy and served from November 24, 1841, until resigning on June 16, 1848. |
| Y000003 | William Lowndes Yancey | Yancey filled Dixon H. Lewis's vacancy and served from December 2, 1844. |
| A000311 | Chester Ashley | Ashley filled William S. Fulton's vacancy and served from November 8, 1844, until his death on April 29, 1848. |
| S000216 | William King Sebastian | Sebastian filled Chester Ashley's vacancy and served from May 12, 1848, until expulsion on July 11, 1861. |
| F000174 | Benjamin Fitzpatrick | Fitzpatrick filled Dixon H. Lewis's vacancy and served from November 25, 1848, to November 30, 1849. |
| C000501 | Jeremiah Clemens | Clemens filled Dixon H. Lewis's vacancy and served from November 30, 1849. |
| F000050 | Francis Ball Fay | Fay filled Robert Rantoul Jr.'s vacancy and served from December 13, 1852. |
| B000857 | David Colbreth Broderick | Broderick served from March 4, 1857, until his death on September 16, 1859. |
| H000353 | Henry Peter Haun | Haun's appointed service ran from November 3, 1859, to March 4, 1860. |
| L000110 | Milton Slocum Latham | Latham's service began March 5, 1860. |
| B000525 | Jacob Beeson Blair | Blair filled John S. Carlile's vacancy and served from December 2, 1861. |
| H000016 | John Sharpenstein Hager | Hager's service began December 23, 1873. |
| C000236 | Eugene Casserly | Casserly resigned on November 29, 1873. |
| F000225 | Edwin Flye | Flye filled James G. Blaine's vacancy and served from December 4, 1876. |
| P000557 | Luke Pryor | Pryor served from January 7, 1880, to November 23, 1880. |
| P000561 | James Lawrence Pugh | Pugh served in the Senate from November 24, 1880. |
| M000740 | John Franklin Miller | Miller served from March 4, 1881, until his death on March 8, 1886. |
| C000352 | George Miles Chilcott | Chilcott's appointed service ran from April 17, 1882, to January 27, 1883. |
| T000004 | Horace Austin Warner Tabor | Tabor served from January 27, 1883, to March 3, 1883. |
| B000686 | Thomas Mead Bowen | Bowen's service began March 4, 1883. |
| B000418 | James Henderson Berry | Berry's service began March 20, 1885. |
| G000065 | Augustus Hill Garland | Garland served until resigning on March 6, 1885. |
| H000428 | George Hearst | Hearst's appointed service ran from March 23, 1886, to August 4, 1886. |
| W000486 | Abram Pease Williams | Williams's service began August 4, 1886. |
| H000428 | George Hearst | Hearst's later service ran from March 4, 1887, until his death on February 28, 1891. |
| C000425 | Clarence Don Clark | Clark served in the House from December 1, 1890, to March 3, 1893. |
| F000068 | Charles Norton Felton | Felton's service began March 19, 1891. |
| A000264 | Edwin Le Roy Antony | Antony filled Roger Q. Mills's vacancy and served from June 14, 1892. |
| P000232 | George Clement Perkins | Perkins's appointed service began July 26, 1893. |
| S000793 | Leland Stanford | Stanford served until his death on June 21, 1893. |
| M000543 | John Lowndes McLaurin | McLaurin's appointed service began June 1, 1897. |
| T000412 | Thomas Battle Turley | Turley's appointed service began July 20, 1897. |
| S000734 | Thomas Spight | Spight filled William V. Sullivan's vacancy and served from July 5, 1898. |
| N000144 | Stephen Asa Northway | Northway served until his death on September 8, 1898. |
| A000153 | William Vincent Allen | Allen's appointed service began December 13, 1899. |
| K000142 | Josiah Leeds Kerr | Kerr filled John Walter Smith's vacancy and served from November 6, 1900. |
| C000690 | James Perry Conner | Conner filled Jonathan P. Dolliver's vacancy and served from December 4, 1900. |
| G000110 | John Henry Gear | Gear served until his death on July 14, 1900. |
| R000450 | Jonathan Ross | Ross's appointed service ended October 18, 1900. |
| D000095 | Cushman Kellogg Davis | Davis served until his death on November 27, 1900. |
| M000567 | James McMillan | McMillan served until his death on August 10, 1902. |
| R000521 | Charles Addison Russell | Russell served until his death on October 23, 1902. |
| T000186 | William Aubrey Thomas | Thomas filled Charles W. F. Dick's vacancy and served from November 8, 1904. |
| H000163 | Marcus Alonzo Hanna | Hanna served until his death on February 15, 1904. |
| T000196 | Charles Winston Thompson | Thompson served until his death on March 20, 1904. |
| H000654 | George Frisbie Hoar | Hoar served until his death on September 30, 1904. |
| G000112 | John McDermeid Gearin | Gearin's appointed service began December 13, 1905. |
| S000077 | Edward Watts Saunders | Saunders filled Claude A. Swanson's vacancy and served from November 6, 1906. |
| B001154 | Joseph Ralph Burton | Burton resigned on June 4, 1906. |
| G000326 | Arthur Pue Gorman | Gorman served until his death on June 4, 1906. |
| G000112 | John McDermeid Gearin | Gearin's appointed service ended January 23, 1907. |
| D000112 | Jeff Davis | Davis served from March 4, 1907, until his death on January 3, 1913. |
| B000994 | William James Bryan | Bryan's appointed service began December 26, 1907. |
| L000114 | Asbury Churchwell Latimer | Latimer served until his death on February 20, 1908. |
| P000547 | Redfield Proctor | Proctor served until his death on March 4, 1908. |
| B000994 | William James Bryan | Bryan died on March 22, 1908. |
| A000160 | William Boyd Allison | Allison served until his death on August 4, 1908. |
| S000917 | John Wolcott Stewart | Stewart's appointed service ended October 20, 1908. |
| T000199 | Fountain Land Thompson | Thompson's appointed service began November 10, 1909. |
| G000312 | James Gordon | Gordon's appointed service began December 27, 1909. |
| T000199 | Fountain Land Thompson | Thompson resigned on January 31, 1910. |
| G000312 | James Gordon | Gordon's appointed service ended February 22, 1910. |
| M000429 | Samuel Douglas McEnery | McEnery served until his death on June 28, 1910. |
| D000035 | John Warwick Daniel | Daniel served until his death on June 29, 1910. |
| C000478 | Alexander Stephens Clay | Clay served until his death on November 13, 1910. |
| K000129 | William Squire Kenyon | Kenyon's service began April 12, 1911. |
| G000060 | Obadiah Gardner | Gardner's appointed service began September 23, 1911. |
| S000551 | Hoke Smith | Smith's service began November 16, 1911. |
| T000098 | Robert Love Taylor | Taylor served until his death on March 31, 1912. |
| N000114 | George Stuart Nixon | Nixon served until his death on June 5, 1912. |
| H000554 | Weldon Brinton Heyburn | Heyburn served until his death on October 17, 1912. |
| R000086 | Isidor Rayner | Rayner served until his death on November 25, 1912. |
| B000044 | Joseph Weldon Bailey | Bailey resigned on January 3, 1913. |
| B000014 | Augustus Octavius Bacon | Bacon served until his death on February 14, 1914. |
| B000749 | William O'Connell Bradley | Bradley served until his death on May 23, 1914. |
| W000305 | William Stanley West | West's appointed service ended November 3, 1914. |
| S000371 | Benjamin Franklin Shively | Shively served until his death on March 14, 1916. |
| B001105 | Edwin Chick Burleigh | Burleigh served until his death on June 16, 1916. |
| C000463 | James Paul Clarke | Clarke served until his death on October 1, 1916. |
| T000013 | Thomas Taggart | Taggart's appointed service ended November 7, 1916. |
| N000029 | Adolphus Peter Nelson | Nelson filled Irvine L. Lenroot's vacancy and served from November 5, 1918. |
| W000723 | James Pleasant Woods | Woods filled Carter Glass's vacancy and served from February 25, 1919. |
| B000753 | James Henry Brady | Brady served until his death on January 13, 1918. |
| H000929 | William Hughes | Hughes served until his death on January 30, 1918. |
| B000896 | Robert Foligny Broussard | Broussard served until his death on April 12, 1918. |
| S000968 | William Joel Stone | Stone served until his death on April 14, 1918. |
| T000274 | Benjamin Ryan Tillman | Tillman served until his death on July 3, 1918. |
| G000023 | Jacob Harold Gallinger | Gallinger served until his death on August 17, 1918. |
| J000051 | Ollie Murray James | James served until his death on August 28, 1918. |
| G000522 | Walter Guion | Guion's appointed service ended November 5, 1918. |
| B000702 | William Bismarck Bowling | Bowling filled J. Thomas Heflin's vacancy and served from December 14, 1920. |
| B000110 | John Hollis Bankhead | Bankhead served in the Senate until his death on March 1, 1920. |
| C000657 | Braxton Bragg Comer | Comer served from March 5, 1920, to November 2, 1920, when a successor was elected. |
| C000938 | William Evans Crow | Crow's appointed service began October 24, 1921. |
| B000873 | Smith Wildman Brookhart | Brookhart's service began December 2, 1922. |
| K000129 | William Squire Kenyon | Kenyon resigned on February 24, 1922. |
| C000938 | William Evans Crow | Crow served until his death on August 2, 1922. |
| W000205 | Thomas Edward Watson | Watson served until his death on September 26, 1922. |
| D000560 | Thomas Coleman du Pont | du Pont's appointed service ended November 7, 1922. |
| R000075 | Charles Augustus Rawson | Rawson's appointed service ended November 7, 1922. |
| F000069 | Rebecca Latimer Felton | Felton's appointed service ended November 21, 1922. |
| A000028 | Alva Blanchard Adams | Adams's appointed service ran from May 17, 1923, to November 30, 1924. |
| C000565 | John Joseph Cochran | Cochran filled Harry B. Hawes's vacancy and served from November 2, 1926. |
| B000873 | Smith Wildman Brookhart | Brookhart's service ended April 12, 1926. |
| F000084 | Bert Manfred Fernald | Fernald served until his death on August 23, 1926. |
| W000499 | George Howard Williams | Williams's appointed service ended December 5, 1926. |
| B001196 | William Morgan Butler | Butler's appointed service ended December 6, 1926. |
| M000621 | Rice William Means | Means's service ended March 3, 1927. |
| W000186 | Charles Winfield Waterman | Waterman served from March 4, 1927, until his death on August 27, 1932. |
| W000561 | Frank Bartlett Willis | Willis served until his death on March 30, 1928. |
| G000288 | Frank Robert Gooding | Gooding served until his death on June 24, 1928. |
| D000560 | Thomas Coleman du Pont | du Pont resigned on December 9, 1928. |
| L000386 | Cyrus Locher | Locher's appointed service ended December 14, 1928. |
| F000130 | Charles Finley | Finley filled John M. Robsion's vacancy and served from February 15, 1930. |
| B001045 | Robert J. Bulkley | start 1930-12-01. |
| M000447 | George McGill | start 1930-12-01. |
| W000550 | Ben M. Williamson | start 1930-12-01. |
| D000111 | James J. Davis | start 1930-12-02. |
| M001002 | Dwight Morrow | start 1930-12-03. |
| S000006 | Frederic Mosley Sackett | Sackett resigned on January 9, 1930. |
| A000126 | Henry Justin Allen | Allen's appointed service ended November 30, 1930. |
| M000392 | Roscoe Conkling McCulloch | McCulloch's appointed service ended November 30, 1930. |
| G000510 | Joseph Ridgway Grundy | Grundy's appointed service ended December 1, 1930. |
| B000053 | David Baird Jr. | Baird's appointed service ended December 2, 1930. |
| M001002 | Dwight Morrow | Morrow served through October 5, 1931; the service crosses a class boundary, so it is represented as a second term. |
| C000138 | Hattie Wyatt Caraway | Caraway's appointed service began November 13, 1931. |
| P000091 | Frank C. Partridge | end 1931-03-31. |
| C000139 | Thaddeus Horatius Caraway | Caraway served until his death on November 6, 1931. |
| L000418 | Huey Long | start 1932-01-25. |
| S000152 | Karl Cortlandt Schuyler | Schuyler's service began December 7, 1932. |
| H000259 | William Julius Harris | Harris served until his death on April 18, 1932. |
| J000257 | Wesley Livsey Jones | Jones served until his death on November 19, 1932. |
| M000993 | Cameron A. Morrison | Morrison's appointed service ended December 4, 1932. |
| W000069 | Walter Walker | Walker's appointed service ended December 6, 1932. |
| M000293 | William Gibbs McAdoo | McAdoo served from March 4, 1933, until resigning on November 8, 1938. |
| C000597 | John S. Cohen | end 1933-01-11. |
| W000104 | Thomas J. Walsh | end 1933-03-02. |
| H000940 | Cordell Hull | end 1933-03-03. |
| H000868 | Robert B. Howell | end 1933-03-11. |
| B000774 | Sam G. Bratton | end 1933-06-24. |
| H000987 | Richard C. Hunter | start 1934-11-07. |
| M001108 | James E. Murray | start 1934-11-07. |
| E000202 | John Edward Erickson | Erickson's appointed service ended November 6, 1934. |
| T000225 | William Henry Thompson | Thompson's appointed service ended November 6, 1934. |
| L000418 | Huey Long | end 1935-09-10. |
| S000113 | Thomas D. Schall | end 1935-12-22. |
| G000205 | Guy Gillette | start 1936-11-04. |
| H000838 | Guy V. Howard | start 1936-11-04. |
| P000218 | Claude Pepper | start 1936-11-04. |
| A000244 | Charles Oscar Andrews | Andrews's service began November 4, 1936. |
| F000200 | Duncan Upshaw Fletcher | Fletcher served until his death on June 17, 1936. |
| M001103 | Richard Louis Murphy | Murphy served until his death on July 16, 1936. |
| B000389 | Elmer Austin Benson | Benson's appointed service ended November 3, 1936. |
| H000612 | William Luther Hill | Hill's appointed service ended November 3, 1936. |
| L000400 | Scott Marion Loftin | Loftin's appointed service ended November 3, 1936. |
| N000132 | Peter Norbeck | Norbeck served until his death on December 20, 1936. |
| G000381 | George McInvale Grant | Grant filled Lister Hill's vacancy and served from June 14, 1938. |
| B000132 | W. Warren Barbour | start 1938-11-09. |
| B000187 | Alexander G. Barry | start 1938-11-09. |
| P000581 | Gladys Pyle | start 1938-11-09. |
| M000615 | James M. Mead | start 1938-12-03. |
| M000893 | Arthur Harry Moore | Moore resigned on January 18, 1938. |
| S000848 | Frederick Steiwer | Steiwer resigned on January 31, 1938. |
| C000769 | Royal Samuel Copeland | Copeland served until his death on June 17, 1938. |
| H000646 | Herbert Emery Hitchcock | Hitchcock's appointed service ended November 8, 1938. |
| M000787 | John Gerald Milton | Milton's appointed service ended November 8, 1938. |
| R000099 | Alfred Evan Reames | Reames's appointed service ended November 8, 1938. |
| L000284 | J. Hamilton Lewis | end 1939-04-09. |
| L000404 | M. M. Logan | end 1939-10-03. |
| B000874 | C. Wayland Brooks | start 1940-11-22. |
| B000634 | William Edgar Borah | Borah served until his death on January 19, 1940. |
| G000158 | Ernest Willard Gibson | Gibson served until his death on June 20, 1940. |
| L000514 | Ernest Lundeen | Lundeen served until his death on August 31, 1940. |
| P000372 | Key Pittman | Pittman served until his death on November 10, 1940. |
| S000478 | James Michael Slattery | Slattery's appointed service ended November 21, 1940. |
| A000062 | George David Aiken | Aiken's service began January 10, 1941. |
| B001222 | Katharine Edgar Byron | Byron filled William D. Byron's vacancy and served from May 27, 1941, to January 3, 1943. |
| O000034 | Wilbert Lee O'Daniel | O'Daniel's service began August 4, 1941. |
| D000480 | Wall Doxey | Doxey's service began September 29, 1941. |
| M000279 | Burnet Rhett Maybank | Maybank's service began November 5, 1941. |
| L000510 | Alva Moore Lumpkin | Lumpkin's appointed service began July 22, 1941. |
| G000159 | Ernest William Gibson Jr. | Gibson's appointed service ended January 3, 1941. |
| N000023 | Matthew M. Neely | end 1941-01-12. |
| S000337 | Morris Sheppard | end 1941-04-09. |
| H000265 | Pat Harrison | end 1941-06-22. |
| H000821 | Andrew Jackson Houston | end 1941-06-26. |
| B001215 | James F. Byrnes | end 1941-07-08. |
| L000510 | Alva M. Lumpkin | end 1941-08-01. |
| E000018 | James Eastland | end 1941-09-28. |
| P000159 | Roger C. Peace | end 1941-11-04. |
| A000028 | Alva Blanchard Adams | Adams served until his death on December 1, 1941. |
| N000030 | Arthur E. Nelson | start 1942-11-18. |
| S000381 | Hugh Ike Shott | start 1942-11-18. |
| S000196 | James G. Scrugham | start 1942-12-07. |
| B000099 | Joseph Hurst Ball | Ball's appointed service ended November 17, 1942. |
| R000443 | Joseph Rosier | Rosier's appointed service ended November 17, 1942. |
| D000480 | Wall Doxey | Doxey's service ended January 2, 1943. |
| B000132 | W. Warren Barbour | end 1943-11-22. |
| J000093 | William E. Jenner | start 1944-11-14. |
| S000553 | H. Alexander Smith | start 1944-12-07. |
| V000050 | Frederick Van Nuys | Van Nuys served until his death on January 25, 1944. |
| L000394 | Henry Cabot Lodge Jr. | Lodge resigned on February 3, 1944. |
| J000026 | Samuel Dillon Jackson | Jackson's appointed service ended November 13, 1944. |
| S000530 | Ellison DuRant Smith | Smith served until his death on November 17, 1944. |
| W000096 | Arthur Walsh | Walsh's appointed service ended December 7, 1944. |
| W000248 | Sinclair Weeks | Weeks's appointed service ended December 19, 1944. |
| K000292 | William Fife Knowland | Knowland's appointed service began August 26, 1945. |
| M000088 | Francis T. Maloney | end 1945-01-16. |
| T000387 | Harry S. Truman | end 1945-01-18. |
| M001029 | John Moses | end 1945-03-03. |
| S000196 | James G. Scrugham | end 1945-06-23. |
| J000140 | Hiram Warren Johnson | Johnson served until his death on August 6, 1945. |
| B001150 | Harold H. Burton | end 1945-09-30. |
| C000290 | Happy Chandler | end 1945-11-01. |
| T000172 | John Thomas | end 1945-11-10. |
| C000758 | John Sherman Cooper | start 1946-11-06. |
| D000585 | Henry Dworshak | start 1946-11-06. |
| B000111 | John Hollis Bankhead II | Bankhead served until his death on June 12, 1946. |
| G000337 | Charles Clinton Gossett | Gossett's appointed service ended November 5, 1946. |
| H000293 | Thomas Charles Hart | Hart's appointed service ended November 5, 1946. |
| H000913 | James Wylie Huffman | Huffman's appointed service ended November 5, 1946. |
| S000792 | William Abner Stanfill | Stanfill's appointed service ended November 5, 1946. |
| S001117 | George Robinson Swift | Swift served from June 15, 1946, to November 5, 1946, when a successor was elected. |
| B000046 | Josiah William Bailey | Bailey served until his death on December 15, 1946. |
| L000296 | William Lewis | Lewis filled John Marshall Robsion's vacancy and served from April 24, 1948. |
| L000428 | Russell B. Long | start 1948-12-31. |
| O000146 | John Holmes Overton | Overton served until his death on May 14, 1948. |
| F000057 | William Crosson Feazel | Feazel's appointed service ended December 30, 1948. |
| U000005 | William Bradley Umstead | Umstead's appointed service ended December 30, 1948. |
| L000224 | Herbert Henry Lehman | Lehman's service began November 9, 1949. |
| W000021 | Robert F. Wagner | end 1949-06-28. |
| M000716 | Bert H. Miller | end 1949-10-08. |
| D000522 | John Foster Dulles | end 1949-11-08. |
| S000639 | Willis Smith | start 1950-11-27. |
| B000565 | Sol Bloom | Bloom served until his death on March 7, 1949. |
| G000353 | Frank Porter Graham | Graham's appointed service ended November 26, 1950. |
| D000048 | Harry Darby | Darby's appointed service ended November 28, 1950. |
| D000469 | Sheridan Downey | Downey resigned on November 30, 1950. |
| W000212 | John Clarence Watts | Watts filled Thomas R. Underwood's vacancy by special election on April 14, 1951. |
| W000344 | Kenneth S. Wherry | end 1951-11-29. |
| B001167 | Prescott Bush | start 1952-11-05. |
| C000758 | John Sherman Cooper | start 1952-11-05. |
| G000481 | Dwight Griswold | start 1952-11-05. |
| M000559 | Brien McMahon | McMahon served until his death on July 28, 1952. |
| M000878 | Arthur Edson Blair Moody | Moody's appointed service ended November 4, 1952. |
| P000575 | William Arthur Purtell | Purtell's appointed service ended November 4, 1952. |
| S000214 | Frederick Andrew Seaton | Seaton's appointed service ended November 4, 1952. |
| K000335 | Thomas Henry Kuchel | Kuchel's appointed service began January 2, 1953. |
| N000009 | William Huston Natcher | Natcher filled Garrett L. Withers's vacancy by special election on August 1, 1953. |
| B001099 | Thomas A. Burke | Burke's appointed service began November 10, 1953. |
| N000116 | Richard Milhous Nixon | Nixon resigned on January 1, 1953. |
| S000639 | Willis Smith | end 1953-06-26. |
| T000289 | Charles W. Tobey | end 1953-07-24. |
| T000009 | Robert A. Taft | end 1953-07-31. |
| A000010 | Hazel Abel | start 1954-11-08. |
| B000356 | George H. Bender | start 1954-12-16. |
| G000481 | Dwight Griswold | end 1954-04-12. |
| H000679 | Clyde Roark Hoey | Hoey served until his death on May 12, 1954. |
| M000279 | Burnet Rhett Maybank | Maybank served until his death on September 1, 1954. |
| B000709 | Eva Kelly Bowring | Bowring's appointed service ended November 7, 1954. |
| R000180 | Samuel Williams Reynolds | Reynolds's appointed service ended November 7, 1954. |
| U000032 | Robert William Upton | Upton's appointed service ended November 7, 1954. |
| C000906 | Edward David Crippa | Crippa's appointed service ended November 28, 1954. |
| L000240 | Alton Asa Lennon | Lennon's appointed service ended November 28, 1954. |
| B000913 | Ernest S. Brown | Brown's appointed service ended December 1, 1954. |
| B001099 | Thomas A. Burke | Burke's appointed service ended December 2, 1954. |
| D000031 | Charles Ezra Daniel | Daniel resigned on December 23, 1954. |
| A000010 | Hazel Abel | end 1954-12-31. |
| C000758 | John Sherman Cooper | start 1956-11-07. |
| R000167 | William Chapman Revercomb | start 1956-11-07. |
| K000176 | Harley Martin Kilgore | Kilgore served until his death on February 28, 1956. |
| H000963 | Robert Humphreys | Humphreys's appointed service ended November 6, 1956. |
| L000025 | William Ramsey Laird III | Laird's appointed service ended November 6, 1956. |
| W000666 | Thomas Albert Wofford | Wofford's appointed service ended November 6, 1956. |
| Y000006 | Ralph Webster Yarborough | Yarborough's service began April 29, 1957. |
| P000553 | William Proxmire | Proxmire's service began August 28, 1957. |
| D000036 | Price Daniel | end 1957-01-14. |
| B000536 | William A. Blakley | end 1957-04-28. |
| M000315 | Joseph McCarthy | end 1957-05-02. |
| S000187 | William Kerr Scott | Scott served until his death on April 16, 1958. |
| H000665 | John Dempsey Hoblitzell Jr. | Hoblitzell's appointed service ended November 4, 1958. |
| E000181 | Clair Engle | Engle served from January 3, 1959, until his death on July 30, 1964. |
| B000982 | Clarence Norman Brunsdale | Brunsdale's appointed service ended August 7, 1960. |
| L000520 | Hall Stoner Lusk | Lusk's appointed service ended November 8, 1960. |
| T000322 | John Goodwin Tower | Tower's service began June 15, 1961. |
| B000536 | William A. Blakley | end 1961-06-14. |
| M000486 | Thomas J. McIntyre | start 1962-11-07. |
| S000434 | Milward Simpson | start 1962-11-07. |
| C000221 | Francis Higbee Case | Case served until his death on June 22, 1962. |
| D000585 | Henry Dworshak | end 1962-07-23. |
| H000561 | John Joseph Hickey | Hickey's appointed service ended November 6, 1962. |
| M001100 | Maurice J. Murphy Jr. | Murphy's appointed service ended November 6, 1962. |
| S000517 | Benjamin A. Smith II | Smith's appointed service ended November 6, 1962. |
| K000144 | Robert S. Kerr | end 1963-01-01. |
| K000044 | Estes Kefauver | end 1963-08-10. |
| H000237 | Fred R. Harris | start 1964-11-04. |
| G000421 | William Joseph Green Jr. | Green served until his death on December 21, 1963. |
| E000055 | James Howard Edmondson | Edmondson's appointed service ended November 3, 1964. |
| M000623 | Edwin Leard Mechem | Mechem's appointed service ended November 3, 1964. |
| W000110 | Herbert Sanford Walters | Walters's appointed service ended November 3, 1964. |
| S000016 | Pierre Emil George Salinger | Salinger resigned on December 31, 1964. |
| V000027 | Guy Adrian Vander Jagt | Vander Jagt filled Robert P. Griffin's vacancy and served from November 8, 1966. |
| J000195 | Olin D. Johnston | end 1965-04-18. |
| R000525 | Donald Stuart Russell | Russell's appointed service ended November 8, 1966. |
| R000317 | Absalom Willis Robertson | Robertson resigned on December 30, 1966. |
| K000114 | Robert Francis Kennedy | Kennedy served until his death on June 6, 1968. |
| S000890 | Adlai Ewing Stevenson III | Stevenson's service began November 17, 1970. |
| S000602 | Ralph Tyler Smith | Smith's appointed service ended November 16, 1970. |
| G000034 | David Henry Gambrell | Gambrell's appointed service ended November 7, 1972. |
| M000332 | John Little McClellan | McClellan served until his death on November 28, 1977. |
| D000566 | David Durenberger | start 1978-11-08. |
| M001121 | Edmund Sixtus Muskie | Muskie resigned on May 7, 1980. |
| K000259 | Gerald D. Kleczka | Kleczka filled Clement J. Zablocki's vacancy and served from April 3, 1984. |
| Z000013 | Edward Zorinsky | end 1987-03-06. |
| R000435 | Ileana Ros-Lehtinen | Ros-Lehtinen filled Claude D. Pepper's vacancy and served from August 29, 1989. |
| C000670 | Gary Condit | Condit filled Anthony L. Coelho's vacancy and served from September 12, 1989. |
| G000134 | Preston M. Geren | Geren filled James C. Wright Jr.'s vacancy and served from September 12, 1989. |
| W000177 | Craig Anthony Washington | Washington filled George T. Leland's vacancy by special election on December 9, 1989. |
| S000248 | José E. Serrano | Serrano filled Robert Garcia's vacancy and served from March 20, 1990. |
| Q000007 | Dan Quayle | end 1989-01-02. |
| M000250 | Spark Masayuki Matsunaga | Matsunaga served until his death on April 15, 1990. |
| J000174 | Sam Johnson | Johnson filled Harry Stephen Bartlett's vacancy and served from May 18, 1991. |
| O000085 | John W. Olver | Olver filled Silvio O. Conte's vacancy and served from June 4, 1991. |
| E000282 | Thomas W. Ewing | Ewing filled Edward R. Madigan's vacancy and served from July 2, 1991. |
| P000099 | Ed Pastor | Pastor filled Morris K. Udall's vacancy and served from September 24, 1991. |
| H000456 | Jon Heinz | end 1991-04-04. |
| F000062 | Dianne Feinstein | Feinstein's service began November 4, 1992. |
| S000269 | John Seymour | Seymour's appointed service ended November 3, 1992. |
| L000293 | Ron Lewis | Lewis filled William Natcher's vacancy and served from May 24, 1994. |
| B000639 | David Lyle Boren | Boren resigned on November 15, 1994. |
| M000236 | Harlan Mathews | Mathews's appointed service ended December 1, 1994. |
| P000009 | Bob Packwood | end 1995-10-01. |
| R000568 | Ciro D. Rodriguez | Rodriguez filled Frank Tejeda's vacancy and served from April 12, 1997. |
| C000813 | Paul D. Coverdell | Coverdell served until his death on July 18, 2000. |
| C001043 | Jean Carnahan | Carnahan's appointed service ended November 23, 2002. |
