### PR TITLE
Add nickname 'Jim' for James E. Risch

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -1291,6 +1291,7 @@
     first: James
     middle: E.
     last: Risch
+    nickname: Jim
     official_full: James E. Risch
   bio:
     birthday: '1943-05-03'


### PR DESCRIPTION
This pull request makes a small update to the `legislators-current.yaml` file by adding a nickname for Senator James E. Risch. The change adds the `nickname` field with the value "Jim", which is a name he commonly goes by.