### PR TITLE
Fix Tuberville's Facebook handle (T000278)

### DIFF
--- a/legislators-social-media.yaml
+++ b/legislators-social-media.yaml
@@ -3260,7 +3260,7 @@
   social:
     twitter: SenTuberville
     twitter_id: 1345739193721487362
-    facebook: RogerMarshallMD
+    facebook: SenatorTuberville
     instagram: sentuberville
 - id:
     bioguide: T000486


### PR DESCRIPTION
Fixes #1059.

`T000278` (Tommy Tuberville) carried `facebook: RogerMarshallMD`, which is `M001198`'s (Roger Marshall) account — the only Facebook handle claimed by two members in the file.

**Evidence for the replacement.** tuberville.senate.gov links two different Facebook URLs:

- `https://www.facebook.com/SenatorTuberville/` — the visible Facebook icon in the site's social row, i.e. the account the office presents as its own.
- `http://www.facebook.com/RogerMarshallMD` — appears only in the page's Yoast SEO metadata, as `<meta property="article:publisher">` and in the JSON-LD `sameAs` array.

The second looks like a copy-paste leftover in the site's SEO plugin configuration, and since `article:publisher` is the field a scraper would naturally read, it's a plausible origin for the mis-assignment.

M001198's own entry is unchanged: marshall.senate.gov links facebook.com/RogerMarshallMD, so that handle is correctly his.

Verified after the edit: the file still parses, all 518 records intact, and no Facebook handle is shared by two members.
