### PR TITLE
Add FEC candidate IDs for members running for another office

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -20082,6 +20082,7 @@
     wikipedia: Andy Barr
     fec:
     - H0KY06104
+    - S6KY00286
     opensecrets: N00031233
     ballotpedia: Andy Barr
     maplight: 1765
@@ -21975,6 +21976,7 @@
     wikipedia: Robin Kelly
     fec:
     - H2IL02172
+    - S6IL00474
     opensecrets: N00035215
     ballotpedia: Robin Kelly
     cspan: 70399
@@ -23289,6 +23291,7 @@
     bioguide: C001103
     fec:
     - H4GA01039
+    - S6GA00374
     govtrack: 412622
     opensecrets: N00035346
     thomas: '02236'
@@ -23636,6 +23639,7 @@
     bioguide: M001196
     fec:
     - H4MA06090
+    - S6MA00296
     govtrack: 412632
     opensecrets: N00035431
     thomas: '02246'
@@ -26578,6 +26582,7 @@
     votesmart: 117519
     fec:
     - H6IL08147
+    - S6IL00482
     opensecrets: N00033240
     maplight: 2213
     cspan: 103408
@@ -27943,6 +27948,7 @@
     bioguide: N000190
     fec:
     - H8SC05158
+    - S6SC04445
     govtrack: 412738
     opensecrets: N00027783
     votesmart: 47930
@@ -28435,6 +28441,7 @@
     bioguide: H001082
     fec:
     - H8OK01157
+    - S6OK04247
     govtrack: 412748
     wikipedia: Kevin Hern
     wikidata: Q58333614
@@ -29865,6 +29872,7 @@
     bioguide: S001215
     fec:
     - H8MI11254
+    - S6MI00426
     govtrack: 412786
     wikipedia: Haley Stevens
     wikidata: Q58322563
@@ -29988,6 +29996,7 @@
     bioguide: C001119
     fec:
     - H6MN02131
+    - S6MN00499
     govtrack: 412789
     opensecrets: N00037039
     wikipedia: Angie Craig
@@ -30232,6 +30241,7 @@
     bioguide: P000614
     fec:
     - H8NH01210
+    - S6NH00141
     govtrack: 412795
     wikipedia: Chris Pappas (American politician)
     wikidata: Q5107684
@@ -32721,6 +32731,7 @@
     bioguide: M001212
     fec:
     - H8AL02171
+    - S6AL00476
     opensecrets: N00041295
     govtrack: 456800
     wikidata: Q63198048
@@ -34959,6 +34970,7 @@
     bioguide: L000595
     fec:
     - H2LA05126
+    - S6LA00664
     opensecrets: N00047972
     govtrack: 456859
     wikipedia: Julia Letlow
@@ -36236,6 +36248,7 @@
     bioguide: C001129
     fec:
     - H4GA10071
+    - S6GA00390
     govtrack: 456895
     opensecrets: N00035370
     wikipedia: Mike Collins (politician)
@@ -36641,6 +36654,7 @@
     bioguide: I000058
     fec:
     - H2MD04315
+    - H2MD04232
     govtrack: 456905
     opensecrets: N00033749
     wikidata: Q22004572
@@ -36723,6 +36737,7 @@
     bioguide: J000307
     fec:
     - H2MI10150
+    - S8MI00372
     govtrack: 456907
     opensecrets: N00041550
     wikidata: Q56027187
@@ -37696,6 +37711,7 @@
     bioguide: F000478
     fec:
     - H2SC07280
+    - S6SC04403
     govtrack: 456938
     opensecrets: N00049165
     wikidata: Q96015883
@@ -37818,6 +37834,7 @@
     bioguide: S001224
     fec:
     - H2TX03290
+    - H2TX00064
     govtrack: 456941
     opensecrets: N00049337
     wikidata: Q115137462
@@ -37939,6 +37956,7 @@
     bioguide: C001130
     fec:
     - H2TX30178
+    - S6TX00552
     govtrack: 456944
     opensecrets: N00049840
     wikidata: Q101428652
@@ -38020,6 +38038,7 @@
     bioguide: H001095
     fec:
     - H0TX07170
+    - S6TX00511
     govtrack: 456946
     opensecrets: N00044362
     wikidata: Q110434665
@@ -38224,6 +38243,7 @@
     bioguide: H001096
     fec:
     - H2WY00166
+    - S6WY00209
     govtrack: 456951
     opensecrets: N00049197
     wikidata: Q110815967
@@ -39792,6 +39812,7 @@
     bioguide: B001324
     fec:
     - H4MO01134
+    - S4MO00250
     govtrack: 456997
     opensecrets: N00053042
     wikipedia: Wesley Bell
@@ -40175,6 +40196,7 @@
     bioguide: G000602
     fec:
     - H4NY04158
+    - H2NY04244
     govtrack: 457010
     opensecrets: N00050425
     wikipedia: Laura Gillen


### PR DESCRIPTION
Adds FEC candidate IDs for sitting members who are running for a different
office this cycle. Each member already has an `id.fec` entry for their current
seat; these are the additional IDs their new campaigns file under.

Listing more than one FEC ID per legislator is the existing convention in this
file — 64 current members already do, including Cantwell, Sanders, Wicker,
Durbin, Reed and Gillibrand, each with both a House and a Senate ID.

Every ID below was checked against the FEC's candidate endpoint
(`/v1/candidate/{id}/`) for a matching surname, state, office and party.

| Legislator | bioguide | FEC ID added | FEC record |
|---|---|---|---|
| Haley M. Stevens | `S001215` | `S6MI00426` | STEVENS, HALEY — Senate, MI |
| Julia Letlow | `L000595` | `S6LA00664` | LETLOW, JULIA — Senate, LA |
| Andy Barr | `B001282` | `S6KY00286` | BARR, GARLAND ANDY — Senate, KY |
| Barry Moore | `M001212` | `S6AL00476` | MOORE, FELIX BARRY — Senate, AL |
| Wesley Hunt | `H001095` | `S6TX00511` | HUNT, WESLEY — Senate, TX |
| Angie Craig | `C001119` | `S6MN00499` | CRAIG, ANGIE — Senate, MN |
| Jasmine Crockett | `C001130` | `S6TX00552` | CROCKETT, JASMINE — Senate, TX |
| Raja Krishnamoorthi | `K000391` | `S6IL00482` | KRISHNAMOORTHI, S — Senate, IL |
| Seth Moulton | `M001196` | `S6MA00296` | MOULTON, SETH — Senate, MA |
| Kevin Hern | `H001082` | `S6OK04247` | HERN, KEVIN — Senate, OK |
| Robin L. Kelly | `K000385` | `S6IL00474` | KELLY, ROBIN — Senate, IL |
| Ralph Norman | `N000190` | `S6SC04445` | NORMAN, RALPH — Senate, SC |
| Mike Collins | `C001129` | `S6GA00390` | COLLINS, MICHAEL A JR — Senate, GA |
| Chris Pappas | `P000614` | `S6NH00141` | PAPPAS, CHRIS — Senate, NH |
| Russell Fry | `F000478` | `S6SC04403` | FRY, RUSSELL — Senate, SC |
| Harriet M. Hageman | `H001096` | `S6WY00209` | HAGEMAN, HARRIET — Senate, WY |
| Earl L. "Buddy" Carter | `C001103` | `S6GA00374` | CARTER, EARL LEROY — Senate, GA |
| Laura Gillen | `G000602` | `H2NY04244` | GILLEN, LAURA — House, NY |
| Keith Self | `S001224` | `H2TX00064` | SELF, KEITH ALAN — House, TX |
| Glenn Ivey | `I000058` | `H2MD04232` | IVEY, GLENN FREDERICK — House, MD |
| John James | `J000307` | `S8MI00372` | JAMES, JOHN — Senate, MI |
| Wesley Bell | `B001324` | `S4MO00250` | BELL, WESLEY — Senate, MO |

Found while reconciling FEC Schedule E independent expenditures: spending filed
under these newer IDs could not be attributed to the member, because only the
older ID was known.
