### PR TITLE
Add President Pro Tempore leadership role for Orrin Hatch

### DIFF
--- a/legislators-historical.yaml
+++ b/legislators-historical.yaml
@@ -438515,6 +438515,11 @@
   bio:
     birthday: '1934-03-22'
     gender: M
+  leadership_roles:
+  - title: President Pro Tempore of the Senate
+    chamber: senate
+    start: '2015-01-06'
+    end: '2019-01-03'
   terms:
   - type: sen
     start: '1977-01-04'


### PR DESCRIPTION
Fixes #517

Adds the `President Pro Tempore of the Senate` leadership role for Orrin Hatch in `legislators-historical.yaml`, with dates 2015-01-06 to 2019-01-03.